### PR TITLE
feat: add support for supplying docker args

### DIFF
--- a/mkosi.extra/usr/local/bin/tinfoil-setup
+++ b/mkosi.extra/usr/local/bin/tinfoil-setup
@@ -16,4 +16,12 @@ if "models" in config:
 
 if "containers" in config:
     for container in config["containers"]:
-        os.system(f"docker run --name {container['name']} --network host -d {container['image']}")
+        cmd_parts = ["docker", "run", "-d", "--name", container["name"], "--network", "host"]
+
+        extra_args = []
+        if "args" in container:
+            extra_args = container["args"] if isinstance(container["args"], list) else [container["args"]]
+
+        cmd_parts.extend(extra_args)
+        cmd_parts.append(container["image"])
+        os.system(" ".join(cmd_parts))


### PR DESCRIPTION
This will let us supply docker args in `tinfoil-config.yml` like so:
```
containers:
  - name: "dia"
    image: "ghcr.io/devnen/dia-tts-server"
    args:
      - "-p 8003:8003"
      - "-v /mnt/ramdisk/model_cache:/app/model_cache"
      - "-v /mnt/ramdisk/reference_audio:/app/reference_audio"
      - "-v /mnt/ramdisk/outputs:/app/outputs"
      - "-v /mnt/ramdisk/voices:/app/voices"
      - "--env HF_HUB_ENABLE_HF_TRANSFER=1"
      - "--gpus all"
```