### PR TITLE
feat: track firewall stage

### DIFF
--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -160,9 +160,13 @@ func run() error {
 	}
 
 	// 7. Firewall
+	start = time.Now()
 	log.Println("Configuring firewall")
 	if err := setupFirewall(config); err != nil {
 		log.Printf("Warning: firewall setup failed: %v", err)
+		tracker.Record(boot.StageFirewall, boot.StatusWarning, time.Since(start), err.Error())
+	} else {
+		tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
 	}
 
 	// 8. Models

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -37,6 +37,7 @@ const (
 	StageCertificate    = "certificate"
 	StageRegistryAuth   = "registry-auth"
 	StageModels         = "models"
+	StageFirewall       = "firewall"
 	StageContainers     = "containers"
 	StageShim           = "shim"
 )
@@ -45,7 +46,7 @@ const (
 // Both boot and shim use this as the starting point.
 var InitialStages = []string{
 	StageConfig, StageIdentity, StageCPUAttestation, StageGPUAttestation,
-	StageCertificate, StageRegistryAuth, StageModels, StageContainers, StageShim,
+	StageCertificate, StageRegistryAuth, StageFirewall, StageModels, StageContainers, StageShim,
 }
 
 // Tracker records boot stages as they complete.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Track the firewall setup as a boot stage and record its status and duration. Adds the `firewall` stage to the initial boot sequence (between registry-auth and models) and reports OK or Warning based on setup results.

<sup>Written for commit a7975ce59ecfc272fd83bf24036a1c46ef9b947f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

