### PR TITLE
feat: separate files on ramdisk between public and private

### DIFF
--- a/mkosi.extra/usr/local/bin/tinfoil-ramdisk
+++ b/mkosi.extra/usr/local/bin/tinfoil-ramdisk
@@ -14,7 +14,14 @@ if [ $SIZE -lt 16 ]; then
 fi
 
 mount -t tmpfs -o size=${SIZE}G tmpfs /mnt/ramdisk
-chmod 777 /mnt/ramdisk
+
+# Public dir: read-only mount for containers (/tinfoil)
+mkdir -p /mnt/ramdisk/public
+chmod 755 /mnt/ramdisk/public
+
+# Private dir: boot + shim only (TLS keys, HPKE, registry creds)
+mkdir -p /mnt/ramdisk/private
+chmod 700 /mnt/ramdisk/private
 
 # Mount tmp as ramdisk
 mount -t tmpfs -o size=512M tmpfs /tmp

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -292,7 +292,7 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 		SecurityOpt:    c.SecurityOpt,
 		ReadonlyRootfs: c.ReadOnly,
 		Tmpfs:          c.Tmpfs,
-		Binds:          []string{boot.RamdiskDir + ":/tinfoil"},
+		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
 	}
 
 	// Restart policy

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -1,19 +1,25 @@
 package boot
 
 const (
-	RamdiskDir         = "/mnt/ramdisk"
-	TLSDir             = RamdiskDir + "/tls"
-	TLSCertPath        = TLSDir + "/cert.pem"
-	TLSKeyPath         = TLSDir + "/key.pem"
-	AttestationPath    = RamdiskDir + "/attestation.json"
-	HPKEKeyPath        = RamdiskDir + "/hpke_key.json"
-	ConfigPath         = RamdiskDir + "/config.yml"
-	ExternalConfigPath = RamdiskDir + "/external-config.yml"
-	ShimConfigPath     = RamdiskDir + "/shim.yml"
-	DockerConfigDir    = RamdiskDir + "/docker-config"
-	DockerConfigPath   = DockerConfigDir + "/config.json"
-	GCloudKeyPath      = RamdiskDir + "/gcloud_key.json"
-	CacheDir           = RamdiskDir + "/tfshim-cache"
-	MPKDir             = RamdiskDir + "/mpk"
-	StatePath          = RamdiskDir + "/boot-state.json"
+	RamdiskDir = "/mnt/ramdisk"
+	PublicDir  = RamdiskDir + "/public"
+	PrivateDir = RamdiskDir + "/private"
+
+	// Public — mounted read-only into containers as /tinfoil
+	ConfigPath         = PublicDir + "/config.yml"
+	ExternalConfigPath = PublicDir + "/external-config.yml"
+	AttestationPath    = PublicDir + "/attestation.json"
+	MPKDir             = PublicDir + "/mpk"
+
+	// Private — only accessible to boot and shim processes
+	TLSDir           = PrivateDir + "/tls"
+	TLSCertPath      = TLSDir + "/cert.pem"
+	TLSKeyPath       = TLSDir + "/key.pem"
+	HPKEKeyPath      = PrivateDir + "/hpke_key.json"
+	ShimConfigPath   = PrivateDir + "/shim.yml"
+	DockerConfigDir  = PrivateDir + "/docker-config"
+	DockerConfigPath = DockerConfigDir + "/config.json"
+	GCloudKeyPath    = PrivateDir + "/gcloud_key.json"
+	CacheDir         = PrivateDir + "/tfshim-cache"
+	StatePath        = PrivateDir + "/boot-state.json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Split the ramdisk into public and private dirs and mount only the public dir read-only into containers. This tightens secret handling and clarifies file locations.

- **Refactors**
  - Create `/mnt/ramdisk/public` (755) and `/mnt/ramdisk/private` (700) in `tinfoil-ramdisk` (remove `chmod 777` on `/mnt/ramdisk`).
  - Bind mount `boot.PublicDir` to `/tinfoil:ro` for all containers.
  - Move paths: public (`config.yml`, `external-config.yml`, `attestation.json`, `mpk/`); private (`tls/*`, `hpke_key.json`, `shim.yml`, `docker-config/*`, `gcloud_key.json`, `tfshim-cache/`, `boot-state.json`).

<sup>Written for commit 897735e54beabf4566de035515ee297cdeba3ac9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

