### PR TITLE
feat: properly implement fresh v3 attestation

### DIFF
--- a/tinfoil/cmd/boot/cpuattest.go
+++ b/tinfoil/cmd/boot/cpuattest.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"crypto/ecdsa"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -77,44 +76,5 @@ func writeAttestationDoc(att *verifier.Document) error {
 		return fmt.Errorf("writing attestation document: %w", err)
 	}
 	log.Println("V2 attestation document written to ramdisk")
-	return nil
-}
-
-const attestationV3Format = "https://tinfoil.sh/predicate/attestation/v3"
-
-type attestationV3 struct {
-	Format   string          `json:"format"`
-	CPU      attestationCPU  `json:"cpu"`
-	GPU      json.RawMessage `json:"gpu,omitempty"`
-	NVSwitch json.RawMessage `json:"nvswitch,omitempty"`
-}
-
-type attestationCPU struct {
-	Platform string `json:"platform"`
-	Report   string `json:"report"`
-}
-
-func writeAttestationV3(cpuAtt *CPUAttestation, gpuEvidence *GPURawEvidence) error {
-	v3 := attestationV3{
-		Format: attestationV3Format,
-		CPU: attestationCPU{
-			Platform: cpuAtt.Platform,
-			Report:   base64.StdEncoding.EncodeToString(cpuAtt.RawReport),
-		},
-	}
-
-	if gpuEvidence != nil {
-		v3.GPU = gpuEvidence.GPU
-		v3.NVSwitch = gpuEvidence.Switch
-	}
-
-	data, err := json.Marshal(v3)
-	if err != nil {
-		return fmt.Errorf("marshaling V3 attestation: %w", err)
-	}
-	if err := os.WriteFile(boot.AttestationV3Path, data, 0644); err != nil {
-		return fmt.Errorf("writing V3 attestation: %w", err)
-	}
-	log.Println("V3 attestation document written to ramdisk")
 	return nil
 }

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -112,10 +112,8 @@ func run() error {
 			log.Printf("GPUs not set in config, detected %d from hardware", gpuCount)
 		}
 	}
-	var gpuEvidence *GPURawEvidence
 	if gpuCount > 0 && config.ShimCfg.DummyAttestation {
 		log.Printf("Skipping GPU attestation for %d GPUs (dummy-attestation mode)", gpuCount)
-		gpuEvidence = dummyGPUEvidence(gpuCount)
 		if err := setGPUReadyState(true); err != nil {
 			log.Printf("Warning: failed to set GPU ready state: %v", err)
 		}
@@ -123,7 +121,7 @@ func run() error {
 	} else if gpuCount > 0 {
 		log.Printf("Verifying GPU attestation (%d GPUs)", gpuCount)
 		var err error
-		gpuEvidence, err = verifyGPUAttestation(gpuCount)
+		_, err = verifyGPUAttestation(gpuCount)
 		if err != nil {
 			tracker.Record("gpu-attestation", boot.StatusFailed, time.Since(start), err.Error())
 			return err
@@ -131,13 +129,6 @@ func run() error {
 		tracker.Record("gpu-attestation", boot.StatusOK, time.Since(start), fmt.Sprintf("%d GPUs", gpuCount))
 	} else {
 		tracker.Record("gpu-attestation", boot.StatusSkipped, time.Since(start), "no GPUs")
-	}
-
-	// Write V3 attestation (CPU + GPU raw evidence, no gzip)
-	if cpuAtt.RawReport != nil {
-		if err := writeAttestationV3(cpuAtt, gpuEvidence); err != nil {
-			log.Printf("Warning: failed to write V3 attestation: %v", err)
-		}
 	}
 
 	// 5. Certificate

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -102,14 +102,15 @@ func run() error {
 	start = time.Now()
 	gpuCount := config.GPUs
 	if gpuCount == 0 {
-		var err error
-		gpuCount, err = detectGPUCount()
+		detected, err := detectGPUCount()
 		if err != nil {
 			tracker.Record("gpu-attestation", boot.StatusFailed, time.Since(start), err.Error())
 			return err
 		}
-		if gpuCount > 0 {
-			log.Printf("GPUs not set in config, detected %d from hardware", gpuCount)
+		if detected > 0 {
+			tracker.Record("gpu-attestation", boot.StatusFailed, time.Since(start),
+				fmt.Sprintf("detected %d GPU(s) but config declares gpus: 0 — set the correct gpu count in the config", detected))
+			return fmt.Errorf("gpu count mismatch: detected %d, config says 0", detected)
 		}
 	}
 	if gpuCount > 0 && config.ShimCfg.DummyAttestation {

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -2,23 +2,25 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"slices"
 	"strings"
 
 	"tinfoil/internal/acpi"
+	tinfoilattestation "tinfoil/internal/attestation"
 	"tinfoil/internal/boot"
 	"tinfoil/internal/config"
 	"tinfoil/internal/key"
 	"tinfoil/internal/key/online"
 	"tinfoil/internal/metrics"
 
-	"log"
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 	ehbpProtocol "github.com/tinfoilsh/encrypted-http-body-protocol/protocol"
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
@@ -126,7 +128,7 @@ func NewShimServer(
 	validator key.Validator,
 	rateLimiter *RateLimiter,
 	att *attestation.Document,
-	attV3 json.RawMessage,
+	identityBody tinfoilattestation.BodyV2,
 	ehbpIdentity *identity.Identity,
 	tlsCert *tls.Certificate,
 	config *config.Config,
@@ -222,14 +224,57 @@ func NewShimServer(
 
 	mux.Handle("/.well-known/tinfoil-attestation", ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+
+		// V3 attestation — always fresh, with verifier-supplied or random nonce
 		if r.URL.Query().Get("v") == "3" {
-			if attV3 == nil {
-				http.Error(w, "V3 attestation not available", http.StatusServiceUnavailable)
+			var nonce []byte
+			if nonceHex := r.URL.Query().Get("nonce"); nonceHex != "" {
+				var err error
+				nonce, err = hex.DecodeString(nonceHex)
+				if err != nil || len(nonce) != 32 {
+					writeJSONError(w, "Invalid nonce: must be exactly 32 bytes (64 hex chars)", errTypeInvalidRequest, http.StatusBadRequest)
+					return
+				}
+			} else {
+				var err error
+				nonce, err = tinfoilattestation.RandomNonce()
+				if err != nil {
+					writeJSONError(w, "Failed to generate nonce", errTypeServer, http.StatusInternalServerError)
+					return
+				}
+			}
+
+			// Collect fresh GPU evidence with nonce
+			var gpuJSON json.RawMessage
+			var gpuNonce32 [32]byte
+			copy(gpuNonce32[:], nonce)
+			gpuEvidence, err := tinfoilattestation.CollectGPUEvidence(gpuNonce32)
+			if err != nil {
+				log.Printf("GPU evidence collection failed (non-fatal): %v", err)
+			} else if len(gpuEvidence.Evidences) > 0 {
+				gpuJSON, _ = json.Marshal(gpuEvidence)
+			}
+
+			// Build signed V3: GPU evidence hash is bound into CPU REPORT_DATA
+			v3, err := tinfoilattestation.BuildV3(
+				identityBody.TLSKeyFP,
+				identityBody.HPKEKey,
+				nonce,
+				gpuJSON,
+				nil, // NVSwitch: TODO when NSCQ support is added
+				tlsCert,
+			)
+			if err != nil {
+				log.Printf("V3 attestation build failed: %v", err)
+				writeJSONError(w, "Failed to build attestation", errTypeServer, http.StatusInternalServerError)
 				return
 			}
-			w.Write(attV3)
+
+			json.NewEncoder(w).Encode(v3)
 			return
 		}
+
+		// Legacy V2
 		json.NewEncoder(w).Encode(att)
 	})))
 

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -129,6 +129,7 @@ func NewShimServer(
 	rateLimiter *RateLimiter,
 	att *attestation.Document,
 	identityBody tinfoilattestation.BodyV2,
+	gpuCount int,
 	ehbpIdentity *identity.Identity,
 	tlsCert *tls.Certificate,
 	config *config.Config,
@@ -244,24 +245,33 @@ func NewShimServer(
 				}
 			}
 
-			// Collect fresh GPU evidence with nonce
-			var gpuJSON json.RawMessage
-			var gpuNonce32 [32]byte
-			copy(gpuNonce32[:], nonce)
-			gpuEvidence, err := tinfoilattestation.CollectGPUEvidence(gpuNonce32)
-			if err != nil {
-				log.Printf("GPU evidence collection failed (non-fatal): %v", err)
-			} else if len(gpuEvidence.Evidences) > 0 {
-				gpuJSON, _ = json.Marshal(gpuEvidence)
+			// Collect fresh GPU and NVSwitch evidence with nonce (skip if no hardware)
+			var gpuJSON, nvswitchJSON json.RawMessage
+			var nonce32 [32]byte
+			copy(nonce32[:], nonce)
+			if gpuCount > 0 {
+				gpuEvidence, err := tinfoilattestation.CollectGPUEvidence(nonce32)
+				if err != nil {
+					log.Printf("GPU evidence collection failed (non-fatal): %v", err)
+				} else if len(gpuEvidence.Evidences) > 0 {
+					gpuJSON, _ = json.Marshal(gpuEvidence)
+				}
+				if gpuCount >= 8 {
+					nvswitchJSON, err = tinfoilattestation.CollectNVSwitchEvidence(nonce32)
+					if err != nil {
+						log.Printf("NVSwitch evidence collection failed (non-fatal): %v", err)
+						nvswitchJSON = nil
+					}
+				}
 			}
 
-			// Build signed V3: GPU evidence hash is bound into CPU REPORT_DATA
+			// Build signed V3: GPU + NVSwitch evidence hashes bound into CPU REPORT_DATA
 			v3, err := tinfoilattestation.BuildV3(
 				identityBody.TLSKeyFP,
 				identityBody.HPKEKey,
 				nonce,
 				gpuJSON,
-				nil, // NVSwitch: TODO when NSCQ support is added
+				nvswitchJSON,
 				tlsCert,
 			)
 			if err != nil {

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -226,26 +226,14 @@ func NewShimServer(
 	mux.Handle("/.well-known/tinfoil-attestation", ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		// V3 attestation — always fresh, with verifier-supplied or random nonce
-		if r.URL.Query().Get("v") == "3" {
-			var nonce []byte
-			if nonceHex := r.URL.Query().Get("nonce"); nonceHex != "" {
-				var err error
-				nonce, err = hex.DecodeString(nonceHex)
-				if err != nil || len(nonce) != 32 {
-					writeJSONError(w, "Invalid nonce: must be exactly 32 bytes (64 hex chars)", errTypeInvalidRequest, http.StatusBadRequest)
-					return
-				}
-			} else {
-				var err error
-				nonce, err = tinfoilattestation.RandomNonce()
-				if err != nil {
-					writeJSONError(w, "Failed to generate nonce", errTypeServer, http.StatusInternalServerError)
-					return
-				}
+		// Fresh attestation with nonce: ?nonce=<64 hex chars>
+		if nonceHex := r.URL.Query().Get("nonce"); nonceHex != "" {
+			nonce, err := hex.DecodeString(nonceHex)
+			if err != nil || len(nonce) != 32 {
+				writeJSONError(w, "Invalid nonce: must be exactly 32 bytes (64 hex chars)", errTypeInvalidRequest, http.StatusBadRequest)
+				return
 			}
 
-			// Collect fresh GPU and NVSwitch evidence with nonce (skip if no hardware)
 			var gpuJSON, nvswitchJSON json.RawMessage
 			var nonce32 [32]byte
 			copy(nonce32[:], nonce)
@@ -265,8 +253,7 @@ func NewShimServer(
 				}
 			}
 
-			// Build signed V3: GPU + NVSwitch evidence hashes bound into CPU REPORT_DATA
-			v3, err := tinfoilattestation.BuildV3(
+			fresh, err := tinfoilattestation.BuildAttestation(
 				identityBody.TLSKeyFP,
 				identityBody.HPKEKey,
 				nonce,
@@ -275,16 +262,16 @@ func NewShimServer(
 				tlsCert,
 			)
 			if err != nil {
-				log.Printf("V3 attestation build failed: %v", err)
+				log.Printf("Fresh attestation failed: %v", err)
 				writeJSONError(w, "Failed to build attestation", errTypeServer, http.StatusInternalServerError)
 				return
 			}
 
-			json.NewEncoder(w).Encode(v3)
+			json.NewEncoder(w).Encode(fresh)
 			return
 		}
 
-		// Legacy V2
+		// Legacy (no nonce)
 		json.NewEncoder(w).Encode(att)
 	})))
 

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -31,7 +31,7 @@ func testServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
 		Body:   "deadbeef",
 	}
 
-	return NewShimServer(nil, nil, att, tinfoilattestation.BodyV2{}, id, nil, cfg, extCfg)
+	return NewShimServer(nil, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg)
 }
 
 func TestPathNotAllowed_Returns404(t *testing.T) {

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
+	tinfoilattestation "tinfoil/internal/attestation"
 	"tinfoil/internal/config"
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 )
@@ -30,7 +31,7 @@ func testServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
 		Body:   "deadbeef",
 	}
 
-	return NewShimServer(nil, nil, att, nil, id, nil, cfg, extCfg)
+	return NewShimServer(nil, nil, att, tinfoilattestation.BodyV2{}, id, nil, cfg, extCfg)
 }
 
 func TestPathNotAllowed_Returns404(t *testing.T) {

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -199,7 +199,10 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 		}
 		copy(identityBody.HPKEKey[:], serverIdentity.MarshalPublicKey())
 
-		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, serverIdentity, realCertParsed, config, externalConfig)
+		gpuCount := tinfoilattestation.DetectGPUCount()
+		log.Printf("Detected %d GPU(s) for attestation", gpuCount)
+
+		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, gpuCount, serverIdentity, realCertParsed, config, externalConfig)
 		handler.Store(http.HandlerFunc(fullHandler.ServeHTTP))
 
 		log.Println("Shim fully operational")

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -22,10 +22,12 @@ import (
 	verifier "github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 	"golang.org/x/time/rate"
 
+	tinfoilattestation "tinfoil/internal/attestation"
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/key"
 	"tinfoil/internal/key/online"
+	tlsutil "tinfoil/internal/tls"
 )
 
 var (
@@ -133,15 +135,6 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 			return err
 		}
 
-		var attV3 json.RawMessage
-		if data, err := os.ReadFile(boot.AttestationV3Path); err == nil {
-			if json.Valid(data) {
-				attV3 = data
-			} else {
-				log.Println("Warning: V3 attestation file is not valid JSON, ignoring")
-			}
-		}
-
 		serverIdentity, err := waitForArtifact("HPKE identity", func() (*identity.Identity, error) {
 			return identity.FromFile(config.HPKEKeyFile)
 		})
@@ -195,7 +188,18 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 			rateLimiter = NewRateLimiter(rate.Limit(config.RateLimit), config.RateBurst)
 		}
 
-		fullHandler := NewShimServer(validator, rateLimiter, att, attV3, serverIdentity, cert.Load(), config, externalConfig)
+		// Build identity body for fresh attestation (binds TLS key + HPKE key to hardware)
+		realCertParsed := cert.Load()
+		tlsPub, ok := realCertParsed.PrivateKey.(*ecdsa.PrivateKey)
+		if !ok {
+			return fmt.Errorf("TLS key is not ECDSA")
+		}
+		identityBody := tinfoilattestation.BodyV2{
+			TLSKeyFP: tlsutil.KeyFPBytes(&tlsPub.PublicKey),
+		}
+		copy(identityBody.HPKEKey[:], serverIdentity.MarshalPublicKey())
+
+		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, serverIdentity, realCertParsed, config, externalConfig)
 		handler.Store(http.HandlerFunc(fullHandler.ServeHTTP))
 
 		log.Println("Shim fully operational")

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/google/go-sev-guest v0.14.1
 	github.com/google/go-tdx-guest v0.3.1
 	github.com/jarcoal/httpmock v1.3.1
-	github.com/klauspost/cpuid/v2 v2.2.10
 	github.com/mackerelio/go-osstat v0.2.6
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -69,8 +69,6 @@ github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInw
 github.com/jarcoal/httpmock v1.3.1/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/klauspost/compress v1.18.1 h1:bcSGx7UbpBqMChDtsF28Lw6v/G94LPrrbMbdC3JH2co=
 github.com/klauspost/compress v1.18.1/go.mod h1:ZQFFVG+MdnR0P+l6wpXgIL4NTtwiKIdBnrBd8Nrxr+0=
-github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
-github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/tinfoil/internal/attestation/attestation.go
+++ b/tinfoil/internal/attestation/attestation.go
@@ -39,7 +39,7 @@ func (a BodyV2) Marshal() [64]byte {
 
 // Report fetches the raw hardware attestation report and platform identifier.
 func Report(userData [64]byte) (report []byte, platform string, err error) {
-	if _, err := os.Stat("/dev/sev-guest"); err == nil {
+	if _, statErr := os.Stat("/dev/sev-guest"); statErr == nil {
 		var qp sevclient.QuoteProvider
 		qp, err = sevclient.GetQuoteProvider()
 		if err != nil {
@@ -53,7 +53,7 @@ func Report(userData [64]byte) (report []byte, platform string, err error) {
 			report = report[:sevabi.ReportSize]
 		}
 		return report, PlatformSEVSNP, nil
-	} else if _, err := os.Stat("/dev/tdx_guest"); err == nil {
+	} else if _, statErr := os.Stat("/dev/tdx_guest"); statErr == nil {
 		var qp tdxclient.QuoteProvider
 		qp, err = tdxclient.GetQuoteProvider()
 		if err != nil {
@@ -227,7 +227,7 @@ func BuildAttestation(
 // The signature covers SHA-256 of the JSON-serialized document (with signature field empty).
 func signAttestation(att *Attestation, tlsCert *tls.Certificate) (string, error) {
 	if tlsCert == nil || tlsCert.PrivateKey == nil {
-		return "", nil
+		return "", fmt.Errorf("TLS certificate or private key is nil, cannot sign attestation")
 	}
 	ecKey, ok := tlsCert.PrivateKey.(*ecdsa.PrivateKey)
 	if !ok {

--- a/tinfoil/internal/attestation/attestation.go
+++ b/tinfoil/internal/attestation/attestation.go
@@ -1,14 +1,20 @@
 package attestation
 
 import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"os"
 
 	sevabi "github.com/google/go-sev-guest/abi"
 	sevclient "github.com/google/go-sev-guest/client"
 	tdxclient "github.com/google/go-tdx-guest/client"
-	"github.com/klauspost/cpuid/v2"
 	verifierattestation "github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 
 	"tinfoil/internal/compress"
@@ -33,7 +39,7 @@ func (a BodyV2) Marshal() [64]byte {
 
 // Report fetches the raw hardware attestation report and platform identifier.
 func Report(userData [64]byte) (report []byte, platform string, err error) {
-	if cpuid.CPU.IsVendor(cpuid.AMD) {
+	if _, err := os.Stat("/dev/sev-guest"); err == nil {
 		var qp sevclient.QuoteProvider
 		qp, err = sevclient.GetQuoteProvider()
 		if err != nil {
@@ -47,7 +53,7 @@ func Report(userData [64]byte) (report []byte, platform string, err error) {
 			report = report[:sevabi.ReportSize]
 		}
 		return report, PlatformSEVSNP, nil
-	} else if cpuid.CPU.IsVendor(cpuid.Intel) {
+	} else if _, err := os.Stat("/dev/tdx_guest"); err == nil {
 		var qp tdxclient.QuoteProvider
 		qp, err = tdxclient.GetQuoteProvider()
 		if err != nil {
@@ -62,7 +68,7 @@ func Report(userData [64]byte) (report []byte, platform string, err error) {
 		}
 		return report, PlatformTDX, nil
 	}
-	return nil, "", fmt.Errorf("attestation report for vendor %s not supported", cpuid.CPU.VendorString)
+	return nil, "", fmt.Errorf("no attestation device found (checked /dev/sev-guest, /dev/tdx_guest)")
 }
 
 // V2Document wraps a raw report into the legacy V2 format (base64+gzip).
@@ -92,4 +98,144 @@ func DummyReport(userData [64]byte) *verifierattestation.Document {
 		Format: "https://tinfoil.sh/predicate/dummy/v2",
 		Body:   hex.EncodeToString(userData[:]),
 	}
+}
+
+// V3 types — shared between boot (writes to ramdisk) and shim (serves endpoint)
+
+const V3Format = "https://tinfoil.sh/predicate/attestation/v3"
+
+type V3 struct {
+	Format      string          `json:"format"`
+	ReportData  V3ReportData    `json:"report_data"`
+	CPU         V3CPU           `json:"cpu"`
+	GPU         json.RawMessage `json:"gpu,omitempty"`
+	NVSwitch    json.RawMessage `json:"nvswitch,omitempty"`
+	Certificate string          `json:"certificate"`
+	Signature   string          `json:"signature"`
+}
+
+type V3ReportData struct {
+	TLSKeyFP        string `json:"tls_key_fp"`
+	HPKEKey         string `json:"hpke_key"`
+	Nonce           string `json:"nonce"`
+	GPUEvidenceHash string `json:"gpu_evidence_hash"`
+}
+
+type V3CPU struct {
+	Platform string `json:"platform"`
+	Report   string `json:"report"`
+}
+
+// ComputeReportData computes the 64-byte REPORT_DATA as:
+//
+//	SHA-256(tls_key_fp || hpke_key || nonce || gpu_evidence_hash)
+//
+// padded to 64 bytes with zeros.
+func ComputeReportData(tlsKeyFP [32]byte, hpkeKey [32]byte, nonce []byte, gpuEvidenceHash []byte) [64]byte {
+	h := sha256.New()
+	h.Write(tlsKeyFP[:])
+	h.Write(hpkeKey[:])
+	h.Write(nonce)
+	h.Write(gpuEvidenceHash)
+	var result [64]byte
+	copy(result[:32], h.Sum(nil))
+	return result
+}
+
+// GPUEvidenceHash computes SHA-256 over the raw GPU evidence JSON.
+func GPUEvidenceHash(gpuJSON []byte) []byte {
+	if len(gpuJSON) == 0 {
+		return make([]byte, 32)
+	}
+	h := sha256.Sum256(gpuJSON)
+	return h[:]
+}
+
+// RandomNonce generates a cryptographically random 32-byte nonce.
+func RandomNonce() ([]byte, error) {
+	nonce := make([]byte, 32)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generating random nonce: %w", err)
+	}
+	return nonce, nil
+}
+
+// BuildV3 constructs and signs a complete V3 attestation document.
+// It collects a fresh CPU report with the gpu evidence hash bound into REPORT_DATA,
+// then signs the entire payload with the TLS private key.
+func BuildV3(
+	tlsKeyFP [32]byte,
+	hpkeKey [32]byte,
+	nonce []byte,
+	gpuJSON json.RawMessage,
+	nvswitchJSON json.RawMessage,
+	tlsCert *tls.Certificate,
+) (*V3, error) {
+	gpuHash := GPUEvidenceHash(gpuJSON)
+	reportData := ComputeReportData(tlsKeyFP, hpkeKey, nonce, gpuHash)
+
+	rawReport, platform, err := Report(reportData)
+	if err != nil {
+		return nil, fmt.Errorf("fetching CPU attestation report: %w", err)
+	}
+
+	// Encode the TLS leaf certificate as PEM
+	certPEM := ""
+	if tlsCert != nil && len(tlsCert.Certificate) > 0 {
+		certPEM = string(pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: tlsCert.Certificate[0],
+		}))
+	}
+
+	v3 := &V3{
+		Format: V3Format,
+		ReportData: V3ReportData{
+			TLSKeyFP:        hex.EncodeToString(tlsKeyFP[:]),
+			HPKEKey:         hex.EncodeToString(hpkeKey[:]),
+			Nonce:           hex.EncodeToString(nonce),
+			GPUEvidenceHash: hex.EncodeToString(gpuHash),
+		},
+		CPU: V3CPU{
+			Platform: platform,
+			Report:   base64.StdEncoding.EncodeToString(rawReport),
+		},
+		GPU:         gpuJSON,
+		NVSwitch:    nvswitchJSON,
+		Certificate: certPEM,
+	}
+
+	// Sign the document (signature field is empty during signing)
+	sig, err := signV3(v3, tlsCert)
+	if err != nil {
+		return nil, fmt.Errorf("signing V3 attestation: %w", err)
+	}
+	v3.Signature = sig
+
+	return v3, nil
+}
+
+// signV3 signs the V3 document with the TLS private key.
+// The signature covers SHA-256 of the JSON-serialized document (with signature field empty).
+func signV3(v3 *V3, tlsCert *tls.Certificate) (string, error) {
+	if tlsCert == nil || tlsCert.PrivateKey == nil {
+		return "", nil
+	}
+	ecKey, ok := tlsCert.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("TLS key is not ECDSA")
+	}
+
+	data, err := json.Marshal(v3)
+	if err != nil {
+		return "", fmt.Errorf("marshaling for signing: %w", err)
+	}
+	digest := sha256.Sum256(data)
+
+	sig, err := ecdsa.SignASN1(rand.Reader, ecKey, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("ECDSA sign: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(sig), nil
 }

--- a/tinfoil/internal/attestation/attestation.go
+++ b/tinfoil/internal/attestation/attestation.go
@@ -100,21 +100,19 @@ func DummyReport(userData [64]byte) *verifierattestation.Document {
 	}
 }
 
-// V3 types — shared between boot (writes to ramdisk) and shim (serves endpoint)
+const AttestationFormat = "https://tinfoil.sh/predicate/attestation/v3"
 
-const V3Format = "https://tinfoil.sh/predicate/attestation/v3"
-
-type V3 struct {
+type Attestation struct {
 	Format      string          `json:"format"`
-	ReportData  V3ReportData    `json:"report_data"`
-	CPU         V3CPU           `json:"cpu"`
+	ReportData  ReportDataInfo  `json:"report_data"`
+	CPU         CPUReport       `json:"cpu"`
 	GPU         json.RawMessage `json:"gpu,omitempty"`
 	NVSwitch    json.RawMessage `json:"nvswitch,omitempty"`
 	Certificate string          `json:"certificate"`
 	Signature   string          `json:"signature"`
 }
 
-type V3ReportData struct {
+type ReportDataInfo struct {
 	TLSKeyFP             string `json:"tls_key_fp"`
 	HPKEKey              string `json:"hpke_key"`
 	Nonce                string `json:"nonce"`
@@ -122,7 +120,7 @@ type V3ReportData struct {
 	NVSwitchEvidenceHash string `json:"nvswitch_evidence_hash,omitempty"`
 }
 
-type V3CPU struct {
+type CPUReport struct {
 	Platform string `json:"platform"`
 	Report   string `json:"report"`
 }
@@ -169,17 +167,17 @@ func RandomNonce() ([]byte, error) {
 	return nonce, nil
 }
 
-// BuildV3 constructs and signs a complete V3 attestation document.
-// It collects a fresh CPU report with the gpu evidence hash bound into REPORT_DATA,
+// BuildAttestation constructs and signs a fresh attestation document.
+// It collects a fresh CPU report with evidence hashes bound into REPORT_DATA,
 // then signs the entire payload with the TLS private key.
-func BuildV3(
+func BuildAttestation(
 	tlsKeyFP [32]byte,
 	hpkeKey [32]byte,
 	nonce []byte,
 	gpuJSON json.RawMessage,
 	nvswitchJSON json.RawMessage,
 	tlsCert *tls.Certificate,
-) (*V3, error) {
+) (*Attestation, error) {
 	gpuHash := EvidenceHash(gpuJSON)
 	nvswitchHash := EvidenceHash(nvswitchJSON)
 	reportData := ComputeReportData(tlsKeyFP, hpkeKey, nonce, gpuHash, nvswitchHash)
@@ -198,16 +196,16 @@ func BuildV3(
 		}))
 	}
 
-	v3 := &V3{
-		Format: V3Format,
-		ReportData: V3ReportData{
+	att := &Attestation{
+		Format: AttestationFormat,
+		ReportData: ReportDataInfo{
 			TLSKeyFP:             hex.EncodeToString(tlsKeyFP[:]),
 			HPKEKey:              hex.EncodeToString(hpkeKey[:]),
 			Nonce:                hex.EncodeToString(nonce),
 			GPUEvidenceHash:      hexOrEmpty(gpuHash),
 			NVSwitchEvidenceHash: hexOrEmpty(nvswitchHash),
 		},
-		CPU: V3CPU{
+		CPU: CPUReport{
 			Platform: platform,
 			Report:   base64.StdEncoding.EncodeToString(rawReport),
 		},
@@ -216,19 +214,18 @@ func BuildV3(
 		Certificate: certPEM,
 	}
 
-	// Sign the document (signature field is empty during signing)
-	sig, err := signV3(v3, tlsCert)
+	sig, err := signAttestation(att, tlsCert)
 	if err != nil {
-		return nil, fmt.Errorf("signing V3 attestation: %w", err)
+		return nil, fmt.Errorf("signing attestation: %w", err)
 	}
-	v3.Signature = sig
+	att.Signature = sig
 
-	return v3, nil
+	return att, nil
 }
 
-// signV3 signs the V3 document with the TLS private key.
+// signAttestation signs the document with the TLS private key.
 // The signature covers SHA-256 of the JSON-serialized document (with signature field empty).
-func signV3(v3 *V3, tlsCert *tls.Certificate) (string, error) {
+func signAttestation(att *Attestation, tlsCert *tls.Certificate) (string, error) {
 	if tlsCert == nil || tlsCert.PrivateKey == nil {
 		return "", nil
 	}
@@ -237,7 +234,7 @@ func signV3(v3 *V3, tlsCert *tls.Certificate) (string, error) {
 		return "", fmt.Errorf("TLS key is not ECDSA")
 	}
 
-	data, err := json.Marshal(v3)
+	data, err := json.Marshal(att)
 	if err != nil {
 		return "", fmt.Errorf("marshaling for signing: %w", err)
 	}

--- a/tinfoil/internal/attestation/attestation.go
+++ b/tinfoil/internal/attestation/attestation.go
@@ -115,10 +115,11 @@ type V3 struct {
 }
 
 type V3ReportData struct {
-	TLSKeyFP        string `json:"tls_key_fp"`
-	HPKEKey         string `json:"hpke_key"`
-	Nonce           string `json:"nonce"`
-	GPUEvidenceHash string `json:"gpu_evidence_hash"`
+	TLSKeyFP             string `json:"tls_key_fp"`
+	HPKEKey              string `json:"hpke_key"`
+	Nonce                string `json:"nonce"`
+	GPUEvidenceHash      string `json:"gpu_evidence_hash,omitempty"`
+	NVSwitchEvidenceHash string `json:"nvswitch_evidence_hash,omitempty"`
 }
 
 type V3CPU struct {
@@ -128,26 +129,34 @@ type V3CPU struct {
 
 // ComputeReportData computes the 64-byte REPORT_DATA as:
 //
-//	SHA-256(tls_key_fp || hpke_key || nonce || gpu_evidence_hash)
+//	SHA-256(tls_key_fp || hpke_key || nonce || gpu_evidence_hash || nvswitch_evidence_hash)
 //
 // padded to 64 bytes with zeros.
-func ComputeReportData(tlsKeyFP [32]byte, hpkeKey [32]byte, nonce []byte, gpuEvidenceHash []byte) [64]byte {
+func ComputeReportData(tlsKeyFP [32]byte, hpkeKey [32]byte, nonce []byte, gpuEvidenceHash []byte, nvswitchEvidenceHash []byte) [64]byte {
 	h := sha256.New()
 	h.Write(tlsKeyFP[:])
 	h.Write(hpkeKey[:])
 	h.Write(nonce)
 	h.Write(gpuEvidenceHash)
+	h.Write(nvswitchEvidenceHash)
 	var result [64]byte
 	copy(result[:32], h.Sum(nil))
 	return result
 }
 
-// GPUEvidenceHash computes SHA-256 over the raw GPU evidence JSON.
-func GPUEvidenceHash(gpuJSON []byte) []byte {
-	if len(gpuJSON) == 0 {
-		return make([]byte, 32)
+func hexOrEmpty(b []byte) string {
+	if len(b) == 0 {
+		return ""
 	}
-	h := sha256.Sum256(gpuJSON)
+	return hex.EncodeToString(b)
+}
+
+// EvidenceHash computes SHA-256 over raw evidence JSON. Returns nil for empty input.
+func EvidenceHash(data []byte) []byte {
+	if len(data) == 0 {
+		return nil
+	}
+	h := sha256.Sum256(data)
 	return h[:]
 }
 
@@ -171,8 +180,9 @@ func BuildV3(
 	nvswitchJSON json.RawMessage,
 	tlsCert *tls.Certificate,
 ) (*V3, error) {
-	gpuHash := GPUEvidenceHash(gpuJSON)
-	reportData := ComputeReportData(tlsKeyFP, hpkeKey, nonce, gpuHash)
+	gpuHash := EvidenceHash(gpuJSON)
+	nvswitchHash := EvidenceHash(nvswitchJSON)
+	reportData := ComputeReportData(tlsKeyFP, hpkeKey, nonce, gpuHash, nvswitchHash)
 
 	rawReport, platform, err := Report(reportData)
 	if err != nil {
@@ -191,10 +201,11 @@ func BuildV3(
 	v3 := &V3{
 		Format: V3Format,
 		ReportData: V3ReportData{
-			TLSKeyFP:        hex.EncodeToString(tlsKeyFP[:]),
-			HPKEKey:         hex.EncodeToString(hpkeKey[:]),
-			Nonce:           hex.EncodeToString(nonce),
-			GPUEvidenceHash: hex.EncodeToString(gpuHash),
+			TLSKeyFP:             hex.EncodeToString(tlsKeyFP[:]),
+			HPKEKey:              hex.EncodeToString(hpkeKey[:]),
+			Nonce:                hex.EncodeToString(nonce),
+			GPUEvidenceHash:      hexOrEmpty(gpuHash),
+			NVSwitchEvidenceHash: hexOrEmpty(nvswitchHash),
 		},
 		CPU: V3CPU{
 			Platform: platform,

--- a/tinfoil/internal/attestation/gpu.go
+++ b/tinfoil/internal/attestation/gpu.go
@@ -88,6 +88,13 @@ func CollectGPUEvidence(nonce [32]byte) (*GPUEvidenceCollection, error) {
 			return nil, fmt.Errorf("GetConfComputeGpuCertificate(%d): %s", i, nvml.ErrorString(ret))
 		}
 
+		if report.AttestationReportSize > uint32(len(report.AttestationReport)) {
+			return nil, fmt.Errorf("GPU %d: attestation report size %d exceeds buffer", i, report.AttestationReportSize)
+		}
+		if cert.AttestationCertChainSize > uint32(len(cert.AttestationCertChain)) {
+			return nil, fmt.Errorf("GPU %d: cert chain size %d exceeds buffer", i, cert.AttestationCertChainSize)
+		}
+
 		evidences = append(evidences, GPUEvidence{
 			Arch:        archName,
 			Certificate: base64.StdEncoding.EncodeToString(cert.AttestationCertChain[:cert.AttestationCertChainSize]),

--- a/tinfoil/internal/attestation/gpu.go
+++ b/tinfoil/internal/attestation/gpu.go
@@ -1,0 +1,82 @@
+package attestation
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+// GPUEvidence holds the raw attestation evidence and certificate for a single GPU.
+type GPUEvidence struct {
+	Arch        string `json:"arch"`
+	Certificate string `json:"certificate"` // base64 attestation cert chain
+	Evidence    string `json:"evidence"`    // base64 SPDM attestation report
+	Nonce       string `json:"nonce"`       // hex nonce
+}
+
+// GPUEvidenceCollection is the top-level structure matching nvattest's JSON output.
+type GPUEvidenceCollection struct {
+	Evidences []GPUEvidence `json:"evidences"`
+}
+
+var archNames = map[nvml.DeviceArchitecture]string{
+	nvml.DEVICE_ARCH_HOPPER:    "HOPPER",
+	nvml.DEVICE_ARCH_BLACKWELL: "BLACKWELL",
+}
+
+// CollectGPUEvidence collects fresh attestation evidence from all GPUs using
+// NVML directly (no nvattest CLI). The nonce must be exactly 32 bytes.
+func CollectGPUEvidence(nonce [32]byte) (*GPUEvidenceCollection, error) {
+	ret := nvml.Init()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("nvml.Init: %s", nvml.ErrorString(ret))
+	}
+	defer nvml.Shutdown()
+
+	count, ret := nvml.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("DeviceGetCount: %s", nvml.ErrorString(ret))
+	}
+
+	var evidences []GPUEvidence
+	for i := 0; i < count; i++ {
+		device, ret := nvml.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("DeviceGetHandleByIndex(%d): %s", i, nvml.ErrorString(ret))
+		}
+
+		arch, ret := device.GetArchitecture()
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("GetArchitecture(%d): %s", i, nvml.ErrorString(ret))
+		}
+		archName, ok := archNames[arch]
+		if !ok {
+			archName = fmt.Sprintf("UNKNOWN_%d", arch)
+		}
+
+		// Collect attestation report with nonce
+		var report nvml.ConfComputeGpuAttestationReport
+		report.Nonce = nonce
+		ret = device.GetConfComputeGpuAttestationReport(&report)
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("GetConfComputeGpuAttestationReport(%d): %s", i, nvml.ErrorString(ret))
+		}
+
+		// Collect certificate chain
+		cert, ret := device.GetConfComputeGpuCertificate()
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("GetConfComputeGpuCertificate(%d): %s", i, nvml.ErrorString(ret))
+		}
+
+		evidences = append(evidences, GPUEvidence{
+			Arch:        archName,
+			Certificate: base64.StdEncoding.EncodeToString(cert.AttestationCertChain[:cert.AttestationCertChainSize]),
+			Evidence:    base64.StdEncoding.EncodeToString(report.AttestationReport[:report.AttestationReportSize]),
+			Nonce:       hex.EncodeToString(nonce[:]),
+		})
+	}
+
+	return &GPUEvidenceCollection{Evidences: evidences}, nil
+}

--- a/tinfoil/internal/attestation/gpu.go
+++ b/tinfoil/internal/attestation/gpu.go
@@ -1,9 +1,13 @@
 package attestation
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"os/exec"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 )
@@ -24,6 +28,20 @@ type GPUEvidenceCollection struct {
 var archNames = map[nvml.DeviceArchitecture]string{
 	nvml.DEVICE_ARCH_HOPPER:    "HOPPER",
 	nvml.DEVICE_ARCH_BLACKWELL: "BLACKWELL",
+}
+
+// DetectGPUCount returns the number of NVIDIA GPUs, or 0 if NVML is unavailable.
+func DetectGPUCount() int {
+	ret := nvml.Init()
+	if ret != nvml.SUCCESS {
+		return 0
+	}
+	defer nvml.Shutdown()
+	count, ret := nvml.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		return 0
+	}
+	return count
 }
 
 // CollectGPUEvidence collects fresh attestation evidence from all GPUs using
@@ -79,4 +97,29 @@ func CollectGPUEvidence(nonce [32]byte) (*GPUEvidenceCollection, error) {
 	}
 
 	return &GPUEvidenceCollection{Evidences: evidences}, nil
+}
+
+// CollectNVSwitchEvidence collects fresh NVSwitch attestation evidence via
+// the nvattest CLI (NSCQ is not exposed through go-nvml). The nonce must be
+// exactly 32 bytes.
+func CollectNVSwitchEvidence(nonce [32]byte) (json.RawMessage, error) {
+	nonceHex := hex.EncodeToString(nonce[:])
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "nvattest", "collect-evidence",
+		"--device", "nvswitch",
+		"--nonce", nonceHex,
+		"--format", "json",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("nvattest collect-evidence nvswitch: %w", err)
+	}
+
+	if !json.Valid(out) {
+		return nil, fmt.Errorf("nvattest returned invalid JSON")
+	}
+
+	return json.RawMessage(out), nil
 }

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -6,7 +6,6 @@ const (
 	TLSCertPath        = TLSDir + "/cert.pem"
 	TLSKeyPath         = TLSDir + "/key.pem"
 	AttestationPath    = RamdiskDir + "/attestation.json"
-	AttestationV3Path  = RamdiskDir + "/attestation-v3.json"
 	HPKEKeyPath        = RamdiskDir + "/hpke_key.json"
 	ConfigPath         = RamdiskDir + "/config.yml"
 	ExternalConfigPath = RamdiskDir + "/external-config.yml"

--- a/tinfoil/internal/metrics/metrics.go
+++ b/tinfoil/internal/metrics/metrics.go
@@ -3,17 +3,31 @@ package metrics
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
+	"os"
+	"strings"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
-	"github.com/klauspost/cpuid/v2"
 	"github.com/mackerelio/go-osstat/cpu"
 	"github.com/mackerelio/go-osstat/memory"
-	"log"
 
 	"tinfoil/internal/auth"
 	"tinfoil/internal/config"
 )
+
+func cpuVendor() string {
+	data, err := os.ReadFile("/proc/cpuinfo")
+	if err != nil {
+		return "unknown"
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if k, v, ok := strings.Cut(line, ":"); ok && strings.TrimSpace(k) == "vendor_id" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return "unknown"
+}
 
 // Metrics represents the system metrics data structure
 type Metrics struct {
@@ -87,7 +101,7 @@ func collectMetrics(metadata *config.Metadata) (*Metrics, error) {
 		ID:      metadata.ID,
 		Domain:  metadata.Domain,
 		Image:   metadata.Image,
-		CPUType: cpuid.CPU.VendorString,
+		CPUType: cpuVendor(),
 	}
 
 	memory, err := memory.Get()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Serve fresh V3 attestation from the shim when a `nonce` is provided, binding the TLS key + HPKE key and GPU/NVSwitch evidence hashes into CPU REPORT_DATA, then signing with the TLS key. Logic moved into `tinfoil/internal/attestation`, and boot-time V3 file generation was removed.

- New Features
  - `/.well-known/tinfoil-attestation?nonce=<64-hex>` returns a fresh document; without `nonce`, it returns legacy V2.
  - GPU evidence is collected via NVML; NVSwitch evidence via `nvattest` when present. Their SHA-256 hashes are bound into REPORT_DATA and raw evidence is included.
  - The document includes the leaf TLS certificate (PEM) and an ECDSA signature over the payload.

- Bug Fixes
  - Validate nonce format and length (must be 32 bytes/64 hex), return 400 on invalid input.
  - Added strict buffer size checks for NVML attestation report and certificate chain; improved error handling and logging during evidence collection.

<sup>Written for commit 024a1f79b5e2a08bc757782b215f08abdf5ffb68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

