### PR TITLE
feat: remove gcloud cli

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -44,7 +44,6 @@ Packages=
     docker-ce=5:29.3.0-1~ubuntu.24.04~noble
     docker-ce-cli=5:29.3.0-1~ubuntu.24.04~noble
     containerd.io=2.2.2-1~ubuntu.24.04~noble
-    google-cloud-cli=560.0.0-0
 
 [Build]
 ToolsTree=default

--- a/tinfoil/cmd/boot/auth.go
+++ b/tinfoil/cmd/boot/auth.go
@@ -79,7 +79,9 @@ func setupRegistryAuth() error {
 	}
 	if gcloudKey != "" {
 		// Write key file for containers that mount it directly (e.g., Pollux)
-		os.WriteFile(boot.GCloudKeyPath, []byte(gcloudKey), 0600)
+		if err := os.WriteFile(boot.GCloudKeyPath, []byte(gcloudKey), 0600); err != nil {
+			log.Printf("Warning: failed to write GCloud key file: %v", err)
+		}
 	}
 	if gcloudKey != "" && gcloudRegistry != "" {
 		registries := strings.Split(gcloudRegistry, ",")

--- a/tinfoil/cmd/boot/auth.go
+++ b/tinfoil/cmd/boot/auth.go
@@ -1,15 +1,12 @@
 package main
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"strings"
-	"time"
 
 	"tinfoil/internal/boot"
 )
@@ -17,7 +14,6 @@ import (
 const (
 	secretGCloudKey      = "GCLOUD_KEY"
 	secretGCloudRegistry = "GCLOUD_REGISTRY"
-	authCommandTimeout   = 60 * time.Second
 )
 
 type DockerConfig struct {
@@ -31,10 +27,9 @@ type DockerAuth struct {
 // setupRegistryAuth configures Docker auth from external-config secrets.
 // Supports:
 //   - REGISTRY_<HOST>_USER/TOKEN (e.g., REGISTRY_GHCR_IO_TOKEN)
-//   - GCLOUD_KEY/GCLOUD_REGISTRY (or gcloud-key/gcloud-registry for backward compat)
+//   - GCLOUD_KEY/GCLOUD_REGISTRY (GCP service account for Artifact Registry)
 func setupRegistryAuth() error {
 	os.Setenv("DOCKER_CONFIG", boot.DockerConfigDir)
-	os.Setenv("CLOUDSDK_CONFIG", boot.GCloudConfigPath)
 
 	ext, err := getExternalConfig()
 	if err != nil || ext.Secrets == nil {
@@ -73,7 +68,7 @@ func setupRegistryAuth() error {
 		log.Printf("Auth configured: %s", host)
 	}
 
-	// GCloud auth via CLI (supports both formats)
+	// GCP Artifact Registry auth via service account JSON key
 	gcloudKey := ext.GetSecret(secretGCloudKey)
 	if gcloudKey == "" {
 		gcloudKey = ext.GetSecret("gcloud-key")
@@ -83,8 +78,19 @@ func setupRegistryAuth() error {
 		gcloudRegistry = ext.GetSecret("gcloud-registry")
 	}
 	if gcloudKey != "" {
-		if err := setupGCloudAuth(gcloudKey, gcloudRegistry); err != nil {
-			log.Printf("Warning: gcloud auth failed: %v", err)
+		// Write key file for containers that mount it directly (e.g., Pollux)
+		os.WriteFile(boot.GCloudKeyPath, []byte(gcloudKey), 0600)
+	}
+	if gcloudKey != "" && gcloudRegistry != "" {
+		registries := strings.Split(gcloudRegistry, ",")
+		for _, reg := range registries {
+			reg = strings.TrimSpace(reg)
+			if reg != "" && registryPattern.MatchString(reg) {
+				cfg.Auths[reg] = DockerAuth{
+					Auth: base64.StdEncoding.EncodeToString([]byte("_json_key_base64:" + base64.StdEncoding.EncodeToString([]byte(gcloudKey)))),
+				}
+				log.Printf("Auth configured: %s (GCP service account)", reg)
+			}
 		}
 	}
 
@@ -101,36 +107,3 @@ func setupRegistryAuth() error {
 	return nil
 }
 
-func setupGCloudAuth(key, registry string) error {
-	if err := os.WriteFile(boot.GCloudKeyPath, []byte(key), 0600); err != nil {
-		return err
-	}
-
-	env := append(os.Environ(), "CLOUDSDK_CONFIG="+boot.GCloudConfigPath)
-
-	if err := runCmd(env, "gcloud", "auth", "activate-service-account", "--quiet", "--key-file", boot.GCloudKeyPath); err != nil {
-		return err
-	}
-
-	if registry != "" && registryPattern.MatchString(registry) {
-		return runCmd(env, "gcloud", "auth", "configure-docker", "--quiet", registry)
-	}
-	return nil
-}
-
-func runCmd(env []string, name string, args ...string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), authCommandTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = env
-	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("%s timed out", name)
-		}
-		return err
-	}
-	return nil
-}

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -13,7 +13,6 @@ const (
 	DockerConfigDir    = RamdiskDir + "/docker-config"
 	DockerConfigPath   = DockerConfigDir + "/config.json"
 	GCloudKeyPath      = RamdiskDir + "/gcloud_key.json"
-	GCloudConfigPath   = RamdiskDir + "/gcloud"
 	CacheDir           = RamdiskDir + "/tfshim-cache"
 	MPKDir             = RamdiskDir + "/mpk"
 	StatePath          = RamdiskDir + "/boot-state.json"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove dependency on `google-cloud-cli` and switch GCP Artifact Registry auth to native Docker config using service account keys. This simplifies boot images and avoids shelling out to gcloud.

- **Refactors**
  - Removed `google-cloud-cli` from `mkosi.conf`.
  - Replaced gcloud commands with direct Docker `config.json` auth using `_json_key_base64`.
  - Support multiple registries via comma-separated `GCLOUD_REGISTRY`.
  - Write the service account key to `GCloudKeyPath`; log a warning if the write fails.
  - Removed use of `CLOUDSDK_CONFIG` and the `GCloudConfigPath` constant.
  - Kept backward compatibility for `gcloud-key`/`gcloud-registry` secrets.

- **Migration**
  - Provide `GCLOUD_KEY` (JSON service account) and `GCLOUD_REGISTRY` (comma-separated hosts like `us-docker.pkg.dev`).
  - Do not rely on pre-configured gcloud; Docker auth is now configured purely from secrets.

<sup>Written for commit 15f4b8ac402d125191c8f1ca3bd46c03ab087e2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

