### PR TITLE
Snapshot VMM-shared out_len/status with READ_ONCE in tdx-guest

### DIFF
--- a/mkosi.extra/opt/tdx-fast-quote/tdx-guest.c
+++ b/mkosi.extra/opt/tdx-fast-quote/tdx-guest.c
@@ -149,7 +149,7 @@ static int wait_for_quote_completion(struct tdx_quote_buf *quote_buf, u32 timeou
 	 * Quote requests usually take a few seconds to complete, so waking up
 	 * once per second to recheck the status is fine for this use case.
 	 */
-	while (quote_buf->status == GET_QUOTE_IN_FLIGHT && i++ < timeout) {
+	while (READ_ONCE(quote_buf->status) == GET_QUOTE_IN_FLIGHT && i++ < timeout) {
 		if (msleep_interruptible(10))
 			return -EINTR;
 	}
@@ -162,6 +162,7 @@ static int tdx_report_new(struct tsm_report *report, void *data)
 	u8 *buf, *reportdata = NULL, *tdreport = NULL;
 	struct tdx_quote_buf *quote_buf = quote_data;
 	struct tsm_desc *desc = &report->desc;
+	u32 out_len;
 	int ret;
 	u64 err;
 
@@ -174,7 +175,7 @@ static int tdx_report_new(struct tsm_report *report, void *data)
 	 * Quote buf status is still in GET_QUOTE_IN_FLIGHT (owned by
 	 * VMM), don't permit any new request.
 	 */
-	if (quote_buf->status == GET_QUOTE_IN_FLIGHT) {
+	if (READ_ONCE(quote_buf->status) == GET_QUOTE_IN_FLIGHT) {
 		ret = -EBUSY;
 		goto done;
 	}
@@ -226,19 +227,25 @@ static int tdx_report_new(struct tsm_report *report, void *data)
 		goto done;
 	}
 
-	if (quote_buf->out_len > GET_QUOTE_BUF_SIZE - sizeof(*quote_buf)) {
+	/*
+	 * quote_buf is shared (decrypted) memory writable by the VMM at any
+	 * time. Snapshot out_len once so the bounds check, copy, and reported
+	 * length all use the same value.
+	 */
+	out_len = READ_ONCE(quote_buf->out_len);
+	if (out_len > GET_QUOTE_BUF_SIZE - sizeof(*quote_buf)) {
 		ret = -EIO;
 		goto done;
 	}
 
-	buf = kvmemdup(quote_buf->data, quote_buf->out_len, GFP_KERNEL);
+	buf = kvmemdup(quote_buf->data, out_len, GFP_KERNEL);
 	if (!buf) {
 		ret = -ENOMEM;
 		goto done;
 	}
 
 	report->outblob = buf;
-	report->outblob_len = quote_buf->out_len;
+	report->outblob_len = out_len;
 
 	/*
 	 * TODO: parse the PEM-formatted cert chain out of the quote buffer when


### PR DESCRIPTION
## Snapshot VMM-shared `out_len`/`status` with `READ_ONCE` in tdx-guest

### Summary

The vendored `tdx-guest.c` driver allocates the GetQuote buffer with `set_memory_decrypted()`, which makes it shared memory the VMM can read and write at any time — not just during the `TDG.VP.VMCALL<GetQuote>` hypercall. The `out_len` and `status` fields in that buffer are therefore concurrently writable by the hypervisor while the guest is reading them.

Previously `quote_buf->out_len` was dereferenced three separate times: once for the bounds check, once as the size argument to `kvmemdup()`, and once when assigning `report->outblob_len`. Because the value can change between reads, the bounds check and the copy can disagree — a small value can pass the check while a larger value is used for the copy, or the reported `outblob_len` can exceed the actual allocation.

### Change

- Snapshot `out_len` into a local via `READ_ONCE()` before the bounds check, and use that local for the check, the `kvmemdup()` size, and `report->outblob_len`.
- Wrap the two `quote_buf->status` reads (`wait_for_quote_completion()` poll loop and the `tdx_report_new()` early-busy check) with `READ_ONCE()` for the same reason.

The honest-VMM path is unchanged.

### Why this matters here

In the TDX threat model the hypervisor is untrusted, and it controls both the shared page and vCPU scheduling, so winning a check/use race is straightforward rather than a tight timing window. Snapshotting the length keeps the copy bounded to the 8 KB shared region regardless of what the VMM does after the check.

### Testing

Kernel headers aren't available in the dev environment, so this was verified by diff review against the upstream `drivers/virt/coco/tdx-guest/tdx-guest.c` pattern and the GHCI spec. The module builds inside the mkosi chroot via `mkosi.postinst.chroot` as before.

---

Found during a security scan of this repo with Claude's assistance.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Snapshot `out_len` and `status` from the VMM-shared GetQuote buffer with READ_ONCE to prevent a race between the bounds check and copy. This keeps the bounds check, copy size, and reported length consistent and safe under concurrent VMM writes.

- **Bug Fixes**
  - Wrapped `quote_buf->status` reads with READ_ONCE in `wait_for_quote_completion()` and the early-busy check in `tdx_report_new()`.
  - Read `quote_buf->out_len` once into a local with READ_ONCE and used it for the bounds check, `kvmemdup()` size, and `report->outblob_len`.

<sup>Written for commit b0ac1d1f3890960958e68ca1df62b254fbddc5e0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

