### PR TITLE
Split ramdisk into private/public and mount only public:ro into containers

### DIFF
--- a/mkosi.extra/etc/containerd/config.toml
+++ b/mkosi.extra/etc/containerd/config.toml
@@ -1,4 +1,4 @@
 version = 3
 
-root = "/mnt/ramdisk/containerd/root"
-state = "/mnt/ramdisk/containerd/run"
+root = "/mnt/ramdisk/private/containerd/root"
+state = "/mnt/ramdisk/private/containerd/run"

--- a/mkosi.extra/etc/docker/daemon.json
+++ b/mkosi.extra/etc/docker/daemon.json
@@ -1,5 +1,5 @@
 {
-    "data-root": "/mnt/ramdisk/docker",
+    "data-root": "/mnt/ramdisk/private/docker",
     "features": {
         "containerd-snapshotter": true
     },

--- a/mkosi.extra/usr/local/bin/tinfoil-ramdisk
+++ b/mkosi.extra/usr/local/bin/tinfoil-ramdisk
@@ -13,10 +13,23 @@ if [ $SIZE -lt 16 ]; then
     SIZE=4
 fi
 
-mount -t tmpfs -o size=${SIZE}G tmpfs /mnt/ramdisk
-chmod 777 /mnt/ramdisk
+mount -t tmpfs -o size=${SIZE}G,mode=0755,nodev,nosuid tmpfs /mnt/ramdisk
+
+# private/ holds enclave keys, secrets, and daemon state — never exposed to
+# workload containers.
+mkdir -p /mnt/ramdisk/private
+chmod 700 /mnt/ramdisk/private
+
+# public/ is bind-mounted read-only into workload containers at /tinfoil.
+mkdir -p /mnt/ramdisk/public
+chmod 755 /mnt/ramdisk/public
+
+# Daemon data roots (docker/containerd start before tinfoil-boot).
+mkdir -p /mnt/ramdisk/private/docker
+mkdir -p /mnt/ramdisk/private/containerd/root
+mkdir -p /mnt/ramdisk/private/containerd/run
 
 # Mount tmp as ramdisk
-mount -t tmpfs -o size=512M tmpfs /tmp
+mount -t tmpfs -o size=512M,mode=1777,nodev,nosuid tmpfs /tmp
 
 echo "Ramdisk ready"

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -292,7 +292,7 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 		SecurityOpt:    c.SecurityOpt,
 		ReadonlyRootfs: c.ReadOnly,
 		Tmpfs:          c.Tmpfs,
-		Binds:          []string{boot.RamdiskDir + ":/tinfoil"},
+		Binds:          []string{boot.RamdiskPublicDir + ":/tinfoil:ro"},
 	}
 
 	// Restart policy

--- a/tinfoil/cmd/boot/identity.go
+++ b/tinfoil/cmd/boot/identity.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 
@@ -41,6 +42,9 @@ func generateIdentity(shimCfg *shimconfig.Config, externalConfig *shimconfig.Ext
 	serverIdentity, err := identity.FromFile(hpkeKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading HPKE identity: %w", err)
+	}
+	if err := os.Chmod(hpkeKeyFile, 0o600); err != nil {
+		return nil, fmt.Errorf("restricting HPKE key permissions: %w", err)
 	}
 
 	hpkeKeyBytes := serverIdentity.MarshalPublicKey()

--- a/tinfoil/internal/acpi/acpi.go
+++ b/tinfoil/internal/acpi/acpi.go
@@ -4,96 +4,69 @@ import (
 	"archive/tar"
 	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
+	"sync"
 
 	"tinfoil/internal/auth"
 	"tinfoil/internal/config"
 )
 
-func HandleQemuACPI(cfg *config.Config, externalConfig *config.ExternalConfig) http.HandlerFunc {
+var acpiFiles = []struct {
+	Path string
+	Name string
+}{
+	{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/acpi/tables/raw", Name: "acpi_tables.bin"},
+	{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/acpi/rsdp/raw", Name: "rsdp.bin"},
+	{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/table-loader/raw", Name: "table_loader.bin"},
+}
+
+func buildArchive() ([]byte, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, af := range acpiFiles {
+		data, err := os.ReadFile(af.Path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", af.Name, err)
+		}
+		hdr := &tar.Header{Name: af.Name, Mode: 0o644, Size: int64(len(data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, fmt.Errorf("writing header for %s: %w", af.Name, err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			return nil, fmt.Errorf("writing %s: %w", af.Name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, fmt.Errorf("closing tar: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// HandleQemuACPI serves the QEMU fw_cfg ACPI tables as a tar archive.
+// The archive is built once from /sys/firmware and cached in process memory;
+// it is never read from or written to disk.
+func HandleQemuACPI(_ *config.Config, externalConfig *config.ExternalConfig) http.HandlerFunc {
+	var (
+		once    sync.Once
+		archive []byte
+		genErr  error
+	)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !auth.RequireBearer(externalConfig.ACPIAPIKey, w, r) {
 			return
 		}
 
-		var buf bytes.Buffer
-
-		archivePath := filepath.Join(cfg.CacheDir, "acpi.tar")
-		force := r.URL.Query().Get("force") == "1"
-
-		if _, err := os.Stat(archivePath); !force && err == nil {
-			data, err := os.ReadFile(archivePath)
-			if err != nil {
-				http.Error(w, fmt.Sprintf("Failed to read ACPI archive: %v", err), http.StatusInternalServerError)
-				return
-			}
-			_, err = buf.Write(data)
-			if err != nil {
-				http.Error(w, fmt.Sprintf("Failed to write ACPI archive to buffer: %v", err), http.StatusInternalServerError)
-				return
-			}
-		} else {
-			tw := tar.NewWriter(&buf)
-			type acpiFile struct {
-				Path string
-				Name string
-			}
-			acpiFiles := []acpiFile{
-				{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/acpi/tables/raw", Name: "acpi_tables.bin"},
-				{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/acpi/rsdp/raw", Name: "rsdp.bin"},
-				{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/table-loader/raw", Name: "table_loader.bin"},
-			}
-
-			for _, af := range acpiFiles {
-				data, err := os.ReadFile(af.Path)
-				if err != nil {
-					http.Error(w, fmt.Sprintf("Failed to read ACPI source file %s", af.Name), http.StatusInternalServerError)
-					return
-				}
-				hdr := &tar.Header{
-					Name: af.Name,
-					Mode: 0644,
-					Size: int64(len(data)),
-				}
-				if err := tw.WriteHeader(hdr); err != nil {
-					http.Error(w, fmt.Sprintf("Failed to write header for ACPI source file %s", af.Name), http.StatusInternalServerError)
-					return
-				}
-				if _, err := tw.Write(data); err != nil {
-					http.Error(w, fmt.Sprintf("Failed to write ACPI source file %s", af.Name), http.StatusInternalServerError)
-					return
-				}
-			}
-
-			tw.Close()
-
-			// Persist to disk
-			if err := os.MkdirAll(filepath.Dir(archivePath), 0o755); err == nil {
-				tmp, err := os.CreateTemp(filepath.Dir(archivePath), "acpi-*.tar")
-				if err == nil {
-					if _, err := io.Copy(tmp, bytes.NewReader(buf.Bytes())); err == nil {
-						tmp.Close()
-						_ = os.Rename(tmp.Name(), archivePath)
-					} else {
-						tmp.Close()
-						_ = os.Remove(tmp.Name())
-					}
-				}
-			}
-		}
-
-		w.Header().Set("Content-Type", "application/x-tar")
-		w.Header().Set("Content-Disposition", "attachment; filename=\""+filepath.Base(archivePath)+"\"")
-		w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
-
-		if _, err := io.Copy(w, &buf); err != nil {
-			http.Error(w, fmt.Sprintf("Failed to copy ACPI archive to response: %v", err), http.StatusInternalServerError)
+		once.Do(func() { archive, genErr = buildArchive() })
+		if genErr != nil {
+			http.Error(w, fmt.Sprintf("Failed to build ACPI archive: %v", genErr), http.StatusInternalServerError)
 			return
 		}
 
+		w.Header().Set("Content-Type", "application/x-tar")
+		w.Header().Set("Content-Disposition", `attachment; filename="acpi.tar"`)
+		w.Header().Set("Content-Length", strconv.Itoa(len(archive)))
+		_, _ = w.Write(archive)
 	}
 }

--- a/tinfoil/internal/auth/bearer.go
+++ b/tinfoil/internal/auth/bearer.go
@@ -1,15 +1,17 @@
 package auth
 
 import (
+	"crypto/subtle"
 	"net/http"
 	"strings"
 )
 
 // RequireBearer returns 401 if the request doesn't carry the expected token.
-// If apiKey is empty, all requests are allowed.
+// An empty apiKey is treated as "not configured" and rejects all requests.
 func RequireBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
 	if apiKey == "" {
-		return true
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return false
 	}
 	header := r.Header.Get("Authorization")
 	if len(header) < 7 || !strings.EqualFold(header[:7], "bearer ") {
@@ -17,7 +19,7 @@ func RequireBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	token := header[7:]
-	if token != apiKey {
+	if subtle.ConstantTimeCompare([]byte(token), []byte(apiKey)) != 1 {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return false
 	}

--- a/tinfoil/internal/auth/bearer_test.go
+++ b/tinfoil/internal/auth/bearer_test.go
@@ -14,7 +14,8 @@ func TestRequireBearer(t *testing.T) {
 		wantOK     bool
 		wantStatus int
 	}{
-		{"empty key allows all", "", "", true, 0},
+		{"empty key rejects all", "", "", false, http.StatusUnauthorized},
+		{"empty key rejects valid-looking token", "", "Bearer something", false, http.StatusUnauthorized},
 		{"valid token", "secret", "Bearer secret", true, 0},
 		{"case insensitive scheme", "secret", "bearer secret", true, 0},
 		{"uppercase scheme", "secret", "BEARER secret", true, 0},

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -1,19 +1,29 @@
 package boot
 
 const (
-	RamdiskDir         = "/mnt/ramdisk"
-	TLSDir             = RamdiskDir + "/tls"
+	RamdiskDir = "/mnt/ramdisk"
+
+	// RamdiskPrivateDir holds enclave secrets and daemon state. It is created
+	// 0700 and is never mounted into workload containers.
+	RamdiskPrivateDir = RamdiskDir + "/private"
+
+	// RamdiskPublicDir holds data that workload containers may read (model
+	// packs). It is bind-mounted read-only into containers at /tinfoil.
+	RamdiskPublicDir = RamdiskDir + "/public"
+
+	TLSDir             = RamdiskPrivateDir + "/tls"
 	TLSCertPath        = TLSDir + "/cert.pem"
 	TLSKeyPath         = TLSDir + "/key.pem"
-	AttestationPath    = RamdiskDir + "/attestation.json"
-	HPKEKeyPath        = RamdiskDir + "/hpke_key.json"
-	ConfigPath         = RamdiskDir + "/config.yml"
-	ExternalConfigPath = RamdiskDir + "/external-config.yml"
-	ShimConfigPath     = RamdiskDir + "/shim.yml"
-	DockerConfigDir    = RamdiskDir + "/docker-config"
+	AttestationPath    = RamdiskPrivateDir + "/attestation.json"
+	HPKEKeyPath        = RamdiskPrivateDir + "/hpke_key.json"
+	ConfigPath         = RamdiskPrivateDir + "/config.yml"
+	ExternalConfigPath = RamdiskPrivateDir + "/external-config.yml"
+	ShimConfigPath     = RamdiskPrivateDir + "/shim.yml"
+	DockerConfigDir    = RamdiskPrivateDir + "/docker-config"
 	DockerConfigPath   = DockerConfigDir + "/config.json"
-	GCloudKeyPath      = RamdiskDir + "/gcloud_key.json"
-	CacheDir           = RamdiskDir + "/tfshim-cache"
-	MPKDir             = RamdiskDir + "/mpk"
-	StatePath          = RamdiskDir + "/boot-state.json"
+	GCloudKeyPath      = RamdiskPrivateDir + "/gcloud_key.json"
+	CacheDir           = RamdiskPrivateDir + "/tfshim-cache"
+	StatePath          = RamdiskPrivateDir + "/boot-state.json"
+
+	MPKDir = RamdiskPublicDir + "/mpk"
 )

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -34,9 +34,9 @@ type Config struct {
 
 	RateLimit   float64 `yaml:"rate-limit"`
 	RateBurst   int     `yaml:"rate-burst"`
-	CacheDir    string  `yaml:"cache-dir" default:"/mnt/ramdisk/tfshim-cache"`
+	CacheDir    string  `yaml:"cache-dir" default:"/mnt/ramdisk/private/tfshim-cache"`
 	Email       string  `yaml:"email" default:"tls@tinfoil.sh"`
-	HPKEKeyFile string  `yaml:"hpke-key-file" default:"/mnt/ramdisk/hpke_key.json"`
+	HPKEKeyFile string  `yaml:"hpke-key-file" default:"/mnt/ramdisk/private/hpke_key.json"`
 
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`


### PR DESCRIPTION
# Isolate enclave secrets from workload containers via ramdisk private/public split

This is the largest change in a series of patches that came out of a security scan of the image (run with help from Claude). It restructures how the ramdisk is laid out so that workload containers no longer see the enclave's private state.

## What was happening

`createAndStartContainer` bind-mounted the entire `/mnt/ramdisk` into every container at `/tinfoil`, read-write. That directory holds the TLS private key, the HPKE private key, `external-config.yml` (every operator-supplied secret), `gcloud_key.json`, the shim config, and the live Docker and containerd data roots. The mount appears to exist so containers can reach model packs at `/tinfoil/mpk`, but it grants far more than that: a process inside any workload container can read the keys that back the attested TLS identity, or write into another container's overlayfs snapshot via `/tinfoil/containerd/...`.

## What this PR changes

**Ramdisk layout** (`tinfoil/internal/boot/paths.go`, `mkosi.extra/usr/local/bin/tinfoil-ramdisk`)
- `/mnt/ramdisk/private` (mode `0700`) — TLS keys, HPKE key, configs, secrets, ACME cache, boot state, and the Docker/containerd data roots. Never mounted into workload containers.
- `/mnt/ramdisk/public` (mode `0755`) — model packs (`mpk/`). This is what containers actually need.
- The tmpfs is now mounted with `nodev,nosuid` and mode `0755` (was `0777`). `/tmp` gets `mode=1777,nodev,nosuid`.

**Container bind** (`tinfoil/cmd/boot/containers.go`)
- Containers now get `RamdiskPublicDir:/tinfoil:ro` instead of the whole ramdisk read-write. The in-container path `/tinfoil/mpk` is unchanged.

**Daemon data roots** (`mkosi.extra/etc/docker/daemon.json`, `mkosi.extra/etc/containerd/config.toml`)
- Moved under `/mnt/ramdisk/private/` so they're outside any container mount.

**Config defaults** (`tinfoil/internal/config/config.go`)
- `cache-dir` and `hpke-key-file` defaults updated to the new private paths.

**HPKE key permissions** (`tinfoil/cmd/boot/identity.go`)
- `chmod 0600` after the upstream library creates the file (it was landing as `0644`).

**ACPI handler** (`tinfoil/internal/acpi/acpi.go`)
- The handler was reading/writing `acpi.tar` on disk inside the cache directory. With the old bind mount a container could overwrite that file and have the shim serve arbitrary bytes. The handler now builds the tar once from `/sys/firmware/qemu_fw_cfg` and caches it in process memory; it never touches disk. The `?force=1` query parameter is removed since there's nothing to invalidate. Also a fair bit shorter.

**Bearer auth** (`tinfoil/internal/auth/bearer.go`)
- `RequireBearer` now rejects (401) when the configured key is empty instead of allowing all requests, and uses `subtle.ConstantTimeCompare` for the token check.

## Behaviour changes to be aware of

- **Metrics and ACPI endpoints now require their API keys to be set.** Deployments that left `METRICS_API_KEY` / `ACPI_API_KEY` empty and relied on the allow-all fallback will see 401s until they configure a key.
- **Containers can no longer read anything under `/tinfoil` except `mpk/`, and cannot write at all.** If a deployed container image was reading `/tinfoil/config.yml` or similar it will need adjusting — though nothing in this repo's configs does.
- All path constants in `tinfoil/internal/boot` keep their names, so Go callers are unchanged; only the underlying filesystem locations move.

## Testing

`go build ./...`, `go vet ./...`, and `go test ./...` all pass. `bash -n` on the ramdisk script passes. I haven't been able to do a full image build + boot locally; happy to iterate if CI surfaces anything.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the ramdisk into private/public and mount only `/mnt/ramdisk/public` read‑only into workload containers to isolate enclave secrets and daemon state. Also tightened bearer auth, locked down HPKE key perms, and served the ACPI archive from in‑memory cache.

- **Refactors**
  - Introduced `/mnt/ramdisk/private` (0700) for TLS/HPKE keys, configs, ACME/cache, and Docker/containerd roots; `/mnt/ramdisk/public` for model packs. Ramdisk/tmp now use `nodev,nosuid` with stricter modes.
  - Containers bind `RamdiskPublicDir:/tinfoil:ro`; `/tinfoil/mpk` path is unchanged.
  - Moved Docker/containerd data roots to `/mnt/ramdisk/private/...`; updated defaults in `config` to private paths.
  - `tinfoil/internal/acpi`: build the fw_cfg ACPI tar once from `/sys/firmware/qemu_fw_cfg` and serve from memory; removed `?force=1`.
  - `tinfoil/internal/auth`: empty bearer key now returns 401; token check uses constant‑time compare. HPKE key is chmod `0600`.

- **Migration**
  - Set `METRICS_API_KEY` and `ACPI_API_KEY`; empty keys now return 401.
  - Ensure workloads read only from `/tinfoil/mpk`; other `/tinfoil` paths are no longer accessible or writable.

<sup>Written for commit cf1c6b156dca0da8bd20c13b6498f6dceceee1d0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

