### PR TITLE
Gate dummy attestation on the measured kernel cmdline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-cmdline = "readonly=on console=ttyS0 earlyprintk=serial root=/dev/sda2 tinfoil-debug=on tinfoil-config-hash=$(shell sha256sum config.yml | cut -d ' ' -f 1)"
+cmdline = readonly=on console=ttyS0 root=/dev/sda2 tinfoil-config-hash=$(shell sha256sum config.yml | cut -d ' ' -f 1)
+debug_flags = earlyprintk=serial tinfoil-debug=on
 
 memory = 4096M
 cpus = 32
@@ -38,7 +39,7 @@ run:
 		-bios /home/ubuntu/cvmimage/OVMF.fd \
 		-kernel ./tinfoilcvm.vmlinuz \
 		-initrd ./tinfoilcvm.initrd \
-		-append $(cmdline) \
+		-append "$(cmdline) $(debug_flags)" \
 		-drive file=./tinfoilcvm.raw,if=none,id=disk0,format=raw,readonly=on \
 		-device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=true \
 		-device scsi-hd,drive=disk0 \
@@ -62,7 +63,7 @@ measure:
 		--mode snp \
 		--vcpus=$(cpus) \
 		--vcpu-type=EPYC-v4 \
-		--append=$(cmdline) \
+		--append="$(cmdline)" \
 		--ovmf ./OVMF.fd \
 		--kernel tinfoilcvm.vmlinuz \
 		--initrd tinfoilcvm.initrd) && \

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -139,6 +139,9 @@ func loadAndVerifyConfig() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing shim config: %w", err)
 	}
+	if shimCfg.DummyAttestation && !isDebugBuild() {
+		return nil, fmt.Errorf("dummy-attestation is set but kernel cmdline lacks tinfoil-debug=on; refusing to disable hardware attestation on a release image")
+	}
 	config.ShimCfg = shimCfg
 
 	shimYAML, err := yaml.Marshal(shimCfg)
@@ -225,6 +228,15 @@ func readDiskAndStripNulls(path string) ([]byte, error) {
 
 	data = bytes.TrimRight(data, "\x00")
 	return data, nil
+}
+
+// isDebugBuild reports whether the kernel was booted with tinfoil-debug=on.
+// Debug-only behaviors (dummy attestation, localhost domain) must be gated on
+// this so they are only reachable on images whose firmware measurement differs
+// from a release image.
+func isDebugBuild() bool {
+	v, err := getCmdlineParam("tinfoil-debug")
+	return err == nil && v == "on"
 }
 
 // getCmdlineParam extracts a parameter value from /proc/cmdline

--- a/tinfoil/cmd/boot/cpuattest.go
+++ b/tinfoil/cmd/boot/cpuattest.go
@@ -33,6 +33,9 @@ func fetchCPUAttestation(id *NodeIdentity, shimCfg *shimconfig.Config) (*CPUAtte
 	userData := aBody.Marshal()
 
 	if id.Domain == "localhost" || shimCfg.DummyAttestation {
+		if !isDebugBuild() {
+			return nil, fmt.Errorf("dummy attestation requested (domain=%q, dummy-attestation=%t) but kernel cmdline lacks tinfoil-debug=on", id.Domain, shimCfg.DummyAttestation)
+		}
 		log.Println("Using dummy attestation report")
 		doc := attestation.DummyReport(userData)
 		if err := writeAttestationDoc(doc); err != nil {


### PR DESCRIPTION
## Gate dummy attestation on the measured kernel cmdline

Found during a security scan (with assistance from Claude).

### What

- Split the Makefile `cmdline` into a release-clean base and a separate `debug_flags` variable. `make run` (local dev) appends the debug flags; `make measure` uses only the base, so the published reference measurement no longer includes `tinfoil-debug=on` or `earlyprintk=serial`.
- Add an `isDebugBuild()` helper that checks `/proc/cmdline` for `tinfoil-debug=on`.
- Refuse to honor `shim.dummy-attestation: true` or `domain=localhost` unless `isDebugBuild()` is true. Boot fails with a clear error instead of silently producing a dummy report.

### Why

The kernel cmdline is part of the firmware-measured launch (RTMR[2] on TDX, the SNP launch digest with `kernel-hashes=on`). With `tinfoil-debug=on` baked into the reference cmdline, the golden measurement that verifiers pin corresponds to a debug-postured boot, and there's no measurement-level distinction between a release image and one that will accept dummy attestation.

After this change, a release image booted with the release cmdline cannot enter dummy mode at all — the config flag is rejected at load time. To use dummy attestation for local development, boot with `tinfoil-debug=on` (which `make run` does automatically), and the resulting measurement will differ from the release measurement, so verifiers won't confuse the two.

### Notes

- `make run` behavior is unchanged for local development.
- `make measure` output will change (it now reflects the release cmdline). If you publish reference measurements from this target, regenerate them.
- The `domain=localhost` trigger comes from the operator-supplied external config rather than the attested config, so it's gated at the point of use in `cpuattest.go` in addition to the config-load gate for `DummyAttestation`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate dummy attestation behind the measured kernel cmdline by requiring tinfoil-debug=on, and remove debug flags from the release cmdline. This prevents release images from using dummy reports and keeps dev vs. release measurements distinct.

- **Bug Fixes**
  - Split Makefile `cmdline` into a release base and `debug_flags`; `make run` appends both, `make measure` uses base only.
  - Added isDebugBuild() that checks `/proc/cmdline` for `tinfoil-debug=on`.
  - Reject `shim.dummy-attestation: true` or `domain=localhost` unless debug; fail early with a clear error.

- **Migration**
  - Regenerate any published reference measurements (they now reflect the release cmdline).
  - Local dev is unchanged; to use dummy attestation, boot with `tinfoil-debug=on` (done by `make run`).

<sup>Written for commit 5101fb8b7049bf968688d43974921ea6304d297d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

