### PR TITLE
Harden shim auth, proxy forwarding, and control-plane validator

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -139,6 +139,7 @@ func loadAndVerifyConfig() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing shim config: %w", err)
 	}
+	shimCfg.ExpectedGPUs = config.GPUs
 	config.ShimCfg = shimCfg
 
 	shimYAML, err := yaml.Marshal(shimCfg)

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -34,7 +34,16 @@ import (
 func pathMatchesPattern(pattern, path string) bool {
 	if strings.HasSuffix(pattern, "*") {
 		prefix := strings.TrimSuffix(pattern, "*")
-		return strings.HasPrefix(path, prefix)
+		if !strings.HasPrefix(path, prefix) {
+			return false
+		}
+		// Require the wildcard to begin at a path-segment boundary so that
+		// "/v1/chat*" cannot match "/v1/chatsmuggled".
+		if strings.HasSuffix(prefix, "/") {
+			return true
+		}
+		rest := path[len(prefix):]
+		return rest == "" || rest[0] == '/'
 	}
 	return pattern == path
 }
@@ -50,14 +59,23 @@ func pathAllowed(allowedPaths []string, path string) bool {
 }
 
 // requiresAuth reports whether path requires API key authentication.
-// If authenticatedEndpoints is nil (not configured), it defaults to only
-// requiring auth for /v1/chat/completions for backwards compatibility.
-// If authenticatedEndpoints is an empty slice, no paths require auth.
+// If authenticatedEndpoints is nil (not configured), all paths require auth.
+// If authenticatedEndpoints is an empty slice, no paths require auth (explicit opt-out).
 func requiresAuth(authenticatedEndpoints *[]string, path string) bool {
 	if authenticatedEndpoints == nil {
-		return path == "/v1/chat/completions"
+		return true
 	}
 	return pathAllowed(*authenticatedEndpoints, path)
+}
+
+// extractBearerToken returns the token portion of an Authorization header,
+// accepting any capitalisation of the "Bearer" scheme.
+func extractBearerToken(header string) string {
+	const scheme = "bearer "
+	if len(header) < len(scheme) || !strings.EqualFold(header[:len(scheme)], scheme) {
+		return ""
+	}
+	return strings.TrimSpace(header[len(scheme):])
 }
 
 // OpenAI-compatible error type strings returned in API error responses.
@@ -147,6 +165,7 @@ func NewShimServer(
 			req.Header.Set("Host", "localhost")
 			req.Host = "localhost"
 			req.Header.Del(ehbpProtocol.EncapsulatedKeyHeader)
+			req.Header.Del("Authorization")
 
 			// Forward original host and protocol to the upstream
 			req.Header.Del("Forwarded")
@@ -178,7 +197,7 @@ func NewShimServer(
 	}
 
 	proxyHandler := ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiKey := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		apiKey := extractBearerToken(r.Header.Get("Authorization"))
 		if validator != nil && requiresAuth(config.AuthenticatedEndpoints, r.URL.Path) {
 			if len(apiKey) == 0 {
 				writeJSONError(w, errMsgAPIKeyRequired, errTypeInvalidRequest, http.StatusUnauthorized)
@@ -189,8 +208,7 @@ func NewShimServer(
 				log.Printf("Warning: failed to validate API key: %v", err)
 				var validationErr *online.ValidationError
 				if errors.As(err, &validationErr) {
-					// Pass through the JSON error body from the control plane
-					w.Header().Set("Content-Type", "application/json")
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 					w.WriteHeader(validationErr.StatusCode)
 					fmt.Fprint(w, validationErr.Message)
 				} else {
@@ -240,15 +258,22 @@ func NewShimServer(
 			if gpuCount > 0 {
 				gpuEvidence, err := tinfoilattestation.CollectGPUEvidence(nonce32)
 				if err != nil {
-					log.Printf("GPU evidence collection failed (non-fatal): %v", err)
-				} else if len(gpuEvidence.Evidences) > 0 {
-					gpuJSON, _ = json.Marshal(gpuEvidence)
+					log.Printf("GPU evidence collection failed for %d expected GPU(s): %v", gpuCount, err)
+					writeJSONError(w, "GPU attestation evidence unavailable", errTypeServer, http.StatusInternalServerError)
+					return
 				}
+				if got := len(gpuEvidence.Evidences); got != gpuCount {
+					log.Printf("GPU evidence count mismatch: expected %d, got %d", gpuCount, got)
+					writeJSONError(w, "GPU attestation evidence incomplete", errTypeServer, http.StatusInternalServerError)
+					return
+				}
+				gpuJSON, _ = json.Marshal(gpuEvidence)
 				if gpuCount >= 8 {
 					nvswitchJSON, err = tinfoilattestation.CollectNVSwitchEvidence(nonce32)
 					if err != nil {
-						log.Printf("NVSwitch evidence collection failed (non-fatal): %v", err)
-						nvswitchJSON = nil
+						log.Printf("NVSwitch evidence collection failed: %v", err)
+						writeJSONError(w, "NVSwitch attestation evidence unavailable", errTypeServer, http.StatusInternalServerError)
+						return
 					}
 				}
 			}

--- a/tinfoil/cmd/shim/api_path_test.go
+++ b/tinfoil/cmd/shim/api_path_test.go
@@ -22,6 +22,11 @@ func TestPathMatchesPattern(t *testing.T) {
 		{"wildcard no match different prefix", "/v1/user/*", "/v1/admin/123", false},
 		{"wildcard no match partial prefix", "/v1/user/*", "/v1/username", false},
 
+		// Segment-boundary enforcement for non-slash-terminated wildcards
+		{"bare wildcard matches self", "/v1/chat*", "/v1/chat", true},
+		{"bare wildcard matches subpath", "/v1/chat*", "/v1/chat/completions", true},
+		{"bare wildcard rejects sibling", "/v1/chat*", "/v1/chatsmuggled", false},
+
 		// Edge cases
 		{"wildcard only matches all", "/*", "/anything/here", true},
 		{"wildcard at root", "/*", "/", true},

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -90,10 +90,10 @@ func TestRequiresAuth(t *testing.T) {
 		path                   string
 		want                   bool
 	}{
-		// Nil (absent from config): default behaviour — only /v1/chat/completions
+		// Nil (absent from config): all paths require auth (secure default)
 		{"default nil, chat completions", nil, "/v1/chat/completions", true},
-		{"default nil, other path", nil, "/v1/models", false},
-		{"default nil, root", nil, "/", false},
+		{"default nil, other path", nil, "/v1/models", true},
+		{"default nil, root", nil, "/", true},
 
 		// Empty list: no endpoints require auth
 		{"empty list, chat completions", ptr([]string{}), "/v1/chat/completions", false},

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -54,6 +54,7 @@ func main() {
 	handler.Store(http.HandlerFunc(bootStagesHandler().ServeHTTP))
 
 	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS13,
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			return cert.Load(), nil
 		},
@@ -199,8 +200,11 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 		}
 		copy(identityBody.HPKEKey[:], serverIdentity.MarshalPublicKey())
 
-		gpuCount := tinfoilattestation.DetectGPUCount()
-		log.Printf("Detected %d GPU(s) for attestation", gpuCount)
+		gpuCount := config.ExpectedGPUs
+		if detected := tinfoilattestation.DetectGPUCount(); detected != gpuCount {
+			log.Printf("Warning: NVML reports %d GPU(s) but attested config expects %d; using attested value", detected, gpuCount)
+		}
+		log.Printf("Expected %d GPU(s) for attestation", gpuCount)
 
 		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, gpuCount, serverIdentity, realCertParsed, config, externalConfig)
 		handler.Store(http.HandlerFunc(fullHandler.ServeHTTP))

--- a/tinfoil/cmd/shim/openai_proxy.go
+++ b/tinfoil/cmd/shim/openai_proxy.go
@@ -62,6 +62,34 @@ func addPaddingToStreamChunk(data string) (string, error) {
 	return string(modified), nil
 }
 
+// unsafeRequestFields are vLLM-specific request fields that allow callers to
+// supply Jinja templates or processor kwargs. Stripping them keeps the
+// upstream's template-rendering surface limited to operator-shipped templates.
+var unsafeRequestFields = []string{
+	"chat_template",
+	"chat_template_kwargs",
+	"mm_processor_kwargs",
+	"guided_decoding_backend",
+}
+
+func stripUnsafeRequestFields(body []byte) ([]byte, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(body, &m); err != nil {
+		return nil, err
+	}
+	changed := false
+	for _, k := range unsafeRequestFields {
+		if _, ok := m[k]; ok {
+			delete(m, k)
+			changed = true
+		}
+	}
+	if !changed {
+		return body, nil
+	}
+	return json.Marshal(m)
+}
+
 type chatRequest struct {
 	Model    string `json:"model"`
 	Stream   bool   `json:"stream"`
@@ -97,7 +125,13 @@ func (t *streamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if err := json.Unmarshal(body, &cr); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
 	}
+	body, err = stripUnsafeRequestFields(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sanitise request body: %w", err)
+	}
 	req.Body = io.NopCloser(bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", len(body)))
 
 	// Make the actual request
 	resp, err := t.base.RoundTrip(req)

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -27,8 +27,8 @@ type Config struct {
 	// When false, no API key checks are performed regardless of AuthenticatedEndpoints.
 	Authenticated bool `yaml:"authenticated" default:"false"`
 	// AuthenticatedEndpoints is the list of endpoint patterns that require API key authentication.
-	// If absent (nil), defaults to ["/v1/chat/completions"] for backwards compatibility.
-	// If present but empty, no endpoints require authentication.
+	// If absent (nil), all endpoints require authentication.
+	// If present but empty, no endpoints require authentication (explicit opt-out).
 	// Supports the same wildcard patterns as Paths (e.g. "/v1/*").
 	AuthenticatedEndpoints *[]string `yaml:"authenticated-endpoints"`
 
@@ -40,6 +40,11 @@ type Config struct {
 
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`
+
+	// ExpectedGPUs is the GPU count from the attested boot config. The shim
+	// uses this (not runtime NVML detection) to decide whether GPU evidence
+	// is mandatory, so a host that breaks NVML cannot silently strip it.
+	ExpectedGPUs int `yaml:"expected-gpus" default:"0"`
 }
 
 const (

--- a/tinfoil/internal/key/online/online_test.go
+++ b/tinfoil/internal/key/online/online_test.go
@@ -1,6 +1,8 @@
 package online
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"testing"
@@ -9,18 +11,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func allowLocalhost(t *testing.T) {
+	t.Helper()
+	saved := AllowedControlPlaneHosts
+	AllowedControlPlaneHosts = append([]string{"localhost"}, saved...)
+	t.Cleanup(func() { AllowedControlPlaneHosts = saved })
+}
+
+func keyHash(k string) string {
+	h := sha256.Sum256([]byte(k))
+	return hex.EncodeToString(h[:])
+}
+
 func TestVerifyOnline(t *testing.T) {
+	allowLocalhost(t)
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
+	goodHash := keyHash("good-key")
+
 	httpmock.RegisterResponder("POST", "https://localhost:8080/validate",
 		func(req *http.Request) (*http.Response, error) {
-			apiKey, err := io.ReadAll(req.Body)
+			body, err := io.ReadAll(req.Body)
 			if err != nil {
 				return httpmock.NewStringResponse(http.StatusInternalServerError, "Internal server error"), nil
 			}
 
-			if string(apiKey) == "good-key" {
+			if string(body) == goodHash {
 				return httpmock.NewStringResponse(http.StatusOK, "OK"), nil
 			}
 
@@ -35,6 +52,12 @@ func TestVerifyOnline(t *testing.T) {
 }
 
 func TestRejectHTTP(t *testing.T) {
+	allowLocalhost(t)
 	_, err := NewValidator("http://localhost:8080/validate")
+	assert.NotNil(t, err)
+}
+
+func TestRejectDisallowedHost(t *testing.T) {
+	_, err := NewValidator("https://evil.example.com/validate")
 	assert.NotNil(t, err)
 }

--- a/tinfoil/internal/key/online/verify.go
+++ b/tinfoil/internal/key/online/verify.go
@@ -2,14 +2,30 @@ package online
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"net/url"
+	"slices"
 	"time"
 )
 
-const validationTimeout = 10 * time.Second
+const (
+	validationTimeout  = 10 * time.Second
+	maxErrorBodyBytes  = 1024
+)
+
+// AllowedControlPlaneHosts is the set of hostnames the validator will talk to.
+// It is a package variable so tests can extend it; production builds should
+// treat it as constant.
+//
+// TODO: replace bare-200 trust with a signed response (Ed25519 over
+// {keyHash, exp, enclaveTLSKeyFP}) verified against an image-baked pubkey.
+var AllowedControlPlaneHosts = []string{
+	"api.tinfoil.sh",
+}
 
 type Validator struct {
 	server string
@@ -17,8 +33,15 @@ type Validator struct {
 }
 
 func NewValidator(server string) (*Validator, error) {
-	if !strings.HasPrefix(server, "https://") {
+	u, err := url.Parse(server)
+	if err != nil {
+		return nil, fmt.Errorf("invalid validation server URL: %w", err)
+	}
+	if u.Scheme != "https" {
 		return nil, fmt.Errorf("validation server must use HTTPS: %s", server)
+	}
+	if !slices.Contains(AllowedControlPlaneHosts, u.Hostname()) {
+		return nil, fmt.Errorf("validation server host %q is not in the allowlist", u.Hostname())
 	}
 	return &Validator{
 		server: server,
@@ -36,7 +59,10 @@ func (e *ValidationError) Error() string {
 }
 
 func (v *Validator) Validate(apiKey string) error {
-	resp, err := v.client.Post(v.server, "application/json", bytes.NewBufferString(apiKey))
+	hash := sha256.Sum256([]byte(apiKey))
+	payload := hex.EncodeToString(hash[:])
+
+	resp, err := v.client.Post(v.server, "text/plain", bytes.NewBufferString(payload))
 	if err != nil {
 		return fmt.Errorf("validation request failed: %w", err)
 	}
@@ -46,7 +72,7 @@ func (v *Validator) Validate(apiKey string) error {
 		return nil
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}


### PR DESCRIPTION
# Harden shim auth, proxy forwarding, and control-plane validator

This PR tightens several security-relevant behaviours in the shim and the online API-key validator. These were identified during a security scan of the codebase carried out with help from Claude.

## Changes

**GPU evidence is now required when the attested config declares GPUs.** Previously the shim derived its GPU count from runtime NVML detection, and treated evidence-collection failures as non-fatal. That meant a host that interfered with NVML could cause the shim to emit a valid CPU attestation with no GPU evidence attached. The boot process now writes the attested `gpus` value into `shim.yml` as `expected-gpus`, the shim uses that value, and the `/.well-known/tinfoil-attestation` handler returns 500 if it cannot collect evidence for every expected GPU (and NVSwitch on 8-GPU systems).

**Authentication defaults to all paths.** When `authenticated: true` is set but `authenticated-endpoints` is omitted, the shim previously only required a key for `/v1/chat/completions`, leaving `/v1/completions`, `/v1/embeddings` and any custom routes open. The default is now "all paths require auth"; an explicit empty list (`authenticated-endpoints: []`) remains the opt-out.

**Wildcard path patterns respect segment boundaries.** `/v1/chat*` no longer matches `/v1/chatsmuggled`; the character following the prefix must be `/` or end-of-path.

**Control-plane validator hardening.** `NewValidator` now requires the server hostname to be in a build-time allowlist (currently `api.tinfoil.sh`) in addition to requiring HTTPS. `Validate` sends `hex(SHA-256(apiKey))` rather than the raw key, and caps the reflected error body at 1 KiB. **Note:** this requires the control plane's `/api/shim/validate` endpoint to accept the SHA-256 hex digest in place of the raw key — please coordinate that change before deploying. A TODO is left for moving to a signed validation response.

**Proxy forwarding hygiene.** The reverse-proxy `Director` now drops the `Authorization` header before forwarding, and the chat-completions transport strips `chat_template`, `chat_template_kwargs`, `mm_processor_kwargs` and `guided_decoding_backend` from request bodies so callers cannot push per-request Jinja into the upstream.

**Miscellaneous.** TLS minimum version set to 1.3; bearer-scheme parsing is now case-insensitive; control-plane error bodies are served as `text/plain` and length-capped.

## Testing

`go build ./...`, `go vet ./...` and `go test ./...` all pass. Existing path-matcher and `requiresAuth` tests updated to reflect the new defaults; new tests added for segment-boundary matching and validator host allowlist.

---
*Part of a security-scan series. Co-authored with Claude.*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the shim, proxy, and control‑plane validator to enforce secure defaults and reduce attack surface. Requires GPU evidence when GPUs are declared, defaults auth to all paths, tightens path matching, sanitizes forwarded requests, and validates keys via SHA‑256 digest to an allowlisted host.

- **Bug Fixes**
  - Require GPU attestation when `expected-gpus` > 0; 500 if GPU/NVSwitch evidence is missing.
  - Use attested `expected-gpus` (from `shim.yml`) instead of NVML count; log mismatches.
  - When `authenticated: true` and `authenticated-endpoints` is omitted, all paths require auth; empty list explicitly opts out.
  - Wildcards respect segment boundaries (e.g., `/v1/chat*` no longer matches `/v1/chatsmuggled`).
  - Strip `Authorization` and unsafe request fields (`chat_template`, `chat_template_kwargs`, `mm_processor_kwargs`, `guided_decoding_backend`) before proxying.
  - Validator: HTTPS-only, host allowlist (`api.tinfoil.sh`), send `hex(SHA-256(apiKey))`, cap error bodies at 1 KiB; serve control-plane errors as `text/plain`.
  - TLS minimum set to 1.3; case-insensitive Bearer parsing.

- **Migration**
  - Control plane `/api/shim/validate` must accept the API key’s hex SHA‑256 digest instead of the raw key.
  - If you relied on the old implicit auth (only `/v1/chat/completions`), set `authenticated-endpoints` explicitly or use `[]` to opt out.

<sup>Written for commit 7f74d50d7edd6fa1e46190c4ae4ca1393350aa61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

