### PR TITLE
Tighten boot-time config and container validation

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -60,7 +60,7 @@ type Container struct {
 	CapDrop     []string    `yaml:"cap_drop,omitempty"`
 	SecurityOpt []string    `yaml:"security_opt,omitempty"`
 	Runtime     string      `yaml:"runtime,omitempty"`      // e.g., "nvidia"
-	NetworkMode string      `yaml:"network_mode,omitempty"` // "host", "bridge", "none" (default: "host")
+	NetworkMode string      `yaml:"network_mode,omitempty"` // "host", "bridge", "none" (default: "bridge")
 	IPC         string      `yaml:"ipc,omitempty"`          // e.g., "host"
 	PidMode     string      `yaml:"pid,omitempty"`          // "host" for host PID namespace
 	GPUs        interface{} `yaml:"gpus,omitempty"`         // "all", "0,1,2,3", or count (int)
@@ -125,14 +125,21 @@ func loadAndVerifyConfig() (*Config, error) {
 		return nil, fmt.Errorf("writing config to ramdisk: %w", err)
 	}
 
-	// Parse config
+	// Parse config strictly so typos in security-relevant fields fail loudly
+	// instead of silently falling back to defaults.
 	var config Config
-	if err := yaml.Unmarshal(configData, &config); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(configData))
+	dec.KnownFields(true)
+	if err := dec.Decode(&config); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
 	if config.GPUs != 0 && config.GPUs != 1 && config.GPUs != 8 {
 		return nil, fmt.Errorf("gpus must be 0, 1, or 8 (got %d)", config.GPUs)
+	}
+
+	if err := validateContainers(config.Containers, isDebugMode()); err != nil {
+		return nil, fmt.Errorf("validating containers: %w", err)
 	}
 
 	shimCfg, err := parseShimConfig(config.ShimRaw)
@@ -225,6 +232,14 @@ func readDiskAndStripNulls(path string) ([]byte, error) {
 
 	data = bytes.TrimRight(data, "\x00")
 	return data, nil
+}
+
+// isDebugMode reports whether the kernel cmdline contains tinfoil-debug=on.
+// The cmdline is measured into RTMR[2] / the SNP launch digest, so debug mode
+// is distinguishable to remote verifiers.
+func isDebugMode() bool {
+	v, err := getCmdlineParam("tinfoil-debug")
+	return err == nil && v == "on"
 }
 
 // getCmdlineParam extracts a parameter value from /proc/cmdline

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -277,10 +277,12 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 		}
 	}
 
-	// Host configuration
+	// Host configuration. Default to bridge networking so workload containers
+	// do not share the host network namespace (and thus the shim's loopback
+	// listeners) unless the attested config explicitly requests it.
 	networkMode := c.NetworkMode
 	if networkMode == "" {
-		networkMode = "host" // Default to host networking
+		networkMode = "bridge"
 	}
 	hostConfig := &container.HostConfig{
 		NetworkMode:    container.NetworkMode(networkMode),

--- a/tinfoil/cmd/boot/containers_test.go
+++ b/tinfoil/cmd/boot/containers_test.go
@@ -93,6 +93,43 @@ func TestBuildEnvNilConfig(t *testing.T) {
 	}
 }
 
+func TestValidateContainers(t *testing.T) {
+	const goodImage = "ghcr.io/tinfoilsh/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	tests := []struct {
+		name      string
+		c         Container
+		debugMode bool
+		wantErr   bool
+	}{
+		{"digest-pinned ok", Container{Name: "ok", Image: goodImage}, false, false},
+		{"tag-only image rejected", Container{Name: "bad", Image: "alpine:latest"}, false, true},
+		{"short digest rejected", Container{Name: "bad", Image: "alpine@sha256:deadbeef"}, false, true},
+		{"missing image rejected", Container{Name: "bad"}, false, true},
+		{"pid host rejected", Container{Name: "x", Image: goodImage, PidMode: "host"}, false, true},
+		{"pid host allowed in debug", Container{Name: "x", Image: goodImage, PidMode: "host"}, true, false},
+		{"ipc host rejected", Container{Name: "x", Image: goodImage, IPC: "host"}, false, true},
+		{"sys_admin cap rejected", Container{Name: "x", Image: goodImage, CapAdd: []string{"SYS_ADMIN"}}, false, true},
+		{"cap_ prefix rejected", Container{Name: "x", Image: goodImage, CapAdd: []string{"CAP_NET_ADMIN"}}, false, true},
+		{"lowercase cap rejected", Container{Name: "x", Image: goodImage, CapAdd: []string{"sys_ptrace"}}, false, true},
+		{"benign cap allowed", Container{Name: "x", Image: goodImage, CapAdd: []string{"IPC_LOCK"}}, false, false},
+		{"dangerous cap allowed in debug", Container{Name: "x", Image: goodImage, CapAdd: []string{"SYS_ADMIN"}}, true, false},
+		{"external env LD_PRELOAD rejected", Container{Name: "x", Image: goodImage, Env: []interface{}{"LD_PRELOAD"}}, false, true},
+		{"external env PYTHONPATH rejected", Container{Name: "x", Image: goodImage, Env: []interface{}{"PYTHONPATH"}}, false, true},
+		{"external env benign allowed", Container{Name: "x", Image: goodImage, Env: []interface{}{"DOMAIN"}}, false, false},
+		{"hardcoded env LD_PRELOAD allowed", Container{Name: "x", Image: goodImage, Env: []interface{}{map[string]interface{}{"LD_PRELOAD": "/x"}}}, false, false},
+		{"secret HF_TOKEN rejected", Container{Name: "x", Image: goodImage, Secrets: []string{"HF_TOKEN"}}, false, true},
+		{"secret API_KEY allowed", Container{Name: "x", Image: goodImage, Secrets: []string{"API_KEY"}}, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateContainers([]Container{tt.c}, tt.debugMode)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("got err=%v, wantErr=%v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestParseDuration(t *testing.T) {
 	tests := []struct {
 		input string

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -155,11 +155,10 @@ func run() error {
 	start = time.Now()
 	log.Println("Configuring firewall")
 	if err := setupFirewall(config); err != nil {
-		log.Printf("Warning: firewall setup failed: %v", err)
-		tracker.Record(boot.StageFirewall, boot.StatusWarning, time.Since(start), err.Error())
-	} else {
-		tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
+		tracker.Record(boot.StageFirewall, boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("firewall setup failed: %w", err)
 	}
+	tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
 
 	// 8. Models
 	start = time.Now()

--- a/tinfoil/cmd/boot/topology.go
+++ b/tinfoil/cmd/boot/topology.go
@@ -195,8 +195,10 @@ func validateTopology(gpuReports, switchReports [][]byte) error {
 	log.Printf("GPU topology OK: all %d GPUs see the same %d switches", expectedGPUCount, expectedSwitchCount)
 
 	// Switch side: each switch's own PDI must be in the GPU-reported set,
-	// and each must see exactly 8 unique GPUs, identical across all switches
+	// each must appear exactly once, and each must see exactly 8 unique GPUs
+	// identical across all switches.
 	var expectedGPUs map[string]struct{}
+	seenSwitchPDIs := make(map[string]struct{}, expectedSwitchCount)
 	for i, report := range switchReports {
 		label := fmt.Sprintf("switch[%d]", i)
 		checkSPDMVersion(report, label)
@@ -216,6 +218,10 @@ func validateTopology(gpuReports, switchReports [][]byte) error {
 		if _, ok := expectedSwitches[devicePDI]; !ok {
 			return fmt.Errorf("%s PDI %s not in GPU-reported switch set", label, devicePDI)
 		}
+		if _, dup := seenSwitchPDIs[devicePDI]; dup {
+			return fmt.Errorf("%s PDI %s already reported by another switch", label, devicePDI)
+		}
+		seenSwitchPDIs[devicePDI] = struct{}{}
 
 		rawGPUs, ok := fields[fieldGPUPDIs]
 		if !ok {

--- a/tinfoil/cmd/boot/topology_test.go
+++ b/tinfoil/cmd/boot/topology_test.go
@@ -40,10 +40,11 @@ type tlvEntry struct {
 // so the Go hex values here are the direct byte-for-byte equivalents.
 
 // test_gpu_topology_check line 34 — switch PDIs reported by each GPU:
-//   b'@\xb9\xc6\xb3\xd7H\xfd\x90'
-//   b'\xfd\xb5)\xf1G<\xb2%'
-//   b'\x10C\xc1N\x83Y\x96c'
-//   b'\xd0\xf6\x9d\x02\x8e\x15\n\xaa'
+//
+//	b'@\xb9\xc6\xb3\xd7H\xfd\x90'
+//	b'\xfd\xb5)\xf1G<\xb2%'
+//	b'\x10C\xc1N\x83Y\x96c'
+//	b'\xd0\xf6\x9d\x02\x8e\x15\n\xaa'
 var (
 	// b'@\xb9\xc6\xb3\xd7H\xfd\x90'  →  @ = 0x40, H = 0x48
 	switchA = []byte{0x40, 0xb9, 0xc6, 0xb3, 0xd7, 0x48, 0xfd, 0x90}
@@ -66,14 +67,15 @@ var (
 )
 
 // OPAQUE_FIELD_ID_SWITCH_GPU_PDIS (line 48-49):
-//   b'@\xb9\xc6\xb3\xd7H\xfd\x90'
-//   b'\xfd\xb5)\xf1G<\xb2%'
-//   b"\xbf\\\xc6'\xc8\x13\xae\xd8"   →  \\ = 0x5c, ' = 0x27
-//   b'\xe2\xd8[Y\x0eq2\x98'           →  [ = 0x5b, Y = 0x59, q = 0x71, 2 = 0x32
-//   b'\x10C\xc1N\x83Y\x96c'
-//   b'1d\x9c\xf1\x1c\x82\x08X'       →  1 = 0x31, d = 0x64, X = 0x58
-//   b'\xd0\xf6\x9d\x02\x8e\x15\n\xaa'
-//   b'\xd0\xf6\x9d\x02\x8e\x15\n\xab'
+//
+//	b'@\xb9\xc6\xb3\xd7H\xfd\x90'
+//	b'\xfd\xb5)\xf1G<\xb2%'
+//	b"\xbf\\\xc6'\xc8\x13\xae\xd8"   →  \\ = 0x5c, ' = 0x27
+//	b'\xe2\xd8[Y\x0eq2\x98'           →  [ = 0x5b, Y = 0x59, q = 0x71, 2 = 0x32
+//	b'\x10C\xc1N\x83Y\x96c'
+//	b'1d\x9c\xf1\x1c\x82\x08X'       →  1 = 0x31, d = 0x64, X = 0x58
+//	b'\xd0\xf6\x9d\x02\x8e\x15\n\xaa'
+//	b'\xd0\xf6\x9d\x02\x8e\x15\n\xab'
 var (
 	gpuPDI0 = []byte{0x40, 0xb9, 0xc6, 0xb3, 0xd7, 0x48, 0xfd, 0x90}
 	gpuPDI1 = []byte{0xfd, 0xb5, 0x29, 0xf1, 0x47, 0x3c, 0xb2, 0x25}
@@ -86,7 +88,8 @@ var (
 )
 
 // test_gpu_topology_check line 43 — expected unique_switches after LE read:
-//   {'639659834ec14310', '90fd48d7b3c6b940', 'aa0a158e029df6d0', '25b23c47f129b5fd'}
+//
+//	{'639659834ec14310', '90fd48d7b3c6b940', 'aa0a158e029df6d0', '25b23c47f129b5fd'}
 //
 // Like the Python reference, our Go code applies readFieldAsLittleEndian to
 // GPU-reported switch PDIs, reversing the byte order before hex encoding.
@@ -257,6 +260,26 @@ func TestValidateTopologySwitchPDINotInGPUSet(t *testing.T) {
 	}
 	if err := validateTopology(gpuReports, switchReports); err == nil {
 		t.Fatal("expected topology error for unknown switch PDI")
+	}
+}
+
+func TestValidateTopologyDuplicateSwitchPDI(t *testing.T) {
+	gpuReports := make([][]byte, 8)
+	for i := range gpuReports {
+		gpuReports[i] = buildSPDMReport([]tlvEntry{
+			{typ: fieldPDI, val: switchPDIsForGPU()},
+		})
+	}
+	// switch[2] reuses switchDevA's PDI: each PDI is in the GPU-reported set,
+	// but the four reports do not cover four distinct devices.
+	switchReports := [][]byte{
+		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevA}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
+		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevB}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
+		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevA}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
+		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevD}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
+	}
+	if err := validateTopology(gpuReports, switchReports); err == nil {
+		t.Fatal("expected topology error for duplicate switch device PDI")
 	}
 }
 

--- a/tinfoil/cmd/boot/validation.go
+++ b/tinfoil/cmd/boot/validation.go
@@ -3,16 +3,81 @@ package main
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"regexp"
+	"strings"
 )
 
 // Input validation patterns
 var (
-	hexHashPattern  = regexp.MustCompile(`^[a-f0-9]{64}$`)                        // SHA256 hex strings
+	hexHashPattern  = regexp.MustCompile(`^[a-f0-9]{64}$`) // SHA256 hex strings
 	uuidPattern     = regexp.MustCompile(`^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`)
-	offsetPattern   = regexp.MustCompile(`^[0-9]+$`)                              // Numeric offset
+	offsetPattern   = regexp.MustCompile(`^[0-9]+$`)                         // Numeric offset
 	registryPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`) // Registry hostnames
+
+	// imageDigestPattern requires an OCI digest pin so the pulled image is
+	// byte-identical to what the attested config commits to.
+	imageDigestPattern = regexp.MustCompile(`@sha256:[a-f0-9]{64}$`)
+
+	// externalEnvDenyPattern blocks env keys that influence code loading or
+	// model selection from being sourced from the unattested external config.
+	externalEnvDenyPattern = regexp.MustCompile(`^(LD_.*|PYTHON.*|PATH|HF_.*|TRANSFORMERS_.*|VLLM_.*|MODEL.*|CUDA_.*|NVIDIA_.*)$`)
 )
+
+// disallowedCaps are Linux capabilities that grant near-root control of the
+// host kernel or network namespace. Workload containers must not request them.
+var disallowedCaps = map[string]bool{
+	"SYS_ADMIN":       true,
+	"NET_ADMIN":       true,
+	"SYS_PTRACE":      true,
+	"SYS_MODULE":      true,
+	"SYS_RAWIO":       true,
+	"SYS_BOOT":        true,
+	"SYS_TIME":        true,
+	"DAC_READ_SEARCH": true,
+}
+
+// validateContainers enforces security invariants on the attested container
+// spec at config-load time so a misconfiguration fails the boot rather than
+// silently weakening the workload isolation.
+func validateContainers(containers []Container, debugMode bool) error {
+	for _, c := range containers {
+		if c.Image == "" {
+			return fmt.Errorf("container %q: image is required", c.Name)
+		}
+		if !imageDigestPattern.MatchString(c.Image) {
+			return fmt.Errorf("container %q: image %q must be pinned by digest (@sha256:<64-hex>)", c.Name, c.Image)
+		}
+		if !debugMode {
+			if c.PidMode == "host" {
+				return fmt.Errorf("container %q: pid=host is only permitted with tinfoil-debug=on", c.Name)
+			}
+			if c.IPC == "host" {
+				return fmt.Errorf("container %q: ipc=host is only permitted with tinfoil-debug=on", c.Name)
+			}
+			for _, name := range c.CapAdd {
+				if disallowedCaps[normalizeCap(name)] {
+					return fmt.Errorf("container %q: capability %s is not permitted outside debug mode", c.Name, name)
+				}
+			}
+		}
+		for _, item := range c.Env {
+			if key, ok := item.(string); ok && externalEnvDenyPattern.MatchString(key) {
+				return fmt.Errorf("container %q: env key %q may not be sourced from external config (matches code-loading denylist)", c.Name, key)
+			}
+		}
+		for _, key := range c.Secrets {
+			if externalEnvDenyPattern.MatchString(key) {
+				return fmt.Errorf("container %q: secret key %q may not be sourced from external config (matches code-loading denylist)", c.Name, key)
+			}
+		}
+	}
+	return nil
+}
+
+func normalizeCap(name string) string {
+	return strings.TrimPrefix(strings.ToUpper(name), "CAP_")
+}
 
 // sha256Hash computes the SHA256 hash of data and returns hex string
 func sha256Hash(data []byte) string {


### PR DESCRIPTION
## Tighten boot-time config and container validation

This PR adds several validation gates at config-load time so that a deployment config which would weaken the attested-workload chain fails the boot loudly rather than running with degraded isolation. These came out of a security scan I ran with Claude's assistance.

### Changes

**Require digest-pinned container images.** The attested config commits to the workload by image reference; a tag-only ref (`image:tag`) lets the registry serve different bytes on each pull, so the measurement no longer pins the workload. Boot now rejects any `image:` that doesn't end in `@sha256:<64-hex>`.

**Default `network_mode` to `bridge`.** Previously containers defaulted to the host network namespace, which shares the shim's loopback listeners and bypasses any per-container network policy. Configs that genuinely need host networking can still set `network_mode: host` explicitly (and that choice is then visible in the attested config).

**Reject host-level namespaces and dangerous capabilities outside debug mode.** `pid: host`, `ipc: host`, and `cap_add` entries for `SYS_ADMIN`, `NET_ADMIN`, `SYS_PTRACE`, `SYS_MODULE`, `SYS_RAWIO`, `SYS_BOOT`, `SYS_TIME`, and `DAC_READ_SEARCH` are now refused unless the kernel cmdline carries `tinfoil-debug=on`. The cmdline is measured into RTMR[2] / the SNP launch digest, so debug mode is distinguishable to verifiers.

**Make firewall setup failures fatal.** If `nft` can't apply the configured inbound-port rules, boot now fails instead of logging a warning and continuing. (The static base ruleset is loaded earlier by systemd; this stage only opens additional ports, so failing closed here is safe.)

**Enforce NVSwitch PDI uniqueness in topology validation.** The switch-side check verified each device PDI was *in* the GPU-reported set but didn't track which had been seen, so four reports could all claim the same switch identity. Duplicates are now rejected.

**Reject unknown YAML fields.** The main config decoder now uses `KnownFields(true)` so a typo in a field name (e.g. `authenticated` vs `Authenticated`) errors instead of silently falling back to the zero value.

**Denylist code-loading env keys from external-config lookup.** String-form `env:` and `secrets:` entries source their *values* from the operator-supplied (unmeasured) external config, by design. Keys matching `LD_*`, `PYTHON*`, `PATH`, `HF_*`, `TRANSFORMERS_*`, `VLLM_*`, `MODEL*`, `CUDA_*`, `NVIDIA_*` are now rejected for that lookup, since those can redirect code or model loading. Hardcoded map-form entries (whose values *are* attested) are unaffected.

### Compatibility

This is a behavior change for existing configs:
- Configs with tag-only image refs will need `@sha256:` digests added.
- Configs relying on the implicit `network_mode: host` default will need it set explicitly.
- Configs with stray/unknown YAML keys will need cleanup.

### Testing

`go build ./... && go vet ./... && go test ./...` all pass. New table-driven tests cover the digest-pin, capability, namespace, and env-denylist checks, plus a topology test for the duplicate-PDI case.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens boot-time validation to fail closed on insecure configs and preserve attested workload integrity. Enforces digest-pinned images, safer defaults, stricter container/env checks, topology sanity, and fatal firewall errors.

- **New Features**
  - Container validation: require `@sha256`-pinned images; default `network_mode` to `bridge`; reject `pid: host`, `ipc: host`, and dangerous `cap_add` outside `tinfoil-debug=on`; denylist external env/secret keys that influence code/model loading.
  - Config parsing: reject unknown YAML fields during decode.
  - Networking: make firewall setup failures fatal instead of warning.
  - Topology: enforce unique NVSwitch device PDIs across switch reports.

- **Migration**
  - Add `@sha256:<64-hex>` digests to all container image refs.
  - Set `network_mode: host` explicitly if host networking is required.
  - Remove or fix unknown/typoed YAML fields.

<sup>Written for commit 8acdb9b80a99c757cbe935549fa09337c8b33638. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

