### PR TITLE
Harden nftables egress, systemd units, docker daemon, and state writes

### DIFF
--- a/mkosi.extra/etc/docker/daemon.json
+++ b/mkosi.extra/etc/docker/daemon.json
@@ -1,5 +1,8 @@
 {
     "data-root": "/mnt/ramdisk/docker",
+    "no-new-privileges": true,
+    "icc": false,
+    "userland-proxy": false,
     "features": {
         "containerd-snapshotter": true
     },

--- a/mkosi.extra/etc/nftables.conf
+++ b/mkosi.extra/etc/nftables.conf
@@ -28,6 +28,29 @@ table inet tinfoil {
     }
 
     chain output {
-        type filter hook output priority 0; policy accept;
+        type filter hook output priority 0; policy drop;
+
+        # Loopback (shim ↔ upstream containers)
+        oif "lo" accept
+
+        # Established/related (return traffic for inbound connections)
+        ct state established,related accept
+
+        # ICMP/ICMPv6 (network diagnostics)
+        ip protocol icmp accept
+        ip6 nexthdr icmpv6 accept
+
+        # DNS resolution
+        udp dport 53 accept
+        tcp dport 53 accept
+
+        # DHCP client
+        udp sport 68 udp dport 67 accept
+
+        # HTTPS (registries, control plane, ACME directory)
+        tcp dport 443 accept
+
+        # HTTP (ACME http-01 challenge fetch, OCSP)
+        tcp dport 80 accept
     }
 }

--- a/mkosi.extra/etc/systemd/system/tinfoil-boot.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-boot.service
@@ -12,6 +12,12 @@ User=root
 Group=root
 StandardOutput=journal+console
 StandardError=journal+console
+NoNewPrivileges=yes
+RestrictSUIDSGID=yes
+ProtectHome=yes
+LockPersonality=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=default.target

--- a/mkosi.extra/etc/systemd/system/tinfoil-shim.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-shim.service
@@ -9,6 +9,18 @@ ExecStart=/usr/local/bin/tinfoil-shim
 Restart=always
 RestartSec=5
 User=root
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/mnt/ramdisk
+ProtectHome=yes
+PrivateTmp=yes
+RestrictSUIDSGID=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=default.target

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -51,7 +52,32 @@ var InitialStages = []string{
 
 // Tracker records boot stages as they complete.
 type Tracker struct {
+	mu    sync.Mutex
 	state State
+}
+
+// writeStateAtomic writes data to StatePath via a temp file + rename so that
+// concurrent readers (e.g. the shim) never observe a partially written file.
+func writeStateAtomic(data []byte) error {
+	tmp, err := os.CreateTemp(RamdiskDir, "boot-state-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temp boot state: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("writing temp boot state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("closing temp boot state: %w", err)
+	}
+	if err := os.Rename(tmpName, StatePath); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("renaming boot state: %w", err)
+	}
+	return nil
 }
 
 // NewTracker creates a tracker with the given stages pre-registered as pending.
@@ -67,6 +93,8 @@ func NewTracker(stages []string) *Tracker {
 
 // Record updates an existing stage by name or appends a new one. Auto-flushes.
 func (t *Tracker) Record(name, status string, duration time.Duration, detail string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	stage := Stage{Name: name, Status: status, Duration: duration, Detail: detail}
 	updated := false
 	for i := range t.state.Stages {
@@ -80,34 +108,39 @@ func (t *Tracker) Record(name, status string, duration time.Duration, detail str
 	if !updated {
 		t.state.Stages = append(t.state.Stages, stage)
 	}
-	if err := t.Flush(); err != nil {
+	if err := t.flushLocked(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to flush boot state: %v\n", err)
 	}
 }
 
 // RecordSubstages sets the substages on an existing stage and flushes.
 func (t *Tracker) RecordSubstages(name string, substages []Stage) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	for i := range t.state.Stages {
 		if t.state.Stages[i].Name == name {
 			t.state.Stages[i].Stages = substages
 			break
 		}
 	}
-	if err := t.Flush(); err != nil {
+	if err := t.flushLocked(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to flush boot state: %v\n", err)
 	}
 }
 
 // Flush writes the current boot state to disk without setting CompletedAt.
 func (t *Tracker) Flush() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.flushLocked()
+}
+
+func (t *Tracker) flushLocked() error {
 	data, err := json.MarshalIndent(t.state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling boot state: %w", err)
 	}
-	if err := os.WriteFile(StatePath, data, 0644); err != nil {
-		return fmt.Errorf("writing boot state: %w", err)
-	}
-	return nil
+	return writeStateAtomic(data)
 }
 
 // Load reads the boot state from the ramdisk.
@@ -169,7 +202,7 @@ func RecordStage(name, status string, duration time.Duration, detail string) err
 	if err != nil {
 		return fmt.Errorf("marshaling boot state: %w", err)
 	}
-	return os.WriteFile(StatePath, data, 0644)
+	return writeStateAtomic(data)
 }
 
 // Complete sets CompletedAt on the persisted state.
@@ -183,5 +216,5 @@ func Complete() error {
 	if err != nil {
 		return fmt.Errorf("marshaling boot state: %w", err)
 	}
-	return os.WriteFile(StatePath, data, 0644)
+	return writeStateAtomic(data)
 }

--- a/tinfoil/internal/dcode/dcode.go
+++ b/tinfoil/internal/dcode/dcode.go
@@ -41,6 +41,9 @@ func Encode(content []byte, domain string) ([]string, error) {
 		end := min(i+maxLength, len(encoded))
 		chunk := encoded[i:end]
 		index := len(domains)
+		if index > 99 {
+			return nil, fmt.Errorf("payload requires %d+ chunks; 2-digit prefix supports at most 100", index+1)
+		}
 		domains = append(domains, fmt.Sprintf("%02d%s%s", index, chunk, domainSuffix))
 	}
 


### PR DESCRIPTION
# Harden network egress, service sandboxing, and state-file handling

Part of a security-scan pass over the image (done with Claude's assistance). This PR collects several defense-in-depth changes that don't alter functionality but reduce the blast radius if a workload or the shim is ever compromised.

## Changes

### nftables: default-drop outbound traffic
The `output` chain previously had `policy accept`, so anything running inside the VM could connect anywhere. It now defaults to `drop` with an explicit allowlist mirroring the `input` chain style: loopback, established/related, ICMP, DNS (53), DHCP, HTTPS (443) and HTTP (80, for ACME/OCSP). This still permits outbound to any host on those ports — a destination-IP allowlist would be tighter but operationally fragile given dynamic registry/CDN endpoints; happy to discuss if there's appetite for that.

### systemd unit sandboxing
`tinfoil-shim.service` gains `ProtectSystem=strict` (with `ReadWritePaths=/mnt/ramdisk`), `NoNewPrivileges`, `PrivateTmp`, and the usual `Protect*`/`Restrict*` set. The shim only needs the ramdisk, network, and attestation devices, so this is a meaningful reduction.

`tinfoil-boot.service` gets a more conservative subset (`NoNewPrivileges`, `RestrictSUIDSGID`, `ProtectHome`, `LockPersonality`, `RestrictRealtime`, `SystemCallArchitectures=native`) since it legitimately drives Docker, mounts, and nft.

### dockerd defaults
`daemon.json` now sets `"no-new-privileges": true`, `"icc": false` (no implicit inter-container traffic), and `"userland-proxy": false`.

### Atomic boot-state writes
`internal/boot/state.go` previously wrote `boot-state.json` with `os.WriteFile` from both the boot and shim processes. A reader could observe a truncated/partial file mid-write. Writes now go through a temp-file + `os.Rename` helper, and `Tracker` is guarded by a mutex for in-process callers.

### dcode chunk-count guard
`Encode` uses a 2-digit `%02d` prefix that `Decode` lex-sorts. That's correct for 0–99 but silently corrupts ordering at 100+. `Encode` now returns an error rather than producing un-decodable output.

## Testing
`go build ./...`, `go vet ./...`, and `go test ./...` all pass. nftables and systemd changes were syntax-reviewed; they can only be fully exercised in a built image.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down outbound network access, tightens systemd and Docker defaults, and makes boot-state writes atomic to reduce risk and prevent partial reads. Also adds a guard in `dcode` to reject payloads that exceed the 2‑digit chunk limit.

- **Security Hardening**
  - nftables: default-drop `output`; allowlist lo, established/related, ICMP/ICMPv6, DNS 53, DHCP 67/68, HTTPS 443, HTTP 80.
  - `tinfoil-shim.service`: `NoNewPrivileges`, `ProtectSystem=strict` with `ReadWritePaths=/mnt/ramdisk`, `PrivateTmp`, and `Protect*/Restrict*`.
  - `tinfoil-boot.service`: `NoNewPrivileges`, `RestrictSUIDSGID`, `ProtectHome`, `LockPersonality`, `RestrictRealtime`, `SystemCallArchitectures=native`.
  - Docker `daemon.json`: `"no-new-privileges": true`, `"icc": false`, `"userland-proxy": false`.

- **Bug Fixes**
  - Boot-state writes are atomic (temp + rename); `Tracker` guarded by a mutex to avoid partial reads and races.
  - `dcode.Encode` returns an error when chunk count would exceed 100 to prevent misordered decoding.

<sup>Written for commit 37063e0a9344aa8997b27cc6e1f3dcd9365ff562. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

