### PR TITLE
fix: do not pin tool chain using snapshot service to improve performance

### DIFF
--- a/build-nvattest.sh
+++ b/build-nvattest.sh
@@ -8,7 +8,6 @@ set -Eeuo pipefail
 UPSTREAM_URL=https://github.com/NVIDIA/attestation-sdk.git
 UPSTREAM_TAG=2026.03.02
 UPSTREAM_SHA=0c1be386a8fbb8f2766a6a556d10df86f5fed9d3
-APT_SNAPSHOT_DATE=20260424T000000Z
 
 # Transitive CMake FetchContent deps. We pre-fetch each at the expected SHA
 # *before* cmake runs and pass FETCHCONTENT_SOURCE_DIR_<NAME>, so a moved
@@ -43,24 +42,16 @@ BUILD="${WORK}/build"
 INSTALL="${WORK}/install"
 mkdir -p "${OUT_DIR}"
 
-# Bootstrap toolchain from snapshot.ubuntu.com (reproducible). ca-certificates
-# first so apt can do TLS to snapshot; integrity is enforced by GPG either way.
-# Drop docker-clean so /var/cache/apt/archives survives across container runs
+# Install build deps from the live archive. The toolchain is throwaway —
+# it never ships in the image — so we don't pin its bytes. The bytes that
+# do ship (the produced .debs) are constrained by the source/dep SHAs
+# above. Drop docker-clean so /var/cache/apt/archives survives across
+# container runs (see Makefile volume mount).
 export DEBIAN_FRONTEND=noninteractive
 rm -f /etc/apt/apt.conf.d/docker-clean
 apt-get update -q
-apt-get install -y --no-install-recommends ca-certificates
-cat > /etc/apt/sources.list.d/ubuntu.sources <<EOF
-Types: deb
-URIs: https://snapshot.ubuntu.com/ubuntu/${APT_SNAPSHOT_DATE}
-Suites: resolute resolute-updates resolute-security
-Components: main universe restricted multiverse
-Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
-Check-Valid-Until: no
-EOF
-apt-get update -q
 apt-get install -y --no-install-recommends \
-    build-essential cmake git perl pkg-config rustc cargo \
+    ca-certificates build-essential cmake git perl pkg-config rustc cargo \
     libxml2-dev curl xz-utils
 
 # Clone upstream and verify SHA.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop pinning the build toolchain to the Ubuntu snapshot and install build deps from the live archive to speed up builds and improve cache reuse. The toolchain is transient and never shipped; determinism is still enforced by verified source/dep SHAs for the produced packages.

<sup>Written for commit 6b274d6b8881fe53a2acfd2523814f1b706727ae. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/127?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

