### PR TITLE
feat: add support for multiGPU B200s

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -17,6 +17,30 @@ Initrds=initrd
 PackageDirectories=packages
 RootPassword=!
 Bootloader=systemd-boot
+KernelModulesInitrdExclude=.*
+KernelModulesInitrdInclude=
+    default
+    virtio
+    scsi
+    sd_mod
+    dm-mod
+    dm-verity
+    dm-crypt
+    dm-bufio
+    ext4
+    vfat
+    nls_
+    sha256
+    sha512
+    aes
+    gcm
+    ecdh
+    ecdsa
+    crct10dif
+    crc32
+    loop
+    overlay
+    tdx_guest
 Packages=
     systemd
     systemd-boot
@@ -36,14 +60,14 @@ Packages=
     udev
     linux-generic
     linux-headers-generic
-    nvidia-driver-open=595.58.03-1ubuntu1
-    nvidia-persistenced=595.58.03-1ubuntu1
-    nvidia-fabricmanager=595.58.03-1ubuntu1
+    nvidia-driver-open=595.71.05-1ubuntu1
+    nvidia-persistenced=595.71.05-1ubuntu1
+    nvidia-fabricmanager=595.71.05-1ubuntu1
+    libnvidia-nscq=595.71.05-1ubuntu1
     nvattest=1.2.0.1772475102-1
-    libnvidia-nscq=595.58.03-1ubuntu1
     nvidia-container-toolkit=1.19.0-1
-    docker-ce=5:29.4.1-1~ubuntu.26.04~resolute
-    docker-ce-cli=5:29.4.1-1~ubuntu.26.04~resolute
+    docker-ce=5:29.4.2-2~ubuntu.26.04~resolute
+    docker-ce-cli=5:29.4.2-2~ubuntu.26.04~resolute
     containerd.io=2.2.3-1~ubuntu.26.04~resolute
 
 [Build]

--- a/mkosi.extra/etc/modprobe.d/nvidia-lkca.conf
+++ b/mkosi.extra/etc/modprobe.d/nvidia-lkca.conf
@@ -1,0 +1,2 @@
+# Required for NVIDIA CC: load ECDSA/ECDH for SPDM before the nvidia module.
+install nvidia /sbin/modprobe ecdsa_generic; /sbin/modprobe ecdh; /sbin/modprobe --ignore-install nvidia

--- a/mkosi.extra/etc/modprobe.d/nvidia-lkca.conf
+++ b/mkosi.extra/etc/modprobe.d/nvidia-lkca.conf
@@ -1,2 +1,2 @@
 # Required for NVIDIA CC: load ECDSA/ECDH for SPDM before the nvidia module.
-install nvidia /sbin/modprobe ecdsa_generic; /sbin/modprobe ecdh; /sbin/modprobe --ignore-install nvidia
+install nvidia /sbin/modprobe ecdsa_generic && /sbin/modprobe ecdh && /sbin/modprobe --ignore-install nvidia

--- a/mkosi.extra/etc/systemd/system/nvidia-fabricmanager.service.d/override.conf
+++ b/mkosi.extra/etc/systemd/system/nvidia-fabricmanager.service.d/override.conf
@@ -1,4 +1,4 @@
 [Unit]
 
 [Service]
-ExecCondition=/usr/local/bin/check-nvidia-gpu
+ExecCondition=/usr/local/bin/check-nvidia-fabric

--- a/mkosi.extra/etc/systemd/system/nvidia-persistenced.service.d/override.conf
+++ b/mkosi.extra/etc/systemd/system/nvidia-persistenced.service.d/override.conf
@@ -3,6 +3,8 @@ After=nvidia-fabricmanager.service
 
 [Service]
 ExecCondition=/usr/local/bin/check-nvidia-gpu
+ExecStartPre=/sbin/modprobe nvidia
+ExecStartPre=/sbin/modprobe nvidia_uvm
 ExecStart=
 ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --uvm-persistence-mode --verbose
 TimeoutSec=1800

--- a/mkosi.extra/usr/local/bin/check-nvidia-fabric
+++ b/mkosi.extra/usr/local/bin/check-nvidia-fabric
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Exit 0 if a PCIe-visible NVIDIA NVSwitch (vendor 10de + class 0x068000)
+# is present in this guest. Used to gate nvidia-fabricmanager.service.
+
+for dev_dir in /sys/bus/pci/devices/*; do
+    vendor=$(cat "$dev_dir/vendor" 2>/dev/null) || continue
+    [ "$vendor" = "0x10de" ] || continue
+    class=$(cat "$dev_dir/class" 2>/dev/null) || continue
+    [ "$class" = "0x068000" ] && exit 0
+done
+exit 1

--- a/repo-check.sh
+++ b/repo-check.sh
@@ -63,6 +63,27 @@ get_versions() {
     ' "$file" | sort -V | uniq
 }
 
+# Returns the latest version in $versions whose major-series matches
+# $current_version's. Falls back to the overall latest if no match.
+# NVIDIA driver R-branches must not cross major series, so this avoids
+# suggesting a "newer" version that's actually in a different branch.
+latest_in_same_series() {
+    local versions="$1"
+    local current_version="$2"
+    local fallback_latest
+    fallback_latest=$(echo "$versions" | tail -1)
+    if [[ "$current_version" =~ ^([0-9]+)\. ]]; then
+        local series="${BASH_REMATCH[1]}"
+        local series_versions
+        series_versions=$(echo "$versions" | grep "^${series}\." || true)
+        if [ -n "$series_versions" ]; then
+            echo "$series_versions" | tail -1
+            return
+        fi
+    fi
+    echo "$fallback_latest"
+}
+
 # Check package in all repos and report
 lookup_package() {
     local pkg_name="$1"
@@ -125,16 +146,12 @@ lookup_package() {
     
     if [ -n "$current_version" ]; then
         if echo "$versions" | grep -qx "$current_version"; then
-            # For NVIDIA, only compare within same driver series (e.g., 580.x.x)
             local compare_latest="$latest"
-            if [[ "$repo" =~ ^NVIDIA ]] && [[ "$current_version" =~ ^([0-9]+)\. ]]; then
-                local series="${BASH_REMATCH[1]}"
-                local series_versions=$(echo "$versions" | grep "^${series}\." || true)
-                if [ -n "$series_versions" ]; then
-                    compare_latest=$(echo "$series_versions" | tail -1)
-                fi
+            # NVIDIA driver R-branches don't cross major series — restrict
+            # the "newer available" comparison to the same series.
+            if [[ "$repo" =~ ^NVIDIA ]]; then
+                compare_latest=$(latest_in_same_series "$versions" "$current_version")
             fi
-            # Check if newer version available
             if version_lt "$current_version" "$compare_latest"; then
                 echo -e "  ${YELLOW}$pkg_name=$current_version${NC} ($repo - newer available: $compare_latest)"
             else
@@ -187,16 +204,19 @@ while IFS= read -r line; do
 done < "$MKOSI_CONF"
 
 echo ""
+# When the pinned nvidia-driver-open is older than what's available in
+# the NVIDIA CUDA repo, remind the operator to also bump the host's
+# nvidia-fabricmanager / libnvidia-nscq to the matching R-branch
+# (NVIDIA's CC support matrix requires guest driver and host FM to be
+# on the same R-branch).
 GUEST_DRIVER=$(grep -E '^[[:space:]]*nvidia-driver-open=' "$MKOSI_CONF" | sed -E 's/^[^=]*=//' | head -1)
 if [ -n "$GUEST_DRIVER" ]; then
     nvidia_versions=$(get_versions "$TMPDIR/nvidia_cuda" "nvidia-driver-open")
-    if [ -n "$nvidia_versions" ] && [[ "$GUEST_DRIVER" =~ ^([0-9]+)\. ]]; then
-        series="${BASH_REMATCH[1]}"
-        series_versions=$(echo "$nvidia_versions" | grep "^${series}\." || true)
-        latest_in_series=$(echo "$series_versions" | tail -1)
-        if [ -n "$latest_in_series" ] && version_lt "$GUEST_DRIVER" "$latest_in_series"; then
+    if [ -n "$nvidia_versions" ]; then
+        latest=$(latest_in_same_series "$nvidia_versions" "$GUEST_DRIVER")
+        if [ -n "$latest" ] && version_lt "$GUEST_DRIVER" "$latest"; then
             echo "=== Host driver update reminder ==="
-            echo -e "  ${YELLOW}Newer nvidia-driver-open available: $latest_in_series (pinned: $GUEST_DRIVER)${NC}"
+            echo -e "  ${YELLOW}Newer nvidia-driver-open available: $latest (pinned: $GUEST_DRIVER)${NC}"
             echo -e "  ${YELLOW}When you bump the guest driver, also update the host's${NC}"
             echo -e "  ${YELLOW}nvidia-fabricmanager and libnvidia-nscq to the same R-branch.${NC}"
             echo ""

--- a/repo-check.sh
+++ b/repo-check.sh
@@ -187,4 +187,21 @@ while IFS= read -r line; do
 done < "$MKOSI_CONF"
 
 echo ""
+GUEST_DRIVER=$(grep -E '^[[:space:]]*nvidia-driver-open=' "$MKOSI_CONF" | sed -E 's/^[^=]*=//' | head -1)
+if [ -n "$GUEST_DRIVER" ]; then
+    nvidia_versions=$(get_versions "$TMPDIR/nvidia_cuda" "nvidia-driver-open")
+    if [ -n "$nvidia_versions" ] && [[ "$GUEST_DRIVER" =~ ^([0-9]+)\. ]]; then
+        series="${BASH_REMATCH[1]}"
+        series_versions=$(echo "$nvidia_versions" | grep "^${series}\." || true)
+        latest_in_series=$(echo "$series_versions" | tail -1)
+        if [ -n "$latest_in_series" ] && version_lt "$GUEST_DRIVER" "$latest_in_series"; then
+            echo "=== Host driver update reminder ==="
+            echo -e "  ${YELLOW}Newer nvidia-driver-open available: $latest_in_series (pinned: $GUEST_DRIVER)${NC}"
+            echo -e "  ${YELLOW}When you bump the guest driver, also update the host's${NC}"
+            echo -e "  ${YELLOW}nvidia-fabricmanager and libnvidia-nscq to the same R-branch.${NC}"
+            echo ""
+        fi
+    fi
+fi
+
 echo "=== Done ==="

--- a/tinfoil/cmd/boot/gpuattest.go
+++ b/tinfoil/cmd/boot/gpuattest.go
@@ -24,70 +24,63 @@ const (
 	gpuDeviceIDB200 = "0x2901"
 )
 
-// detectGPUCount returns the number of NVIDIA 3D-controller PCI devices
-// in the guest. The caller validates against the config-declared count.
-func detectGPUCount() (int, error) {
-	pciPath := "/sys/bus/pci/devices"
+// forEachNVIDIAGPU iterates over PCI devices that are NVIDIA GPUs
+// (vendor 0x10de + 3D-controller class), invoking fn with each device's
+// sysfs entry name. Walking stops if fn returns false.
+func forEachNVIDIAGPU(fn func(entryName string) bool) error {
+	const pciPath = "/sys/bus/pci/devices"
 	entries, err := os.ReadDir(pciPath)
 	if err != nil {
-		return 0, fmt.Errorf("reading PCI devices: %w", err)
+		return fmt.Errorf("reading PCI devices: %w", err)
 	}
-	count := 0
 	for _, entry := range entries {
 		vendor, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "vendor"))
-		if err != nil {
-			continue
-		}
-		if strings.TrimSpace(string(vendor)) != nvidiaVendorID {
+		if err != nil || strings.TrimSpace(string(vendor)) != nvidiaVendorID {
 			continue
 		}
 		class, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "class"))
-		if err != nil {
+		if err != nil || strings.TrimSpace(string(class)) != nvidiaGPUClass {
 			continue
 		}
-		if strings.TrimSpace(string(class)) == nvidiaGPUClass {
-			count++
+		if !fn(entry.Name()) {
+			return nil
 		}
+	}
+	return nil
+}
+
+// detectGPUCount returns the number of NVIDIA 3D-controller PCI devices
+// in the guest. The caller validates against the config-declared count.
+func detectGPUCount() (int, error) {
+	count := 0
+	if err := forEachNVIDIAGPU(func(string) bool { count++; return true }); err != nil {
+		return 0, err
 	}
 	return count, nil
 }
 
 // detectGPUArch returns "h100", "h200", "b200", or "" from the first GPU.
 func detectGPUArch() (string, error) {
-	pciPath := "/sys/bus/pci/devices"
-	entries, err := os.ReadDir(pciPath)
-	if err != nil {
-		return "", fmt.Errorf("reading PCI devices: %w", err)
-	}
-	for _, entry := range entries {
-		vendor, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "vendor"))
+	const pciPath = "/sys/bus/pci/devices"
+	var arch string
+	err := forEachNVIDIAGPU(func(entryName string) bool {
+		device, err := os.ReadFile(filepath.Join(pciPath, entryName, "device"))
 		if err != nil {
-			continue
-		}
-		if strings.TrimSpace(string(vendor)) != nvidiaVendorID {
-			continue
-		}
-		class, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "class"))
-		if err != nil {
-			continue
-		}
-		if strings.TrimSpace(string(class)) != nvidiaGPUClass {
-			continue
-		}
-		device, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "device"))
-		if err != nil {
-			continue
+			return true
 		}
 		switch strings.TrimSpace(string(device)) {
 		case gpuDeviceIDH100:
-			return "h100", nil
+			arch = "h100"
 		case gpuDeviceIDH200:
-			return "h200", nil
+			arch = "h200"
 		case gpuDeviceIDB200:
-			return "b200", nil
+			arch = "b200"
+		default:
+			return true
 		}
-	}
-	return "", nil
+		return false
+	})
+	return arch, err
 }
 
 func runNvattest(device string) error {

--- a/tinfoil/cmd/boot/gpuattest.go
+++ b/tinfoil/cmd/boot/gpuattest.go
@@ -16,12 +16,16 @@ import (
 )
 
 const (
-	nvattestTimeout   = 5 * time.Minute
-	nvidiaVendorID    = "0x10de"
-	multiGPUThreshold = 12 // 8 GPUs + 4 NVSwitches
+	nvattestTimeout = 5 * time.Minute
+	nvidiaVendorID  = "0x10de"
+	nvidiaGPUClass  = "0x030200" // 3D controller
+	gpuDeviceIDH100 = "0x2331"
+	gpuDeviceIDH200 = "0x2335"
+	gpuDeviceIDB200 = "0x2901"
 )
 
-// detectGPUCount scans PCI devices and returns 0, 1, or 8.
+// detectGPUCount returns the number of NVIDIA 3D-controller PCI devices
+// in the guest. The caller validates against the config-declared count.
 func detectGPUCount() (int, error) {
 	pciPath := "/sys/bus/pci/devices"
 	entries, err := os.ReadDir(pciPath)
@@ -30,21 +34,60 @@ func detectGPUCount() (int, error) {
 	}
 	count := 0
 	for _, entry := range entries {
-		data, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "vendor"))
+		vendor, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "vendor"))
 		if err != nil {
 			continue
 		}
-		if strings.TrimSpace(string(data)) == nvidiaVendorID {
+		if strings.TrimSpace(string(vendor)) != nvidiaVendorID {
+			continue
+		}
+		class, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "class"))
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(class)) == nvidiaGPUClass {
 			count++
 		}
 	}
-	if count >= multiGPUThreshold {
-		return 8, nil
+	return count, nil
+}
+
+// detectGPUArch returns "h100", "h200", "b200", or "" from the first GPU.
+func detectGPUArch() (string, error) {
+	pciPath := "/sys/bus/pci/devices"
+	entries, err := os.ReadDir(pciPath)
+	if err != nil {
+		return "", fmt.Errorf("reading PCI devices: %w", err)
 	}
-	if count > 0 {
-		return 1, nil
+	for _, entry := range entries {
+		vendor, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "vendor"))
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(vendor)) != nvidiaVendorID {
+			continue
+		}
+		class, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "class"))
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(class)) != nvidiaGPUClass {
+			continue
+		}
+		device, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "device"))
+		if err != nil {
+			continue
+		}
+		switch strings.TrimSpace(string(device)) {
+		case gpuDeviceIDH100:
+			return "h100", nil
+		case gpuDeviceIDH200:
+			return "h200", nil
+		case gpuDeviceIDB200:
+			return "b200", nil
+		}
 	}
-	return 0, nil
+	return "", nil
 }
 
 func runNvattest(device string) error {
@@ -194,20 +237,32 @@ func verifyGPUAttestation(expectedGPUs int) (*GPURawEvidence, error) {
 	evidence.GPU = gpuRaw
 
 	if expectedGPUs > 1 {
-		if err := runNvattest("nvswitch"); err != nil {
-			return nil, err
-		}
-
-		log.Println("Collecting NVSwitch evidence for topology validation")
-		switchReports, switchRaw, err := collectEvidence("nvswitch")
+		arch, err := detectGPUArch()
 		if err != nil {
-			return nil, fmt.Errorf("collecting switch evidence: %w", err)
+			return nil, fmt.Errorf("detecting GPU arch: %w", err)
 		}
-		evidence.Switch = switchRaw
+		switch arch {
+		case "b200":
+			// B200 MPT: NVSwitches are not exposed to the guest.
+			log.Printf("HGX B200 MPT: no in-guest NVSwitch evidence")
 
-		log.Println("Validating PPCIe topology")
-		if err := validateTopology(gpuReports, switchReports); err != nil {
-			return nil, fmt.Errorf("topology validation failed: %w", err)
+		case "h100", "h200", "":
+			if err := runNvattest("nvswitch"); err != nil {
+				return nil, err
+			}
+			log.Println("Collecting NVSwitch evidence for topology validation")
+			switchReports, switchRaw, err := collectEvidence("nvswitch")
+			if err != nil {
+				return nil, fmt.Errorf("collecting switch evidence: %w", err)
+			}
+			evidence.Switch = switchRaw
+			log.Printf("Validating Hopper PPCIe topology (%d GPUs, %d switches)", expectedGPUs, hopperSwitchCount)
+			if err := validateTopology(gpuReports, switchReports, expectedGPUs, hopperSwitchCount); err != nil {
+				return nil, fmt.Errorf("topology validation failed: %w", err)
+			}
+
+		default:
+			return nil, fmt.Errorf("unsupported multi-GPU arch %q for in-guest attestation", arch)
 		}
 	}
 

--- a/tinfoil/cmd/boot/topology.go
+++ b/tinfoil/cmd/boot/topology.go
@@ -26,9 +26,9 @@ const (
 	fieldGPUPDIs           = 26 // Switch report: connected GPU PDIs, followed by port map
 	fieldOpaqueDataVersion = 34 // Opaque data format version
 
-	// HGX H100/H200 topology: 8 GPUs connected to 4 NVSwitches
-	expectedGPUCount    = 8
-	expectedSwitchCount = 4
+	// HGX H100/H200 PPCIe: 8 GPUs ↔ 4 NVSwitches.
+	hopperGPUCount    = 8
+	hopperSwitchCount = 4
 )
 
 // checkSPDMVersion validates the SPDM version byte in the response and warns
@@ -148,19 +148,17 @@ func setsEqual(a, b map[string]struct{}) bool {
 	return true
 }
 
-// validateTopology cross-checks GPU and switch attestation reports to verify
-// the PPCIe fabric forms a correct 8-GPU / 4-switch mesh.
-//
-// For each GPU: extract the switch PDIs from opaque field 22 and verify all
-// GPUs report the same 4 switches.
-// For each switch: verify its own PDI (field 22) is in the GPU-reported set,
-// and that the GPU PDIs from field 26 are the same 8 GPUs across all switches.
-func validateTopology(gpuReports, switchReports [][]byte) error {
-	if len(gpuReports) != expectedGPUCount {
-		return fmt.Errorf("expected %d GPU reports, got %d", expectedGPUCount, len(gpuReports))
+// validateTopology cross-checks GPU and switch SPDM reports to verify
+// the fabric forms a correct gpuCount × switchCount mesh: every GPU
+// must see the same set of switchCount switches (opaque field 22),
+// every switch must report itself in that set and see the same gpuCount
+// GPUs (opaque field 26).
+func validateTopology(gpuReports, switchReports [][]byte, gpuCount, switchCount int) error {
+	if len(gpuReports) != gpuCount {
+		return fmt.Errorf("expected %d GPU reports, got %d", gpuCount, len(gpuReports))
 	}
-	if len(switchReports) != expectedSwitchCount {
-		return fmt.Errorf("expected %d switch reports, got %d", expectedSwitchCount, len(switchReports))
+	if len(switchReports) != switchCount {
+		return fmt.Errorf("expected %d switch reports, got %d", switchCount, len(switchReports))
 	}
 
 	// GPU side: every GPU must see exactly 4 unique switches, identical across all GPUs
@@ -183,8 +181,8 @@ func validateTopology(gpuReports, switchReports [][]byte) error {
 		if err != nil {
 			return fmt.Errorf("%s: %w", label, err)
 		}
-		if len(switchPDIs) != expectedSwitchCount {
-			return fmt.Errorf("%s sees %d switches, expected %d", label, len(switchPDIs), expectedSwitchCount)
+		if len(switchPDIs) != switchCount {
+			return fmt.Errorf("%s sees %d switches, expected %d", label, len(switchPDIs), switchCount)
 		}
 		if expectedSwitches == nil {
 			expectedSwitches = switchPDIs
@@ -192,7 +190,7 @@ func validateTopology(gpuReports, switchReports [][]byte) error {
 			return fmt.Errorf("%s switch set differs from GPU[0]", label)
 		}
 	}
-	log.Printf("GPU topology OK: all %d GPUs see the same %d switches", expectedGPUCount, expectedSwitchCount)
+	log.Printf("GPU topology OK: all %d GPUs see the same %d switches", gpuCount, switchCount)
 
 	// Switch side: each switch's own PDI must be in the GPU-reported set,
 	// and each must see exactly 8 unique GPUs, identical across all switches
@@ -221,12 +219,12 @@ func validateTopology(gpuReports, switchReports [][]byte) error {
 		if !ok {
 			return fmt.Errorf("%s: missing GPU PDI field", label)
 		}
-		gpuPDIs, err := parsePDISet(rawGPUs, expectedGPUCount, false)
+		gpuPDIs, err := parsePDISet(rawGPUs, gpuCount, false)
 		if err != nil {
 			return fmt.Errorf("%s: %w", label, err)
 		}
-		if len(gpuPDIs) != expectedGPUCount {
-			return fmt.Errorf("%s sees %d GPUs, expected %d", label, len(gpuPDIs), expectedGPUCount)
+		if len(gpuPDIs) != gpuCount {
+			return fmt.Errorf("%s sees %d GPUs, expected %d", label, len(gpuPDIs), gpuCount)
 		}
 		if expectedGPUs == nil {
 			expectedGPUs = gpuPDIs
@@ -234,7 +232,7 @@ func validateTopology(gpuReports, switchReports [][]byte) error {
 			return fmt.Errorf("%s GPU set differs from switch[0]", label)
 		}
 	}
-	log.Printf("Switch topology OK: all %d switches see the same %d GPUs", expectedSwitchCount, expectedGPUCount)
+	log.Printf("Switch topology OK: all %d switches see the same %d GPUs", switchCount, gpuCount)
 
 	return nil
 }

--- a/tinfoil/cmd/boot/topology_test.go
+++ b/tinfoil/cmd/boot/topology_test.go
@@ -156,7 +156,7 @@ func TestSwitchTopologyCheck(t *testing.T) {
 		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevC}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
 		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevD}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
 	}
-	if err := validateTopology(gpuReports, switchReports); err != nil {
+	if err := validateTopology(gpuReports, switchReports, hopperGPUCount, hopperSwitchCount); err != nil {
 		t.Fatalf("expected topology OK, got: %v", err)
 	}
 }
@@ -197,13 +197,13 @@ func TestGPUTopologyCheckWithDisabledLinks(t *testing.T) {
 // --- Additional failure cases (no Python equivalents) ---
 
 func TestValidateTopologyWrongGPUCount(t *testing.T) {
-	if err := validateTopology(make([][]byte, 7), make([][]byte, 4)); err == nil {
+	if err := validateTopology(make([][]byte, 7), make([][]byte, 4), hopperGPUCount, hopperSwitchCount); err == nil {
 		t.Fatal("expected error for wrong GPU count")
 	}
 }
 
 func TestValidateTopologyWrongSwitchCount(t *testing.T) {
-	if err := validateTopology(make([][]byte, 8), make([][]byte, 3)); err == nil {
+	if err := validateTopology(make([][]byte, 8), make([][]byte, 3), hopperGPUCount, hopperSwitchCount); err == nil {
 		t.Fatal("expected error for wrong switch count")
 	}
 }
@@ -235,7 +235,7 @@ func TestValidateTopologyGPUSeesDifferentSwitches(t *testing.T) {
 		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevC}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
 		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevD}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
 	}
-	if err := validateTopology(gpuReports, switchReports); err == nil {
+	if err := validateTopology(gpuReports, switchReports, hopperGPUCount, hopperSwitchCount); err == nil {
 		t.Fatal("expected topology error for mismatched switch set")
 	}
 }
@@ -255,7 +255,7 @@ func TestValidateTopologySwitchPDINotInGPUSet(t *testing.T) {
 		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevC}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
 		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevD}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
 	}
-	if err := validateTopology(gpuReports, switchReports); err == nil {
+	if err := validateTopology(gpuReports, switchReports, hopperGPUCount, hopperSwitchCount); err == nil {
 		t.Fatal("expected topology error for unknown switch PDI")
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add multi-GPU support for HGX B200s. We detect GPU arch/count, skip in-guest NVSwitch attestation on B200 MPT, and tighten boot/service setup for NVIDIA CC.

- **New Features**
  - Detect GPUs by PCI class and identify arch via device IDs (`h100`/`h200`/`b200`).
  - On multi-GPU: skip NVSwitch evidence on B200; keep PPCIe switch attestation + topology validation on H100/H200.
  - Generalize topology validation to accept GPU/switch counts; update tests and logs; define `hopperGPUCount`/`hopperSwitchCount`.
  - Gate `nvidia-fabricmanager` via new `/usr/local/bin/check-nvidia-fabric` (NVSwitch PCI class 0x068000); keep `nvidia-persistenced` gated by GPU and pre-load `nvidia`/`nvidia_uvm`.
  - Ensure CC SPDM: load `ecdsa_generic`/`ecdh` before `nvidia` and hard-fail if crypto modules fail; use a slim, explicit initrd module list (adds crypto, filesystems, and `tdx_guest`).
  - Improve `repo-check.sh`: restrict NVIDIA driver suggestions to the same major series and remind to update host `nvidia-fabricmanager`/`libnvidia-nscq` when bumping guest `nvidia-driver-open`.

- **Dependencies**
  - Update NVIDIA/Docker packages: `nvidia-driver-open`, `nvidia-persistenced`, `nvidia-fabricmanager`, `libnvidia-nscq` → 595.71.05-1ubuntu1; `docker-ce`/`docker-ce-cli` → 29.4.2.

<sup>Written for commit 09158b71c25f78703ff5bafdf3aa068da5a3a4b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

