### PR TITLE
feat: support more GPU shapes

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -93,6 +93,22 @@ const (
 	externalDiskPath = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_tinfoil-ext-config"
 )
 
+var supportedGPUCounts = map[int]bool{
+	0: true,
+	1: true,
+	2: true,
+	4: true,
+	6: true,
+	8: true,
+}
+
+func validateGPUCount(count int) error {
+	if !supportedGPUCounts[count] {
+		return fmt.Errorf("gpus must be one of 0, 1, 2, 4, 6, or 8 (got %d)", count)
+	}
+	return nil
+}
+
 // loadAndVerifyConfig reads the config from disk and verifies its hash
 func loadAndVerifyConfig() (*Config, error) {
 	if _, err := os.Stat(configDiskPath); os.IsNotExist(err) {
@@ -131,8 +147,8 @@ func loadAndVerifyConfig() (*Config, error) {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
-	if config.GPUs != 0 && config.GPUs != 1 && config.GPUs != 8 {
-		return nil, fmt.Errorf("gpus must be 0, 1, or 8 (got %d)", config.GPUs)
+	if err := validateGPUCount(config.GPUs); err != nil {
+		return nil, err
 	}
 
 	shimCfg, err := parseShimConfig(config.ShimRaw)

--- a/tinfoil/cmd/boot/config_test.go
+++ b/tinfoil/cmd/boot/config_test.go
@@ -1,0 +1,17 @@
+package main
+
+import "testing"
+
+func TestValidateGPUCount(t *testing.T) {
+	for _, count := range []int{0, 1, 2, 4, 6, 8} {
+		if err := validateGPUCount(count); err != nil {
+			t.Fatalf("expected GPU count %d to be valid: %v", count, err)
+		}
+	}
+
+	for _, count := range []int{-1, 3, 5, 7, 9} {
+		if err := validateGPUCount(count); err == nil {
+			t.Fatalf("expected GPU count %d to be invalid", count)
+		}
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow more GPU shapes in boot config: 0, 1, 2, 4, 6, or 8 GPUs (previously only 0, 1, or 8). This broadens cluster configurations while validating inputs.

- **New Features**
  - Centralized GPU count validation and used it during config load with a clearer error message.
  - Added a unit test covering valid and invalid GPU counts.

<sup>Written for commit 933456f611ad2d4bafdd48d37b728babc38848cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

