### PR TITLE
fix: move external-config.yml out of the container-visible PublicDir

### DIFF
--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -5,21 +5,22 @@ const (
 	PublicDir  = RamdiskDir + "/public"
 	PrivateDir = RamdiskDir + "/private"
 
-	// Public — mounted read-only into containers as /tinfoil
-	ConfigPath         = PublicDir + "/config.yml"
-	ExternalConfigPath = PublicDir + "/external-config.yml"
-	AttestationPath    = PublicDir + "/attestation.json"
-	MPKDir             = PublicDir + "/mpk"
+	// Public — mounted read-only into containers as /tinfoil.
+	ConfigPath      = PublicDir + "/config.yml"
+	AttestationPath = PublicDir + "/attestation.json"
+	MPKDir          = PublicDir + "/mpk"
 
-	// Private — only accessible to boot and shim processes
-	TLSDir           = PrivateDir + "/tls"
-	TLSCertPath      = TLSDir + "/cert.pem"
-	TLSKeyPath       = TLSDir + "/key.pem"
-	HPKEKeyPath      = PrivateDir + "/hpke_key.json"
-	ShimConfigPath   = PrivateDir + "/shim.yml"
-	DockerConfigDir  = PrivateDir + "/docker-config"
-	DockerConfigPath = DockerConfigDir + "/config.json"
-	GCloudKeyPath    = PrivateDir + "/gcloud_key.json"
-	CacheDir         = PrivateDir + "/tfshim-cache"
-	StatePath        = PrivateDir + "/boot-state.json"
+	// Private — only accessible to boot and shim processes (mode 0700).
+	// Holds CVM-level secrets and material that must never reach a container.
+	TLSDir             = PrivateDir + "/tls"
+	TLSCertPath        = TLSDir + "/cert.pem"
+	TLSKeyPath         = TLSDir + "/key.pem"
+	HPKEKeyPath        = PrivateDir + "/hpke_key.json"
+	ShimConfigPath     = PrivateDir + "/shim.yml"
+	ExternalConfigPath = PrivateDir + "/external-config.yml"
+	DockerConfigDir    = PrivateDir + "/docker-config"
+	DockerConfigPath   = DockerConfigDir + "/config.json"
+	GCloudKeyPath      = PrivateDir + "/gcloud_key.json"
+	CacheDir           = PrivateDir + "/tfshim-cache"
+	StatePath          = PrivateDir + "/boot-state.json"
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moves `external-config.yml` out of the container-mounted `PublicDir` into `PrivateDir` so containers cannot read it. Clarifies that `PrivateDir` holds CVM-level secrets and is mode 0700.

- **Bug Fixes**
  - `ExternalConfigPath` now points to `PrivateDir` (`/private/external-config.yml`) instead of `PublicDir`.
  - Updated comments to document `PrivateDir` purpose and permissions.

<sup>Written for commit 164568de71797318693b6a9698b8c3ae8b72d0c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

