### PR TITLE
feat: default network is now bridge with only connection to shim allowed

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -60,7 +60,7 @@ type Container struct {
 	CapDrop     []string    `yaml:"cap_drop,omitempty"`
 	SecurityOpt []string    `yaml:"security_opt,omitempty"`
 	Runtime     string      `yaml:"runtime,omitempty"`      // e.g., "nvidia"
-	NetworkMode string      `yaml:"network_mode,omitempty"` // "host", "bridge", "none" (default: "host")
+	NetworkMode string      `yaml:"network_mode,omitempty"` // "host", "bridge", "none" (default: "bridge")
 	IPC         string      `yaml:"ipc,omitempty"`          // e.g., "host"
 	PidMode     string      `yaml:"pid,omitempty"`          // "host" for host PID namespace
 	GPUs        interface{} `yaml:"gpus,omitempty"`         // "all", "0,1,2,3", or count (int)
@@ -198,6 +198,12 @@ func loadConfigFromRamdisk() (*Config, error) {
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
+
+	shimCfg, err := parseShimConfig(config.ShimRaw)
+	if err != nil {
+		return nil, fmt.Errorf("parsing shim config: %w", err)
+	}
+	config.ShimCfg = shimCfg
 
 	return &config, nil
 }

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -15,11 +16,14 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 )
+
+const shimLoopbackHostIP = "127.0.0.1"
 
 const healthPollInterval = 5 * time.Second
 
@@ -40,14 +44,18 @@ func launchContainers(config *Config) error {
 
 	log.Printf("Launching %d containers", len(config.Containers))
 	var errors []string
-	for _, c := range config.Containers {
+	for i, c := range config.Containers {
 		log.Printf("Pulling image %s (%s)", c.Name, c.Image)
 		if err := pullImage(cli, c.Image); err != nil {
 			log.Printf("Error pulling image for %s: %v", c.Name, err)
 			errors = append(errors, fmt.Sprintf("%s: pulling image: %v", c.Name, err))
 			continue
 		}
-		if err := createAndStartContainer(cli, c, extConfig); err != nil {
+		publishPort := 0
+		if i == 0 {
+			publishPort = config.ShimCfg.UpstreamPort
+		}
+		if err := createAndStartContainer(cli, c, extConfig, publishPort); err != nil {
 			log.Printf("Error starting container %s: %v", c.Name, err)
 			errors = append(errors, fmt.Sprintf("%s: %v", c.Name, err))
 		}
@@ -105,11 +113,15 @@ func launchContainersAndWaitHealthy(tracker *boot.Tracker, config *Config) error
 	errs := make([]error, len(config.Containers))
 	var wg sync.WaitGroup
 	for i, c := range config.Containers {
+		publishPort := 0
+		if i == 0 {
+			publishPort = config.ShimCfg.UpstreamPort
+		}
 		wg.Add(1)
-		go func(i int, c Container) {
+		go func(i int, c Container, publishPort int) {
 			defer wg.Done()
-			errs[i] = runContainer(cli, c, extConfig, &substages, &mu, flush)
-		}(i, c)
+			errs[i] = runContainer(cli, c, extConfig, publishPort, &substages, &mu, flush)
+		}(i, c, publishPort)
 	}
 	wg.Wait()
 
@@ -135,6 +147,7 @@ func runContainer(
 	cli *client.Client,
 	c Container,
 	extConfig *shimconfig.ExternalConfig,
+	publishPort int,
 	substages *[]boot.Stage,
 	mu *sync.Mutex,
 	flush func(),
@@ -167,7 +180,7 @@ func runContainer(
 
 	// Create + start
 	startPhase := time.Now()
-	if err := createAndStartContainer(cli, c, extConfig); err != nil {
+	if err := createAndStartContainer(cli, c, extConfig, publishPort); err != nil {
 		detail := fmt.Sprintf("starting: %v", err)
 		record("start", boot.StatusFailed, time.Since(startPhase), detail)
 		finish(boot.StatusFailed, detail)
@@ -246,7 +259,7 @@ func lastHealthLog(h *container.Health) string {
 }
 
 // createAndStartContainer creates and starts a container (image must already be pulled).
-func createAndStartContainer(cli *client.Client, c Container, extConfig *shimconfig.ExternalConfig) error {
+func createAndStartContainer(cli *client.Client, c Container, extConfig *shimconfig.ExternalConfig, publishPort int) error {
 	if c.Image == "" {
 		return fmt.Errorf("no image specified for container %s", c.Name)
 	}
@@ -280,7 +293,7 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 	// Host configuration
 	networkMode := c.NetworkMode
 	if networkMode == "" {
-		networkMode = "host" // Default to host networking
+		networkMode = "bridge"
 	}
 	hostConfig := &container.HostConfig{
 		NetworkMode:    container.NetworkMode(networkMode),
@@ -293,6 +306,26 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 		ReadonlyRootfs: c.ReadOnly,
 		Tmpfs:          c.Tmpfs,
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
+	}
+
+	// Auto-publish the shim's upstream port on host loopback for the
+	// upstream container.
+	//
+	// By convention the first entry in `containers:` is the upstream.
+	if publishPort > 0 && networkMode != "host" {
+		if publishPort < 1 || publishPort > 65535 {
+			return fmt.Errorf("invalid upstream port %d for container %s", publishPort, c.Name)
+		}
+		port, err := nat.NewPort("tcp", strconv.Itoa(publishPort))
+		if err != nil {
+			return fmt.Errorf("building port spec for container %s: %w", c.Name, err)
+		}
+		containerConfig.ExposedPorts = nat.PortSet{port: struct{}{}}
+		hostConfig.PortBindings = nat.PortMap{port: []nat.PortBinding{{
+			HostIP:   shimLoopbackHostIP,
+			HostPort: strconv.Itoa(publishPort),
+		}}}
+		log.Printf("Container %s: publishing upstream port %d on %s", c.Name, publishPort, shimLoopbackHostIP)
 	}
 
 	// Restart policy

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/creasty/defaults v1.8.0
 	github.com/docker/cli v29.2.0+incompatible
 	github.com/docker/docker v28.5.2+incompatible
+	github.com/docker/go-connections v0.6.0
 	github.com/docker/go-units v0.5.0
 	github.com/go-acme/lego/v4 v4.30.1
 	github.com/google/go-sev-guest v0.14.1
@@ -33,7 +34,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
-	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default container networking is now `bridge`, and we auto-publish only the shim’s `upstreamPort` to 127.0.0.1 for the upstream container (first in `containers:`) to limit host exposure. This improves isolation; previous default (`host`) now requires opt-in.

- **Migration**
  - Set `network_mode: host` to keep prior behavior for specific containers.
  - Ensure the shim `upstreamPort` is valid; that TCP port is published on 127.0.0.1 for the first container only.
  - Place the upstream container first in `containers:`.

- **Dependencies**
  - Add direct dependency on `github.com/docker/go-connections`.

<sup>Written for commit 961cafeffc581ce5f997bde23376817a3d609ca2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

