### PR TITLE
Sec/ramdisk hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ initrd.cpio.zst
 tinfoil-boot/tinfoil-boot
 tinfoil/boot
 tinfoil/shim
-mkosi.extra/usr/local/bin/tinfoil-boot
-mkosi.extra/usr/local/bin/tinfoil-shim
+mkosi.extra/usr/bin/tinfoil-boot
+mkosi.extra/usr/bin/tinfoil-shim

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ deepclean:
 	sudo rm -f packages/nvattest_*.deb packages/libnvat_*.deb
 
 build: nvattest
-	mkdir -p packages mkosi.extra/usr/local/bin
-	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/local/bin/tinfoil-boot ./cmd/boot
-	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/local/bin/tinfoil-shim ./cmd/shim
+	mkdir -p packages mkosi.extra/usr/bin
+	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-boot ./cmd/boot
+	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-shim ./cmd/shim
 	mkosi --force
 	rm -f tinfoilcvm
 

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,14 @@ cpus = 32
 
 all: clean build
 
+# tinfoilcvm.hash is written as an artifact of `build`; read it from there if
+# present, otherwise extract from the UKI as a fallback.
 hash:
-	objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | cut -d "=" -f 2
+	@if [ -f tinfoilcvm.hash ]; then \
+	    cat tinfoilcvm.hash; \
+	else \
+	    objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | cut -d "=" -f 2; \
+	fi
 
 clean:
 	sudo rm -rf tinfoilcvm.*
@@ -23,6 +29,8 @@ build: nvattest
 	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-shim ./cmd/shim
 	mkosi --force
 	rm -f tinfoilcvm
+	objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | cut -d "=" -f 2 > tinfoilcvm.hash
+	@echo "image hash: $$(cat tinfoilcvm.hash)"
 
 # TEMPORARY: drop once cuda-ubuntu2604 ships nvattest. See build-nvattest.sh.
 nvattest: packages/nvattest_1.2.0.1772475102-1_amd64.deb

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,14 @@
-cmdline = "readonly=on console=ttyS0 earlyprintk=serial root=/dev/sda2 tinfoil-debug=on tinfoil-config-hash=$(shell sha256sum config.yml | cut -d ' ' -f 1)"
-
-memory = 4096M
-cpus = 32
-
 all: clean build
 
 # tinfoilcvm.hash is written as an artifact of `build`; read it from there if
 # present, otherwise extract the dm-verity roothash from the UKI's .cmdline
-# section. grep -oE finds the roothash= token regardless of position so the
+# section. grep -aoE finds the roothash= token regardless of position so the
 # command stays correct even if mkosi adds other kv pairs to the cmdline.
 hash:
 	@if [ -f tinfoilcvm.hash ]; then \
 	    cat tinfoilcvm.hash; \
 	else \
-	    objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | grep -oE 'roothash=[a-f0-9]+' | cut -d= -f2; \
+	    objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | grep -aoE 'roothash=[a-f0-9]+' | cut -d= -f2; \
 	fi
 
 clean:
@@ -31,7 +26,7 @@ build: nvattest
 	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-shim ./cmd/shim
 	mkosi --force
 	rm -f tinfoilcvm
-	objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | grep -oE 'roothash=[a-f0-9]+' | cut -d= -f2 > tinfoilcvm.hash
+	objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | grep -aoE 'roothash=[a-f0-9]+' | cut -d= -f2 > tinfoilcvm.hash
 	@echo "image hash: $$(cat tinfoilcvm.hash)"
 
 # TEMPORARY: drop once cuda-ubuntu2604 ships nvattest. See build-nvattest.sh.
@@ -49,44 +44,3 @@ packages/nvattest_1.2.0.1772475102-1_amd64.deb: build-nvattest.sh
 
 python-lockfile:
 	pip-compile --generate-hashes --allow-unsafe --output-file=mkosi.extra/opt/venv-requirements.txt python-requirements.in
-
-run:
-	stty intr ^]
-	sudo ~/qemu/build/qemu-system-x86_64 \
-		-enable-kvm \
-		-cpu EPYC-v4 \
-		-machine q35 -smp $(cpus),maxcpus=$(cpus) \
-		-m $(memory) \
-		-no-reboot \
-		-bios /home/ubuntu/cvmimage/OVMF.fd \
-		-kernel ./tinfoilcvm.vmlinuz \
-		-initrd ./tinfoilcvm.initrd \
-		-append $(cmdline) \
-		-drive file=./tinfoilcvm.raw,if=none,id=disk0,format=raw,readonly=on \
-		-device virtio-scsi-pci,id=scsi0,disable-legacy=on,iommu_platform=true \
-		-device scsi-hd,drive=disk0 \
-		-drive file=config.yml,if=none,id=disk1,format=raw,readonly=on \
-		-device virtio-scsi-pci,id=scsi1,disable-legacy=on,iommu_platform=true \
-		-device scsi-hd,drive=disk1 \
-		-machine memory-encryption=sev0,vmport=off \
-		-object memory-backend-memfd,id=ram1,size=$(memory),share=true,prealloc=false \
-		-machine memory-backend=ram1 -object sev-snp-guest,id=sev0,policy=0x30000,cbitpos=51,reduced-phys-bits=5,kernel-hashes=on \
-		-net nic,model=e1000 -net user,hostfwd=tcp::8444-:443 \
-		-nographic -monitor pty -monitor unix:monitor,server,nowait
-	stty intr ^c
-
-# -drive file=~/models/qwen-0.5b.mpk,if=none,id=disk2,format=raw,readonly=on \
-# -device virtio-scsi-pci,id=scsi2,disable-legacy=on,iommu_platform=true \
-# -device scsi-hd,drive=disk2 \
-# -machine memory-encryption=sev0,vmport=off \
-
-measure:
-	@MEASUREMENT=$$(sev-snp-measure \
-		--mode snp \
-		--vcpus=$(cpus) \
-		--vcpu-type=EPYC-v4 \
-		--append=$(cmdline) \
-		--ovmf ./OVMF.fd \
-		--kernel tinfoilcvm.vmlinuz \
-		--initrd tinfoilcvm.initrd) && \
-	echo "{ \"measurement\": \"$$MEASUREMENT\" }"

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,14 @@ cpus = 32
 all: clean build
 
 # tinfoilcvm.hash is written as an artifact of `build`; read it from there if
-# present, otherwise extract from the UKI as a fallback.
+# present, otherwise extract the dm-verity roothash from the UKI's .cmdline
+# section. grep -oE finds the roothash= token regardless of position so the
+# command stays correct even if mkosi adds other kv pairs to the cmdline.
 hash:
 	@if [ -f tinfoilcvm.hash ]; then \
 	    cat tinfoilcvm.hash; \
 	else \
-	    objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | cut -d "=" -f 2; \
+	    objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | grep -oE 'roothash=[a-f0-9]+' | cut -d= -f2; \
 	fi
 
 clean:
@@ -29,7 +31,7 @@ build: nvattest
 	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-shim ./cmd/shim
 	mkosi --force
 	rm -f tinfoilcvm
-	objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | cut -d "=" -f 2 > tinfoilcvm.hash
+	objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | grep -oE 'roothash=[a-f0-9]+' | cut -d= -f2 > tinfoilcvm.hash
 	@echo "image hash: $$(cat tinfoilcvm.hash)"
 
 # TEMPORARY: drop once cuda-ubuntu2604 ships nvattest. See build-nvattest.sh.

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,0 @@
-models:
-  - name: "casperhansen/llama-3.3-70b-instruct-awq"
-    mpk: "a5682a25b389ffec1f815014f32db5e8408ede5f9858b4892e60f70e04072499_39785426944_105c64df-38c7-599e-8e98-71699d45be86"

--- a/mkosi.extra/etc/containerd/config.toml
+++ b/mkosi.extra/etc/containerd/config.toml
@@ -1,4 +1,4 @@
 version = 3
 
-root = "/mnt/ramdisk/containerd/root"
-state = "/mnt/ramdisk/containerd/run"
+root = "/mnt/ramdisk/private/containerd/root"
+state = "/mnt/ramdisk/private/containerd/run"

--- a/mkosi.extra/etc/docker/daemon.json
+++ b/mkosi.extra/etc/docker/daemon.json
@@ -1,5 +1,5 @@
 {
-    "data-root": "/mnt/ramdisk/docker",
+    "data-root": "/mnt/ramdisk/private/docker",
     "features": {
         "containerd-snapshotter": true
     },

--- a/mkosi.extra/etc/systemd/system/tinfoil-boot.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-boot.service
@@ -7,7 +7,7 @@ Wants=nvidia-persistenced.service nvidia-fabricmanager.service nvidia-cdi-refres
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/local/bin/tinfoil-boot
+ExecStart=/usr/bin/tinfoil-boot
 User=root
 Group=root
 StandardOutput=journal+console

--- a/mkosi.extra/etc/systemd/system/tinfoil-shim.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-shim.service
@@ -5,7 +5,7 @@ Requires=tinfoil-ramdisk.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/tinfoil-shim
+ExecStart=/usr/bin/tinfoil-shim
 Restart=always
 RestartSec=5
 User=root

--- a/mkosi.extra/usr/local/bin/tinfoil-ramdisk
+++ b/mkosi.extra/usr/local/bin/tinfoil-ramdisk
@@ -13,17 +13,23 @@ if [ $SIZE -lt 16 ]; then
     SIZE=4
 fi
 
-mount -t tmpfs -o size=${SIZE}G tmpfs /mnt/ramdisk
+mount -t tmpfs -o size=${SIZE}G,mode=0755,nodev,nosuid tmpfs /mnt/ramdisk
 
-# Public dir: read-only mount for containers (/tinfoil)
-mkdir -p /mnt/ramdisk/public
-chmod 755 /mnt/ramdisk/public
-
-# Private dir: boot + shim only (TLS keys, HPKE, registry creds)
+# Private dir: boot + shim only (TLS keys, HPKE, registry creds, daemon state).
 mkdir -p /mnt/ramdisk/private
 chmod 700 /mnt/ramdisk/private
 
-# Mount tmp as ramdisk
-mount -t tmpfs -o size=512M tmpfs /tmp
+# Public dir: read-only bind mount into workload containers at /tinfoil.
+mkdir -p /mnt/ramdisk/public
+chmod 755 /mnt/ramdisk/public
+
+# Daemon data roots live under private/ so they sit behind the 0700 parent and
+# outside any container mount. docker/containerd start before tinfoil-boot, so
+# these must exist by the time their units are activated.
+mkdir -p /mnt/ramdisk/private/docker
+mkdir -p /mnt/ramdisk/private/containerd/root
+mkdir -p /mnt/ramdisk/private/containerd/run
+
+mount -t tmpfs -o size=512M,mode=1777,nodev,nosuid tmpfs /tmp
 
 echo "Ramdisk ready"

--- a/mkosi.extra/usr/local/bin/tinfoil-ramdisk
+++ b/mkosi.extra/usr/local/bin/tinfoil-ramdisk
@@ -23,13 +23,6 @@ chmod 700 /mnt/ramdisk/private
 mkdir -p /mnt/ramdisk/public
 chmod 755 /mnt/ramdisk/public
 
-# Daemon data roots live under private/ so they sit behind the 0700 parent and
-# outside any container mount. docker/containerd start before tinfoil-boot, so
-# these must exist by the time their units are activated.
-mkdir -p /mnt/ramdisk/private/docker
-mkdir -p /mnt/ramdisk/private/containerd/root
-mkdir -p /mnt/ramdisk/private/containerd/run
-
 mount -t tmpfs -o size=512M,mode=1777,nodev,nosuid tmpfs /tmp
 
 echo "Ramdisk ready"

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -24,8 +24,7 @@ systemctl mask nvidia-powerd.service
 
 systemctl mask systemd-networkd-persistent-storage.service
 
-mkdir -p /mnt/ramdisk/docker-config
-echo "export DOCKER_CONFIG=/mnt/ramdisk/docker-config" >> /root/.bashrc
+echo "export DOCKER_CONFIG=/mnt/ramdisk/private/docker-config" >> /root/.bashrc
 
 # Build patched tdx-guest.ko. The audit surface is the small
 # /opt/tdx-fast-quote/fast-quote.patch; the accompanying tdx-guest.c is the

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -24,9 +24,6 @@ systemctl mask nvidia-powerd.service
 
 systemctl mask systemd-networkd-persistent-storage.service
 
-# Pre-create the ramdisk mount point in the read-only rootfs so
-# tinfoil-ramdisk.service has somewhere to mount the tmpfs onto.
-mkdir -p /mnt/ramdisk
 echo "export DOCKER_CONFIG=/mnt/ramdisk/private/docker-config" >> /root/.bashrc
 
 # Build patched tdx-guest.ko. The audit surface is the small

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -24,6 +24,9 @@ systemctl mask nvidia-powerd.service
 
 systemctl mask systemd-networkd-persistent-storage.service
 
+# Pre-create the ramdisk mount point in the read-only rootfs so
+# tinfoil-ramdisk.service has somewhere to mount the tmpfs onto.
+mkdir -p /mnt/ramdisk
 echo "export DOCKER_CONFIG=/mnt/ramdisk/private/docker-config" >> /root/.bashrc
 
 # Build patched tdx-guest.ko. The audit surface is the small

--- a/tinfoil/cmd/boot/cert.go
+++ b/tinfoil/cmd/boot/cert.go
@@ -99,7 +99,7 @@ func obtainCertificate(id *NodeIdentity, att *verifier.Document, shimCfg *shimco
 		var listenPort int
 		if shimCfg.TLSChallengeMode == "http" {
 			httpChallengeDomains = []string{id.Domain}
-			listenPort = shimCfg.ListenPort
+			listenPort = boot.ShimListenPort
 		}
 		mgr, err := tlsutil.NewCertProxyManager(
 			domains, boot.CacheDir, shimCfg.ControlPlane, id.TLSKey,
@@ -120,7 +120,7 @@ func obtainCertificate(id *NodeIdentity, att *verifier.Document, shimCfg *shimco
 		mgr, err := tlsutil.NewCertManager(
 			domains, shimCfg.Email, boot.CacheDir, dir,
 			tlsutil.ChallengeMode(shimCfg.TLSChallengeMode),
-			shimCfg.ListenPort, id.TLSKey,
+			boot.ShimListenPort, id.TLSKey,
 			cfDNS, cfZone,
 		)
 		if err != nil {

--- a/tinfoil/cmd/boot/cert.go
+++ b/tinfoil/cmd/boot/cert.go
@@ -102,7 +102,7 @@ func obtainCertificate(id *NodeIdentity, att *verifier.Document, shimCfg *shimco
 			listenPort = shimCfg.ListenPort
 		}
 		mgr, err := tlsutil.NewCertProxyManager(
-			domains, shimCfg.CacheDir, shimCfg.ControlPlane, id.TLSKey,
+			domains, boot.CacheDir, shimCfg.ControlPlane, id.TLSKey,
 			httpChallengeDomains, listenPort, certAuthToken,
 		)
 		if err != nil {
@@ -118,7 +118,7 @@ func obtainCertificate(id *NodeIdentity, att *verifier.Document, shimCfg *shimco
 			dir = lego.LEDirectoryStaging
 		}
 		mgr, err := tlsutil.NewCertManager(
-			domains, shimCfg.Email, shimCfg.CacheDir, dir,
+			domains, shimCfg.Email, boot.CacheDir, dir,
 			tlsutil.ChallengeMode(shimCfg.TLSChallengeMode),
 			shimCfg.ListenPort, id.TLSKey,
 			cfDNS, cfZone,

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/creasty/defaults"
 	"gopkg.in/yaml.v3"
 
 	"tinfoil/internal/boot"
@@ -16,14 +15,14 @@ import (
 
 // Config represents the main configuration file
 type Config struct {
-	ShimRaw    map[string]interface{} `yaml:"shim"`
-	ShimCfg    *shimconfig.Config     `yaml:"-"`
-	Network    NetworkConfig          `yaml:"network"`
-	CPUs       int                    `yaml:"cpus"`
-	Memory     int                    `yaml:"memory"`
-	GPUs       int                    `yaml:"gpus"`
-	Models     []ModelSpec            `yaml:"models"`
-	Containers []Container            `yaml:"containers"`
+	ShimRaw    yaml.Node          `yaml:"shim"`
+	ShimCfg    *shimconfig.Config `yaml:"-"`
+	Network    NetworkConfig      `yaml:"network"`
+	CPUs       int                `yaml:"cpus"`
+	Memory     int                `yaml:"memory"`
+	GPUs       int                `yaml:"gpus"`
+	Models     []ModelSpec        `yaml:"models"`
+	Containers []Container        `yaml:"containers"`
 }
 
 // NetworkConfig defines network-level firewall rules enforced via nftables.
@@ -151,7 +150,7 @@ func loadAndVerifyConfig() (*Config, error) {
 		return nil, err
 	}
 
-	shimCfg, err := parseShimConfig(config.ShimRaw)
+	shimCfg, err := shimconfig.Decode(&config.ShimRaw)
 	if err != nil {
 		return nil, fmt.Errorf("parsing shim config: %w", err)
 	}
@@ -172,21 +171,6 @@ func loadAndVerifyConfig() (*Config, error) {
 	return &config, nil
 }
 
-func parseShimConfig(raw map[string]interface{}) (*shimconfig.Config, error) {
-	var cfg shimconfig.Config
-	if err := defaults.Set(&cfg); err != nil {
-		return nil, fmt.Errorf("setting defaults: %w", err)
-	}
-	yamlBytes, err := yaml.Marshal(raw)
-	if err != nil {
-		return nil, fmt.Errorf("marshaling: %w", err)
-	}
-	if err := yaml.Unmarshal(yamlBytes, &cfg); err != nil {
-		return nil, fmt.Errorf("unmarshaling: %w", err)
-	}
-	return &cfg, nil
-}
-
 // loadConfigFromRamdisk reads config directly from ramdisk without verification (for debugging)
 func loadConfigFromRamdisk() (*Config, error) {
 	data, err := os.ReadFile(boot.ConfigPath)
@@ -199,7 +183,7 @@ func loadConfigFromRamdisk() (*Config, error) {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
-	shimCfg, err := parseShimConfig(config.ShimRaw)
+	shimCfg, err := shimconfig.Decode(&config.ShimRaw)
 	if err != nil {
 		return nil, fmt.Errorf("parsing shim config: %w", err)
 	}

--- a/tinfoil/cmd/boot/identity.go
+++ b/tinfoil/cmd/boot/identity.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 
-	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 )
 
@@ -35,17 +34,12 @@ func generateIdentity(shimCfg *shimconfig.Config, externalConfig *shimconfig.Ext
 		domain = "localhost"
 	}
 
-	hpkeKeyFile := shimCfg.HPKEKeyFile
-	if hpkeKeyFile == "" {
-		hpkeKeyFile = boot.HPKEKeyPath
-	}
-	serverIdentity, err := identity.FromFile(hpkeKeyFile)
+	serverIdentity, err := identity.FromFile(shimCfg.HPKEKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading HPKE identity: %w", err)
 	}
-	// identity.FromFile creates the key file with 0644 on first run; tighten
-	// it so the HPKE private key isn't world-readable on the ramdisk.
-	if err := os.Chmod(hpkeKeyFile, 0o600); err != nil {
+	// identity.FromFile creates the key file with 0644 on first run.
+	if err := os.Chmod(shimCfg.HPKEKeyFile, 0o600); err != nil {
 		return nil, fmt.Errorf("restricting HPKE key permissions: %w", err)
 	}
 

--- a/tinfoil/cmd/boot/identity.go
+++ b/tinfoil/cmd/boot/identity.go
@@ -34,13 +34,9 @@ func generateIdentity(shimCfg *shimconfig.Config, externalConfig *shimconfig.Ext
 		domain = "localhost"
 	}
 
-	serverIdentity, err := identity.FromFile(shimCfg.HPKEKeyFile)
+	serverIdentity, err := loadOrCreateHPKEIdentity(shimCfg.HPKEKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading HPKE identity: %w", err)
-	}
-	// identity.FromFile creates the key file with 0644 on first run.
-	if err := os.Chmod(shimCfg.HPKEKeyFile, 0o600); err != nil {
-		return nil, fmt.Errorf("restricting HPKE key permissions: %w", err)
 	}
 
 	hpkeKeyBytes := serverIdentity.MarshalPublicKey()
@@ -59,4 +55,25 @@ func generateIdentity(shimCfg *shimconfig.Config, externalConfig *shimconfig.Ext
 		HPKEKeyBytes: hpkeKeyBytes,
 		Domain:       domain,
 	}, nil
+}
+
+// loadOrCreateHPKEIdentity returns the HPKE identity at path, generating and
+// persisting a new one with mode 0600 when the file does not yet exist.
+// identity.FromFile would create a fresh key world-readable (0644).
+func loadOrCreateHPKEIdentity(path string) (*identity.Identity, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		i, err := identity.NewIdentity()
+		if err != nil {
+			return nil, fmt.Errorf("creating HPKE identity: %w", err)
+		}
+		b, err := i.Export()
+		if err != nil {
+			return nil, fmt.Errorf("exporting HPKE identity: %w", err)
+		}
+		if err := os.WriteFile(path, b, 0o600); err != nil {
+			return nil, fmt.Errorf("writing HPKE identity: %w", err)
+		}
+		return i, nil
+	}
+	return identity.FromFile(path)
 }

--- a/tinfoil/cmd/boot/identity.go
+++ b/tinfoil/cmd/boot/identity.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 
@@ -41,6 +42,11 @@ func generateIdentity(shimCfg *shimconfig.Config, externalConfig *shimconfig.Ext
 	serverIdentity, err := identity.FromFile(hpkeKeyFile)
 	if err != nil {
 		return nil, fmt.Errorf("loading HPKE identity: %w", err)
+	}
+	// identity.FromFile creates the key file with 0644 on first run; tighten
+	// it so the HPKE private key isn't world-readable on the ramdisk.
+	if err := os.Chmod(hpkeKeyFile, 0o600); err != nil {
+		return nil, fmt.Errorf("restricting HPKE key permissions: %w", err)
 	}
 
 	hpkeKeyBytes := serverIdentity.MarshalPublicKey()

--- a/tinfoil/cmd/boot/identity.go
+++ b/tinfoil/cmd/boot/identity.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
 
+	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 )
 
@@ -34,7 +35,7 @@ func generateIdentity(shimCfg *shimconfig.Config, externalConfig *shimconfig.Ext
 		domain = "localhost"
 	}
 
-	serverIdentity, err := loadOrCreateHPKEIdentity(shimCfg.HPKEKeyFile)
+	serverIdentity, err := loadOrCreateHPKEIdentity(boot.HPKEKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("loading HPKE identity: %w", err)
 	}

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -60,7 +60,7 @@ func main() {
 	}
 
 	srv := &http.Server{
-		Addr: ":443",
+		Addr: fmt.Sprintf(":%d", boot.ShimListenPort),
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if h, ok := handler.Load().(http.Handler); ok {
 				h.ServeHTTP(w, r)

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -136,7 +136,7 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 		}
 
 		serverIdentity, err := waitForArtifact("HPKE identity", func() (*identity.Identity, error) {
-			return identity.FromFile(config.HPKEKeyFile)
+			return identity.FromFile(boot.HPKEKeyPath)
 		})
 		if err != nil {
 			return err

--- a/tinfoil/internal/acpi/acpi.go
+++ b/tinfoil/internal/acpi/acpi.go
@@ -4,96 +4,81 @@ import (
 	"archive/tar"
 	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
+	"sync"
 
 	"tinfoil/internal/auth"
 	"tinfoil/internal/config"
 )
 
-func HandleQemuACPI(cfg *config.Config, externalConfig *config.ExternalConfig) http.HandlerFunc {
+var acpiFiles = []struct {
+	Path string
+	Name string
+}{
+	{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/acpi/tables/raw", Name: "acpi_tables.bin"},
+	{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/acpi/rsdp/raw", Name: "rsdp.bin"},
+	{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/table-loader/raw", Name: "table_loader.bin"},
+}
+
+func buildArchive() ([]byte, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, af := range acpiFiles {
+		data, err := os.ReadFile(af.Path)
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", af.Name, err)
+		}
+		hdr := &tar.Header{Name: af.Name, Mode: 0o644, Size: int64(len(data))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return nil, fmt.Errorf("writing header for %s: %w", af.Name, err)
+		}
+		if _, err := tw.Write(data); err != nil {
+			return nil, fmt.Errorf("writing %s: %w", af.Name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		return nil, fmt.Errorf("closing tar: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// HandleQemuACPI serves the QEMU fw_cfg ACPI tables as a tar archive.
+//
+// The archive is built once from /sys/firmware/qemu_fw_cfg on the first
+// successful request and then served from an in-memory cache; the previous
+// implementation persisted it to disk under cfg.CacheDir, which is no longer
+// necessary now that the cache dir is private and writable only by the shim.
+//
+// Build errors are not cached, so a transient failure on the first request
+// won't permanently poison the endpoint.
+func HandleQemuACPI(_ *config.Config, externalConfig *config.ExternalConfig) http.HandlerFunc {
+	var (
+		mu      sync.Mutex
+		archive []byte
+	)
 	return func(w http.ResponseWriter, r *http.Request) {
 		if !auth.RequireBearer(externalConfig.ACPIAPIKey, w, r) {
 			return
 		}
 
-		var buf bytes.Buffer
-
-		archivePath := filepath.Join(cfg.CacheDir, "acpi.tar")
-		force := r.URL.Query().Get("force") == "1"
-
-		if _, err := os.Stat(archivePath); !force && err == nil {
-			data, err := os.ReadFile(archivePath)
+		mu.Lock()
+		if archive == nil {
+			data, err := buildArchive()
 			if err != nil {
-				http.Error(w, fmt.Sprintf("Failed to read ACPI archive: %v", err), http.StatusInternalServerError)
+				mu.Unlock()
+				http.Error(w, fmt.Sprintf("Failed to build ACPI archive: %v", err), http.StatusInternalServerError)
 				return
 			}
-			_, err = buf.Write(data)
-			if err != nil {
-				http.Error(w, fmt.Sprintf("Failed to write ACPI archive to buffer: %v", err), http.StatusInternalServerError)
-				return
-			}
-		} else {
-			tw := tar.NewWriter(&buf)
-			type acpiFile struct {
-				Path string
-				Name string
-			}
-			acpiFiles := []acpiFile{
-				{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/acpi/tables/raw", Name: "acpi_tables.bin"},
-				{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/acpi/rsdp/raw", Name: "rsdp.bin"},
-				{Path: "/sys/firmware/qemu_fw_cfg/by_name/etc/table-loader/raw", Name: "table_loader.bin"},
-			}
-
-			for _, af := range acpiFiles {
-				data, err := os.ReadFile(af.Path)
-				if err != nil {
-					http.Error(w, fmt.Sprintf("Failed to read ACPI source file %s", af.Name), http.StatusInternalServerError)
-					return
-				}
-				hdr := &tar.Header{
-					Name: af.Name,
-					Mode: 0644,
-					Size: int64(len(data)),
-				}
-				if err := tw.WriteHeader(hdr); err != nil {
-					http.Error(w, fmt.Sprintf("Failed to write header for ACPI source file %s", af.Name), http.StatusInternalServerError)
-					return
-				}
-				if _, err := tw.Write(data); err != nil {
-					http.Error(w, fmt.Sprintf("Failed to write ACPI source file %s", af.Name), http.StatusInternalServerError)
-					return
-				}
-			}
-
-			tw.Close()
-
-			// Persist to disk
-			if err := os.MkdirAll(filepath.Dir(archivePath), 0o755); err == nil {
-				tmp, err := os.CreateTemp(filepath.Dir(archivePath), "acpi-*.tar")
-				if err == nil {
-					if _, err := io.Copy(tmp, bytes.NewReader(buf.Bytes())); err == nil {
-						tmp.Close()
-						_ = os.Rename(tmp.Name(), archivePath)
-					} else {
-						tmp.Close()
-						_ = os.Remove(tmp.Name())
-					}
-				}
-			}
+			archive = data
 		}
+		body := archive
+		mu.Unlock()
 
 		w.Header().Set("Content-Type", "application/x-tar")
-		w.Header().Set("Content-Disposition", "attachment; filename=\""+filepath.Base(archivePath)+"\"")
-		w.Header().Set("Content-Length", strconv.Itoa(buf.Len()))
-
-		if _, err := io.Copy(w, &buf); err != nil {
-			http.Error(w, fmt.Sprintf("Failed to copy ACPI archive to response: %v", err), http.StatusInternalServerError)
-			return
-		}
-
+		w.Header().Set("Content-Disposition", `attachment; filename="acpi.tar"`)
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write(body)
 	}
 }

--- a/tinfoil/internal/auth/bearer.go
+++ b/tinfoil/internal/auth/bearer.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"crypto/subtle"
 	"net/http"
 	"strings"
 )
@@ -17,7 +18,7 @@ func RequireBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
 		return false
 	}
 	token := header[7:]
-	if token != apiKey {
+	if subtle.ConstantTimeCompare([]byte(token), []byte(apiKey)) != 1 {
 		http.Error(w, "Unauthorized", http.StatusUnauthorized)
 		return false
 	}

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -23,4 +23,7 @@ const (
 	GCloudKeyPath      = PrivateDir + "/gcloud_key.json"
 	CacheDir           = PrivateDir + "/tfshim-cache"
 	StatePath          = PrivateDir + "/boot-state.json"
+
+	// ShimListenPort is the public TLS port served by tinfoil-shim.
+	ShimListenPort = 443
 )

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -34,9 +34,9 @@ type Config struct {
 
 	RateLimit   float64 `yaml:"rate-limit"`
 	RateBurst   int     `yaml:"rate-burst"`
-	CacheDir    string  `yaml:"cache-dir" default:"/mnt/ramdisk/tfshim-cache"`
+	CacheDir    string  `yaml:"cache-dir" default:"/mnt/ramdisk/private/tfshim-cache"`
 	Email       string  `yaml:"email" default:"tls@tinfoil.sh"`
-	HPKEKeyFile string  `yaml:"hpke-key-file" default:"/mnt/ramdisk/hpke_key.json"`
+	HPKEKeyFile string  `yaml:"hpke-key-file" default:"/mnt/ramdisk/private/hpke_key.json"`
 
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/creasty/defaults"
 	"gopkg.in/yaml.v3"
-
-	"tinfoil/internal/boot"
 )
 
 type Config struct {
@@ -34,11 +32,9 @@ type Config struct {
 	// Supports the same wildcard patterns as Paths (e.g. "/v1/*").
 	AuthenticatedEndpoints *[]string `yaml:"authenticated-endpoints"`
 
-	RateLimit   float64 `yaml:"rate-limit"`
-	RateBurst   int     `yaml:"rate-burst"`
-	CacheDir    string  `yaml:"cache-dir"`
-	Email       string  `yaml:"email" default:"tls@tinfoil.sh"`
-	HPKEKeyFile string  `yaml:"hpke-key-file"`
+	RateLimit float64 `yaml:"rate-limit"`
+	RateBurst int     `yaml:"rate-burst"`
+	Email     string  `yaml:"email" default:"tls@tinfoil.sh"`
 
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`
@@ -89,13 +85,6 @@ func Load(configFile, externalConfigFile string) (*Config, *ExternalConfig, erro
 	}
 	if err := yaml.Unmarshal(configBytes, &config); err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal config: %v", err)
-	}
-
-	if config.CacheDir == "" {
-		config.CacheDir = boot.CacheDir
-	}
-	if config.HPKEKeyFile == "" {
-		config.HPKEKeyFile = boot.HPKEKeyPath
 	}
 
 	if config.UpstreamPort == 0 {

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/creasty/defaults"
 	"gopkg.in/yaml.v3"
+
+	"tinfoil/internal/boot"
 )
 
 type Config struct {
@@ -34,9 +36,9 @@ type Config struct {
 
 	RateLimit   float64 `yaml:"rate-limit"`
 	RateBurst   int     `yaml:"rate-burst"`
-	CacheDir    string  `yaml:"cache-dir" default:"/mnt/ramdisk/private/tfshim-cache"`
+	CacheDir    string  `yaml:"cache-dir"`
 	Email       string  `yaml:"email" default:"tls@tinfoil.sh"`
-	HPKEKeyFile string  `yaml:"hpke-key-file" default:"/mnt/ramdisk/private/hpke_key.json"`
+	HPKEKeyFile string  `yaml:"hpke-key-file"`
 
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`
@@ -87,6 +89,13 @@ func Load(configFile, externalConfigFile string) (*Config, *ExternalConfig, erro
 	}
 	if err := yaml.Unmarshal(configBytes, &config); err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal config: %v", err)
+	}
+
+	if config.CacheDir == "" {
+		config.CacheDir = boot.CacheDir
+	}
+	if config.HPKEKeyFile == "" {
+		config.HPKEKeyFile = boot.HPKEKeyPath
 	}
 
 	if config.UpstreamPort == 0 {

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Config struct {
-	ListenPort   int `yaml:"listen-port" default:"443"`
 	UpstreamPort int `yaml:"upstream-port"`
 
 	Paths         []string `yaml:"paths"`

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -71,35 +71,55 @@ func (e *ExternalConfig) GetSecret(key string) string {
 	return v
 }
 
-// Load loads the config from the given files
-func Load(configFile, externalConfigFile string) (*Config, *ExternalConfig, error) {
+// Decode populates a Config from a yaml.Node (a parsed YAML subtree),
+// applies defaults, and validates. Used by boot, which has already parsed
+// the parent config and needs to type the `shim:` subsection.
+func Decode(n *yaml.Node) (*Config, error) {
 	var config Config
 	if err := defaults.Set(&config); err != nil {
-		return nil, nil, fmt.Errorf("failed to set defaults: %v", err)
+		return nil, fmt.Errorf("failed to set defaults: %v", err)
 	}
+	if err := n.Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to decode config: %v", err)
+	}
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
 
+func (c *Config) Validate() error {
+	if c.UpstreamPort == 0 {
+		return fmt.Errorf("upstream port is not set")
+	}
+	if !slices.Contains([]string{"self-signed", "acme", "cert-proxy"}, c.TLSMode) {
+		return fmt.Errorf("invalid TLS mode: %s (must be self-signed, acme, or cert-proxy)", c.TLSMode)
+	}
+	if !slices.Contains([]string{"production", "staging"}, c.TLSEnv) {
+		return fmt.Errorf("invalid TLS environment: %s (must be production or staging)", c.TLSEnv)
+	}
+	if !slices.Contains([]string{"tls", "dns", "http"}, c.TLSChallengeMode) {
+		return fmt.Errorf("invalid TLS challenge mode: %s (must be tls, dns, or http)", c.TLSChallengeMode)
+	}
+	if c.TLSWildcard && c.TLSChallengeMode != "dns" {
+		return fmt.Errorf("tls-wildcard requires tls-challenge: dns (wildcard certs cannot use %s challenge)", c.TLSChallengeMode)
+	}
+	return nil
+}
+
+// Load reads and parses both config files from disk.
+func Load(configFile, externalConfigFile string) (*Config, *ExternalConfig, error) {
 	configBytes, err := os.ReadFile(configFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read config file: %v", err)
 	}
-	if err := yaml.Unmarshal(configBytes, &config); err != nil {
+	var node yaml.Node
+	if err := yaml.Unmarshal(configBytes, &node); err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal config: %v", err)
 	}
-
-	if config.UpstreamPort == 0 {
-		return nil, nil, fmt.Errorf("upstream port is not set")
-	}
-	if !slices.Contains([]string{"self-signed", "acme", "cert-proxy"}, config.TLSMode) {
-		return nil, nil, fmt.Errorf("invalid TLS mode: %s (must be self-signed, acme, or cert-proxy)", config.TLSMode)
-	}
-	if !slices.Contains([]string{"production", "staging"}, config.TLSEnv) {
-		return nil, nil, fmt.Errorf("invalid TLS environment: %s (must be production or staging)", config.TLSEnv)
-	}
-	if !slices.Contains([]string{"tls", "dns", "http"}, config.TLSChallengeMode) {
-		return nil, nil, fmt.Errorf("invalid TLS challenge mode: %s (must be tls, dns, or http)", config.TLSChallengeMode)
-	}
-	if config.TLSWildcard && config.TLSChallengeMode != "dns" {
-		return nil, nil, fmt.Errorf("tls-wildcard requires tls-challenge: dns (wildcard certs cannot use %s challenge)", config.TLSChallengeMode)
+	config, err := Decode(&node)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	externalConfigBytes, err := os.ReadFile(externalConfigFile)
@@ -117,5 +137,5 @@ func Load(configFile, externalConfigFile string) (*Config, *ExternalConfig, erro
 	externalConfig.MetricsAPIKey = externalConfig.GetSecret(SecretMetricsAPIKey)
 	externalConfig.ACPIAPIKey = externalConfig.GetSecret(SecretACPIAPIKey)
 
-	return &config, &externalConfig, nil
+	return config, &externalConfig, nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens the ramdisk and auth paths, serves ACPI data from memory, and makes `boot/paths.go` the single source of truth for shim paths and ports. Moves runtime state under `/mnt/ramdisk/private`, tightens tmpfs options, and locks down HPKE handling.

- **Bug Fixes**
  - Mount `/mnt/ramdisk` with `mode=0755,nodev,nosuid` and `/tmp` with `mode=1777,nodev,nosuid`.
  - Move `docker` and `containerd` state to `/mnt/ramdisk/private/...`; set `DOCKER_CONFIG` to `/mnt/ramdisk/private/docker-config`.
  - Generate/load HPKE key at `boot.HPKEKeyPath` with mode `0600`; use constant-time bearer token checks.

- **Refactors**
  - Serve QEMU ACPI fw_cfg as an in-memory tar; remove `?force=1`.
  - Make `boot/paths.go` authoritative: drop `cache-dir`, `hpke-key-file`, and `listen-port` from config; use `boot.CacheDir`, `boot.HPKEKeyPath`, and `boot.ShimListenPort`.
  - Decode `shim:` from a `yaml.Node` with validation; remove `parseShimConfig`.
  - Install `tinfoil-boot`/`tinfoil-shim` to `/usr/bin`; simplify Makefile (write `tinfoilcvm.hash`, robust roothash parsing, drop run/measure); remove stale `config.yml`; pre-create `/mnt/ramdisk` in rootfs and drop redundant daemon mkdirs.

<sup>Written for commit 9d29bce5109d9e03ddd16357d8eaa1fd7b19f532. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

