### PR TITLE
fix: install tinfoil-boot and tinfoil-shim to /usr/bin in release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt-get install -y pipx ubuntu-keyring debian-archive-keyring make jq binutils
           sudo pipx install git+https://github.com/systemd/mkosi.git@54c625c380ef5500f17460981a3c67b109b6a847 #v25.3
           sudo pipx ensurepath
-          mkdir -p packages mkosi.extra/usr/local/bin
+          mkdir -p packages mkosi.extra/usr/bin
 
       - name: Setup Go
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5  # v6.2.0
@@ -56,11 +56,11 @@ jobs:
 
       - name: Build tinfoil binaries
         run: |
-          mkdir -p mkosi.extra/usr/local/bin
+          mkdir -p mkosi.extra/usr/bin
           cd tinfoil
-          go build -ldflags="-s -w" -o ../mkosi.extra/usr/local/bin/tinfoil-boot ./cmd/boot
-          go build -ldflags="-s -w" -o ../mkosi.extra/usr/local/bin/tinfoil-shim ./cmd/shim
-          sha256sum ../mkosi.extra/usr/local/bin/tinfoil-boot ../mkosi.extra/usr/local/bin/tinfoil-shim
+          go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-boot ./cmd/boot
+          go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-shim ./cmd/shim
+          sha256sum ../mkosi.extra/usr/bin/tinfoil-boot ../mkosi.extra/usr/bin/tinfoil-shim
 
       # TEMPORARY: drop once cuda-ubuntu2604 ships nvattest. The image
       # digest is also pinned in Makefile; rotate both together via


### PR DESCRIPTION
The released v0.8.0 image is unbootable: `tinfoil-boot.service` and `tinfoil-shim.service` exit with `203/EXEC` because their `ExecStart=/usr/bin/...` paths don't resolve in the published rootfs — the binaries are installed at `/usr/local/bin/` instead. The unit files and the Makefile were moved to `/usr/bin/` as part of #134, but the release workflow has its own copy of the build commands and still installs to `/usr/local/bin/`, so the published artifact ends up with mismatched paths. Local `make build` is unaffected because it uses the Makefile.

Updates the workflow's `mkdir`, `go build -o`, and `sha256sum` lines to use `mkosi.extra/usr/bin/`, matching the Makefile and the unit files. After this lands, a v0.8.x retag will produce a bootable image; tinfoild fetches by tag so consumers don't need any change.

---

The deeper cause is that the workflow duplicates the build commands from the Makefile, which is what allowed them to drift. The cleaner fix is to delete the duplicated steps and have the workflow call `make build` (with an `IMAGE_VERSION` plumbed through to mkosi) so there's a single source of truth. That requires teaching the Makefile to take an optional version and handling sudo/PATH propagation in CI; deferred to a follow-up to keep this change minimal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the release CI to install `tinfoil-boot` and `tinfoil-shim` into /usr/bin so the systemd units resolve and the published image boots. Updates the workflow to use mkosi.extra/usr/bin for mkdir, go build outputs, and sha256sum instead of mkosi.extra/usr/local/bin, matching the Makefile and unit files.

<sup>Written for commit db828e3f59e57f14f9e3d95ede36a5eb1c489b5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

