### PR TITLE
fix(tls): include certAuthToken in the mixed relay flow

### DIFF
--- a/tinfoil/internal/tls/certproxy.go
+++ b/tinfoil/internal/tls/certproxy.go
@@ -148,9 +148,11 @@ func (m *CertProxyManager) obtainWithHTTPRelay(csrPEM []byte) ([]byte, error) {
 	reqBody, err := json.Marshal(struct {
 		CSR         string   `json:"csr"`
 		HTTPDomains []string `json:"http_domains"`
+		Token       string   `json:"token,omitempty"`
 	}{
 		CSR:         string(csrPEM),
 		HTTPDomains: m.httpChallengeDomains,
+		Token:       m.certAuthToken,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
@@ -230,7 +232,11 @@ func (m *CertProxyManager) obtainWithHTTPRelay(csrPEM []byte) ([]byte, error) {
 
 	readyBody, err := json.Marshal(struct {
 		OrderID string `json:"order_id"`
-	}{OrderID: phase1.OrderID})
+		Token   string `json:"token,omitempty"`
+	}{
+		OrderID: phase1.OrderID,
+		Token:   m.certAuthToken,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal ready request: %w", err)
 	}


### PR DESCRIPTION
Previously, the token was only being included in the basic flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include the cert auth token in the mixed HTTP relay certificate flow to fix auth failures. The `token` is now sent in both the initial order request and the "ready" request in obtainWithHTTPRelay, matching the basic flow and allowing authenticated relays to succeed.

<sup>Written for commit 4d38a0329bea733b2cf8e7cbc4b78d98fb10f701. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

