### PR TITLE
fix: open http port for mixed HTTP challenge

### DIFF
--- a/tinfoil/cmd/boot/cert.go
+++ b/tinfoil/cmd/boot/cert.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/go-acme/lego/v4/lego"
@@ -99,7 +102,12 @@ func obtainCertificate(id *NodeIdentity, att *verifier.Document, shimCfg *shimco
 		var listenPort int
 		if shimCfg.TLSChallengeMode == "http" {
 			httpChallengeDomains = []string{id.Domain}
-			listenPort = boot.ShimListenPort
+			listenPort = boot.HTTPChallengePort
+			closeFW, err := openHTTP01Firewall(listenPort)
+			if err != nil {
+				return fmt.Errorf("opening HTTP-01 firewall: %w", err)
+			}
+			defer closeFW()
 		}
 		mgr, err := tlsutil.NewCertProxyManager(
 			domains, boot.CacheDir, shimCfg.ControlPlane, id.TLSKey,
@@ -171,4 +179,26 @@ func writeTLSArtifacts(cert *tls.Certificate, key *ecdsa.PrivateKey) error {
 
 	log.Println("TLS certificate and key written to ramdisk")
 	return nil
+}
+
+var nftHandleRE = regexp.MustCompile(`# handle (\d+)`)
+
+func openHTTP01Firewall(port int) (func(), error) {
+	// nft delete rule wants a handle, not a match expression.
+	args := []string{"--echo", "--handle", "add", "rule", "inet", "tinfoil", "input", "tcp", "dport", strconv.Itoa(port), "accept"}
+	out, err := exec.Command("nft", args...).CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("nft %v: %w (%s)", args, err, out)
+	}
+	m := nftHandleRE.FindSubmatch(out)
+	if m == nil {
+		return nil, fmt.Errorf("nft add rule returned no handle: %s", out)
+	}
+	handle := string(m[1])
+	return func() {
+		del := []string{"delete", "rule", "inet", "tinfoil", "input", "handle", handle}
+		if out, err := exec.Command("nft", del...).CombinedOutput(); err != nil {
+			log.Printf("warning: nft delete HTTP-01 rule (handle %s) failed: %v (%s)", handle, err, out)
+		}
+	}, nil
 }

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -26,4 +26,8 @@ const (
 
 	// ShimListenPort is the public TLS port served by tinfoil-shim.
 	ShimListenPort = 443
+
+	// HTTPChallengePort is the plaintext-HTTP port served by tinfoil-boot
+	// during cert-proxy + tls-challenge.
+	HTTPChallengePort = 80
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Opens port 80 during HTTP-01 challenges so cert-proxy can complete mixed HTTP validation. Adds a temporary `nft` firewall rule and cleans it up after issuance.

- **Bug Fixes**
  - Use `boot.HTTPChallengePort` (80) for HTTP challenges instead of `boot.ShimListenPort` (443).
  - Add `openHTTP01Firewall` to insert an `nft` rule with `--handle` and delete it by handle afterward.
  - Define `HTTPChallengePort` in `tinfoil/internal/boot/paths.go`.

<sup>Written for commit e2606505bf7f3df91c604ce88639679f49ecd7ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

