### PR TITLE
feat(security): harden kernel cap defaults for containers

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -64,7 +64,6 @@ type Container struct {
 	Volumes     []string    `yaml:"volumes,omitempty"` // "source:target[:opts]"
 	Devices     []string    `yaml:"devices,omitempty"`
 	CapAdd      []string    `yaml:"cap_add,omitempty"`
-	CapDrop     []string    `yaml:"cap_drop,omitempty"`
 	SecurityOpt []string    `yaml:"security_opt,omitempty"`
 	Runtime     string      `yaml:"runtime,omitempty"`      // e.g., "nvidia"
 	NetworkMode string      `yaml:"network_mode,omitempty"` // no longer honoured; flagged at parse time so legacy configs fail loud
@@ -73,11 +72,14 @@ type Container struct {
 	GPUs        interface{} `yaml:"gpus,omitempty"`         // "all", "0,1,2,3", or count (int)
 
 	// Resource limits
-	ShmSize  string            `yaml:"shm_size,omitempty"`  // "2g"
-	Memory   string            `yaml:"memory,omitempty"`    // "512m", "2g"
-	CPUs     float64           `yaml:"cpus,omitempty"`      // 0.5, 2.0
-	Tmpfs    map[string]string `yaml:"tmpfs,omitempty"`     // {"/tmp": "size=100m"}
-	ReadOnly bool              `yaml:"read_only,omitempty"` // read-only rootfs
+	ShmSize string            `yaml:"shm_size,omitempty"` // "2g"
+	Memory  string            `yaml:"memory,omitempty"`   // "512m", "2g"
+	CPUs    float64           `yaml:"cpus,omitempty"`     // 0.5, 2.0
+	Tmpfs   map[string]string `yaml:"tmpfs,omitempty"`    // {"/tmp": "size=100m"}
+	// ReadOnly and PidsLimit are pointers so we can tell "operator left it
+	// unset" (apply the hardened default) from "operator wrote false / 0".
+	ReadOnly  *bool  `yaml:"read_only,omitempty"`
+	PidsLimit *int64 `yaml:"pids_limit,omitempty"`
 
 	// Lifecycle
 	Restart     string       `yaml:"restart,omitempty"`      // "no", "always", "on-failure", "unless-stopped"

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -306,19 +307,30 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 		}
 	}
 
-	// Host configuration
+	// Security defaults per container-security-defaults.md.
+	secOpts := c.SecurityOpt
+	if !slices.Contains(secOpts, "no-new-privileges:true") {
+		secOpts = append(append([]string(nil), c.SecurityOpt...), "no-new-privileges:true")
+	}
+	pidsLimit := c.PidsLimit
+	if pidsLimit == nil {
+		n := int64(256)
+		pidsLimit = &n
+	}
+
 	hostConfig := &container.HostConfig{
 		NetworkMode:    container.NetworkMode(containernet.NetworkName),
 		Runtime:        c.Runtime,
 		IpcMode:        container.IpcMode(c.IPC),
 		PidMode:        container.PidMode(c.PidMode),
 		CapAdd:         c.CapAdd,
-		CapDrop:        c.CapDrop,
-		SecurityOpt:    c.SecurityOpt,
-		ReadonlyRootfs: c.ReadOnly,
+		CapDrop:        []string{"ALL"},
+		SecurityOpt:    secOpts,
+		ReadonlyRootfs: c.ReadOnly == nil || *c.ReadOnly,
 		Tmpfs:          c.Tmpfs,
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
 	}
+	hostConfig.Resources.PidsLimit = pidsLimit
 
 	// Restart policy
 	if c.Restart != "" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens container defaults for stronger isolation. We now drop all capabilities, enforce no-new-privileges, and default to a read‑only rootfs and a 256 PID limit unless explicitly overridden.

- **New Features**
  - Drop all capabilities by default (`CapDrop: ALL`); use `CapAdd` to opt in.
  - Add `no-new-privileges:true` if not already set in `security_opt`.
  - Default `read_only` to true when unset.
  - Default `pids_limit` to 256 when unset.

- **Migration**
  - Remove `cap_drop` from container configs; use `cap_add` for required caps.
  - Explicitly set `read_only: false` to opt out of the hardened default.
  - Set `pids_limit` to a custom value if 256 is not suitable.

<sup>Written for commit 297a46d4725778536d2d8ed5ef062c9f5da9148f. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/139?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

