### PR TITLE
Jules/networks

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -15,28 +15,49 @@ import (
 
 // Config represents the main configuration file
 type Config struct {
-	ShimRaw    yaml.Node          `yaml:"shim"`
-	ShimCfg    *shimconfig.Config `yaml:"-"`
-	Network    NetworkConfig      `yaml:"network"`
-	CPUs       int                `yaml:"cpus"`
-	Memory     int                `yaml:"memory"`
-	GPUs       int                `yaml:"gpus"`
-	Models     []ModelSpec        `yaml:"models"`
-	Containers []Container        `yaml:"containers"`
+	ShimRaw    yaml.Node               `yaml:"shim"`
+	ShimCfg    *shimconfig.Config      `yaml:"-"`
+	CVMNetwork CVMNetworkConfig        `yaml:"cvm-network"`
+	Networks   map[string]*NetworkSpec `yaml:"networks"`
+	CPUs       int                     `yaml:"cpus"`
+	Memory     int                     `yaml:"memory"`
+	GPUs       int                     `yaml:"gpus"`
+	Models     []ModelSpec             `yaml:"models"`
+	Containers []Container             `yaml:"containers"`
 }
 
-// NetworkConfig defines network-level firewall rules enforced via nftables.
-// The shim's listen-port is always allowed implicitly.
-type NetworkConfig struct {
-	AllowedInboundPorts []int `yaml:"allowed-inbound-ports"`
-	// TrustedDomains is an allowlist of hostnames containers may reach over the
-	// public internet. tinfoil-egress resolves each name to one or more IPs at
-	// boot and refreshes every 60s. Cannot be combined with TrustAllDomains.
-	TrustedDomains []string `yaml:"trusted-domains"`
-	// TrustAllDomains opts the enclave into unrestricted public Internet egress.
-	// RFC1918 / link-local destinations remain blocked; only public addresses
-	// are reachable. Cannot be combined with a non-empty TrustedDomains.
-	TrustAllDomains bool `yaml:"trust-all-domains"`
+// CVMNetworkConfig scopes host-firewall knobs that affect the CVM as a
+// whole, distinct from per-bridge `networks:`.
+type CVMNetworkConfig struct {
+	// InboundPorts is the TCP-port allowlist on the CVM's external
+	// interface beyond the shim's :443 (which is always open).
+	InboundPorts []int `yaml:"inbound-ports"`
+}
+
+// NetworkSpec is one entry in the top-level `networks:` map. Egress
+// defaults to "closed" via UnmarshalYAML so `name: {}` is a one-line
+// closed bridge.
+type NetworkSpec struct {
+	Egress string   `yaml:"egress"`
+	Allow  []string `yaml:"allow"`
+}
+
+func (n *NetworkSpec) UnmarshalYAML(node *yaml.Node) error {
+	// `name:` with a null scalar body decodes to a ScalarNode here.
+	if node.Kind == yaml.ScalarNode {
+		n.Egress = "closed"
+		return nil
+	}
+	type alias NetworkSpec
+	var raw alias
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	*n = NetworkSpec(raw)
+	if n.Egress == "" {
+		n.Egress = "closed"
+	}
+	return nil
 }
 
 // ModelSpec represents a model pack specification
@@ -65,11 +86,11 @@ type Container struct {
 	Devices     []string    `yaml:"devices,omitempty"`
 	CapAdd      []string    `yaml:"cap_add,omitempty"`
 	SecurityOpt []string    `yaml:"security_opt,omitempty"`
-	Runtime     string      `yaml:"runtime,omitempty"`      // e.g., "nvidia"
-	NetworkMode string      `yaml:"network_mode,omitempty"` // no longer honoured; flagged at parse time so legacy configs fail loud
-	IPC         string      `yaml:"ipc,omitempty"`          // e.g., "host"
-	PidMode     string      `yaml:"pid,omitempty"`          // "host" for host PID namespace
-	GPUs        interface{} `yaml:"gpus,omitempty"`         // "all", "0,1,2,3", or count (int)
+	Runtime     string      `yaml:"runtime,omitempty"`  // e.g., "nvidia"
+	Networks    []string    `yaml:"networks,omitempty"` // names of entries in top-level `networks:`
+	IPC         string      `yaml:"ipc,omitempty"`      // e.g., "host"
+	PidMode     string      `yaml:"pid,omitempty"`      // "host" for host PID namespace
+	GPUs        interface{} `yaml:"gpus,omitempty"`     // "all", "0,1,2,3", or count (int)
 
 	// Resource limits
 	ShmSize string            `yaml:"shm_size,omitempty"` // "2g"
@@ -193,20 +214,32 @@ func loadAndVerifyConfig() (*Config, error) {
 	return &config, nil
 }
 
-// writeEgressConfig persists just the trusted-domains list to the private
-// ramdisk so tinfoil-egress can load it once at startup. No-op when
-// trusted-domains is empty (the egress service isn't started in that case).
+// writeEgressConfig persists the per-allowlist-network FQDN map to the
+// private ramdisk so tinfoil-egress can load it once at startup. No-op
+// when no network has `egress: allowlist` (the daemon isn't started).
 func writeEgressConfig(cfg *Config) error {
-	if len(cfg.Network.TrustedDomains) == 0 {
+	out := egressFile{Networks: map[string]egressFileEntry{}}
+	for name, spec := range cfg.Networks {
+		if spec.Egress != "allowlist" {
+			continue
+		}
+		out.Networks[name] = egressFileEntry{Allow: spec.Allow}
+	}
+	if len(out.Networks) == 0 {
 		return nil
 	}
-	data, err := yaml.Marshal(struct {
-		TrustedDomains []string `yaml:"trusted-domains"`
-	}{TrustedDomains: cfg.Network.TrustedDomains})
+	data, err := yaml.Marshal(out)
 	if err != nil {
 		return fmt.Errorf("marshaling: %w", err)
 	}
 	return os.WriteFile(boot.EgressConfigPath, data, 0600)
+}
+
+type egressFile struct {
+	Networks map[string]egressFileEntry `yaml:"networks"`
+}
+type egressFileEntry struct {
+	Allow []string `yaml:"allow"`
 }
 
 // loadConfigFromRamdisk reads config directly from ramdisk without verification (for debugging)

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -28,21 +28,37 @@ import (
 const healthPollInterval = 5 * time.Second
 
 func setupContainerNetwork(cli *client.Client, cfg *Config) error {
-	_, err := cli.NetworkInspect(context.Background(), containernet.NetworkName, dockernetwork.InspectOptions{})
-	if cerrdefs.IsNotFound(err) {
-		_, err = cli.NetworkCreate(context.Background(), containernet.NetworkName, dockernetwork.CreateOptions{
-			Driver: "bridge",
-			Options: map[string]string{
-				"com.docker.network.bridge.name": containernet.BridgeName,
-			},
-		})
-		if err != nil {
-			return fmt.Errorf("creating docker network %q: %w", containernet.NetworkName, err)
+	for name := range cfg.Networks {
+		if err := ensureNetwork(cli, name); err != nil {
+			return err
 		}
-	} else if err != nil {
-		return fmt.Errorf("checking whether docker network %q exists: %w", containernet.NetworkName, err)
 	}
-	return setupContainerNetworkFirewall(cfg.Network.TrustedDomains, cfg.Network.TrustAllDomains)
+	if shimUpstreamSet(cfg) {
+		if err := ensureNetwork(cli, containernet.ShimNetName); err != nil {
+			return err
+		}
+	}
+	return setupContainerNetworkFirewall(cfg)
+}
+
+func ensureNetwork(cli *client.Client, name string) error {
+	_, err := cli.NetworkInspect(context.Background(), name, dockernetwork.InspectOptions{})
+	if err == nil {
+		return nil
+	}
+	if !cerrdefs.IsNotFound(err) {
+		return fmt.Errorf("checking whether docker network %q exists: %w", name, err)
+	}
+	_, err = cli.NetworkCreate(context.Background(), name, dockernetwork.CreateOptions{
+		Driver: "bridge",
+		Options: map[string]string{
+			"com.docker.network.bridge.name": name,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("creating docker network %q: %w", name, err)
+	}
+	return nil
 }
 
 // launchContainers starts all containers from the config
@@ -73,7 +89,7 @@ func launchContainers(config *Config) error {
 			errors = append(errors, fmt.Sprintf("%s: pulling image: %v", c.Name, err))
 			continue
 		}
-		if err := createAndStartContainer(cli, c, extConfig); err != nil {
+		if err := createAndStartContainer(cli, c, config, extConfig); err != nil {
 			log.Printf("Error starting container %s: %v", c.Name, err)
 			errors = append(errors, fmt.Sprintf("%s: %v", c.Name, err))
 		}
@@ -138,7 +154,7 @@ func launchContainersAndWaitHealthy(tracker *boot.Tracker, config *Config) error
 		wg.Add(1)
 		go func(i int, c Container) {
 			defer wg.Done()
-			errs[i] = runContainer(cli, c, extConfig, &substages, &mu, flush)
+			errs[i] = runContainer(cli, c, config, extConfig, &substages, &mu, flush)
 		}(i, c)
 	}
 	wg.Wait()
@@ -164,6 +180,7 @@ func launchContainersAndWaitHealthy(tracker *boot.Tracker, config *Config) error
 func runContainer(
 	cli *client.Client,
 	c Container,
+	cfg *Config,
 	extConfig *shimconfig.ExternalConfig,
 	substages *[]boot.Stage,
 	mu *sync.Mutex,
@@ -197,7 +214,7 @@ func runContainer(
 
 	// Create + start
 	startPhase := time.Now()
-	if err := createAndStartContainer(cli, c, extConfig); err != nil {
+	if err := createAndStartContainer(cli, c, cfg, extConfig); err != nil {
 		detail := fmt.Sprintf("starting: %v", err)
 		record("start", boot.StatusFailed, time.Since(startPhase), detail)
 		finish(boot.StatusFailed, detail)
@@ -275,8 +292,39 @@ func lastHealthLog(h *container.Health) string {
 	return fmt.Sprintf("exit %d", last.ExitCode)
 }
 
+// attachOrder returns the bridges to connect to a container. Docker needs
+// the first network at ContainerCreate time, so it's returned separately.
+// The egress-capable network (if any) goes first; shim-net is appended
+// last for the shim's upstream.
+func attachOrder(c Container, cfg *Config) (first string, rest []string) {
+	var egress string
+	var closed []string
+	for _, n := range c.Networks {
+		if cfg.Networks[n].Egress != "closed" {
+			egress = n
+			continue
+		}
+		closed = append(closed, n)
+	}
+	if egress != "" {
+		first = egress
+		rest = append(rest, closed...)
+	} else if len(closed) > 0 {
+		first = closed[0]
+		rest = append(rest, closed[1:]...)
+	}
+	if shimUpstreamSet(cfg) && c.Name == cfg.ShimCfg.UpstreamContainer {
+		if first == "" {
+			first = containernet.ShimNetName
+		} else {
+			rest = append(rest, containernet.ShimNetName)
+		}
+	}
+	return first, rest
+}
+
 // createAndStartContainer creates and starts a container (image must already be pulled).
-func createAndStartContainer(cli *client.Client, c Container, extConfig *shimconfig.ExternalConfig) error {
+func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig) error {
 	if c.Image == "" {
 		return fmt.Errorf("no image specified for container %s", c.Name)
 	}
@@ -318,8 +366,10 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 		pidsLimit = &n
 	}
 
+	first, rest := attachOrder(c, cfg)
+
+	// Host configuration
 	hostConfig := &container.HostConfig{
-		NetworkMode:    container.NetworkMode(containernet.NetworkName),
 		Runtime:        c.Runtime,
 		IpcMode:        container.IpcMode(c.IPC),
 		PidMode:        container.PidMode(c.PidMode),
@@ -331,6 +381,11 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
 	}
 	hostConfig.Resources.PidsLimit = pidsLimit
+	if first == "" {
+		hostConfig.NetworkMode = "none"
+	} else {
+		hostConfig.NetworkMode = container.NetworkMode(first)
+	}
 
 	// Restart policy
 	if c.Restart != "" {
@@ -371,15 +426,34 @@ func createAndStartContainer(cli *client.Client, c Container, extConfig *shimcon
 
 	log.Printf("Creating container %s", c.Name)
 
-	networkingConfig := &dockernetwork.NetworkingConfig{
-		EndpointsConfig: map[string]*dockernetwork.EndpointSettings{
-			containernet.NetworkName: {},
-		},
+	// Pin the egress-capable network's GwPriority so Docker installs the
+	// default route through it; equal priorities are non-deterministic.
+	gwPriority := func(name string) int {
+		if cfg.Networks[name] != nil && cfg.Networks[name].Egress != "closed" {
+			return 100
+		}
+		return 0
+	}
+
+	var networkingConfig *dockernetwork.NetworkingConfig
+	if first != "" {
+		networkingConfig = &dockernetwork.NetworkingConfig{
+			EndpointsConfig: map[string]*dockernetwork.EndpointSettings{
+				first: {GwPriority: gwPriority(first)},
+			},
+		}
 	}
 
 	resp, err := cli.ContainerCreate(context.Background(), containerConfig, hostConfig, networkingConfig, nil, c.Name)
 	if err != nil {
 		return fmt.Errorf("creating container: %w", err)
+	}
+
+	for _, n := range rest {
+		ep := &dockernetwork.EndpointSettings{GwPriority: gwPriority(n)}
+		if err := cli.NetworkConnect(context.Background(), n, resp.ID, ep); err != nil {
+			return fmt.Errorf("connecting container %s to %s: %w", c.Name, n, err)
+		}
 	}
 
 	if err := cli.ContainerStart(context.Background(), resp.ID, container.StartOptions{}); err != nil {

--- a/tinfoil/cmd/boot/firewall.go
+++ b/tinfoil/cmd/boot/firewall.go
@@ -5,87 +5,105 @@ import (
 	"log"
 	"math"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"tinfoil/internal/containernet"
 )
 
-// setupContainerNetworkFirewall adds forward rules for the container-net bridge.
-// Must be called after the bridge interface exists so iif/oif resolve by index.
-// trustedDomains and trustAllDomains are validated for exclusivity by the caller.
-func setupContainerNetworkFirewall(trustedDomains []string, trustAllDomains bool) error {
-	privateIPv4Ranges := "{ 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 127.0.0.0/8 }"
-	privateIPv6Ranges := "{ fc00::/7, fe80::/10, ff00::/8, ::ffff:0:0/96, 64:ff9b::/96, 100::/64, 2001:db8::/32, ::1/128 }"
+// Private destination ranges blocked even on `egress: open` networks.
+const (
+	privateIPv4Ranges = "{ 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 127.0.0.0/8 }"
+	privateIPv6Ranges = "{ fc00::/7, fe80::/10, ff00::/8, ::ffff:0:0/96, 64:ff9b::/96, 100::/64, 2001:db8::/32, ::1/128 }"
+)
+
+// setupContainerNetworkFirewall installs one bridge's worth of nftables
+// rules per declared network plus the implicit shim-net, in a single
+// transaction, then starts tinfoil-egress if any network needs it.
+// Must be called after the bridge interfaces exist so iif/oif resolve
+// by index.
+func setupContainerNetworkFirewall(cfg *Config) error {
+	names := make([]string, 0, len(cfg.Networks))
+	for k := range cfg.Networks {
+		names = append(names, k)
+	}
+	sort.Strings(names)
 
 	var script strings.Builder
-
-	// Allow container ↔ container traffic. Only fires when br_netfilter is
-	// loaded with bridge-nf-call-iptables=1, in which case bridged frames
-	// also traverse this L3 forward hook and would otherwise be dropped
-	// (both endpoints sit in the bridge's RFC1918 subnet).
-	fmt.Fprintf(&script, "add rule inet tinfoil forward iif %q oif %q accept\n",
-		containernet.BridgeName, containernet.BridgeName)
-
-	// Allow return traffic into containers for connections they initiated.
-	fmt.Fprintf(&script, "add rule inet tinfoil forward oif %q ct state established,related accept\n",
-		containernet.BridgeName)
-
-	// Block new connections from container-net to the host (the shim's :443,
-	// admin endpoints, etc.). Inserted first so it fires before the static
-	// `tcp dport 443 accept`. Scoped to `ct state new` so reply traffic on
-	// host→container connections (the shim's responses from the upstream)
-	// still matches the static `ct state established,related accept` rule.
-	fmt.Fprintf(&script, "insert rule inet tinfoil input iif %q ct state new drop\n",
-		containernet.BridgeName)
-
-	switch {
-	case trustAllDomains:
-		// One rule per address family: nft rejects multiple verdicts in a
-		// single rule (`accept` is terminal).
-		fmt.Fprintf(&script, "add rule inet tinfoil forward iif %q ip daddr != %s accept\n",
-			containernet.BridgeName, privateIPv4Ranges)
-		fmt.Fprintf(&script, "add rule inet tinfoil forward iif %q ip6 daddr != %s accept\n",
-			containernet.BridgeName, privateIPv6Ranges)
-
-	case len(trustedDomains) > 0:
-		fmt.Fprintf(&script, "add set inet tinfoil container-outgoing-allow { type ipv4_addr; }\n")
-		fmt.Fprintf(&script, "add rule inet tinfoil forward iif %q ip daddr %s drop\n",
-			containernet.BridgeName, privateIPv4Ranges)
-		fmt.Fprintf(&script, "add rule inet tinfoil forward iif %q ip6 daddr %s drop\n",
-			containernet.BridgeName, privateIPv6Ranges)
-		// Allow only trusted IPs; chain policy drops everything else.
-		fmt.Fprintf(&script, "add rule inet tinfoil forward iif %q ip daddr @container-outgoing-allow accept\n",
-			containernet.BridgeName)
+	for _, name := range names {
+		writeBridgeRules(&script, name, cfg.Networks[name])
 	}
-
+	if shimUpstreamSet(cfg) {
+		writeBridgeRules(&script, containernet.ShimNetName, &NetworkSpec{Egress: "closed"})
+	}
 	if err := runNft(script.String()); err != nil {
-		return fmt.Errorf("installing container-net firewall rules: %w", err)
+		return fmt.Errorf("installing container-network firewall rules: %w", err)
 	}
 
-	switch {
-	case trustAllDomains:
-		log.Println("Firewall: trust-all-domains active, unrestricted public egress permitted")
-	case len(trustedDomains) > 0:
-		// Start the service synchronously for the initial population. systemctl
-		// start blocks until the oneshot exits, so any resolution or nftables
-		// failure here surfaces as a boot error.
+	for _, name := range names {
+		log.Printf("Firewall: network %q egress=%s", name, cfg.Networks[name].Egress)
+	}
+	if shimUpstreamSet(cfg) {
+		log.Printf("Firewall: network %q egress=closed (implicit shim channel)", containernet.ShimNetName)
+	}
+
+	for _, spec := range cfg.Networks {
+		if spec.Egress != "allowlist" {
+			continue
+		}
+		// Type=notify; `systemctl start` blocks until the daemon resolves
+		// the first set of IPs and signals READY=1, so failures here
+		// surface as a boot error.
 		log.Println("Firewall: starting tinfoil-egress for initial IP population")
-		if out, err := exec.Command("systemctl", "start",
-			"tinfoil-egress.service").CombinedOutput(); err != nil {
+		if out, err := exec.Command("systemctl", "start", "tinfoil-egress.service").CombinedOutput(); err != nil {
 			return fmt.Errorf("tinfoil-egress.service failed on initial run: %w (%s)", err, out)
 		}
-		log.Println("Firewall: trusted-domains mode active, IP allowlist populated")
-	default:
-		log.Println("Firewall: deny-by-default active, no public egress permitted")
+		break
 	}
-
 	return nil
+}
+
+func writeBridgeRules(script *strings.Builder, bridge string, spec *NetworkSpec) {
+	// Allow container ↔ container traffic. Only fires when br_netfilter is
+	// loaded with bridge-nf-call-iptables=1, in which case bridged frames
+	// also traverse this L3 forward hook and would otherwise be dropped.
+	fmt.Fprintf(script, "add rule inet tinfoil forward iif %q oif %q accept\n", bridge, bridge)
+
+	// Allow return traffic into containers for connections they initiated.
+	fmt.Fprintf(script, "add rule inet tinfoil forward oif %q ct state established,related accept\n", bridge)
+
+	// Block new connections from the bridge to the host. Scoped to
+	// `ct state new` so reply traffic on host→container connections
+	// (e.g. the shim's responses) still matches the static
+	// `ct state established,related accept` rule.
+	fmt.Fprintf(script, "insert rule inet tinfoil input iif %q ct state new drop\n", bridge)
+
+	switch spec.Egress {
+	case "open":
+		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip daddr != %s accept\n",
+			bridge, privateIPv4Ranges)
+		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip6 daddr != %s accept\n",
+			bridge, privateIPv6Ranges)
+	case "allowlist":
+		setName := containernet.AllowSetPrefix + bridge
+		fmt.Fprintf(script, "add set inet tinfoil %s { type ipv4_addr; }\n", setName)
+		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip daddr %s drop\n",
+			bridge, privateIPv4Ranges)
+		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip6 daddr %s drop\n",
+			bridge, privateIPv6Ranges)
+		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip daddr @%s accept\n",
+			bridge, setName)
+	}
+}
+
+func shimUpstreamSet(cfg *Config) bool {
+	return cfg.ShimCfg != nil && cfg.ShimCfg.UpstreamContainer != ""
 }
 
 // setupFirewall opens additional inbound ports beyond the shim's listen-port
 // (which is already allowed by the static nftables.conf baked into the image).
 func setupFirewall(config *Config) error {
-	ports := config.Network.AllowedInboundPorts
+	ports := config.CVMNetwork.InboundPorts
 	if len(ports) == 0 {
 		log.Println("No additional inbound ports to open")
 		return nil

--- a/tinfoil/cmd/boot/firewall_test.go
+++ b/tinfoil/cmd/boot/firewall_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+)
+
+// renderFirewallScript returns the nft script setupContainerNetworkFirewall
+// would commit, minus the runNft call.
+func renderFirewallScript(cfg *Config) string {
+	var s strings.Builder
+	for name, spec := range cfg.Networks {
+		writeBridgeRules(&s, name, spec)
+	}
+	if shimUpstreamSet(cfg) {
+		writeBridgeRules(&s, "shim-net", &NetworkSpec{Egress: "closed"})
+	}
+	return s.String()
+}
+
+func TestFirewall_ClosedBridgeHasNoEgressRule(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"ipc-exec": {Egress: "closed"},
+	}}
+	script := renderFirewallScript(cfg)
+	if !strings.Contains(script, `iif "ipc-exec" oif "ipc-exec" accept`) {
+		t.Error("closed bridge should still allow intra-bridge traffic")
+	}
+	if !strings.Contains(script, `oif "ipc-exec" ct state established`) {
+		t.Error("closed bridge should still allow return traffic")
+	}
+	if !strings.Contains(script, `input iif "ipc-exec" ct state new drop`) {
+		t.Error("closed bridge should block container→host")
+	}
+	if strings.Contains(script, "ip daddr") {
+		t.Errorf("closed bridge must not emit egress rules; got:\n%s", script)
+	}
+}
+
+func TestFirewall_OpenBridgeEmitsPublicAccept(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"web": {Egress: "open"},
+	}}
+	script := renderFirewallScript(cfg)
+	if !strings.Contains(script, `iif "web" ip daddr != { 10.0.0.0/8`) {
+		t.Errorf("open bridge should accept public v4; got:\n%s", script)
+	}
+	if !strings.Contains(script, `iif "web" ip6 daddr != {`) {
+		t.Error("open bridge should accept public v6")
+	}
+}
+
+func TestFirewall_AllowlistEmitsSetAndAcceptRule(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
+	}}
+	script := renderFirewallScript(cfg)
+	if !strings.Contains(script, `add set inet tinfoil allow-control`) {
+		t.Errorf("allowlist must declare its set; got:\n%s", script)
+	}
+	if !strings.Contains(script, `iif "control" ip daddr @allow-control accept`) {
+		t.Errorf("allowlist must reference its set; got:\n%s", script)
+	}
+	if !strings.Contains(script, `iif "control" ip daddr {`) {
+		t.Error("allowlist must drop private destinations")
+	}
+}
+
+func TestFirewall_ShimNetAlwaysClosed(t *testing.T) {
+	cfg := &Config{
+		ShimCfg: &shimconfig.Config{UpstreamContainer: "x"},
+		Networks: map[string]*NetworkSpec{
+			"web": {Egress: "open"},
+		},
+	}
+	script := renderFirewallScript(cfg)
+	if !strings.Contains(script, `iif "shim-net" oif "shim-net" accept`) {
+		t.Errorf("shim-net should emit intra-bridge accept; got:\n%s", script)
+	}
+	if strings.Contains(script, `iif "shim-net" ip daddr !`) {
+		t.Error("shim-net must not get an egress-open rule")
+	}
+}
+
+func TestAttachOrder_EgressFirstThenClosedThenShim(t *testing.T) {
+	cfg := &Config{
+		ShimCfg: &shimconfig.Config{UpstreamContainer: "api"},
+		Networks: map[string]*NetworkSpec{
+			"control":  {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
+			"ipc-exec": {Egress: "closed"},
+			"ipc-a":    {Egress: "closed"},
+		},
+	}
+	c := Container{Name: "api", Networks: []string{"ipc-exec", "control", "ipc-a"}}
+	first, rest := attachOrder(c, cfg)
+	if first != "control" {
+		t.Errorf("egress network should be first, got %q", first)
+	}
+	// shim-net must come last
+	if len(rest) == 0 || rest[len(rest)-1] != "shim-net" {
+		t.Errorf("shim-net should be last, got rest=%v", rest)
+	}
+}
+
+func TestAttachOrder_NoNetworksNonShim(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{}}
+	c := Container{Name: "lonely"}
+	first, rest := attachOrder(c, cfg)
+	if first != "" || len(rest) != 0 {
+		t.Errorf("unattached non-shim container should get nothing, got %q %v", first, rest)
+	}
+}
+
+func TestAttachOrder_NoNetworksShimUpstreamGetsShimNet(t *testing.T) {
+	cfg := &Config{
+		ShimCfg:  &shimconfig.Config{UpstreamContainer: "upstream"},
+		Networks: map[string]*NetworkSpec{},
+	}
+	c := Container{Name: "upstream"}
+	first, rest := attachOrder(c, cfg)
+	if first != "shim-net" {
+		t.Errorf("upstream-with-no-networks should attach to shim-net, got %q", first)
+	}
+	if len(rest) != 0 {
+		t.Errorf("expected no additional networks, got %v", rest)
+	}
+}

--- a/tinfoil/cmd/boot/network_validate.go
+++ b/tinfoil/cmd/boot/network_validate.go
@@ -4,37 +4,66 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"slices"
 	"strings"
+
+	"tinfoil/internal/containernet"
 )
 
 var rfc1123HostnamePattern = regexp.MustCompile(
 	`^(?i)([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`,
 )
-const maxHostnameLength = 253
+
+const (
+	maxHostnameLength = 253
+	maxBridgeNameLen = 15
+)
+
+var validEgressModes = []string{"closed", "allowlist", "open"}
+
+var networkNamePattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 func validateNetwork(cfg *Config) error {
-	for i, c := range cfg.Containers {
-		if c.NetworkMode != "" {
-			return fmt.Errorf(
-				"containers[%d] %q: network_mode is removed in v0.9.0; "+
-					"see network.trusted-domains and network.trust-all-domains "+
-					"for the supported egress controls",
-				i, c.Name,
-			)
+	for _, port := range cfg.CVMNetwork.InboundPorts {
+		if port < 1 || port > 65535 {
+			return fmt.Errorf("cvm-network.inbound-ports: %d is not in 1..65535", port)
 		}
 	}
 
-	n := cfg.Network
-	if n.TrustAllDomains && len(n.TrustedDomains) > 0 {
-		return fmt.Errorf(
-			"network.trust-all-domains: true and a non-empty network.trusted-domains " +
-				"are mutually exclusive; pick one",
-		)
+	// Materialize nil entries (from `name:` with no body) as default-closed.
+	for name, spec := range cfg.Networks {
+		if spec == nil {
+			cfg.Networks[name] = &NetworkSpec{Egress: "closed"}
+		}
 	}
 
-	for i, host := range n.TrustedDomains {
-		if err := validateTrustedDomain(host); err != nil {
-			return fmt.Errorf("network.trusted-domains[%d] %q: %w", i, host, err)
+	for name, spec := range cfg.Networks {
+		if err := validateNetworkEntry(name, spec); err != nil {
+			return fmt.Errorf("networks.%s: %w", name, err)
+		}
+	}
+
+	for i, c := range cfg.Containers {
+		seen := map[string]bool{}
+		egressCount := 0
+		for _, n := range c.Networks {
+			if seen[n] {
+				return fmt.Errorf("containers[%d] %q: network %q listed twice", i, c.Name, n)
+			}
+			seen[n] = true
+			if n == containernet.ShimNetName {
+				return fmt.Errorf("containers[%d] %q: %q is reserved", i, c.Name, containernet.ShimNetName)
+			}
+			spec, ok := cfg.Networks[n]
+			if !ok {
+				return fmt.Errorf("containers[%d] %q: network %q not declared", i, c.Name, n)
+			}
+			if spec.Egress != "closed" {
+				egressCount++
+			}
+		}
+		if egressCount > 1 {
+			return fmt.Errorf("containers[%d] %q: at most one attached network may have egress != closed", i, c.Name)
 		}
 	}
 
@@ -47,29 +76,48 @@ func validateNetwork(cfg *Config) error {
 			}
 		}
 		if !found {
-			return fmt.Errorf(
-				"shim.upstream-container %q does not match any containers[].name",
-				cfg.ShimCfg.UpstreamContainer,
-			)
+			return fmt.Errorf("shim.upstream-container %q does not match any containers[].name", cfg.ShimCfg.UpstreamContainer)
 		}
 	}
 	return nil
 }
 
-func validateTrustedDomain(host string) error {
+func validateNetworkEntry(name string, spec *NetworkSpec) error {
+	if name == "" {
+		return fmt.Errorf("empty network name")
+	}
+	if name == containernet.ShimNetName {
+		return fmt.Errorf("name %q is reserved", containernet.ShimNetName)
+	}
+	if len(name) > maxBridgeNameLen {
+		return fmt.Errorf("name exceeds %d-char interface-name limit", maxBridgeNameLen)
+	}
+	if !networkNamePattern.MatchString(name) {
+		return fmt.Errorf("name must be lowercase alphanumeric + hyphens (got %q)", name)
+	}
+	if !slices.Contains(validEgressModes, spec.Egress) {
+		return fmt.Errorf("egress: %q is not one of closed | allowlist | open", spec.Egress)
+	}
+	if spec.Egress != "allowlist" && len(spec.Allow) > 0 {
+		return fmt.Errorf("allow: only valid when egress: allowlist (got egress: %s)", spec.Egress)
+	}
+	for i, host := range spec.Allow {
+		if err := validateAllowEntry(host); err != nil {
+			return fmt.Errorf("allow[%d] %q: %w", i, host, err)
+		}
+	}
+	return nil
+}
+
+func validateAllowEntry(host string) error {
 	if host == "" {
 		return fmt.Errorf("empty entry")
 	}
-	if host == "*" {
-		return fmt.Errorf(`bare "*" is not a hostname; use network.trust-all-domains: true`)
-	}
 	if strings.Contains(host, "*") {
-		// Accept wildcard syntax so v0.9.0 configs forward-port; reject until
-		// the in-enclave resolver that resolves them ships.
-		return fmt.Errorf("wildcard hostnames are not yet supported; enumerate hosts explicitly")
+		return fmt.Errorf("wildcards are reserved for future tinfoil-dns support")
 	}
 	if ip := net.ParseIP(host); ip != nil {
-		return fmt.Errorf("IP literals are not allowed; use a hostname so tinfoil-egress can refresh it")
+		return fmt.Errorf("IP literals are not allowed; use a hostname")
 	}
 	if len(host) > maxHostnameLength {
 		return fmt.Errorf("hostname exceeds %d-byte DNS limit", maxHostnameLength)

--- a/tinfoil/cmd/boot/network_validate_test.go
+++ b/tinfoil/cmd/boot/network_validate_test.go
@@ -4,128 +4,222 @@ import (
 	"strings"
 	"testing"
 
+	"gopkg.in/yaml.v3"
+
 	shimconfig "tinfoil/internal/config"
 )
 
-func TestValidateNetwork(t *testing.T) {
-	tests := []struct {
-		name       string
-		cfg        Config
-		wantErr    bool
-		wantErrSub string
-	}{
-		{
-			name: "empty network → deny posture is legal",
-			cfg:  Config{},
-		},
-		{
-			name: "trusted-domains only",
-			cfg: Config{Network: NetworkConfig{
-				TrustedDomains: []string{"api.exa.ai", "api.tinfoil.sh"},
-			}},
-		},
-		{
-			name: "trust-all-domains only",
-			cfg: Config{Network: NetworkConfig{
-				TrustAllDomains: true,
-			}},
-		},
-		{
-			name: "trust-all-domains: false treated as absent",
-			cfg: Config{Network: NetworkConfig{
-				TrustedDomains:  []string{"api.exa.ai"},
-				TrustAllDomains: false,
-			}},
-		},
-		{
-			name: "trust-all-domains: true plus a non-empty allowlist → reject",
-			cfg: Config{Network: NetworkConfig{
-				TrustedDomains:  []string{"api.exa.ai"},
-				TrustAllDomains: true,
-			}},
-			wantErr:    true,
-			wantErrSub: "mutually exclusive",
-		},
-		{
-			name: `trusted-domains: ["*"] → reject with pointer to the boolean`,
-			cfg: Config{Network: NetworkConfig{
-				TrustedDomains: []string{"*"},
-			}},
-			wantErr:    true,
-			wantErrSub: "trust-all-domains: true",
-		},
-		{
-			name: `wildcard subdomain → reject as not yet supported`,
-			cfg: Config{Network: NetworkConfig{
-				TrustedDomains: []string{"*.model.tinfoil.sh"},
-			}},
-			wantErr:    true,
-			wantErrSub: "not yet supported",
-		},
-		{
-			name: "IP literal → reject",
-			cfg: Config{Network: NetworkConfig{
-				TrustedDomains: []string{"1.2.3.4"},
-			}},
-			wantErr:    true,
-			wantErrSub: "IP literals",
-		},
-		{
-			name: "overlong hostname (>253 bytes) → reject",
-			cfg: Config{Network: NetworkConfig{
-				// 5 × 63-char labels joined by dots is 319 chars, comfortably
-				// over the 253-byte DNS cap while keeping each label legal.
-				TrustedDomains: []string{
-					strings.Repeat("a", 63) + "." +
-						strings.Repeat("b", 63) + "." +
-						strings.Repeat("c", 63) + "." +
-						strings.Repeat("d", 63) + "." +
-						strings.Repeat("e", 63),
-				},
-			}},
-			wantErr:    true,
-			wantErrSub: "253-byte DNS limit",
-		},
-		{
-			name: "container.network_mode → reject with migration pointer",
-			cfg: Config{Containers: []Container{
-				{Name: "doc-upload", NetworkMode: "host"},
-			}},
-			wantErr:    true,
-			wantErrSub: "network_mode is removed",
-		},
-		{
-			name: "shim.upstream-container matches a container → accept",
-			cfg: Config{
-				ShimCfg:    &shimconfig.Config{UpstreamContainer: "router"},
-				Containers: []Container{{Name: "router"}, {Name: "worker"}},
-			},
-		},
-		{
-			name: "shim.upstream-container with no matching container → reject",
-			cfg: Config{
-				ShimCfg:    &shimconfig.Config{UpstreamContainer: "ghost"},
-				Containers: []Container{{Name: "router"}},
-			},
-			wantErr:    true,
-			wantErrSub: "does not match any containers",
-		},
+// parseTestConfig mirrors loadAndVerifyConfig: unmarshal, decode shim,
+// run validateNetwork. Uses raw YAML so tests exercise NetworkSpec's
+// UnmarshalYAML default-egress behavior.
+func parseTestConfig(t *testing.T, src string) (*Config, error) {
+	t.Helper()
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(src), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateNetwork(&tt.cfg)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error containing %q, got nil", tt.wantErrSub)
-				}
-				if !strings.Contains(err.Error(), tt.wantErrSub) {
-					t.Fatalf("error mismatch: got %q, want substring %q", err, tt.wantErrSub)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+	if cfg.ShimRaw.Kind != 0 {
+		s, err := shimconfig.Decode(&cfg.ShimRaw)
+		if err == nil {
+			cfg.ShimCfg = s
+		}
+	}
+	return &cfg, validateNetwork(&cfg)
+}
+
+func mustReject(t *testing.T, src, errSub string) {
+	t.Helper()
+	_, err := parseTestConfig(t, src)
+	if err == nil {
+		t.Fatalf("expected error containing %q, got nil", errSub)
+	}
+	if !strings.Contains(err.Error(), errSub) {
+		t.Fatalf("error %q should contain %q", err, errSub)
+	}
+}
+
+func TestValidateNetwork_ReservedShimNet(t *testing.T) {
+	mustReject(t, `
+shim: {upstream-port: 8080}
+networks: {shim-net: {}}
+containers: [{name: app, image: nginx}]
+`, "reserved")
+}
+
+func TestValidateNetwork_ContainerReferencesShimNet(t *testing.T) {
+	mustReject(t, `
+shim: {upstream-port: 8080}
+networks: {control: {egress: closed}}
+containers: [{name: app, image: nginx, networks: [control, shim-net]}]
+`, "reserved")
+}
+
+func TestValidateNetwork_EgressDefaultsToClosed(t *testing.T) {
+	src := `
+shim: {upstream-port: 8080}
+networks: {ipc-exec: {}}
+containers: [{name: app, image: nginx, networks: [ipc-exec]}]
+`
+	cfg, err := parseTestConfig(t, src)
+	if err != nil {
+		t.Fatalf("expected accept, got: %v", err)
+	}
+	if cfg.Networks["ipc-exec"].Egress != "closed" {
+		t.Fatalf("expected egress: closed default, got %+v", cfg.Networks["ipc-exec"])
+	}
+}
+
+func TestValidateNetwork_EgressDefaultsOnNullBody(t *testing.T) {
+	src := `
+shim: {upstream-port: 8080}
+networks:
+  ipc-exec:
+containers: [{name: app, image: nginx, networks: [ipc-exec]}]
+`
+	cfg, err := parseTestConfig(t, src)
+	if err != nil {
+		t.Fatalf("expected accept, got: %v", err)
+	}
+	if cfg.Networks["ipc-exec"].Egress != "closed" {
+		t.Fatalf("expected egress: closed default on null body, got %+v", cfg.Networks["ipc-exec"])
+	}
+}
+
+func TestValidateNetwork_InvalidEgressValue(t *testing.T) {
+	mustReject(t, `
+shim: {upstream-port: 8080}
+networks: {weird: {egress: maybe}}
+containers: [{name: app, image: nginx, networks: [weird]}]
+`, "egress")
+}
+
+func TestValidateNetwork_AllowOnlyForAllowlist(t *testing.T) {
+	mustReject(t, `
+shim: {upstream-port: 8080}
+networks: {control: {egress: open, allow: [api.tinfoil.sh]}}
+containers: [{name: app, image: nginx, networks: [control]}]
+`, "egress: allowlist")
+}
+
+func TestValidateNetwork_AllowHostnamesValidated(t *testing.T) {
+	cases := []struct{ name, host, errSub string }{
+		{"wildcard", "*.tinfoil.sh", "wildcards"},
+		{"ip literal", "1.2.3.4", "IP literals"},
+		{"empty", "", "empty"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			mustReject(t, `
+shim: {upstream-port: 8080}
+networks:
+  control:
+    egress: allowlist
+    allow: ["`+c.host+`"]
+containers: [{name: app, image: nginx, networks: [control]}]
+`, c.errSub)
 		})
+	}
+}
+
+func TestValidateNetwork_ContainerRefsUnknownNetwork(t *testing.T) {
+	mustReject(t, `
+shim: {upstream-port: 8080}
+networks: {control: {egress: allowlist, allow: [api.tinfoil.sh]}}
+containers: [{name: app, image: nginx, networks: [control, mystery]}]
+`, "mystery")
+}
+
+func TestValidateNetwork_SingleEgressClassEnforced(t *testing.T) {
+	mustReject(t, `
+shim: {upstream-port: 8080}
+networks:
+  control: {egress: allowlist, allow: [api.tinfoil.sh]}
+  web: {egress: open}
+containers: [{name: app, image: nginx, networks: [control, web]}]
+`, "at most one")
+}
+
+func TestValidateNetwork_OneEgressPlusMultipleClosedIsFine(t *testing.T) {
+	_, err := parseTestConfig(t, `
+shim: {upstream-port: 8080}
+networks:
+  control: {egress: allowlist, allow: [api.tinfoil.sh]}
+  ipc-a: {}
+  ipc-b: {}
+containers: [{name: app, image: nginx, networks: [control, ipc-a, ipc-b]}]
+`)
+	if err != nil {
+		t.Fatalf("expected accept, got: %v", err)
+	}
+}
+
+func TestValidateNetwork_InboundPortsRange(t *testing.T) {
+	cases := []struct {
+		port int
+		ok   bool
+	}{
+		{1, true}, {65535, true},
+		{0, false}, {-1, false}, {70000, false},
+	}
+	for _, c := range cases {
+		cfg := Config{CVMNetwork: CVMNetworkConfig{InboundPorts: []int{c.port}}}
+		err := validateNetwork(&cfg)
+		if c.ok != (err == nil) {
+			t.Errorf("port %d: ok=%v err=%v", c.port, c.ok, err)
+		}
+	}
+}
+
+func TestValidateNetwork_ShimUpstreamMustMatch(t *testing.T) {
+	cfg := Config{
+		ShimCfg: &shimconfig.Config{
+			UpstreamPort:      8080,
+			UpstreamContainer: "ghost",
+			TLSMode:           "self-signed",
+			TLSEnv:            "production",
+			TLSChallengeMode:  "dns",
+		},
+		Containers: []Container{{Name: "real", Image: "nginx"}},
+	}
+	if err := validateNetwork(&cfg); err == nil {
+		t.Fatal("expected error for non-existent upstream")
+	}
+}
+
+func TestValidateNetwork_NetworkNameLength(t *testing.T) {
+	tooLong := strings.Repeat("a", 16)
+	mustReject(t, `
+shim: {upstream-port: 8080}
+networks:
+  `+tooLong+`: {}
+containers: [{name: app, image: nginx, networks: ["`+tooLong+`"]}]
+`, "interface-name")
+}
+
+func TestValidateAllowEntry_LongHostnames(t *testing.T) {
+	long := strings.Repeat("a.", 130) + "x" // 261 chars
+	if err := validateAllowEntry(long); err == nil || !strings.Contains(err.Error(), "253-byte") {
+		t.Fatalf("expected 253-byte error, got: %v", err)
+	}
+	if err := validateAllowEntry("api.tinfoil.sh"); err != nil {
+		t.Fatalf("expected accept, got: %v", err)
+	}
+}
+
+func TestValidateNetwork_AcceptsFullExample(t *testing.T) {
+	_, err := parseTestConfig(t, `
+shim: {upstream-port: 8080}
+cvm-network: {inbound-ports: [9090]}
+networks:
+  control: {egress: allowlist, allow: [api.tinfoil.sh, buckets.tinfoil.sh]}
+  web: {egress: open}
+  ipc-exec: {}
+containers:
+  - {name: api-server, image: nginx, networks: [control, ipc-exec]}
+  - {name: executor,   image: nginx, networks: [web, ipc-exec]}
+  - {name: lonely,     image: nginx}
+`)
+	if err != nil {
+		t.Fatalf("expected full §3.1 example to validate, got: %v", err)
 	}
 }

--- a/tinfoil/cmd/egress/main.go
+++ b/tinfoil/cmd/egress/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"tinfoil/internal/boot"
+	"tinfoil/internal/containernet"
 
 	"gopkg.in/yaml.v3"
 )
@@ -24,7 +25,11 @@ func init() {
 }
 
 type egressConfig struct {
-	TrustedDomains []string `yaml:"trusted-domains"`
+	Networks map[string]egressNetwork `yaml:"networks"`
+}
+
+type egressNetwork struct {
+	Allow []string `yaml:"allow"`
 }
 
 func main() {
@@ -35,27 +40,24 @@ func main() {
 }
 
 func run() error {
-	domains, err := loadDomains()
+	cfg, err := loadConfig()
 	if err != nil {
 		return err
 	}
-	if len(domains) == 0 {
-		log.Println("no trusted domains configured, exiting")
+	if len(cfg.Networks) == 0 {
+		log.Println("no allowlist networks configured, exiting")
 		return nil
 	}
 
-	prev := readState()
+	state := readState()
 
 	// Initial population must succeed before notifying systemd; tinfoil-boot
 	// blocks on `systemctl start` until READY=1 so any failure here surfaces
 	// as a boot error.
-	next, err := refresh(domains, prev)
-	if err != nil {
+	if err := refresh(cfg, state); err != nil {
 		return fmt.Errorf("initial population: %w", err)
 	}
-	prev = next
 	notifyReady()
-	log.Printf("initial population: %d IP(s) resolved", len(prev))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
@@ -69,17 +71,14 @@ func run() error {
 			log.Println("shutting down")
 			return nil
 		case <-ticker.C:
-			next, err := refresh(domains, prev)
-			if err != nil {
+			if err := refresh(cfg, state); err != nil {
 				log.Printf("refresh failed: %v", err)
-				continue
 			}
-			prev = next
 		}
 	}
 }
 
-func loadDomains() ([]string, error) {
+func loadConfig() (*egressConfig, error) {
 	data, err := os.ReadFile(boot.EgressConfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("reading egress config: %w", err)
@@ -88,51 +87,53 @@ func loadDomains() ([]string, error) {
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing egress config: %w", err)
 	}
-	return cfg.TrustedDomains, nil
+	return &cfg, nil
 }
 
-func refresh(domains, prev []string) ([]string, error) {
-	current, err := resolve(domains)
-	if err != nil {
-		return nil, err
-	}
+// refresh resolves each allowlist network's FQDNs and commits the
+// per-set delta in one nft transaction. state is mutated in place.
+func refresh(cfg *egressConfig, state map[string][]string) error {
+	for name, net := range cfg.Networks {
+		current, err := resolve(net.Allow)
+		if err != nil {
+			return fmt.Errorf("network %q: %w", name, err)
+		}
+		setName := containernet.AllowSetPrefix + name
 
-	// Defensive: ensure the set exists. Normally created by tinfoil-boot.
-	exec.Command("nft", "add", "set", "inet", "tinfoil", "container-outgoing-allow",
-		"{ type ipv4_addr; }").Run()
+		// Defensive: ensure the set exists. Normally created by tinfoil-boot.
+		exec.Command("nft", "add", "set", "inet", "tinfoil", setName,
+			"{ type ipv4_addr; }").Run()
 
-	// Flushing and reloading could lead to a race condition where new outgoing
-	// connections that should be allowed are not, so instead we calculate the
-	// IPs to add and the set of IPs to remove from the set.
-	toAdd := difference(current, prev)
-	toRemove := difference(prev, current)
+		// Flushing and reloading could lead to a race condition where new outgoing
+		// connections that should be allowed are not, so instead we calculate the
+		// IPs to add and the set of IPs to remove from the set.
+		prev := state[name]
+		toAdd := difference(current, prev)
+		toRemove := difference(prev, current)
+		state[name] = current
+		if len(toAdd) == 0 && len(toRemove) == 0 {
+			continue
+		}
 
-	if len(toAdd) == 0 && len(toRemove) == 0 {
-		return current, nil
-	}
+		// Commit add+remove in one transaction so the set never appears with only
+		// one half of the delta applied.
+		var script strings.Builder
+		if len(toAdd) > 0 {
+			fmt.Fprintf(&script, "add element inet tinfoil %s { %s }\n",
+				setName, strings.Join(toAdd, ", "))
+		}
+		if len(toRemove) > 0 {
+			fmt.Fprintf(&script, "delete element inet tinfoil %s { %s }\n",
+				setName, strings.Join(toRemove, ", "))
+		}
 
-	// Commit add+remove in one transaction so the set never appears with only
-	// one half of the delta applied.
-	var script strings.Builder
-	if len(toAdd) > 0 {
-		fmt.Fprintf(&script, "add element inet tinfoil container-outgoing-allow { %s }\n",
-			strings.Join(toAdd, ", "))
+		cmd := exec.Command("nft", "-f", "-")
+		cmd.Stdin = strings.NewReader(script.String())
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("updating %s: %w (%s)", setName, err, out)
+		}
 	}
-	if len(toRemove) > 0 {
-		fmt.Fprintf(&script, "delete element inet tinfoil container-outgoing-allow { %s }\n",
-			strings.Join(toRemove, ", "))
-	}
-
-	cmd := exec.Command("nft", "-f", "-")
-	cmd.Stdin = strings.NewReader(script.String())
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return nil, fmt.Errorf("updating container-outgoing-allow set: %w (%s)", err, out)
-	}
-
-	if err := writeState(current); err != nil {
-		return nil, fmt.Errorf("persisting state: %w", err)
-	}
-	return current, nil
+	return writeState(state)
 }
 
 func resolve(domains []string) ([]string, error) {
@@ -153,29 +154,45 @@ func resolve(domains []string) ([]string, error) {
 			}
 		}
 	}
-	if len(ips) == 0 {
+	// Empty allow list is legal (deny everything for the network); only
+	// fail when the operator listed domains and none resolved.
+	if len(ips) == 0 && len(domains) > 0 {
 		return nil, fmt.Errorf("no IPv4 addresses resolved for %v", domains)
 	}
 	return ips, nil
 }
 
-func readState() []string {
+// State file: `<network>: <ip1>,<ip2>,...` one per line.
+func readState() map[string][]string {
+	out := map[string][]string{}
 	data, err := os.ReadFile(boot.EgressStatePath)
 	if err != nil {
-		return nil
+		return out
 	}
-	var ips []string
-	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
-		if line != "" {
-			ips = append(ips, line)
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		name, ipsStr, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
 		}
+		name = strings.TrimSpace(name)
+		var ips []string
+		for _, ip := range strings.Split(ipsStr, ",") {
+			ip = strings.TrimSpace(ip)
+			if ip != "" {
+				ips = append(ips, ip)
+			}
+		}
+		out[name] = ips
 	}
-	return ips
+	return out
 }
 
-func writeState(ips []string) error {
-	return os.WriteFile(boot.EgressStatePath,
-		[]byte(strings.Join(ips, "\n")+"\n"), 0600)
+func writeState(state map[string][]string) error {
+	var b strings.Builder
+	for name, ips := range state {
+		fmt.Fprintf(&b, "%s: %s\n", name, strings.Join(ips, ","))
+	}
+	return os.WriteFile(boot.EgressStatePath, []byte(b.String()), 0600)
 }
 
 // difference returns elements in a that are not in b.

--- a/tinfoil/cmd/egress/main.go
+++ b/tinfoil/cmd/egress/main.go
@@ -110,7 +110,6 @@ func refresh(cfg *egressConfig, state map[string][]string) error {
 		prev := state[name]
 		toAdd := difference(current, prev)
 		toRemove := difference(prev, current)
-		state[name] = current
 		if len(toAdd) == 0 && len(toRemove) == 0 {
 			continue
 		}
@@ -132,6 +131,8 @@ func refresh(cfg *egressConfig, state map[string][]string) error {
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("updating %s: %w (%s)", setName, err, out)
 		}
+		// Only record the new state after the kernel accepts the delta;
+		state[name] = current
 	}
 	return writeState(state)
 }

--- a/tinfoil/cmd/shim/upstream.go
+++ b/tinfoil/cmd/shim/upstream.go
@@ -10,8 +10,8 @@ import (
 	"tinfoil/internal/containernet"
 )
 
-// resolveUpstreamHost returns the named container's IP on the container
-// network, retrying briefly so a slow Docker daemon doesn't fail the shim.
+// resolveUpstreamHost returns the named container's IP on shim-net,
+// retrying briefly so a slow Docker daemon doesn't fail the shim.
 func resolveUpstreamHost(ctx context.Context, name string) (string, error) {
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
@@ -35,10 +35,10 @@ func resolveUpstreamHost(ctx context.Context, name string) (string, error) {
 		case info.NetworkSettings == nil:
 			lastErr = fmt.Errorf("container %q has no network settings yet", name)
 		default:
-			if ep, ok := info.NetworkSettings.Networks[containernet.NetworkName]; ok && ep != nil && ep.IPAddress != "" {
+			if ep, ok := info.NetworkSettings.Networks[containernet.ShimNetName]; ok && ep != nil && ep.IPAddress != "" {
 				return ep.IPAddress, nil
 			}
-			lastErr = fmt.Errorf("container %q has no IP on %q", name, containernet.NetworkName)
+			lastErr = fmt.Errorf("container %q has no IP on %q", name, containernet.ShimNetName)
 		}
 
 		select {

--- a/tinfoil/internal/containernet/network.go
+++ b/tinfoil/internal/containernet/network.go
@@ -1,17 +1,7 @@
-// Package containernet exposes shared constants for the Docker network that
-// holds in-CVM workload containers. Both tinfoil-boot (which creates the
-// network) and tinfoil-shim (which dials a container on it) reference these,
-// so they live here to avoid drift between the two components.
+// Package containernet exposes shared constants for in-CVM container
+// networks. Both tinfoil-boot and tinfoil-shim reference these to avoid
+// drift.
 package containernet
-
-// NetworkName is the Docker network name tinfoil-boot creates and joins all
-// workload containers to. The shim resolves the upstream container's IP on
-// this network.
-const NetworkName = "container-net"
-
-// BridgeName is the Linux bridge interface backing NetworkName. Linux caps
-// interface names at 15 characters, which is why this matches NetworkName.
-const BridgeName = "container-net"
 
 // ShimNetName is the implicit Docker network connecting the shim (host
 // netns) to its upstream container. Always closed; never declarable by

--- a/tinfoil/internal/containernet/network.go
+++ b/tinfoil/internal/containernet/network.go
@@ -12,3 +12,12 @@ const NetworkName = "container-net"
 // BridgeName is the Linux bridge interface backing NetworkName. Linux caps
 // interface names at 15 characters, which is why this matches NetworkName.
 const BridgeName = "container-net"
+
+// ShimNetName is the implicit Docker network connecting the shim (host
+// netns) to its upstream container. Always closed; never declarable by
+// the operator.
+const ShimNetName = "shim-net"
+
+// AllowSetPrefix is the nftables-set name prefix for an `egress:
+// allowlist` network's resolved IPs: allow-<network-name>.
+const AllowSetPrefix = "allow-"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces per-bridge container networks with explicit egress controls (v0.10 config), replacing the single `container-net`. The firewall and `tinfoil-egress` now enforce allowlists per network, and the shim uses an implicit `shim-net` for its upstream path.

- **New Features**
  - Config: add `cvm-network.inbound-ports`, a `networks:` map with `egress: closed|allowlist|open` and `allow: []`, and per-container `networks: []`. Default egress is `closed`.
  - Networking: create one Docker bridge per declared network; containers attach with the egress-capable network first (default route via `GwPriority`), then closed nets; the shim’s upstream container auto-attaches to `shim-net`.
  - Firewall: install nft rules per bridge; always block private destinations; start `tinfoil-egress` if any network uses `allowlist`; allow sets are named `allow-<network>`.
  - `tinfoil-egress`: reads a per-network config, resolves hostnames, updates each `allow-<network>` set atomically, and records state only after nft commits; state file stores `<network>: ip,ip,...` per line.
  - `tinfoil-shim`: resolves the upstream container’s IP on `shim-net`.
  - Validation: enforce 1 egress-enabled network per container, reserved name `shim-net`, bridge-name pattern/length, valid port ranges, and hostname-only allowlists (no IPs or wildcards). Tests added for firewall and validation.

- **Migration**
  - Replace `network.*` with `cvm-network.inbound-ports` and a `networks:` map; move per-container `network_mode` to `containers[].networks` (remove `network_mode` entirely).
  - For allowlists, move hostnames under `networks.<name>.allow` and set `egress: allowlist`; `egress: open` replaces the old “trust all domains.”
  - Do not declare or reference `shim-net`; it’s reserved and added automatically when `shim.upstream-container` is set.
  - Ensure network names are lowercase alphanumeric with hyphens, ≤15 chars, and that each container lists at most one egress-enabled network.

<sup>Written for commit d6cd518e7b29edbfc11cf1ad24facd3d413560f8. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/140?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

