### PR TITLE
Allow TLS key to be used for app signing

### DIFF
--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -405,7 +405,7 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		// already widened the file mode to 0644 so the bind-mount view is
 		// readable. The containing dir is 0700 root-only, so other host
 		// processes still cannot reach the file by path.
-		hostConfig.Binds = append(hostConfig.Binds, boot.TLSKeyPath+":/tinfoil/tls.key:ro")
+		hostConfig.Binds = append(hostConfig.Binds, boot.TLSKeyPath+":/tinfoil-app/tls.key:ro")
 	}
 	hostConfig.Resources.PidsLimit = pidsLimit
 	if first == "" {

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -380,6 +380,9 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		Tmpfs:          c.Tmpfs,
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
 	}
+	if cfg.ShimCfg != nil && cfg.ShimCfg.EnableAppSigning && shimUpstreamSet(cfg) && c.Name == cfg.ShimCfg.UpstreamContainer {
+		hostConfig.Binds = append(hostConfig.Binds, boot.TLSKeyPath+":/tinfoil/tls.key:ro")
+	}
 	hostConfig.Resources.PidsLimit = pidsLimit
 	if first == "" {
 		hostConfig.NetworkMode = "none"

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -101,6 +102,21 @@ func launchContainers(config *Config) error {
 	return nil
 }
 
+// prepareAppSigningKey widens the TLS-key file mode to 0644 when the operator
+// opted in to app-signing. The containing directory remains 0700, so only the
+// targeted bind-mount surfaces the key — other host users still can't reach
+// the path. No-op when EnableAppSigning is false.
+func prepareAppSigningKey(cfg *Config) error {
+	if cfg.ShimCfg == nil || !cfg.ShimCfg.EnableAppSigning {
+		return nil
+	}
+	if err := os.Chmod(boot.TLSKeyPath, 0o644); err != nil {
+		return fmt.Errorf("chmod %s: %w", boot.TLSKeyPath, err)
+	}
+	log.Printf("App-signing: %s mode widened to 0644 for upstream-container bind-mount", boot.TLSKeyPath)
+	return nil
+}
+
 // launchContainersAndWaitHealthy launches all containers in parallel with
 // health checking. Each container is tracked as a substage of "containers"
 // with per-phase sub-substages (pull, start, healthy).
@@ -121,6 +137,10 @@ func launchContainersAndWaitHealthy(tracker *boot.Tracker, config *Config) error
 
 	if err := setupContainerNetwork(cli, config); err != nil {
 		return fmt.Errorf("creating container network: %w", err)
+	}
+
+	if err := prepareAppSigningKey(config); err != nil {
+		return fmt.Errorf("preparing app-signing key: %w", err)
 	}
 
 	start := time.Now()
@@ -381,6 +401,10 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
 	}
 	if cfg.ShimCfg != nil && cfg.ShimCfg.EnableAppSigning && shimUpstreamSet(cfg) && c.Name == cfg.ShimCfg.UpstreamContainer {
+		// Container is non-root (Tinfoil policy); prepareAppSigningKey has
+		// already widened the file mode to 0644 so the bind-mount view is
+		// readable. The containing dir is 0700 root-only, so other host
+		// processes still cannot reach the file by path.
 		hostConfig.Binds = append(hostConfig.Binds, boot.TLSKeyPath+":/tinfoil/tls.key:ro")
 	}
 	hostConfig.Resources.PidsLimit = pidsLimit

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -382,10 +382,8 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
 	}
 	if cfg.ShimCfg != nil && cfg.ShimCfg.EnableAppSigning && shimUpstreamSet(cfg) && c.Name == cfg.ShimCfg.UpstreamContainer {
-		// Widen the TLS-key file mode so the non-root container UID (Tinfoil
-		// policy) can read it through the bind-mount below. The containing
-		// directory stays 0700 root-only, so other host processes still
-		// can't reach the file by path.
+		// widening the file lets non-root users in the upstream container read it,
+		// while the directory hardening still keeps everyone else out.
 		if err := os.Chmod(boot.TLSKeyPath, 0o644); err != nil {
 			return fmt.Errorf("widening %s for app-signing: %w", boot.TLSKeyPath, err)
 		}

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -102,21 +102,6 @@ func launchContainers(config *Config) error {
 	return nil
 }
 
-// prepareAppSigningKey widens the TLS-key file mode to 0644 when the operator
-// opted in to app-signing. The containing directory remains 0700, so only the
-// targeted bind-mount surfaces the key — other host users still can't reach
-// the path. No-op when EnableAppSigning is false.
-func prepareAppSigningKey(cfg *Config) error {
-	if cfg.ShimCfg == nil || !cfg.ShimCfg.EnableAppSigning {
-		return nil
-	}
-	if err := os.Chmod(boot.TLSKeyPath, 0o644); err != nil {
-		return fmt.Errorf("chmod %s: %w", boot.TLSKeyPath, err)
-	}
-	log.Printf("App-signing: %s mode widened to 0644 for upstream-container bind-mount", boot.TLSKeyPath)
-	return nil
-}
-
 // launchContainersAndWaitHealthy launches all containers in parallel with
 // health checking. Each container is tracked as a substage of "containers"
 // with per-phase sub-substages (pull, start, healthy).
@@ -137,10 +122,6 @@ func launchContainersAndWaitHealthy(tracker *boot.Tracker, config *Config) error
 
 	if err := setupContainerNetwork(cli, config); err != nil {
 		return fmt.Errorf("creating container network: %w", err)
-	}
-
-	if err := prepareAppSigningKey(config); err != nil {
-		return fmt.Errorf("preparing app-signing key: %w", err)
 	}
 
 	start := time.Now()
@@ -401,10 +382,13 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
 	}
 	if cfg.ShimCfg != nil && cfg.ShimCfg.EnableAppSigning && shimUpstreamSet(cfg) && c.Name == cfg.ShimCfg.UpstreamContainer {
-		// Container is non-root (Tinfoil policy); prepareAppSigningKey has
-		// already widened the file mode to 0644 so the bind-mount view is
-		// readable. The containing dir is 0700 root-only, so other host
-		// processes still cannot reach the file by path.
+		// Widen the TLS-key file mode so the non-root container UID (Tinfoil
+		// policy) can read it through the bind-mount below. The containing
+		// directory stays 0700 root-only, so other host processes still
+		// can't reach the file by path.
+		if err := os.Chmod(boot.TLSKeyPath, 0o644); err != nil {
+			return fmt.Errorf("widening %s for app-signing: %w", boot.TLSKeyPath, err)
+		}
 		hostConfig.Binds = append(hostConfig.Binds, boot.TLSKeyPath+":/tinfoil-app/tls.key:ro")
 	}
 	hostConfig.Resources.PidsLimit = pidsLimit

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -42,8 +42,8 @@ type Config struct {
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`
 
 	// When true, the per-boot TLS private key is bind-mounted read-only into
-	// the upstream container at /tinfoil/tls.key. The container can use it
-	// to sign application output.
+	// the upstream container at /tinfoil-app/tls.key. The container can use
+	// it to sign application output.
 	EnableAppSigning bool `yaml:"enable-app-signing" default:"false"`
 }
 

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -40,6 +40,11 @@ type Config struct {
 
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`
+
+	// When true, the per-boot TLS private key is bind-mounted read-only into
+	// the upstream container at /tinfoil/tls.key. The container can use it
+	// to sign application output.
+	EnableAppSigning bool `yaml:"enable-app-signing" default:"false"`
 }
 
 const (


### PR DESCRIPTION
When app signing is enabled in configuration, mount the TLS key under (ro) tinfoil-app/tls.key. The application process can use this to sign outputs

Verified by building locally