### PR TITLE
fix(boot): drop wall-clock pull timeout

### DIFF
--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -466,8 +466,7 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 
 // pullImage pulls an image using the Docker SDK with auth from Docker config
 func pullImage(cli *client.Client, imageName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	opts := image.PullOptions{}
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the 30-minute wall-clock timeout for image pulls so long pulls don’t get canceled. We now use a background context and rely on Docker’s own timeouts/retries, reducing failures on slow registries or large images.

<sup>Written for commit 156a07b516b7447e114506e26ff1978d57c45a52. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/143?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

