### PR TITLE
bit: support all GPU shapes

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -123,18 +123,11 @@ const (
 	externalDiskPath = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_tinfoil-ext-config"
 )
 
-var supportedGPUCounts = map[int]bool{
-	0: true,
-	1: true,
-	2: true,
-	4: true,
-	6: true,
-	8: true,
-}
+const maxGPUCount = 8
 
 func validateGPUCount(count int) error {
-	if !supportedGPUCounts[count] {
-		return fmt.Errorf("gpus must be one of 0, 1, 2, 4, 6, or 8 (got %d)", count)
+	if count < 0 || count > maxGPUCount {
+		return fmt.Errorf("gpus must be between 0 and %d (got %d)", maxGPUCount, count)
 	}
 	return nil
 }

--- a/tinfoil/cmd/boot/config_test.go
+++ b/tinfoil/cmd/boot/config_test.go
@@ -3,13 +3,13 @@ package main
 import "testing"
 
 func TestValidateGPUCount(t *testing.T) {
-	for _, count := range []int{0, 1, 2, 4, 6, 8} {
+	for count := range maxGPUCount + 1 {
 		if err := validateGPUCount(count); err != nil {
 			t.Fatalf("expected GPU count %d to be valid: %v", count, err)
 		}
 	}
 
-	for _, count := range []int{-1, 3, 5, 7, 9} {
+	for _, count := range []int{-1, 9} {
 		if err := validateGPUCount(count); err == nil {
 			t.Fatalf("expected GPU count %d to be invalid", count)
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Support all GPU shapes in boot config by allowing any GPU count between 0 and 8 (inclusive) instead of a fixed allowlist. Replaced the allowlist with a `maxGPUCount` range check and updated tests.

<sup>Written for commit 959f7f7d95922c5e8e580660b0a15edf273812b5. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/144?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

