### PR TITLE
fix: fail boot if firewall setup fails

### DIFF
--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -155,11 +155,10 @@ func run() error {
 	start = time.Now()
 	log.Println("Configuring firewall")
 	if err := setupFirewall(config); err != nil {
-		log.Printf("Warning: firewall setup failed: %v", err)
-		tracker.Record(boot.StageFirewall, boot.StatusWarning, time.Since(start), err.Error())
-	} else {
-		tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
+		tracker.Record(boot.StageFirewall, boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("firewall setup failed: %w", err)
 	}
+	tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
 
 	// 8. Models
 	start = time.Now()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Boot now fails if firewall setup fails instead of proceeding with a warning. We record `boot.StageFirewall` as `boot.StatusFailed` and return an error to stop startup; on success we record `boot.StatusOK`.

<sup>Written for commit d0c67fff1941814787342a9fc5e0cf3d5084fbef. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/145?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

