### PR TITLE
feat: check that PDIs are unique for NVSwitches

### DIFF
--- a/tinfoil/cmd/boot/topology.go
+++ b/tinfoil/cmd/boot/topology.go
@@ -193,8 +193,10 @@ func validateTopology(gpuReports, switchReports [][]byte, gpuCount, switchCount 
 	log.Printf("GPU topology OK: all %d GPUs see the same %d switches", gpuCount, switchCount)
 
 	// Switch side: each switch's own PDI must be in the GPU-reported set,
-	// and each must see exactly 8 unique GPUs, identical across all switches
+	// each must appear exactly once, and each must see exactly gpuCount
+	// unique GPUs, identical across all switches.
 	var expectedGPUs map[string]struct{}
+	seenSwitchPDIs := make(map[string]struct{}, switchCount)
 	for i, report := range switchReports {
 		label := fmt.Sprintf("switch[%d]", i)
 		checkSPDMVersion(report, label)
@@ -214,6 +216,10 @@ func validateTopology(gpuReports, switchReports [][]byte, gpuCount, switchCount 
 		if _, ok := expectedSwitches[devicePDI]; !ok {
 			return fmt.Errorf("%s PDI %s not in GPU-reported switch set", label, devicePDI)
 		}
+		if _, dup := seenSwitchPDIs[devicePDI]; dup {
+			return fmt.Errorf("%s PDI %s already reported by another switch", label, devicePDI)
+		}
+		seenSwitchPDIs[devicePDI] = struct{}{}
 
 		rawGPUs, ok := fields[fieldGPUPDIs]
 		if !ok {

--- a/tinfoil/cmd/boot/topology_test.go
+++ b/tinfoil/cmd/boot/topology_test.go
@@ -260,6 +260,26 @@ func TestValidateTopologySwitchPDINotInGPUSet(t *testing.T) {
 	}
 }
 
+func TestValidateTopologyDuplicateSwitchPDI(t *testing.T) {
+	gpuReports := make([][]byte, 8)
+	for i := range gpuReports {
+		gpuReports[i] = buildSPDMReport([]tlvEntry{
+			{typ: fieldPDI, val: switchPDIsForGPU()},
+		})
+	}
+	// switch[2] reuses switchDevA's PDI: each PDI is in the GPU-reported set,
+	// but the four reports do not cover four distinct devices.
+	switchReports := [][]byte{
+		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevA}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
+		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevB}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
+		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevA}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
+		buildSPDMReport([]tlvEntry{{typ: fieldPDI, val: switchDevD}, {typ: fieldGPUPDIs, val: allGPUPDIs()}}),
+	}
+	if err := validateTopology(gpuReports, switchReports, hopperGPUCount, hopperSwitchCount); err == nil {
+		t.Fatal("expected topology error for duplicate switch device PDI")
+	}
+}
+
 // Verify our hex encoding of the reference PDIs matches expectations.
 func TestReferencePDIHexEncoding(t *testing.T) {
 	// switchA raw bytes: b'@\xb9\xc6\xb3\xd7H\xfd\x90'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enforces unique NVSwitch PDIs during topology validation so each switch appears exactly once. Prevents misconfigured or duplicated switch identities from passing boot checks.

- **New Features**
  - In `validateTopology`, track seen switch PDIs and error on duplicates; still require each PDI to be in the GPU-reported set.
  - Added `TestValidateTopologyDuplicateSwitchPDI` to verify duplicates are rejected.

<sup>Written for commit cefe5356878bcd24b8570e4b38ad596f77e58721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

