### PR TITLE
Jules/state docker hardening

### DIFF
--- a/mkosi.extra/etc/docker/daemon.json
+++ b/mkosi.extra/etc/docker/daemon.json
@@ -1,5 +1,8 @@
 {
     "data-root": "/mnt/ramdisk/private/docker",
+    "no-new-privileges": true,
+    "icc": false,
+    "userland-proxy": false,
     "features": {
         "containerd-snapshotter": true
     },

--- a/mkosi.extra/etc/systemd/system/tinfoil-boot.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-boot.service
@@ -12,6 +12,12 @@ User=root
 Group=root
 StandardOutput=journal+console
 StandardError=journal+console
+NoNewPrivileges=yes
+RestrictSUIDSGID=yes
+ProtectHome=yes
+LockPersonality=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=default.target

--- a/mkosi.extra/etc/systemd/system/tinfoil-shim.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-shim.service
@@ -9,6 +9,18 @@ ExecStart=/usr/bin/tinfoil-shim
 Restart=always
 RestartSec=5
 User=root
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/mnt/ramdisk /run/docker.sock
+ProtectHome=yes
+PrivateTmp=yes
+RestrictSUIDSGID=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+RestrictRealtime=yes
+SystemCallArchitectures=native
 
 [Install]
 WantedBy=default.target

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -25,7 +25,10 @@ import (
 	"tinfoil/internal/containernet"
 )
 
-const healthPollInterval = 5 * time.Second
+const (
+	healthPollInterval = 5 * time.Second
+	defaultPidsLimit   int64 = 65536
+)
 
 func setupContainerNetwork(cli *client.Client, cfg *Config) error {
 	for name := range cfg.Networks {
@@ -362,7 +365,7 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 	}
 	pidsLimit := c.PidsLimit
 	if pidsLimit == nil {
-		n := int64(256)
+		n := defaultPidsLimit
 		pidsLimit = &n
 	}
 

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sync"
 	"time"
 )
 
@@ -51,7 +53,36 @@ var InitialStages = []string{
 
 // Tracker records boot stages as they complete.
 type Tracker struct {
+	mu    sync.Mutex
 	state State
+}
+
+// writeStateAtomic writes data to path via a temp file in the same directory
+// + rename so concurrent readers never observe a partial file.
+func writeStateAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("creating boot state dir: %w", err)
+	}
+	tmp, err := os.CreateTemp(dir, "boot-state-*.json")
+	if err != nil {
+		return fmt.Errorf("creating temp boot state: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return fmt.Errorf("writing temp boot state: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("closing temp boot state: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return fmt.Errorf("renaming boot state: %w", err)
+	}
+	return nil
 }
 
 // NewTracker creates a tracker with the given stages pre-registered as pending.
@@ -67,6 +98,8 @@ func NewTracker(stages []string) *Tracker {
 
 // Record updates an existing stage by name or appends a new one. Auto-flushes.
 func (t *Tracker) Record(name, status string, duration time.Duration, detail string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	stage := Stage{Name: name, Status: status, Duration: duration, Detail: detail}
 	updated := false
 	for i := range t.state.Stages {
@@ -80,34 +113,39 @@ func (t *Tracker) Record(name, status string, duration time.Duration, detail str
 	if !updated {
 		t.state.Stages = append(t.state.Stages, stage)
 	}
-	if err := t.Flush(); err != nil {
+	if err := t.flushLocked(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to flush boot state: %v\n", err)
 	}
 }
 
 // RecordSubstages sets the substages on an existing stage and flushes.
 func (t *Tracker) RecordSubstages(name string, substages []Stage) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	for i := range t.state.Stages {
 		if t.state.Stages[i].Name == name {
 			t.state.Stages[i].Stages = substages
 			break
 		}
 	}
-	if err := t.Flush(); err != nil {
+	if err := t.flushLocked(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to flush boot state: %v\n", err)
 	}
 }
 
 // Flush writes the current boot state to disk without setting CompletedAt.
 func (t *Tracker) Flush() error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.flushLocked()
+}
+
+func (t *Tracker) flushLocked() error {
 	data, err := json.MarshalIndent(t.state, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshaling boot state: %w", err)
 	}
-	if err := os.WriteFile(StatePath, data, 0644); err != nil {
-		return fmt.Errorf("writing boot state: %w", err)
-	}
-	return nil
+	return writeStateAtomic(StatePath, data)
 }
 
 // Load reads the boot state from the ramdisk.
@@ -169,7 +207,7 @@ func RecordStage(name, status string, duration time.Duration, detail string) err
 	if err != nil {
 		return fmt.Errorf("marshaling boot state: %w", err)
 	}
-	return os.WriteFile(StatePath, data, 0644)
+	return writeStateAtomic(StatePath, data)
 }
 
 // Complete sets CompletedAt on the persisted state.
@@ -183,5 +221,5 @@ func Complete() error {
 	if err != nil {
 		return fmt.Errorf("marshaling boot state: %w", err)
 	}
-	return os.WriteFile(StatePath, data, 0644)
+	return writeStateAtomic(StatePath, data)
 }

--- a/tinfoil/internal/boot/state_test.go
+++ b/tinfoil/internal/boot/state_test.go
@@ -1,0 +1,34 @@
+package boot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteStateAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "boot-state.json")
+
+	payload := []byte(`{"stages":[],"started_at":"2026-01-01T00:00:00Z"}`)
+	if err := writeStateAtomic(path, payload); err != nil {
+		t.Fatalf("writeStateAtomic: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != string(payload) {
+		t.Fatalf("got %q, want %q", got, payload)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.Name() != "boot-state.json" {
+			t.Fatalf("leftover temp file %q in state dir", e.Name())
+		}
+	}
+}

--- a/tinfoil/internal/dcode/dcode.go
+++ b/tinfoil/internal/dcode/dcode.go
@@ -41,6 +41,9 @@ func Encode(content []byte, domain string) ([]string, error) {
 		end := min(i+maxLength, len(encoded))
 		chunk := encoded[i:end]
 		index := len(domains)
+		if index > 99 {
+			return nil, fmt.Errorf("payload requires %d+ chunks; 2-digit prefix supports at most 100", index+1)
+		}
 		domains = append(domains, fmt.Sprintf("%02d%s%s", index, chunk, domainSuffix))
 	}
 

--- a/tinfoil/internal/dcode/dcode_test.go
+++ b/tinfoil/internal/dcode/dcode_test.go
@@ -44,3 +44,17 @@ func TestDcode(t *testing.T) {
 	}
 	assert.Equal(t, att, *decoded)
 }
+
+func TestEncodeRejectsTooManyChunks(t *testing.T) {
+	// Force >100 chunks: each chunk is one base32 char + index prefix + suffix.
+	domain := "x.example.com"
+	maxLength := 63 - len(".x.example.com") - 2
+	if maxLength <= 0 {
+		t.Fatal("test domain too long")
+	}
+	content := make([]byte, maxLength*101)
+	_, err := Encode(content, domain)
+	if err == nil {
+		t.Fatal("expected error when chunk count exceeds 100")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened Docker and `systemd` services, and made boot-state persistence atomic and thread-safe to prevent partial reads and races. Also raised the default container PID limit and enforced a safe chunk cap in `dcode`.

- Bug Fixes
  - Persist boot state via temp file + rename and guard with a mutex in `Tracker`; added `writeStateAtomic` test.
  - `dcode.Encode` now errors when payload requires >100 chunks; added coverage.

- Refactors
  - Docker daemon: enable `no-new-privileges`, disable `icc` and `userland-proxy`.
  - `systemd` units: add sandboxing (`NoNewPrivileges`, `ProtectSystem=strict`, `PrivateTmp`, `Protect*`, `LockPersonality`, `RestrictRealtime`, `SystemCallArchitectures=native`).
  - Containers: increase default `pids_limit` to `65536`.

<sup>Written for commit fd0b51f86e365f2542bdf38e50efd31f306b4459. Summary will update on new commits. <a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/149?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

