### PR TITLE
Harden shim auth and path validation

### DIFF
--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -84,6 +84,8 @@ const (
 // where applicable. See https://platform.openai.com/docs/guides/error-codes
 const (
 	errMsgAPIKeyRequired = "API key is required."
+	errMsgInvalidAPIKey  = "Incorrect API key provided."
+	errMsgQuotaExceeded  = "Insufficient quota."
 	errMsgRateLimited    = "Rate limit reached for requests."
 	errMsgServerError    = "The server had an error while processing your request."
 )
@@ -98,6 +100,25 @@ func writeJSONError(w http.ResponseWriter, message string, errorType string, sta
 			"type":    errorType,
 		},
 	})
+}
+
+func writeValidationFailure(w http.ResponseWriter, err error) {
+	var validationErr *online.ValidationError
+	if !errors.As(err, &validationErr) {
+		writeJSONError(w, errMsgServerError, errTypeServer, http.StatusInternalServerError)
+		return
+	}
+
+	switch validationErr.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		writeJSONError(w, errMsgInvalidAPIKey, errTypeInvalidRequest, validationErr.StatusCode)
+	case http.StatusPaymentRequired:
+		writeJSONError(w, errMsgQuotaExceeded, errTypeInsufficientQuota, validationErr.StatusCode)
+	case http.StatusTooManyRequests:
+		writeJSONError(w, errMsgRateLimited, errTypeInsufficientQuota, validationErr.StatusCode)
+	default:
+		writeJSONError(w, errMsgServerError, errTypeServer, http.StatusInternalServerError)
+	}
 }
 
 func corsMiddleware(config *config.Config, next http.Handler) http.Handler {
@@ -201,15 +222,7 @@ func NewShimServer(
 
 			if err := validator.Validate(apiKey); err != nil {
 				log.Printf("Warning: failed to validate API key: %v", err)
-				var validationErr *online.ValidationError
-				if errors.As(err, &validationErr) {
-					// Pass through the JSON error body from the control plane
-					w.Header().Set("Content-Type", "application/json")
-					w.WriteHeader(validationErr.StatusCode)
-					fmt.Fprint(w, validationErr.Message)
-				} else {
-					writeJSONError(w, errMsgServerError, errTypeServer, http.StatusInternalServerError)
-				}
+				writeValidationFailure(w, err)
 				return
 			}
 		}

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -63,6 +63,16 @@ func requiresAuth(authenticatedEndpoints *[]string, path string) bool {
 	return pathAllowed(*authenticatedEndpoints, path)
 }
 
+// extractBearerToken returns the token portion of an Authorization header,
+// accepting any capitalization of the "Bearer" scheme.
+func extractBearerToken(header string) string {
+	const scheme = "bearer "
+	if len(header) < len(scheme) || !strings.EqualFold(header[:len(scheme)], scheme) {
+		return ""
+	}
+	return strings.TrimSpace(header[len(scheme):])
+}
+
 // OpenAI-compatible error type strings returned in API error responses.
 const (
 	errTypeInvalidRequest    = "invalid_request_error"
@@ -182,7 +192,7 @@ func NewShimServer(
 	}
 
 	proxyHandler := ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		apiKey := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		apiKey := extractBearerToken(r.Header.Get("Authorization"))
 		if validator != nil && requiresAuth(config.AuthenticatedEndpoints, r.URL.Path) {
 			if len(apiKey) == 0 {
 				writeJSONError(w, errMsgAPIKeyRequired, errTypeInvalidRequest, http.StatusUnauthorized)

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -27,16 +27,19 @@ import (
 )
 
 // pathMatchesPattern checks if a request path matches a pattern.
-// Patterns can be exact matches or use a trailing * for prefix matching.
+// Patterns can be exact matches or use a trailing * for segment-boundary prefix matching.
 // Examples:
 //   - "/v1/models" matches only "/v1/models"
 //   - "/v1/user/*" matches "/v1/user/123", "/v1/user/abc/settings", etc.
 func pathMatchesPattern(pattern, path string) bool {
-	if strings.HasSuffix(pattern, "*") {
-		prefix := strings.TrimSuffix(pattern, "*")
+	prefix, wildcard := strings.CutSuffix(pattern, "*")
+	if !wildcard {
+		return pattern == path
+	}
+	if strings.HasSuffix(prefix, "/") {
 		return strings.HasPrefix(path, prefix)
 	}
-	return pattern == path
+	return path == prefix || strings.HasPrefix(path, prefix+"/")
 }
 
 // pathAllowed checks if the request path matches any of the allowed patterns.

--- a/tinfoil/cmd/shim/api_path_test.go
+++ b/tinfoil/cmd/shim/api_path_test.go
@@ -22,6 +22,11 @@ func TestPathMatchesPattern(t *testing.T) {
 		{"wildcard no match different prefix", "/v1/user/*", "/v1/admin/123", false},
 		{"wildcard no match partial prefix", "/v1/user/*", "/v1/username", false},
 
+		// Segment-boundary enforcement for non-slash-terminated wildcards.
+		{"bare wildcard matches self", "/v1/chat*", "/v1/chat", true},
+		{"bare wildcard matches subpath", "/v1/chat*", "/v1/chat/completions", true},
+		{"bare wildcard rejects sibling", "/v1/chat*", "/v1/chatsmuggled", false},
+
 		// Edge cases
 		{"wildcard only matches all", "/*", "/anything/here", true},
 		{"wildcard at root", "/*", "/", true},

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
@@ -136,6 +138,23 @@ func TestExtractBearerToken(t *testing.T) {
 		if got := extractBearerToken(tt.header); got != tt.want {
 			t.Errorf("extractBearerToken(%q) = %q, want %q", tt.header, got, tt.want)
 		}
+	}
+}
+
+func TestWriteValidationFailureDoesNotLeakInternalError(t *testing.T) {
+	err := errors.New("control-plane details")
+	rec := httptest.NewRecorder()
+
+	writeValidationFailure(rec, err)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusInternalServerError, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), err.Error()) {
+		t.Fatalf("validation error leaked raw error: %q", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), errMsgServerError) {
+		t.Fatalf("expected generic server error, got: %q", rec.Body.String())
 	}
 }
 

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
+	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 	tinfoilattestation "tinfoil/internal/attestation"
 	"tinfoil/internal/config"
-	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 )
 
 func testServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
@@ -116,6 +116,26 @@ func TestRequiresAuth(t *testing.T) {
 				t.Errorf("requiresAuth(%v, %q) = %v, want %v", tt.authenticatedEndpoints, tt.path, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestExtractBearerToken(t *testing.T) {
+	tests := []struct {
+		header string
+		want   string
+	}{
+		{"Bearer sk-test", "sk-test"},
+		{"bearer sk-test", "sk-test"},
+		{"BEARER   sk-test  ", "sk-test"},
+		{"Token sk-test", ""},
+		{"Bearer", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		if got := extractBearerToken(tt.header); got != tt.want {
+			t.Errorf("extractBearerToken(%q) = %q, want %q", tt.header, got, tt.want)
+		}
 	}
 }
 

--- a/tinfoil/internal/key/online/online_test.go
+++ b/tinfoil/internal/key/online/online_test.go
@@ -38,3 +38,23 @@ func TestRejectHTTP(t *testing.T) {
 	_, err := NewValidator("http://localhost:8080/validate")
 	assert.NotNil(t, err)
 }
+
+func TestValidationErrorCarriesOnlyStatus(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("POST", "https://localhost:8080/validate",
+		httpmock.NewStringResponder(http.StatusUnauthorized, "internal validator details"))
+
+	v, err := NewValidator("https://localhost:8080/validate")
+	assert.Nil(t, err)
+
+	err = v.Validate("bad-key")
+	if assert.NotNil(t, err) {
+		validationErr, ok := err.(*ValidationError)
+		if assert.True(t, ok) {
+			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
+			assert.NotContains(t, validationErr.Error(), "internal validator details")
+		}
+	}
+}

--- a/tinfoil/internal/key/online/verify.go
+++ b/tinfoil/internal/key/online/verify.go
@@ -3,7 +3,6 @@ package online
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -28,11 +27,10 @@ func NewValidator(server string) (*Validator, error) {
 
 type ValidationError struct {
 	StatusCode int
-	Message    string
 }
 
 func (e *ValidationError) Error() string {
-	return e.Message
+	return http.StatusText(e.StatusCode)
 }
 
 func (v *Validator) Validate(apiKey string) error {
@@ -46,13 +44,7 @@ func (v *Validator) Validate(apiKey string) error {
 		return nil
 	}
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response body: %w", err)
-	}
-
 	return &ValidationError{
 		StatusCode: resp.StatusCode,
-		Message:    string(body),
 	}
 }


### PR DESCRIPTION
## Summary
- Enforce path wildcard matching on segment boundaries so sibling paths are not accidentally allowed.
- Accept bearer auth scheme casing consistently while preserving Authorization for upstream router/tool-loop flows.
- Normalize API-key validator failures into stable client-facing JSON errors instead of forwarding control-plane bodies.

## Test plan
- `go test ./...` from `cvmimage/tinfoil`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened shim auth and path validation to close edge cases and avoid leaking internal error details. Prevents sibling path bypass, accepts any Bearer casing, and returns stable JSON errors on key validation failures.

- **Bug Fixes**
  - Enforce wildcard matching on segment boundaries (e.g., "/v1/chat*" matches "/v1/chat" and "/v1/chat/…", not "/v1/chatsmuggled").
  - Accept any casing for the Authorization "Bearer" scheme.
  - Normalize validator failures to stable JSON errors: 401/403 → "Incorrect API key provided.", 402 → "Insufficient quota.", 429 → rate limited message, others → generic 500 without control-plane details.

<sup>Written for commit 0e51601bf7c7378ab9e542fe0256f08ef80234cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/151?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

