### PR TITLE
Require configured GPU evidence for fresh attestation

### DIFF
--- a/tinfoil/internal/attestation/gpu.go
+++ b/tinfoil/internal/attestation/gpu.go
@@ -30,20 +30,6 @@ var archNames = map[nvml.DeviceArchitecture]string{
 	nvml.DEVICE_ARCH_BLACKWELL: "BLACKWELL",
 }
 
-// DetectGPUCount returns the number of NVIDIA GPUs, or 0 if NVML is unavailable.
-func DetectGPUCount() int {
-	ret := nvml.Init()
-	if ret != nvml.SUCCESS {
-		return 0
-	}
-	defer nvml.Shutdown()
-	count, ret := nvml.DeviceGetCount()
-	if ret != nvml.SUCCESS {
-		return 0
-	}
-	return count
-}
-
 // CollectGPUEvidence collects fresh attestation evidence from all GPUs using
 // NVML directly (no nvattest CLI). The nonce must be exactly 32 bytes.
 func CollectGPUEvidence(nonce [32]byte) (*GPUEvidenceCollection, error) {


### PR DESCRIPTION
## Summary
- Pass the attested configured GPU count into the shim config instead of using runtime detection as policy.
- Require fresh nonce attestation to include the configured number of GPU evidence records.
- Require NVSwitch evidence for 8-GPU fresh attestation rather than returning incomplete attestation.

## Test plan
- `go test ./...` from `cvmimage/tinfoil`

## Notes
- This PR is intentionally stacked on #151 and should wait for live GPU/NVSwitch validation before merging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fresh attestation now strictly enforces the configured GPU count and requires NVSwitch evidence when applicable. The shim returns 500 if GPU/NVSwitch evidence is missing, incomplete, or does not match `ExpectedGPUs`.

- **New Features**
  - Copy `GPUs` into shim `ExpectedGPUs` and validate attestation against it.
  - Return 500 if GPU evidence collection fails or count != `ExpectedGPUs`.
  - When `ExpectedGPUs >= 8`, require NVSwitch evidence; return 500 if missing.
  - Remove runtime GPU detection (`DetectGPUCount`) and rely on `expected-gpus` in config.

<sup>Written for commit 788ffba421deb4e61645470e4c195782391bce96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

