### PR TITLE
fix: make default shm large to support vllm and pytorch by default

### DIFF
--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -443,6 +443,9 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		if size, err := units.RAMInBytes(c.ShmSize); err == nil {
 			hostConfig.ShmSize = size
 		}
+	} else if avail := containerMemoryBytes(&c, cfg); avail > 0 {
+		// Matching the kernel's default tmpfs sizing (50% of RAM).
+		hostConfig.ShmSize = avail / 2
 	}
 	if c.Memory != "" {
 		if mem, err := units.RAMInBytes(c.Memory); err == nil {
@@ -563,6 +566,18 @@ func pullImage(cli *client.Client, imageName string) error {
 		}
 	}
 	return nil
+}
+
+func containerMemoryBytes(c *Container, cfg *Config) int64 {
+	if c.Memory != "" {
+		if mem, err := units.RAMInBytes(c.Memory); err == nil {
+			return mem
+		}
+	}
+	if cfg != nil && cfg.Memory > 0 {
+		return int64(cfg.Memory) * 1024 * 1024
+	}
+	return 0
 }
 
 // buildEnv parses env entries and secrets from external config

--- a/tinfoil/cmd/boot/containers_test.go
+++ b/tinfoil/cmd/boot/containers_test.go
@@ -94,6 +94,29 @@ func TestBuildEnvNilConfig(t *testing.T) {
 	}
 }
 
+func TestContainerMemoryBytes(t *testing.T) {
+	const mib = int64(1024 * 1024)
+	tests := []struct {
+		name string
+		c    Container
+		cfg  *Config
+		want int64
+	}{
+		{"explicit container limit", Container{Memory: "2g"}, &Config{Memory: 8192}, 2 * 1024 * mib},
+		{"falls back to enclave memory", Container{}, &Config{Memory: 8192}, 8192 * mib},
+		{"explicit overrides enclave", Container{Memory: "512m"}, &Config{Memory: 8192}, 512 * mib},
+		{"unparseable container limit falls back", Container{Memory: "lots"}, &Config{Memory: 4096}, 4096 * mib},
+		{"nothing known", Container{}, &Config{}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containerMemoryBytes(&tt.c, tt.cfg); got != tt.want {
+				t.Errorf("containerMemoryBytes() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseDuration(t *testing.T) {
 	tests := []struct {
 		input string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Default /dev/shm is now set to 50% of container memory when not specified, matching kernel tmpfs sizing. This lets vLLM and PyTorch run without manual shm configuration.

- **Bug Fixes**
  - If `ShmSize` is unset, use half of available memory from container `Memory` or `Config.Memory`.
  - Added `containerMemoryBytes` helper and unit tests.

<sup>Written for commit 34da7631ecd8d19064e6da51f2e080758503fb5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

