### PR TITLE
fix: harden shim and egress

### DIFF
--- a/mkosi.extra/etc/systemd/system/tinfoil-shim.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-shim.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Tinfoil Shim Service
-After=tinfoil-ramdisk.service
-Requires=tinfoil-ramdisk.service
+After=tinfoil-ramdisk.service nftables.service
+Requires=tinfoil-ramdisk.service nftables.service
 
 [Service]
 Type=simple
@@ -10,10 +10,13 @@ Restart=always
 RestartSec=5
 User=root
 NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 ProtectSystem=strict
 ReadWritePaths=/mnt/ramdisk
 ProtectHome=yes
 PrivateTmp=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 RestrictSUIDSGID=yes
 ProtectKernelModules=yes
 ProtectKernelTunables=yes

--- a/tinfoil/cmd/boot/firewall.go
+++ b/tinfoil/cmd/boot/firewall.go
@@ -11,10 +11,21 @@ import (
 	"tinfoil/internal/containernet"
 )
 
-// Private destination ranges blocked even on `egress: open` networks.
+// Non-public destination ranges blocked even on `egress: open` and
+// `egress: allowlist` networks. This keeps broad/public egress from reaching
+// host/provider/internal address space while preserving same-bridge IPC, which
+// is accepted before these routed-egress rules.
+//
+// References:
+//   - RFC 1918: private-use networks.
+//   - RFC 3927: IPv4 link-local.
+//   - RFC 5737: documentation/test networks.
+//   - RFC 6598: shared address space for carrier-grade NAT.
+//   - RFC 6890 / IANA IPv4 Special-Purpose Address Registry: loopback,
+//     "this network", benchmarking, multicast, reserved, and broadcast space.
 const (
-	privateIPv4Ranges = "{ 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 169.254.0.0/16, 127.0.0.0/8 }"
-	privateIPv6Ranges = "{ fc00::/7, fe80::/10, ff00::/8, ::ffff:0:0/96, 64:ff9b::/96, 100::/64, 2001:db8::/32, ::1/128 }"
+	nonPublicIPv4Ranges = "{ 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.2.0/24, 192.168.0.0/16, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 240.0.0.0/4, 255.255.255.255/32 }"
+	nonPublicIPv6Ranges = "{ fc00::/7, fe80::/10, ff00::/8, ::ffff:0:0/96, 64:ff9b::/96, 100::/64, 2001:db8::/32, ::1/128 }"
 )
 
 // setupContainerNetworkFirewall installs one bridge's worth of nftables
@@ -81,16 +92,16 @@ func writeBridgeRules(script *strings.Builder, bridge string, spec *NetworkSpec)
 	switch spec.Egress {
 	case "open":
 		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip daddr != %s accept\n",
-			bridge, privateIPv4Ranges)
+			bridge, nonPublicIPv4Ranges)
 		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip6 daddr != %s accept\n",
-			bridge, privateIPv6Ranges)
+			bridge, nonPublicIPv6Ranges)
 	case "allowlist":
 		setName := containernet.AllowSetPrefix + bridge
 		fmt.Fprintf(script, "add set inet tinfoil %s { type ipv4_addr; }\n", setName)
 		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip daddr %s drop\n",
-			bridge, privateIPv4Ranges)
+			bridge, nonPublicIPv4Ranges)
 		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip6 daddr %s drop\n",
-			bridge, privateIPv6Ranges)
+			bridge, nonPublicIPv6Ranges)
 		fmt.Fprintf(script, "add rule inet tinfoil forward iif %q ip daddr @%s accept\n",
 			bridge, setName)
 	}

--- a/tinfoil/cmd/boot/firewall_test.go
+++ b/tinfoil/cmd/boot/firewall_test.go
@@ -44,11 +44,30 @@ func TestFirewall_OpenBridgeEmitsPublicAccept(t *testing.T) {
 		"web": {Egress: "open"},
 	}}
 	script := renderFirewallScript(cfg)
-	if !strings.Contains(script, `iif "web" ip daddr != { 10.0.0.0/8`) {
+	if !strings.Contains(script, `iif "web" ip daddr != {`) {
 		t.Errorf("open bridge should accept public v4; got:\n%s", script)
 	}
 	if !strings.Contains(script, `iif "web" ip6 daddr != {`) {
 		t.Error("open bridge should accept public v6")
+	}
+}
+
+func TestFirewall_OpenBridgeBlocksNonPublicIPv4Ranges(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"web": {Egress: "open"},
+	}}
+	script := renderFirewallScript(cfg)
+	for _, cidr := range []string{
+		"100.64.0.0/10",   // RFC 6598 shared address space.
+		"198.18.0.0/15",   // RFC 6890 benchmarking.
+		"198.51.100.0/24", // RFC 5737 documentation.
+		"224.0.0.0/4",     // RFC 6890 multicast.
+		"240.0.0.0/4",     // RFC 6890 reserved.
+		"255.255.255.255/32",
+	} {
+		if !strings.Contains(script, cidr) {
+			t.Errorf("open bridge should exclude %s from public egress; got:\n%s", cidr, script)
+		}
 	}
 }
 
@@ -65,6 +84,27 @@ func TestFirewall_AllowlistEmitsSetAndAcceptRule(t *testing.T) {
 	}
 	if !strings.Contains(script, `iif "control" ip daddr {`) {
 		t.Error("allowlist must drop private destinations")
+	}
+}
+
+func TestFirewall_AllowlistDropsNonPublicBeforeAllowSet(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
+	}}
+	script := renderFirewallScript(cfg)
+	dropRule := `iif "control" ip daddr {`
+	dropIdx := strings.Index(script, dropRule)
+	allowIdx := strings.Index(script, `iif "control" ip daddr @allow-control accept`)
+	if dropIdx == -1 || allowIdx == -1 {
+		t.Fatalf("expected non-public drop before allow set; got:\n%s", script)
+	}
+	if dropIdx > allowIdx {
+		t.Fatalf("non-public drop must precede allow set; got:\n%s", script)
+	}
+	for _, cidr := range []string{"100.64.0.0/10", "198.18.0.0/15"} {
+		if !strings.Contains(script, cidr) {
+			t.Errorf("allowlist bridge should drop %s before allow set; got:\n%s", cidr, script)
+		}
 	}
 }
 

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -35,6 +35,11 @@ var (
 	externalConfigFile = flag.String("e", boot.ExternalConfigPath, "Path to external config file")
 )
 
+const (
+	shimReadHeaderTimeout = 10 * time.Second
+	shimIdleTimeout       = 2 * time.Minute
+)
+
 func main() {
 	flag.Parse()
 	log.SetFlags(0)
@@ -60,7 +65,9 @@ func main() {
 	}
 
 	srv := &http.Server{
-		Addr: fmt.Sprintf(":%d", boot.ShimListenPort),
+		Addr:              fmt.Sprintf(":%d", boot.ShimListenPort),
+		ReadHeaderTimeout: shimReadHeaderTimeout,
+		IdleTimeout:       shimIdleTimeout,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if h, ok := handler.Load().(http.Handler); ok {
 				h.ServeHTTP(w, r)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened the shim and container egress rules to block all non‑public address space while keeping same-bridge IPC, and tightened the shim server and unit sandboxing to reduce network attack surface.

- **Bug Fixes**
  - Firewall: accept only public destinations in `egress: open`; in `egress: allowlist`, drop non‑public ranges before the allow set. Expanded non‑public sets for IPv4/IPv6 and added tests.
  - Systemd: shim now orders after and requires `nftables.service`; restricts address families to `AF_INET`, `AF_INET6`, `AF_UNIX`; adds `CapabilityBoundingSet=CAP_NET_BIND_SERVICE` and `AmbientCapabilities=CAP_NET_BIND_SERVICE`.
  - Shim HTTP server: set `ReadHeaderTimeout` (10s) and `IdleTimeout` (2m) to mitigate slowloris and idle connections.

<sup>Written for commit 5220e2dc119735792abb353e877a13c5e59d3026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/154?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

