### PR TITLE
feat: better boot observability and container status enpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ tinfoil-boot/tinfoil-boot
 tinfoil/boot
 tinfoil/shim
 mkosi.extra/usr/bin/tinfoil-boot
+mkosi.extra/usr/bin/tinfoil-container-status
 mkosi.extra/usr/bin/tinfoil-egress
 mkosi.extra/usr/bin/tinfoil-shim

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ deepclean:
 go-binaries:
 	mkdir -p mkosi.extra/usr/bin
 	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-boot ./cmd/boot
+	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-container-status ./cmd/container-status
 	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-egress ./cmd/egress
 	cd tinfoil && go build -ldflags="-s -w" -o ../mkosi.extra/usr/bin/tinfoil-shim ./cmd/shim
 

--- a/mkosi.extra/etc/systemd/system/tinfoil-container-status.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-container-status.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Tinfoil Container Status Publisher
+After=tinfoil-ramdisk.service docker.service containerd.service
+Requires=tinfoil-ramdisk.service docker.service containerd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/tinfoil-container-status
+Restart=always
+RestartSec=5
+User=root
+Group=root
+StandardOutput=journal+console
+StandardError=journal+console
+NoNewPrivileges=yes
+ProtectSystem=strict
+ReadWritePaths=/mnt/ramdisk/public
+ProtectHome=yes
+PrivateTmp=yes
+RestrictSUIDSGID=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+LockPersonality=yes
+RestrictRealtime=yes
+RestrictAddressFamilies=AF_UNIX
+CapabilityBoundingSet=
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=default.target

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -178,6 +178,7 @@ func loadAndVerifyConfig() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing shim config: %w", err)
 	}
+	shimCfg.ExpectedGPUs = config.GPUs
 	config.ShimCfg = shimCfg
 
 	if shimCfg.UpstreamContainer == "" && len(config.Containers) > 0 {
@@ -251,6 +252,7 @@ func loadConfigFromRamdisk() (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parsing shim config: %w", err)
 	}
+	shimCfg.ExpectedGPUs = config.GPUs
 	config.ShimCfg = shimCfg
 
 	if err := validateNetwork(&config); err != nil {

--- a/tinfoil/cmd/container-status/main.go
+++ b/tinfoil/cmd/container-status/main.go
@@ -1,0 +1,254 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/containerd/errdefs"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/client"
+	"gopkg.in/yaml.v3"
+
+	"tinfoil/internal/boot"
+)
+
+const (
+	pollInterval = 5 * time.Second
+)
+
+type declaredContainer struct {
+	Name    string `yaml:"name"`
+	Image   string `yaml:"image"`
+	Restart string `yaml:"restart"`
+}
+
+type declaredConfig struct {
+	Containers []declaredContainer `yaml:"containers"`
+}
+
+type containerStatusClient interface {
+	ContainerInspect(context.Context, string) (container.InspectResponse, error)
+}
+
+type containersResponse struct {
+	ObservedAt  time.Time         `json:"observed_at"`
+	Containers  []containerStatus `json:"containers"`
+	Unavailable string            `json:"unavailable,omitempty"`
+}
+
+type containerStatus struct {
+	Name          string           `json:"name"`
+	Image         string           `json:"image"`
+	Declared      bool             `json:"declared"`
+	Created       bool             `json:"created"`
+	Status        string           `json:"status,omitempty"`
+	RestartCount  int              `json:"restart_count"`
+	RestartPolicy string           `json:"restart_policy,omitempty"`
+	OOMKilled     bool             `json:"oom_killed"`
+	ExitCode      int              `json:"exit_code"`
+	Error         string           `json:"error,omitempty"`
+	StartedAt     string           `json:"started_at,omitempty"`
+	FinishedAt    string           `json:"finished_at,omitempty"`
+	Health        *containerHealth `json:"health,omitempty"`
+}
+
+type containerHealth struct {
+	Status            string     `json:"status"`
+	FailingStreak     int        `json:"failing_streak"`
+	LastCheckStart    *time.Time `json:"last_check_start,omitempty"`
+	LastCheckEnd      *time.Time `json:"last_check_end,omitempty"`
+	LastCheckExitCode *int       `json:"last_check_exit_code,omitempty"`
+}
+
+func main() {
+	log.SetFlags(0)
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		log.Fatalf("creating docker client: %v", err)
+	}
+	defer cli.Close()
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	log.Printf("Starting tinfoil container-status publisher")
+	publishAndLog(ctx, cli)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			publishAndLog(ctx, cli)
+		}
+	}
+}
+
+func publishAndLog(ctx context.Context, cli containerStatusClient) {
+	if err := publishContainerStatus(ctx, cli, boot.ConfigPath, boot.ContainerStatusPath); err != nil {
+		log.Printf("container status publish failed: %v", err)
+	}
+}
+
+func publishContainerStatus(ctx context.Context, cli containerStatusClient, configPath, outputPath string) error {
+	declared, err := loadDeclaredContainers(configPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("loading declared containers: %w", err)
+	}
+
+	states, inspectErr := inspectDeclaredContainers(ctx, cli, declared)
+	resp := containersResponse{
+		ObservedAt: time.Now().UTC(),
+		Containers: states,
+	}
+	if inspectErr != nil {
+		resp.Unavailable = inspectErr.Error()
+	}
+
+	data, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling status: %w", err)
+	}
+	data = append(data, '\n')
+	if err := atomicWriteFile(outputPath, data, 0o644); err != nil {
+		return fmt.Errorf("writing status: %w", err)
+	}
+	return inspectErr
+}
+
+func loadDeclaredContainers(path string) ([]declaredContainer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var cfg declaredConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg.Containers, nil
+}
+
+func inspectDeclaredContainers(ctx context.Context, cli containerStatusClient, declared []declaredContainer) ([]containerStatus, error) {
+	states := make([]containerStatus, 0, len(declared))
+	for _, c := range declared {
+		if c.Name == "" {
+			continue
+		}
+		inspect, err := cli.ContainerInspect(ctx, c.Name)
+		if err != nil {
+			if errdefs.IsNotFound(err) {
+				states = append(states, containerStatus{
+					Name:          c.Name,
+					Image:         c.Image,
+					Declared:      true,
+					Created:       false,
+					RestartPolicy: c.Restart,
+					Error:         "container not found",
+				})
+				continue
+			}
+			return states, fmt.Errorf("inspecting %s: %w", c.Name, err)
+		}
+		states = append(states, containerStatusFromInspect(c, inspect))
+	}
+	return states, nil
+}
+
+func containerStatusFromInspect(declared declaredContainer, inspect container.InspectResponse) containerStatus {
+	status := containerStatus{
+		Name:          declared.Name,
+		Image:         declared.Image,
+		Declared:      true,
+		Created:       true,
+		RestartPolicy: declared.Restart,
+	}
+
+	if inspect.Config != nil && inspect.Config.Image != "" {
+		status.Image = inspect.Config.Image
+	}
+	if inspect.ContainerJSONBase == nil {
+		return status
+	}
+
+	if inspect.Name != "" {
+		status.Name = strings.TrimPrefix(inspect.Name, "/")
+	}
+	if inspect.HostConfig != nil && inspect.HostConfig.RestartPolicy.Name != "" {
+		status.RestartPolicy = string(inspect.HostConfig.RestartPolicy.Name)
+		if inspect.HostConfig.RestartPolicy.MaximumRetryCount > 0 {
+			status.RestartPolicy = fmt.Sprintf("%s:%d", status.RestartPolicy, inspect.HostConfig.RestartPolicy.MaximumRetryCount)
+		}
+	}
+	status.RestartCount = inspect.RestartCount
+	if inspect.State == nil {
+		return status
+	}
+
+	status.Status = string(inspect.State.Status)
+	status.OOMKilled = inspect.State.OOMKilled
+	status.ExitCode = inspect.State.ExitCode
+	status.Error = inspect.State.Error
+	status.StartedAt = inspect.State.StartedAt
+	status.FinishedAt = inspect.State.FinishedAt
+	status.Health = containerHealthFromDocker(inspect.State.Health)
+
+	return status
+}
+
+func containerHealthFromDocker(health *container.Health) *containerHealth {
+	if health == nil {
+		return nil
+	}
+	out := &containerHealth{
+		Status:        string(health.Status),
+		FailingStreak: health.FailingStreak,
+	}
+	if len(health.Log) == 0 {
+		return out
+	}
+	last := health.Log[len(health.Log)-1]
+	if last == nil {
+		return out
+	}
+	out.LastCheckStart = &last.Start
+	out.LastCheckEnd = &last.End
+	out.LastCheckExitCode = &last.ExitCode
+	return out
+}
+
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer os.Remove(tmpName)
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(perm); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}

--- a/tinfoil/cmd/container-status/main_test.go
+++ b/tinfoil/cmd/container-status/main_test.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/containerd/errdefs"
+	"github.com/docker/docker/api/types/container"
+)
+
+type fakeContainerClient struct {
+	inspect map[string]container.InspectResponse
+	errs    map[string]error
+}
+
+func (f fakeContainerClient) ContainerInspect(_ context.Context, name string) (container.InspectResponse, error) {
+	if err := f.errs[name]; err != nil {
+		return container.InspectResponse{}, err
+	}
+	if inspect, ok := f.inspect[name]; ok {
+		return inspect, nil
+	}
+	return container.InspectResponse{}, errdefs.ErrNotFound
+}
+
+func TestInspectDeclaredContainers_MissingContainer(t *testing.T) {
+	states, err := inspectDeclaredContainers(context.Background(), fakeContainerClient{}, []declaredContainer{{
+		Name:    "model",
+		Image:   "example/model:latest",
+		Restart: "always",
+	}})
+	if err != nil {
+		t.Fatalf("inspectDeclaredContainers returned error: %v", err)
+	}
+	if len(states) != 1 {
+		t.Fatalf("got %d states, want 1", len(states))
+	}
+	got := states[0]
+	if !got.Declared || got.Created {
+		t.Fatalf("missing container declared/created = %v/%v, want true/false", got.Declared, got.Created)
+	}
+	if got.Error != "container not found" {
+		t.Fatalf("missing container error = %q", got.Error)
+	}
+	if got.RestartPolicy != "always" {
+		t.Fatalf("restart policy = %q, want always", got.RestartPolicy)
+	}
+}
+
+func TestContainerStatusFromInspect_RunningContainer(t *testing.T) {
+	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "declared:latest", Restart: "unless-stopped"}, container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			Name:         "/model",
+			RestartCount: 2,
+			State: &container.State{
+				Status:    "running",
+				Running:   true,
+				StartedAt: "2026-01-02T03:04:05Z",
+			},
+			HostConfig: &container.HostConfig{RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped}},
+		},
+		Config: &container.Config{Image: "actual:latest"},
+	})
+
+	if got.Name != "model" || got.Image != "actual:latest" {
+		t.Fatalf("name/image = %q/%q", got.Name, got.Image)
+	}
+	if !got.Created || got.Status != "running" {
+		t.Fatalf("created/status = %v/%q", got.Created, got.Status)
+	}
+	if got.RestartCount != 2 || got.RestartPolicy != "unless-stopped" {
+		t.Fatalf("restart count/policy = %d/%q", got.RestartCount, got.RestartPolicy)
+	}
+	if got.StartedAt != "2026-01-02T03:04:05Z" {
+		t.Fatalf("started_at = %q", got.StartedAt)
+	}
+}
+
+func TestContainerStatusFromInspect_RestartingContainer(t *testing.T) {
+	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			Name:         "/model",
+			RestartCount: 4,
+			State: &container.State{
+				Status:     "restarting",
+				Restarting: true,
+				ExitCode:   1,
+				Error:      "restart loop",
+			},
+			HostConfig: &container.HostConfig{RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyOnFailure, MaximumRetryCount: 10}},
+		},
+	})
+
+	if got.Status != "restarting" || got.RestartCount != 4 {
+		t.Fatalf("status/restart_count = %q/%d", got.Status, got.RestartCount)
+	}
+	if got.RestartPolicy != "on-failure:10" {
+		t.Fatalf("restart policy = %q", got.RestartPolicy)
+	}
+	if got.ExitCode != 1 || got.Error != "restart loop" {
+		t.Fatalf("exit/error = %d/%q", got.ExitCode, got.Error)
+	}
+}
+
+func TestContainerStatusFromInspect_OOMKilledExitedContainer(t *testing.T) {
+	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			State: &container.State{
+				Status:     "exited",
+				OOMKilled:  true,
+				ExitCode:   137,
+				FinishedAt: "2026-01-02T03:05:05Z",
+			},
+		},
+	})
+
+	if !got.OOMKilled || got.ExitCode != 137 || got.Status != "exited" {
+		t.Fatalf("oom/exit/status = %v/%d/%q", got.OOMKilled, got.ExitCode, got.Status)
+	}
+	if got.FinishedAt == "" {
+		t.Fatal("expected finished_at to be set")
+	}
+}
+
+func TestContainerStatusFromInspect_UnhealthyHealthcheck(t *testing.T) {
+	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	end := start.Add(time.Second)
+	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			State: &container.State{
+				Status: "running",
+				Health: &container.Health{
+					Status:        container.Unhealthy,
+					FailingStreak: 3,
+					Log: []*container.HealthcheckResult{
+						{Start: start.Add(-time.Minute), End: end.Add(-time.Minute), ExitCode: 0, Output: "old"},
+						{Start: start, End: end, ExitCode: 1, Output: "model still loading"},
+					},
+				},
+			},
+		},
+	})
+
+	if got.Health == nil {
+		t.Fatal("expected health state")
+	}
+	if got.Health.Status != container.Unhealthy || got.Health.FailingStreak != 3 {
+		t.Fatalf("health status/streak = %q/%d", got.Health.Status, got.Health.FailingStreak)
+	}
+	if got.Health.LastCheckExitCode == nil || *got.Health.LastCheckExitCode != 1 {
+		t.Fatalf("last health check = %#v", got.Health)
+	}
+}
+
+func TestInspectDeclaredContainers_UnexpectedError(t *testing.T) {
+	boom := errors.New("docker unavailable")
+	states, err := inspectDeclaredContainers(context.Background(), fakeContainerClient{
+		errs: map[string]error{"model": boom},
+	}, []declaredContainer{{Name: "model"}})
+	if err == nil || !strings.Contains(err.Error(), boom.Error()) {
+		t.Fatalf("expected docker error, got %v", err)
+	}
+	if len(states) != 0 {
+		t.Fatalf("expected no states before first inspect failure, got %#v", states)
+	}
+}
+
+func TestPublishContainerStatusWritesJSON(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yml")
+	outputPath := filepath.Join(dir, "container-status.json")
+	if err := os.WriteFile(configPath, []byte(`containers:
+  - name: model
+    image: declared:latest
+    restart: always
+`), 0o644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+
+	err := publishContainerStatus(context.Background(), fakeContainerClient{
+		inspect: map[string]container.InspectResponse{
+			"model": {
+				ContainerJSONBase: &container.ContainerJSONBase{
+					Name:  "/model",
+					State: &container.State{Status: "running", Running: true},
+				},
+			},
+		},
+	}, configPath, outputPath)
+	if err != nil {
+		t.Fatalf("publishContainerStatus returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+	var got containersResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshaling output: %v", err)
+	}
+	if len(got.Containers) != 1 || got.Containers[0].Name != "model" || got.Containers[0].Status != "running" {
+		t.Fatalf("unexpected output: %#v", got)
+	}
+	if got.ObservedAt.IsZero() {
+		t.Fatal("expected observed_at to be set")
+	}
+}

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -172,7 +172,7 @@ func NewShimServer(
 	rateLimiter *RateLimiter,
 	att *attestation.Document,
 	identityBody tinfoilattestation.BodyV2,
-	gpuCount int,
+	expectedGPUs int,
 	ehbpIdentity *identity.Identity,
 	tlsCert *tls.Certificate,
 	config *config.Config,
@@ -212,13 +212,6 @@ func NewShimServer(
 			log.Printf("proxy error: %v", err)
 			writeJSONError(w, errMsgServerError, errTypeServer, http.StatusBadGateway)
 		},
-	}
-
-	globalMiddleware := func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Tinfoil-Pt", string(att.Format))
-			next.ServeHTTP(w, r)
-		})
 	}
 
 	proxyHandler := ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -266,6 +259,50 @@ func NewShimServer(
 		proxyHandler.ServeHTTP(w, r)
 	}))
 
+	registerObservabilityHandlers(mux, ehbpMiddleware, att, identityBody, expectedGPUs, ehbpIdentity, tlsCert, config, externalConfig)
+
+	return wrapShimMux(config, att, mux)
+}
+
+func NewObservabilityServer(
+	att *attestation.Document,
+	identityBody tinfoilattestation.BodyV2,
+	expectedGPUs int,
+	ehbpIdentity *identity.Identity,
+	tlsCert *tls.Certificate,
+	config *config.Config,
+	externalConfig *config.ExternalConfig,
+) http.Handler {
+	ehbpMiddleware := ehbpIdentity.Middleware()
+	mux := http.NewServeMux()
+	registerObservabilityHandlers(mux, ehbpMiddleware, att, identityBody, expectedGPUs, ehbpIdentity, tlsCert, config, externalConfig)
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		writeWorkloadUnavailable(w)
+	})
+	return wrapShimMux(config, att, mux)
+}
+
+func wrapShimMux(config *config.Config, att *attestation.Document, mux *http.ServeMux) http.Handler {
+	globalMiddleware := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Tinfoil-Pt", string(att.Format))
+			next.ServeHTTP(w, r)
+		})
+	}
+	return corsMiddleware(config, globalMiddleware(mux))
+}
+
+func registerObservabilityHandlers(
+	mux *http.ServeMux,
+	ehbpMiddleware func(http.Handler) http.Handler,
+	att *attestation.Document,
+	identityBody tinfoilattestation.BodyV2,
+	expectedGPUs int,
+	ehbpIdentity *identity.Identity,
+	tlsCert *tls.Certificate,
+	config *config.Config,
+	externalConfig *config.ExternalConfig,
+) {
 	mux.Handle("/.well-known/tinfoil-attestation", ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
@@ -280,18 +317,25 @@ func NewShimServer(
 			var gpuJSON, nvswitchJSON json.RawMessage
 			var nonce32 [32]byte
 			copy(nonce32[:], nonce)
-			if gpuCount > 0 {
+			if expectedGPUs > 0 {
 				gpuEvidence, err := tinfoilattestation.CollectGPUEvidence(nonce32)
 				if err != nil {
-					log.Printf("GPU evidence collection failed (non-fatal): %v", err)
-				} else if len(gpuEvidence.Evidences) > 0 {
-					gpuJSON, _ = json.Marshal(gpuEvidence)
+					log.Printf("GPU evidence collection failed for %d expected GPU(s): %v", expectedGPUs, err)
+					writeJSONError(w, "GPU attestation evidence unavailable", errTypeServer, http.StatusInternalServerError)
+					return
 				}
-				if gpuCount >= 8 {
+				if got := len(gpuEvidence.Evidences); got != expectedGPUs {
+					log.Printf("GPU evidence count mismatch: expected %d, got %d", expectedGPUs, got)
+					writeJSONError(w, "GPU attestation evidence incomplete", errTypeServer, http.StatusInternalServerError)
+					return
+				}
+				gpuJSON, _ = json.Marshal(gpuEvidence)
+				if expectedGPUs >= 8 {
 					nvswitchJSON, err = tinfoilattestation.CollectNVSwitchEvidence(nonce32)
 					if err != nil {
-						log.Printf("NVSwitch evidence collection failed (non-fatal): %v", err)
-						nvswitchJSON = nil
+						log.Printf("NVSwitch evidence collection failed: %v", err)
+						writeJSONError(w, "NVSwitch attestation evidence unavailable", errTypeServer, http.StatusInternalServerError)
+						return
 					}
 				}
 			}
@@ -349,7 +393,31 @@ func NewShimServer(
 	mux.HandleFunc("/.well-known/tinfoil-metrics", metrics.HandleMetrics(externalConfig))
 	mux.HandleFunc("/.well-known/tinfoil-acpi", acpi.HandleQemuACPI(config, externalConfig))
 	mux.HandleFunc("/.well-known/metrics", metrics.HandlePrometheusMetrics(&externalConfig.Metadata, externalConfig.MetricsAPIKey))
+	mux.HandleFunc("/.well-known/tinfoil-containers", containersHandler())
 	mux.HandleFunc(ehbpProtocol.KeysPath, ehbpIdentity.ConfigHandler)
+}
 
-	return corsMiddleware(config, globalMiddleware(mux))
+func writeWorkloadUnavailable(w http.ResponseWriter) {
+	status := "pending"
+	var state any
+	if s, err := boot.Load(); err == nil {
+		state = s
+		if s.HasFailed() {
+			status = "failed"
+		}
+	}
+	body := map[string]any{
+		"error": map[string]any{
+			"message": "Workload proxy is not ready.",
+			"type":    errTypeServer,
+			"status":  status,
+		},
+	}
+	if state != nil {
+		body["boot"] = state
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	json.NewEncoder(w).Encode(body)
 }

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -18,6 +18,11 @@ import (
 
 func testServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
 	t.Helper()
+	return testFullServer(t, paths, upstreamPort)
+}
+
+func testFullServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
+	t.Helper()
 
 	id, err := identity.NewIdentity()
 	if err != nil {
@@ -36,6 +41,24 @@ func testServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
 	upstreamAddr := fmt.Sprintf("127.0.0.1:%d", upstreamPort)
 
 	return NewShimServer(nil, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, upstreamAddr)
+}
+
+func testObservabilityServer(t *testing.T, paths []string) http.Handler {
+	t.Helper()
+
+	id, err := identity.NewIdentity()
+	if err != nil {
+		t.Fatalf("creating identity: %v", err)
+	}
+
+	cfg := &config.Config{Paths: paths}
+	extCfg := &config.ExternalConfig{}
+	att := &attestation.Document{
+		Format: "https://tinfoil.sh/predicate/dummy/v2",
+		Body:   "deadbeef",
+	}
+
+	return NewObservabilityServer(att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg)
 }
 
 func TestPathNotAllowed_Returns404(t *testing.T) {
@@ -177,5 +200,44 @@ func TestNoPathsConfigured_AllPathsAllowed(t *testing.T) {
 	// It will hit the EHBP middleware, which is fine — just verify it's not 404.
 	if rec.Code == http.StatusNotFound {
 		t.Fatalf("with no paths configured, should not return 404, got: %s", rec.Body.String())
+	}
+}
+
+func TestObservabilityServer_WorkloadReturns503BeforeReady(t *testing.T) {
+	handler := testObservabilityServer(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 before proxy ready, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Workload proxy is not ready.") {
+		t.Fatalf("expected proxy readiness error, got: %s", rec.Body.String())
+	}
+}
+
+func TestObservabilityServer_WellKnownEndpointsBypassProxyReadiness(t *testing.T) {
+	handler := testObservabilityServer(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/tinfoil-certificate", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusServiceUnavailable && strings.Contains(rec.Body.String(), "Workload proxy is not ready.") {
+		t.Fatalf("well-known endpoint should bypass proxy readiness gate: %s", rec.Body.String())
+	}
+}
+
+func TestFullServer_WorkloadReachesProxyPath(t *testing.T) {
+	handler := testFullServer(t, nil, 9999)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusServiceUnavailable && strings.Contains(rec.Body.String(), "Workload proxy is not ready.") {
+		t.Fatalf("ready proxy gate should not block workload path: %s", rec.Body.String())
 	}
 }

--- a/tinfoil/cmd/shim/containers.go
+++ b/tinfoil/cmd/shim/containers.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"net/http"
+	"os"
+
+	"tinfoil/internal/boot"
+)
+
+func containersHandler() http.HandlerFunc {
+	return serveContainerStatusFile(boot.ContainerStatusPath)
+}
+
+func serveContainerStatusFile(path string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			http.Error(w, "container status not available", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(data)
+	}
+}

--- a/tinfoil/cmd/shim/containers_test.go
+++ b/tinfoil/cmd/shim/containers_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestServeContainerStatusFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "container-status.json")
+	if err := os.WriteFile(path, []byte(`{"containers":[]}`), 0o644); err != nil {
+		t.Fatalf("writing status: %v", err)
+	}
+
+	handler := serveContainerStatusFile(path)
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/tinfoil-containers", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Fatalf("content type = %q", got)
+	}
+	if got := rec.Body.String(); got != `{"containers":[]}` {
+		t.Fatalf("body = %q", got)
+	}
+}
+
+func TestServeContainerStatusFileMissing(t *testing.T) {
+	handler := serveContainerStatusFile(filepath.Join(t.TempDir(), "missing.json"))
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/tinfoil-containers", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d: %s", rec.Code, rec.Body.String())
+	}
+}

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -106,9 +106,8 @@ func bootStagesHandler() http.Handler {
 
 const artifactPollInterval = 1 * time.Second
 
-// upgradeWhenReady polls for boot artifacts on the ramdisk, waits for all
-// boot stages to complete, then builds the full shim handler and swaps it in.
-// On failure the shim stays in boot-stages-only mode.
+// upgradeWhenReady advances the public handler through three explicit phases:
+// boot stages only, observability only, and finally workload proxying.
 func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificate]) {
 	start := time.Now()
 
@@ -150,7 +149,28 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 			return err
 		}
 
-		// Wait for all boot stages (except shim) to resolve
+		// Build identity body for fresh attestation (binds TLS key + HPKE key to hardware)
+		realCertParsed := cert.Load()
+		tlsPub, ok := realCertParsed.PrivateKey.(*ecdsa.PrivateKey)
+		if !ok {
+			return fmt.Errorf("TLS key is not ECDSA")
+		}
+		identityBody := tinfoilattestation.BodyV2{
+			TLSKeyFP: tlsutil.KeyFPBytes(&tlsPub.PublicKey),
+		}
+		copy(identityBody.HPKEKey[:], serverIdentity.MarshalPublicKey())
+
+		expectedGPUs := config.ExpectedGPUs
+		log.Printf("Expected %d GPU(s) for attestation", expectedGPUs)
+
+		observabilityHandler := NewObservabilityServer(att, identityBody, expectedGPUs, serverIdentity, realCertParsed, config, externalConfig)
+		handler.Store(http.HandlerFunc(observabilityHandler.ServeHTTP))
+
+		log.Println("Shim observability ready")
+
+		// Wait for all boot stages (except shim) to resolve before proxying
+		// workload traffic. Well-known observability endpoints stay live while
+		// containers load, restart, or fail.
 		waitUntil(func() bool {
 			state, err := boot.Load()
 			if err != nil {
@@ -164,12 +184,9 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 			return true
 		})
 
-		// Abort if any boot stage failed
 		if state, err := boot.Load(); err == nil && state.HasFailed() {
-			return fmt.Errorf("boot stage failed, not upgrading shim")
+			return fmt.Errorf("boot stage failed, not enabling proxy")
 		}
-
-		start = time.Now()
 
 		// API key validator
 		var validator key.Validator
@@ -196,25 +213,11 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 			rateLimiter = NewRateLimiter(rate.Limit(config.RateLimit), config.RateBurst)
 		}
 
-		// Build identity body for fresh attestation (binds TLS key + HPKE key to hardware)
-		realCertParsed := cert.Load()
-		tlsPub, ok := realCertParsed.PrivateKey.(*ecdsa.PrivateKey)
-		if !ok {
-			return fmt.Errorf("TLS key is not ECDSA")
-		}
-		identityBody := tinfoilattestation.BodyV2{
-			TLSKeyFP: tlsutil.KeyFPBytes(&tlsPub.PublicKey),
-		}
-		copy(identityBody.HPKEKey[:], serverIdentity.MarshalPublicKey())
-
-		gpuCount := tinfoilattestation.DetectGPUCount()
-		log.Printf("Detected %d GPU(s) for attestation", gpuCount)
-
 		upstreamHost := resolveUpstreamHost(config.UpstreamContainer)
 		upstreamAddr := fmt.Sprintf("%s:%d", upstreamHost, config.UpstreamPort)
 		log.Printf("Shim upstream resolved: %s → %s", config.UpstreamContainer, upstreamAddr)
 
-		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, gpuCount, serverIdentity, realCertParsed, config, externalConfig, upstreamAddr)
+		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, expectedGPUs, serverIdentity, realCertParsed, config, externalConfig, upstreamAddr)
 		handler.Store(http.HandlerFunc(fullHandler.ServeHTTP))
 
 		log.Println("Shim fully operational")

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -6,9 +6,10 @@ const (
 	PrivateDir = RamdiskDir + "/private"
 
 	// Public — mounted read-only into containers as /tinfoil.
-	ConfigPath      = PublicDir + "/config.yml"
-	AttestationPath = PublicDir + "/attestation.json"
-	MPKDir          = PublicDir + "/mpk"
+	ConfigPath          = PublicDir + "/config.yml"
+	AttestationPath     = PublicDir + "/attestation.json"
+	ContainerStatusPath = PublicDir + "/container-status.json"
+	MPKDir              = PublicDir + "/mpk"
 
 	// Private — only accessible to boot, egress, and shim processes (mode 0700).
 	// Holds CVM-level secrets and material that must never reach a container.

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -40,6 +40,10 @@ type Config struct {
 
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`
+
+	// ExpectedGPUs is copied from the attested top-level boot config so the
+	// shim does not need to probe hardware on its public request path.
+	ExpectedGPUs int `yaml:"expected-gpus" default:"0"`
 }
 
 const (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a container status publisher and a new observability endpoint so you can see container health during boot. Also introduces an observability-only phase before proxying and enforces GPU/NVSwitch attestation to match the expected hardware.

- New Features
  - Adds `tinfoil-container-status` daemon + `tinfoil-container-status.service` that inspects declared containers every 5s and writes JSON to `/mnt/ramdisk/public/container-status.json` atomically.
  - Exposes `/.well-known/tinfoil-containers` from the shim to serve that JSON (200) or 503 if unavailable.
  - Shim now starts in observability-only mode: `/.well-known/*` works immediately; other paths return 503 “Workload proxy is not ready.” until the proxy is enabled.
  - GPU attestation now requires the configured number of GPUs and, if ≥8, NVSwitch evidence; mismatches or unavailable evidence return 500.

- Migration
  - Ensure the top-level boot config’s GPU count is correct; it is propagated as `expected-gpus` to the shim and enforced by the attestation endpoint. Set to 0 to disable GPU evidence requirements.
  - Enable and start `tinfoil-container-status.service` so the container status file is produced and `/.well-known/tinfoil-containers` responds.

<sup>Written for commit 366a06dccdddd4171fe7496ffa72802bb3cd2e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

