### PR TITLE
feat: verify OAuth access tokens inside the enclave

### DIFF
--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -19,7 +19,6 @@ import (
 	"tinfoil/internal/boot"
 	"tinfoil/internal/config"
 	"tinfoil/internal/key"
-	"tinfoil/internal/key/online"
 	"tinfoil/internal/metrics"
 
 	"github.com/tinfoilsh/encrypted-http-body-protocol/identity"
@@ -112,7 +111,7 @@ func writeJSONError(w http.ResponseWriter, message string, errorType string, sta
 }
 
 func writeValidationFailure(w http.ResponseWriter, err error) {
-	var validationErr *online.ValidationError
+	var validationErr *key.ValidationError
 	if !errors.As(err, &validationErr) {
 		writeJSONError(w, errMsgServerError, errTypeServer, http.StatusInternalServerError)
 		return

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -88,13 +88,6 @@ const (
 	errTypeServer            = "server_error"
 )
 
-// subjectHeader carries the authenticated principal (JWT `sub`) from the shim to
-// the upstream workload after a JWT access token is verified in-enclave. The
-// upstream trusts it because the shim is the only path to it and unconditionally
-// strips any client-supplied value before setting its own. Must match the header
-// the upstream (confidential-model-router) reads.
-const subjectHeader = "X-Tinfoil-Subject"
-
 // Client-facing error messages, aligned with OpenAI's standard error messages
 // where applicable. See https://platform.openai.com/docs/guides/error-codes
 const (
@@ -221,20 +214,7 @@ func NewShimServer(
 	}
 
 	proxyHandler := ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Never trust a client-supplied identity header: the shim is the sole
-		// authority for subjectHeader and (re)sets it only after verifying a
-		// JWT below. Strip it unconditionally, including on unauthenticated
-		// paths, so a forged value can never reach the upstream.
-		r.Header.Del(subjectHeader)
-
 		apiKey := extractBearerToken(r.Header.Get("Authorization"))
-
-		// rateLimitID identifies the caller for the shim's local rate limiter.
-		// It defaults to the bearer credential and is replaced with the verified
-		// JWT subject when available, so a user's bucket is stable across the
-		// short-lived token's refreshes (and across multiple tokens).
-		rateLimitID := apiKey
-
 		if validator != nil && requiresAuth(config.AuthenticatedEndpoints, r.URL.Path) {
 			if len(apiKey) == 0 {
 				writeJSONError(w, errMsgAPIKeyRequired, errTypeInvalidRequest, http.StatusUnauthorized)
@@ -248,19 +228,10 @@ func NewShimServer(
 				Path:          r.URL.Path,
 			}
 
-			res, err := validator.Validate(validationReq)
-			if err != nil {
+			if err := validator.Validate(validationReq); err != nil {
 				log.Printf("Warning: failed to validate API key: %v", err)
 				writeValidationFailure(w, err)
 				return
-			}
-
-			// Forward the verified principal to the upstream so it can attribute
-			// usage and rate limits to a stable identity rather than the
-			// rotating bearer token. Empty for opaque keys (online validator).
-			if res.Subject != "" {
-				r.Header.Set(subjectHeader, res.Subject)
-				rateLimitID = res.Subject
 			}
 		}
 
@@ -269,7 +240,7 @@ func NewShimServer(
 				writeJSONError(w, errMsgAPIKeyRequired, errTypeInvalidRequest, http.StatusUnauthorized)
 				return
 			}
-			limiter := rateLimiter.Limit(rateLimitID)
+			limiter := rateLimiter.Limit(apiKey)
 			if !limiter.Allow() {
 				writeJSONError(w, errMsgRateLimited, errTypeInvalidRequest, http.StatusTooManyRequests)
 				return

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -88,6 +88,13 @@ const (
 	errTypeServer            = "server_error"
 )
 
+// subjectHeader carries the authenticated principal (JWT `sub`) from the shim to
+// the upstream workload after a JWT access token is verified in-enclave. The
+// upstream trusts it because the shim is the only path to it and unconditionally
+// strips any client-supplied value before setting its own. Must match the header
+// the upstream (confidential-model-router) reads.
+const subjectHeader = "X-Tinfoil-Subject"
+
 // Client-facing error messages, aligned with OpenAI's standard error messages
 // where applicable. See https://platform.openai.com/docs/guides/error-codes
 const (
@@ -214,7 +221,20 @@ func NewShimServer(
 	}
 
 	proxyHandler := ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Never trust a client-supplied identity header: the shim is the sole
+		// authority for subjectHeader and (re)sets it only after verifying a
+		// JWT below. Strip it unconditionally, including on unauthenticated
+		// paths, so a forged value can never reach the upstream.
+		r.Header.Del(subjectHeader)
+
 		apiKey := extractBearerToken(r.Header.Get("Authorization"))
+
+		// rateLimitID identifies the caller for the shim's local rate limiter.
+		// It defaults to the bearer credential and is replaced with the verified
+		// JWT subject when available, so a user's bucket is stable across the
+		// short-lived token's refreshes (and across multiple tokens).
+		rateLimitID := apiKey
+
 		if validator != nil && requiresAuth(config.AuthenticatedEndpoints, r.URL.Path) {
 			if len(apiKey) == 0 {
 				writeJSONError(w, errMsgAPIKeyRequired, errTypeInvalidRequest, http.StatusUnauthorized)
@@ -228,10 +248,19 @@ func NewShimServer(
 				Path:          r.URL.Path,
 			}
 
-			if err := validator.Validate(validationReq); err != nil {
+			res, err := validator.Validate(validationReq)
+			if err != nil {
 				log.Printf("Warning: failed to validate API key: %v", err)
 				writeValidationFailure(w, err)
 				return
+			}
+
+			// Forward the verified principal to the upstream so it can attribute
+			// usage and rate limits to a stable identity rather than the
+			// rotating bearer token. Empty for opaque keys (online validator).
+			if res.Subject != "" {
+				r.Header.Set(subjectHeader, res.Subject)
+				rateLimitID = res.Subject
 			}
 		}
 
@@ -240,7 +269,7 @@ func NewShimServer(
 				writeJSONError(w, errMsgAPIKeyRequired, errTypeInvalidRequest, http.StatusUnauthorized)
 				return
 			}
-			limiter := rateLimiter.Limit(apiKey)
+			limiter := rateLimiter.Limit(rateLimitID)
 			if !limiter.Allow() {
 				writeJSONError(w, errMsgRateLimited, errTypeInvalidRequest, http.StatusTooManyRequests)
 				return

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -26,6 +26,7 @@ import (
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/key"
+	localjwt "tinfoil/internal/key/jwt"
 	"tinfoil/internal/key/online"
 	tlsutil "tinfoil/internal/tls"
 )
@@ -197,9 +198,23 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 			}
 
 			if config.Authenticated {
-				validator, err = online.NewValidator(controlPlaneURL.JoinPath("api", "shim", "validate-key").String())
+				onlineValidator, err := online.NewValidator(controlPlaneURL.JoinPath("api", "shim", "validate-key").String())
 				if err != nil {
 					return fmt.Errorf("initializing API key verifier: %w", err)
+				}
+
+				// Verify OAuth JWT access tokens locally against the control
+				// plane's JWKS so they need no per-request round trip; opaque
+				// keys still fall through to the online validator. If the JWKS
+				// cannot be fetched at boot, fall back to online-only.
+				jwksURL := controlPlaneURL.JoinPath(".well-known", "jwks.json").String()
+				jwtValidator, err := localjwt.NewValidator(jwksURL, config.ControlPlane, localjwt.AccessTokenAudience, localjwt.RequiredScope)
+				if err != nil {
+					log.Printf("Warning: local JWT validation unavailable, using online-only: %v", err)
+					validator = onlineValidator
+				} else {
+					log.Println("Local JWT validation enabled (OAuth access tokens verified in-enclave)")
+					validator = key.NewChain(jwtValidator, onlineValidator)
 				}
 			} else {
 				log.Println("Warning: API key verification disabled (unauthenticated endpoint)")

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -205,17 +205,13 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 
 				// Verify OAuth JWT access tokens locally against the control
 				// plane's JWKS so they need no per-request round trip; opaque
-				// keys still fall through to the online validator. If the JWKS
-				// cannot be fetched at boot, fall back to online-only.
+				// keys still fall through to the online validator. The JWKS
+				// loads best-effort and self-heals via refresh, so a
+				// control-plane blip at boot never disables local verification.
 				jwksURL := controlPlaneURL.JoinPath(".well-known", "jwks.json").String()
-				jwtValidator, err := localjwt.NewValidator(jwksURL, config.ControlPlane, localjwt.AccessTokenAudience, localjwt.RequiredScope)
-				if err != nil {
-					log.Printf("Warning: local JWT validation unavailable, using online-only: %v", err)
-					validator = onlineValidator
-				} else {
-					log.Println("Local JWT validation enabled (OAuth access tokens verified in-enclave)")
-					validator = key.NewChain(jwtValidator, onlineValidator)
-				}
+				jwtValidator := localjwt.NewValidator(jwksURL, config.ControlPlane, localjwt.AccessTokenAudience, localjwt.RequiredScope)
+				log.Println("Local JWT validation enabled (OAuth access tokens verified in-enclave)")
+				validator = key.NewChain(jwtValidator, onlineValidator)
 			} else {
 				log.Println("Warning: API key verification disabled (unauthenticated endpoint)")
 			}

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/go-acme/lego/v4 v4.30.1
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/google/go-sev-guest v0.14.1
 	github.com/google/go-tdx-guest v0.3.1
 	github.com/jarcoal/httpmock v1.3.1
@@ -35,7 +36,6 @@ require (
 	github.com/docker/docker-credential-helpers v0.9.5 // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/go-configfs-tsm v0.2.2 // indirect

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	// AccessTokenAudience must match the control plane's OAuthAccessTokenAudience
-	// (the aud claim stamped on inference access tokens).
-	AccessTokenAudience = "https://inference.tinfoil.sh"
+	// AccessTokenAudience is the logical, endpoint-agnostic identifier for the
+	// Tinfoil inference API in the aud claim. Every inference endpoint shares
+	// it because the control plane mints a token without knowing which endpoint
+	// will serve it. Must match the control plane's OAuthAccessTokenAudience.
+	AccessTokenAudience = "tinfoil-inference"
 
 	// RequiredScope is the OAuth scope a token must carry to call chat inference.
 	RequiredScope = "inference:chat"

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -52,6 +52,7 @@ type signingKeys struct {
 	mu          sync.RWMutex
 	set         jose.JSONWebKeySet
 	lastRefresh time.Time
+	lastAttempt time.Time
 }
 
 func newSigningKeys(jwksURL string) (*signingKeys, error) {
@@ -100,16 +101,20 @@ func (s *signingKeys) lookup(kid string) (jose.JSONWebKey, bool) {
 	return matches[0], true
 }
 
-// refreshIfStale refreshes the JWKS when it has not been refreshed within
-// minRefreshInterval, so a rotated key can be picked up on demand without
-// letting unknown-kid tokens trigger unbounded fetches.
+// refreshIfStale triggers an on-demand JWKS refresh when a token carries an
+// unknown key id, so a rotated key can be picked up without a restart. It is
+// throttled on the last attempt time rather than the last success, so that a
+// JWKS outage combined with unknown-kid traffic cannot fan out into unbounded
+// fetch attempts.
 func (s *signingKeys) refreshIfStale() {
-	s.mu.RLock()
-	fresh := time.Since(s.lastRefresh) < minRefreshInterval
-	s.mu.RUnlock()
-	if fresh {
+	s.mu.Lock()
+	if time.Since(s.lastRefresh) < minRefreshInterval || time.Since(s.lastAttempt) < minRefreshInterval {
+		s.mu.Unlock()
 		return
 	}
+	s.lastAttempt = time.Now()
+	s.mu.Unlock()
+
 	if err := s.refresh(context.Background()); err != nil {
 		log.Printf("Warning: on-demand JWKS refresh failed: %v", err)
 	}
@@ -164,7 +169,12 @@ func (v *Validator) Validate(req key.Request) error {
 		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
-	if typ, _ := token.Headers[0].ExtraHeaders[jose.HeaderType].(string); !strings.EqualFold(typ, accessTokenType) {
+	// RFC 9068 registers the access-token type as "at+jwt"; RFC 7515 also
+	// permits the equivalent media type carrying an "application/" prefix, so
+	// accept both forms case-insensitively.
+	typ, _ := token.Headers[0].ExtraHeaders[jose.HeaderType].(string)
+	typ = strings.TrimPrefix(strings.ToLower(typ), "application/")
+	if typ != accessTokenType {
 		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -171,14 +171,14 @@ func NewValidator(jwksURL, issuer, audience, requiredScope string) *Validator {
 	}
 }
 
-func (v *Validator) Validate(req key.Request) error {
+func (v *Validator) Validate(req key.Request) (key.Result, error) {
 	if !isAccessTokenJWT(req.APIKey) {
-		return key.ErrUnsupportedToken
+		return key.Result{}, key.ErrUnsupportedToken
 	}
 
 	token, err := josejwt.ParseSigned(req.APIKey, []jose.SignatureAlgorithm{jose.EdDSA})
 	if err != nil || len(token.Headers) == 0 {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	// RFC 9068 registers the access-token type as "at+jwt"; RFC 7515 also
@@ -186,7 +186,7 @@ func (v *Validator) Validate(req key.Request) error {
 	// accept both forms case-insensitively.
 	typ, _ := token.Headers[0].ExtraHeaders[jose.HeaderType].(string)
 	if normalizeType(typ) != accessTokenType {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	signingKey, ok := v.keys.lookup(token.Headers[0].KeyID)
@@ -194,17 +194,17 @@ func (v *Validator) Validate(req key.Request) error {
 		v.keys.refreshIfAllowed()
 		signingKey, ok = v.keys.lookup(token.Headers[0].KeyID)
 		if !ok {
-			return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+			return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 		}
 	}
 
 	var claims josejwt.Claims
 	var ext accessTokenClaims
 	if err := token.Claims(signingKey, &claims, &ext); err != nil {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 	if claims.Subject == "" || claims.Expiry == nil || claims.IssuedAt == nil || claims.ID == "" || ext.ClientID == "" {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	if err := claims.Validate(josejwt.Expected{
@@ -212,14 +212,16 @@ func (v *Validator) Validate(req key.Request) error {
 		AnyAudience: josejwt.Audience{v.audience},
 		Time:        time.Now(),
 	}); err != nil {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	if !scopeContains(ext.Scope, v.scope) {
-		return &key.ValidationError{StatusCode: http.StatusForbidden}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusForbidden}
 	}
 
-	return nil
+	// The verified subject lets the shim forward a stable identity to the
+	// upstream so usage/rate limits attach to the user, not the rotating token.
+	return key.Result{Subject: claims.Subject}, nil
 }
 
 // isAccessTokenJWT reports whether s is explicitly typed as an access-token

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -1,0 +1,229 @@
+// Package jwt verifies OAuth 2.0 JWT access tokens (RFC 9068) locally inside
+// the enclave. It fetches the control plane's JWKS once at boot, refreshes it
+// periodically to follow signing-key rotation, and validates token signatures
+// and claims without a per-request call to the control plane.
+package jwt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+
+	"tinfoil/internal/key"
+)
+
+const (
+	// AccessTokenAudience must match the control plane's OAuthAccessTokenAudience
+	// (the aud claim stamped on inference access tokens).
+	AccessTokenAudience = "https://inference.tinfoil.sh"
+
+	// RequiredScope is the OAuth scope a token must carry to call chat inference.
+	RequiredScope = "inference:chat"
+
+	// accessTokenType is the RFC 9068 "typ" header that distinguishes an OAuth
+	// access token from other JWTs signed by the same key.
+	accessTokenType = "at+jwt"
+
+	// refreshInterval is how often the cached JWKS is refreshed to follow
+	// signing-key rotation.
+	refreshInterval = 15 * time.Minute
+
+	// minRefreshInterval throttles on-demand refreshes triggered by an unknown
+	// key id so malformed tokens cannot force unbounded JWKS fetches.
+	minRefreshInterval = time.Minute
+
+	// fetchTimeout bounds a single JWKS fetch.
+	fetchTimeout = 10 * time.Second
+)
+
+// signingKeys caches a JWKS and refreshes it from the issuer.
+type signingKeys struct {
+	url    string
+	client *http.Client
+
+	mu          sync.RWMutex
+	set         jose.JSONWebKeySet
+	lastRefresh time.Time
+}
+
+func newSigningKeys(jwksURL string) (*signingKeys, error) {
+	s := &signingKeys{url: jwksURL, client: &http.Client{Timeout: fetchTimeout}}
+	if err := s.refresh(context.Background()); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (s *signingKeys) refresh(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, s.url, nil)
+	if err != nil {
+		return fmt.Errorf("building jwks request: %w", err)
+	}
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetching jwks: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetching jwks: unexpected status %d", resp.StatusCode)
+	}
+	var set jose.JSONWebKeySet
+	if err := json.NewDecoder(resp.Body).Decode(&set); err != nil {
+		return fmt.Errorf("decoding jwks: %w", err)
+	}
+	if len(set.Keys) == 0 {
+		return fmt.Errorf("jwks contains no keys")
+	}
+	s.mu.Lock()
+	s.set = set
+	s.lastRefresh = time.Now()
+	s.mu.Unlock()
+	return nil
+}
+
+// lookup returns the verification key for kid, if present.
+func (s *signingKeys) lookup(kid string) (jose.JSONWebKey, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	matches := s.set.Key(kid)
+	if len(matches) == 0 {
+		return jose.JSONWebKey{}, false
+	}
+	return matches[0], true
+}
+
+// refreshIfStale refreshes the JWKS when it has not been refreshed within
+// minRefreshInterval, so a rotated key can be picked up on demand without
+// letting unknown-kid tokens trigger unbounded fetches.
+func (s *signingKeys) refreshIfStale() {
+	s.mu.RLock()
+	fresh := time.Since(s.lastRefresh) < minRefreshInterval
+	s.mu.RUnlock()
+	if fresh {
+		return
+	}
+	if err := s.refresh(context.Background()); err != nil {
+		log.Printf("Warning: on-demand JWKS refresh failed: %v", err)
+	}
+}
+
+func (s *signingKeys) startBackgroundRefresh() {
+	go func() {
+		ticker := time.NewTicker(refreshInterval)
+		defer ticker.Stop()
+		for range ticker.C {
+			if err := s.refresh(context.Background()); err != nil {
+				log.Printf("Warning: periodic JWKS refresh failed: %v", err)
+			}
+		}
+	}()
+}
+
+// Validator verifies RFC 9068 JWT access tokens against a cached JWKS. Opaque
+// (non-JWT) credentials yield key.ErrUnsupportedToken so a Chain falls back to
+// the control-plane validator.
+type Validator struct {
+	keys     *signingKeys
+	issuer   string
+	audience string
+	scope    string
+}
+
+// NewValidator fetches the issuer's JWKS, starts periodic refresh, and returns
+// a Validator. It returns an error if the initial JWKS fetch fails so the
+// caller can fall back to online-only validation.
+func NewValidator(jwksURL, issuer, audience, requiredScope string) (*Validator, error) {
+	keys, err := newSigningKeys(jwksURL)
+	if err != nil {
+		return nil, err
+	}
+	keys.startBackgroundRefresh()
+	return &Validator{
+		keys:     keys,
+		issuer:   strings.TrimRight(issuer, "/"),
+		audience: audience,
+		scope:    requiredScope,
+	}, nil
+}
+
+func (v *Validator) Validate(req key.Request) error {
+	if !looksLikeJWT(req.APIKey) {
+		return key.ErrUnsupportedToken
+	}
+
+	token, err := josejwt.ParseSigned(req.APIKey, []jose.SignatureAlgorithm{jose.EdDSA})
+	if err != nil || len(token.Headers) == 0 {
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+	}
+
+	if typ, _ := token.Headers[0].ExtraHeaders[jose.HeaderType].(string); !strings.EqualFold(typ, accessTokenType) {
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+	}
+
+	signingKey, ok := v.keys.lookup(token.Headers[0].KeyID)
+	if !ok {
+		v.keys.refreshIfStale()
+		signingKey, ok = v.keys.lookup(token.Headers[0].KeyID)
+		if !ok {
+			return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		}
+	}
+
+	var claims josejwt.Claims
+	var ext struct {
+		Scope string `json:"scope"`
+	}
+	if err := token.Claims(signingKey, &claims, &ext); err != nil {
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+	}
+
+	if err := claims.Validate(josejwt.Expected{
+		Issuer:      v.issuer,
+		AnyAudience: josejwt.Audience{v.audience},
+		Time:        time.Now(),
+	}); err != nil {
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+	}
+
+	if !scopeContains(ext.Scope, v.scope) {
+		return &key.ValidationError{StatusCode: http.StatusForbidden}
+	}
+
+	return nil
+}
+
+// looksLikeJWT reports whether s has the three-segment compact JWS shape, so
+// opaque API keys (which contain no dots) are routed to the online validator.
+func looksLikeJWT(s string) bool {
+	if s == "" {
+		return false
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" {
+			return false
+		}
+	}
+	return true
+}
+
+// scopeContains reports whether the space-delimited scope string includes want.
+func scopeContains(scope, want string) bool {
+	for _, s := range strings.Fields(scope) {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -6,6 +6,7 @@ package jwt
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -34,6 +35,10 @@ const (
 	// access token from other JWTs signed by the same key.
 	accessTokenType = "at+jwt"
 
+	// chatCompletionsPath is the only OpenAI-compatible path authorized by the
+	// inference:chat scope.
+	chatCompletionsPath = "/v1/chat/completions"
+
 	// refreshInterval is how often the cached JWKS is refreshed to follow
 	// signing-key rotation.
 	refreshInterval = 15 * time.Minute
@@ -53,7 +58,6 @@ type signingKeys struct {
 
 	mu          sync.RWMutex
 	set         jose.JSONWebKeySet
-	lastRefresh time.Time
 	lastAttempt time.Time
 }
 
@@ -92,7 +96,6 @@ func (s *signingKeys) refresh(ctx context.Context) error {
 	}
 	s.mu.Lock()
 	s.set = set
-	s.lastRefresh = time.Now()
 	s.mu.Unlock()
 	return nil
 }
@@ -108,12 +111,12 @@ func (s *signingKeys) lookup(kid string) (jose.JSONWebKey, bool) {
 	return matches[0], true
 }
 
-// refreshIfStale triggers an on-demand JWKS refresh when a token carries an
+// refreshIfAllowed triggers an on-demand JWKS refresh when a token carries an
 // unknown key id, so a rotated key can be picked up without a restart. It is
 // throttled on the last attempt time rather than the last success, so that a
 // JWKS outage combined with unknown-kid traffic cannot fan out into unbounded
 // fetch attempts.
-func (s *signingKeys) refreshIfStale() {
+func (s *signingKeys) refreshIfAllowed() {
 	s.mu.Lock()
 	if time.Since(s.lastAttempt) < minRefreshInterval {
 		s.mu.Unlock()
@@ -170,7 +173,7 @@ func NewValidator(jwksURL, issuer, audience, requiredScope string) *Validator {
 }
 
 func (v *Validator) Validate(req key.Request) error {
-	if !looksLikeJWT(req.APIKey) {
+	if !isAccessTokenJWT(req.APIKey) {
 		return key.ErrUnsupportedToken
 	}
 
@@ -183,14 +186,13 @@ func (v *Validator) Validate(req key.Request) error {
 	// permits the equivalent media type carrying an "application/" prefix, so
 	// accept both forms case-insensitively.
 	typ, _ := token.Headers[0].ExtraHeaders[jose.HeaderType].(string)
-	typ = strings.TrimPrefix(strings.ToLower(typ), "application/")
-	if typ != accessTokenType {
+	if normalizeType(typ) != accessTokenType {
 		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	signingKey, ok := v.keys.lookup(token.Headers[0].KeyID)
 	if !ok {
-		v.keys.refreshIfStale()
+		v.keys.refreshIfAllowed()
 		signingKey, ok = v.keys.lookup(token.Headers[0].KeyID)
 		if !ok {
 			return &key.ValidationError{StatusCode: http.StatusUnauthorized}
@@ -217,16 +219,16 @@ func (v *Validator) Validate(req key.Request) error {
 	if !scopeContains(ext.Scope, v.scope) {
 		return &key.ValidationError{StatusCode: http.StatusForbidden}
 	}
+	if req.Path != chatCompletionsPath {
+		return &key.ValidationError{StatusCode: http.StatusForbidden}
+	}
 
 	return nil
 }
 
-// looksLikeJWT reports whether s has the three-segment compact JWS shape, so
-// opaque API keys (which contain no dots) are routed to the online validator.
-func looksLikeJWT(s string) bool {
-	if s == "" {
-		return false
-	}
+// isAccessTokenJWT reports whether s is explicitly typed as an access-token
+// JWT. Opaque credentials that happen to contain dots stay on the online path.
+func isAccessTokenJWT(s string) bool {
 	parts := strings.Split(s, ".")
 	if len(parts) != 3 {
 		return false
@@ -236,7 +238,21 @@ func looksLikeJWT(s string) bool {
 			return false
 		}
 	}
-	return true
+	raw, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return false
+	}
+	var header struct {
+		Type string `json:"typ"`
+	}
+	if err := json.Unmarshal(raw, &header); err != nil {
+		return false
+	}
+	return normalizeType(header.Type) == accessTokenType
+}
+
+func normalizeType(typ string) string {
+	return strings.TrimPrefix(strings.ToLower(typ), "application/")
 }
 
 // scopeContains reports whether the space-delimited scope string includes want.

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -171,14 +171,14 @@ func NewValidator(jwksURL, issuer, audience, requiredScope string) *Validator {
 	}
 }
 
-func (v *Validator) Validate(req key.Request) (key.Result, error) {
+func (v *Validator) Validate(req key.Request) error {
 	if !isAccessTokenJWT(req.APIKey) {
-		return key.Result{}, key.ErrUnsupportedToken
+		return key.ErrUnsupportedToken
 	}
 
 	token, err := josejwt.ParseSigned(req.APIKey, []jose.SignatureAlgorithm{jose.EdDSA})
 	if err != nil || len(token.Headers) == 0 {
-		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	// RFC 9068 registers the access-token type as "at+jwt"; RFC 7515 also
@@ -186,7 +186,7 @@ func (v *Validator) Validate(req key.Request) (key.Result, error) {
 	// accept both forms case-insensitively.
 	typ, _ := token.Headers[0].ExtraHeaders[jose.HeaderType].(string)
 	if normalizeType(typ) != accessTokenType {
-		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	signingKey, ok := v.keys.lookup(token.Headers[0].KeyID)
@@ -194,17 +194,17 @@ func (v *Validator) Validate(req key.Request) (key.Result, error) {
 		v.keys.refreshIfAllowed()
 		signingKey, ok = v.keys.lookup(token.Headers[0].KeyID)
 		if !ok {
-			return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
+			return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 		}
 	}
 
 	var claims josejwt.Claims
 	var ext accessTokenClaims
 	if err := token.Claims(signingKey, &claims, &ext); err != nil {
-		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 	if claims.Subject == "" || claims.Expiry == nil || claims.IssuedAt == nil || claims.ID == "" || ext.ClientID == "" {
-		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	if err := claims.Validate(josejwt.Expected{
@@ -212,16 +212,14 @@ func (v *Validator) Validate(req key.Request) (key.Result, error) {
 		AnyAudience: josejwt.Audience{v.audience},
 		Time:        time.Now(),
 	}); err != nil {
-		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	if !scopeContains(ext.Scope, v.scope) {
-		return key.Result{}, &key.ValidationError{StatusCode: http.StatusForbidden}
+		return &key.ValidationError{StatusCode: http.StatusForbidden}
 	}
 
-	// The verified subject lets the shim forward a stable identity to the
-	// upstream so usage/rate limits attach to the user, not the rotating token.
-	return key.Result{Subject: claims.Subject}, nil
+	return nil
 }
 
 // isAccessTokenJWT reports whether s is explicitly typed as an access-token

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -28,16 +28,15 @@ const (
 	// will serve it. Must match the control plane's OAuthAccessTokenAudience.
 	AccessTokenAudience = "tinfoil-inference"
 
-	// RequiredScope is the OAuth scope a token must carry to call chat inference.
-	RequiredScope = "inference:chat"
+	// RequiredScope is the OAuth scope a token must carry to call the inference
+	// API. It is intentionally broad: it authorizes every inference endpoint
+	// rather than a single route, so access can be narrowed later by minting
+	// more specific scopes without re-issuing existing tokens.
+	RequiredScope = "inference:api"
 
 	// accessTokenType is the RFC 9068 "typ" header that distinguishes an OAuth
 	// access token from other JWTs signed by the same key.
 	accessTokenType = "at+jwt"
-
-	// chatCompletionsPath is the only OpenAI-compatible path authorized by the
-	// inference:chat scope.
-	chatCompletionsPath = "/v1/chat/completions"
 
 	// refreshInterval is how often the cached JWKS is refreshed to follow
 	// signing-key rotation.
@@ -217,9 +216,6 @@ func (v *Validator) Validate(req key.Request) error {
 	}
 
 	if !scopeContains(ext.Scope, v.scope) {
-		return &key.ValidationError{StatusCode: http.StatusForbidden}
-	}
-	if req.Path != chatCompletionsPath {
 		return &key.ValidationError{StatusCode: http.StatusForbidden}
 	}
 

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -55,12 +55,17 @@ type signingKeys struct {
 	lastAttempt time.Time
 }
 
-func newSigningKeys(jwksURL string) (*signingKeys, error) {
+// newSigningKeys builds a JWKS cache and makes a best-effort initial load so
+// the first request need not pay for an inline fetch. Failure is not fatal: the
+// cache starts empty and the on-demand and background refresh paths populate it
+// once the control plane is reachable, so a control-plane blip at boot never
+// disables local verification.
+func newSigningKeys(jwksURL string) *signingKeys {
 	s := &signingKeys{url: jwksURL, client: &http.Client{Timeout: fetchTimeout}}
 	if err := s.refresh(context.Background()); err != nil {
-		return nil, err
+		log.Printf("Warning: initial JWKS fetch failed; local verification will recover once the control plane is reachable: %v", err)
 	}
-	return s, nil
+	return s
 }
 
 func (s *signingKeys) refresh(ctx context.Context) error {
@@ -142,21 +147,19 @@ type Validator struct {
 	scope    string
 }
 
-// NewValidator fetches the issuer's JWKS, starts periodic refresh, and returns
-// a Validator. It returns an error if the initial JWKS fetch fails so the
-// caller can fall back to online-only validation.
-func NewValidator(jwksURL, issuer, audience, requiredScope string) (*Validator, error) {
-	keys, err := newSigningKeys(jwksURL)
-	if err != nil {
-		return nil, err
-	}
+// NewValidator builds a Validator over a best-effort JWKS cache and starts
+// periodic refresh. It does not fail when the control plane is briefly
+// unreachable at boot: local verification recovers automatically once the
+// JWKS can be fetched (see newSigningKeys).
+func NewValidator(jwksURL, issuer, audience, requiredScope string) *Validator {
+	keys := newSigningKeys(jwksURL)
 	keys.startBackgroundRefresh()
 	return &Validator{
 		keys:     keys,
 		issuer:   strings.TrimRight(issuer, "/"),
 		audience: audience,
 		scope:    requiredScope,
-	}, nil
+	}
 }
 
 func (v *Validator) Validate(req key.Request) error {

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -115,7 +115,7 @@ func (s *signingKeys) lookup(kid string) (jose.JSONWebKey, bool) {
 // fetch attempts.
 func (s *signingKeys) refreshIfStale() {
 	s.mu.Lock()
-	if time.Since(s.lastRefresh) < minRefreshInterval || time.Since(s.lastAttempt) < minRefreshInterval {
+	if time.Since(s.lastAttempt) < minRefreshInterval {
 		s.mu.Unlock()
 		return
 	}
@@ -147,6 +147,11 @@ type Validator struct {
 	issuer   string
 	audience string
 	scope    string
+}
+
+type accessTokenClaims struct {
+	Scope    string `json:"scope"`
+	ClientID string `json:"client_id"`
 }
 
 // NewValidator builds a Validator over a best-effort JWKS cache and starts
@@ -193,10 +198,11 @@ func (v *Validator) Validate(req key.Request) error {
 	}
 
 	var claims josejwt.Claims
-	var ext struct {
-		Scope string `json:"scope"`
-	}
+	var ext accessTokenClaims
 	if err := token.Claims(signingKey, &claims, &ext); err != nil {
+		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+	}
+	if claims.Subject == "" || claims.Expiry == nil || claims.IssuedAt == nil || claims.ID == "" || ext.ClientID == "" {
 		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -22,11 +22,11 @@ import (
 )
 
 const (
-	// AccessTokenAudience is the logical, endpoint-agnostic identifier for the
-	// Tinfoil inference API in the aud claim. Every inference endpoint shares
-	// it because the control plane mints a token without knowing which endpoint
-	// will serve it. Must match the control plane's OAuthAccessTokenAudience.
-	AccessTokenAudience = "tinfoil-inference"
+	// AccessTokenAudience is the resource indicator (RFC 8707) for the Tinfoil
+	// inference API in the aud claim. Every inference endpoint shares it because
+	// the control plane mints a token without knowing which endpoint will serve
+	// it. Must match the control plane's OAuthAccessTokenAudience.
+	AccessTokenAudience = "https://inference.tinfoil.sh"
 
 	// RequiredScope is the OAuth scope a token must carry to call the inference
 	// API. It is intentionally broad: it authorizes every inference endpoint

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -34,7 +34,7 @@ func mintToken(t *testing.T, priv ed25519.PrivateKey, kid, typ string, claims jo
 	}
 	token, err := josejwt.Signed(signer).
 		Claims(claims).
-		Claims(map[string]interface{}{"scope": scope}).
+		Claims(map[string]interface{}{"scope": scope, "client_id": "tinfoil-chat"}).
 		Serialize()
 	if err != nil {
 		t.Fatalf("serialize: %v", err)
@@ -130,6 +130,18 @@ func TestValidateRejectsExpired(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now().Add(-time.Hour)), RequiredScope)
+	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+}
+
+func TestValidateRejectsMissingExpiration(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	claims := validClaims(time.Now())
+	claims.Expiry = nil
+	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
 	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
 }
 
@@ -234,6 +246,40 @@ func TestRefreshIfStaleThrottlesFailedAttempts(t *testing.T) {
 
 	if got := atomic.LoadInt32(&fetches); got != 2 {
 		t.Fatalf("expected 1 boot + 1 throttled on-demand fetch, got %d", got)
+	}
+}
+
+func TestValidateRefreshesUnknownKidAfterRecentSuccess(t *testing.T) {
+	firstPub, _, _ := ed25519.GenerateKey(nil)
+	secondPub, secondPriv, _ := ed25519.GenerateKey(nil)
+
+	var useSecond atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		pub := firstPub
+		kid := testKID
+		if useSecond.Load() {
+			pub = secondPub
+			kid = "test-key-2"
+		}
+		set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+			Key:       pub,
+			KeyID:     kid,
+			Algorithm: string(jose.EdDSA),
+			Use:       "sig",
+		}}}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(set); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	defer srv.Close()
+
+	v := newTestValidator(t, srv.URL)
+	useSecond.Store(true)
+
+	token := mintToken(t, secondPriv, "test-key-2", "at+jwt", validClaims(time.Now()), RequiredScope)
+	if err := v.Validate(key.Request{APIKey: token}); err != nil {
+		t.Fatalf("expected unknown kid to refresh immediately, got %v", err)
 	}
 }
 

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -73,11 +73,7 @@ func validClaims(now time.Time) josejwt.Claims {
 
 func newTestValidator(t *testing.T, jwksURL string) *Validator {
 	t.Helper()
-	v, err := NewValidator(jwksURL, testIssuer, AccessTokenAudience, RequiredScope)
-	if err != nil {
-		t.Fatalf("new validator: %v", err)
-	}
-	return v
+	return NewValidator(jwksURL, testIssuer, AccessTokenAudience, RequiredScope)
 }
 
 func expectStatus(t *testing.T, err error, want int) {
@@ -221,10 +217,7 @@ func TestRefreshIfStaleThrottlesFailedAttempts(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	s, err := newSigningKeys(srv.URL) // successful boot fetch (#1)
-	if err != nil {
-		t.Fatalf("boot: %v", err)
-	}
+	s := newSigningKeys(srv.URL) // successful boot fetch (#1)
 	failing.Store(true)
 
 	// Make the cache look stale so on-demand refresh is eligible to run.
@@ -241,5 +234,51 @@ func TestRefreshIfStaleThrottlesFailedAttempts(t *testing.T) {
 
 	if got := atomic.LoadInt32(&fetches); got != 2 {
 		t.Fatalf("expected 1 boot + 1 throttled on-demand fetch, got %d", got)
+	}
+}
+
+func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:       pub,
+		KeyID:     testKID,
+		Algorithm: string(jose.EdDSA),
+		Use:       "sig",
+	}}}
+	body, err := json.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshal jwks: %v", err)
+	}
+
+	var serving atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !serving.Load() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	// Boot while the JWKS endpoint is unavailable: the validator must come up
+	// with an empty key set instead of failing.
+	v := newTestValidator(t, srv.URL)
+
+	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
+	if err := v.Validate(key.Request{APIKey: token}); err == nil {
+		t.Fatal("expected rejection while no signing keys are cached")
+	}
+
+	// Once the JWKS is reachable, the unknown-kid path triggers an on-demand
+	// refresh and the same token validates without a restart.
+	serving.Store(true)
+	v.keys.mu.Lock()
+	v.keys.lastRefresh = time.Now().Add(-2 * minRefreshInterval)
+	v.keys.lastAttempt = time.Now().Add(-2 * minRefreshInterval)
+	v.keys.mu.Unlock()
+
+	if err := v.Validate(key.Request{APIKey: token}); err != nil {
+		t.Fatalf("expected token to validate after JWKS became available, got %v", err)
 	}
 }

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -87,6 +87,10 @@ func expectStatus(t *testing.T, err error, want int) {
 	}
 }
 
+func chatRequest(token string) key.Request {
+	return key.Request{APIKey: token, Path: chatCompletionsPath}
+}
+
 func TestValidateAcceptsValidToken(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	srv := jwksServer(t, pub, testKID)
@@ -94,7 +98,7 @@ func TestValidateAcceptsValidToken(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(key.Request{APIKey: token}); err != nil {
+	if err := v.Validate(chatRequest(token)); err != nil {
 		t.Fatalf("expected valid token, got %v", err)
 	}
 }
@@ -111,6 +115,18 @@ func TestValidateFallsThroughForOpaqueKey(t *testing.T) {
 	}
 }
 
+func TestValidateFallsThroughForDottedOpaqueKey(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	err := v.Validate(key.Request{APIKey: "opaque.with.dots"})
+	if !errors.Is(err, key.ErrUnsupportedToken) {
+		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
+	}
+}
+
 func TestValidateRejectsWrongAudience(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	srv := jwksServer(t, pub, testKID)
@@ -120,7 +136,7 @@ func TestValidateRejectsWrongAudience(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Audience = josejwt.Audience{"https://example.com"}
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsExpired(t *testing.T) {
@@ -130,7 +146,7 @@ func TestValidateRejectsExpired(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now().Add(-time.Hour)), RequiredScope)
-	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsMissingExpiration(t *testing.T) {
@@ -142,7 +158,7 @@ func TestValidateRejectsMissingExpiration(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Expiry = nil
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsMissingScope(t *testing.T) {
@@ -152,7 +168,7 @@ func TestValidateRejectsMissingScope(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), "models:read")
-	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusForbidden)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusForbidden)
 }
 
 func TestValidateRejectsWrongIssuer(t *testing.T) {
@@ -164,17 +180,20 @@ func TestValidateRejectsWrongIssuer(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Issuer = "https://evil.example.com"
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
-func TestValidateRejectsWrongType(t *testing.T) {
+func TestValidateFallsThroughForWrongType(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	srv := jwksServer(t, pub, testKID)
 	defer srv.Close()
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "JWT", validClaims(time.Now()), RequiredScope)
-	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+	err := v.Validate(chatRequest(token))
+	if !errors.Is(err, key.ErrUnsupportedToken) {
+		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
+	}
 }
 
 func TestValidateRejectsForeignSignature(t *testing.T) {
@@ -187,7 +206,7 @@ func TestValidateRejectsForeignSignature(t *testing.T) {
 	// verification against the published key must fail.
 	_, foreignPriv, _ := ed25519.GenerateKey(nil)
 	token := mintToken(t, foreignPriv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
@@ -198,12 +217,22 @@ func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
 
 	// RFC 9068 / RFC 7515 permit the media type with an "application/" prefix.
 	token := mintToken(t, priv, testKID, "application/at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(key.Request{APIKey: token}); err != nil {
+	if err := v.Validate(chatRequest(token)); err != nil {
 		t.Fatalf("expected application/at+jwt to be accepted, got %v", err)
 	}
 }
 
-func TestRefreshIfStaleThrottlesFailedAttempts(t *testing.T) {
+func TestValidateRejectsChatTokenOnNonChatPath(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
+	expectStatus(t, v.Validate(key.Request{APIKey: token, Path: "/v1/embeddings"}), http.StatusForbidden)
+}
+
+func TestRefreshIfAllowedThrottlesFailedAttempts(t *testing.T) {
 	pub, _, _ := ed25519.GenerateKey(nil)
 	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
 		Key:       pub,
@@ -232,16 +261,15 @@ func TestRefreshIfStaleThrottlesFailedAttempts(t *testing.T) {
 	s := newSigningKeys(srv.URL) // successful boot fetch (#1)
 	failing.Store(true)
 
-	// Make the cache look stale so on-demand refresh is eligible to run.
+	// Make on-demand refresh eligible to run.
 	s.mu.Lock()
-	s.lastRefresh = time.Now().Add(-2 * minRefreshInterval)
 	s.lastAttempt = time.Now().Add(-2 * minRefreshInterval)
 	s.mu.Unlock()
 
 	// A burst of unknown-kid lookups during an outage must trigger at most one
 	// on-demand fetch within the throttle window, not one per call.
 	for i := 0; i < 5; i++ {
-		s.refreshIfStale()
+		s.refreshIfAllowed()
 	}
 
 	if got := atomic.LoadInt32(&fetches); got != 2 {
@@ -278,7 +306,7 @@ func TestValidateRefreshesUnknownKidAfterRecentSuccess(t *testing.T) {
 	useSecond.Store(true)
 
 	token := mintToken(t, secondPriv, "test-key-2", "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(key.Request{APIKey: token}); err != nil {
+	if err := v.Validate(chatRequest(token)); err != nil {
 		t.Fatalf("expected unknown kid to refresh immediately, got %v", err)
 	}
 }
@@ -312,7 +340,7 @@ func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(key.Request{APIKey: token}); err == nil {
+	if err := v.Validate(chatRequest(token)); err == nil {
 		t.Fatal("expected rejection while no signing keys are cached")
 	}
 
@@ -320,11 +348,10 @@ func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
 	// refresh and the same token validates without a restart.
 	serving.Store(true)
 	v.keys.mu.Lock()
-	v.keys.lastRefresh = time.Now().Add(-2 * minRefreshInterval)
 	v.keys.lastAttempt = time.Now().Add(-2 * minRefreshInterval)
 	v.keys.mu.Unlock()
 
-	if err := v.Validate(key.Request{APIKey: token}); err != nil {
+	if err := v.Validate(chatRequest(token)); err != nil {
 		t.Fatalf("expected token to validate after JWKS became available, got %v", err)
 	}
 }

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -179,4 +180,66 @@ func TestValidateRejectsForeignSignature(t *testing.T) {
 	_, foreignPriv, _ := ed25519.GenerateKey(nil)
 	token := mintToken(t, foreignPriv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
 	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+}
+
+func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	// RFC 9068 / RFC 7515 permit the media type with an "application/" prefix.
+	token := mintToken(t, priv, testKID, "application/at+jwt", validClaims(time.Now()), RequiredScope)
+	if err := v.Validate(key.Request{APIKey: token}); err != nil {
+		t.Fatalf("expected application/at+jwt to be accepted, got %v", err)
+	}
+}
+
+func TestRefreshIfStaleThrottlesFailedAttempts(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:       pub,
+		KeyID:     testKID,
+		Algorithm: string(jose.EdDSA),
+		Use:       "sig",
+	}}}
+	body, err := json.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshal jwks: %v", err)
+	}
+
+	var fetches int32
+	var failing atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&fetches, 1)
+		if failing.Load() {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	s, err := newSigningKeys(srv.URL) // successful boot fetch (#1)
+	if err != nil {
+		t.Fatalf("boot: %v", err)
+	}
+	failing.Store(true)
+
+	// Make the cache look stale so on-demand refresh is eligible to run.
+	s.mu.Lock()
+	s.lastRefresh = time.Now().Add(-2 * minRefreshInterval)
+	s.lastAttempt = time.Now().Add(-2 * minRefreshInterval)
+	s.mu.Unlock()
+
+	// A burst of unknown-kid lookups during an outage must trigger at most one
+	// on-demand fetch within the throttle window, not one per call.
+	for i := 0; i < 5; i++ {
+		s.refreshIfStale()
+	}
+
+	if got := atomic.LoadInt32(&fetches); got != 2 {
+		t.Fatalf("expected 1 boot + 1 throttled on-demand fetch, got %d", got)
+	}
 }

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -91,6 +91,14 @@ func chatRequest(token string) key.Request {
 	return key.Request{APIKey: token, Path: "/v1/chat/completions"}
 }
 
+// validateErr runs the validator and returns only the error, for the many
+// rejection cases that do not care about the Result. The accepted-token tests
+// call Validate directly to assert the surfaced subject.
+func validateErr(val *Validator, req key.Request) error {
+	_, err := val.Validate(req)
+	return err
+}
+
 func TestValidateAcceptsValidToken(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	srv := jwksServer(t, pub, testKID)
@@ -98,8 +106,12 @@ func TestValidateAcceptsValidToken(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(chatRequest(token)); err != nil {
+	res, err := v.Validate(chatRequest(token))
+	if err != nil {
 		t.Fatalf("expected valid token, got %v", err)
+	}
+	if res.Subject != "user_1" {
+		t.Fatalf("Subject = %q, want user_1", res.Subject)
 	}
 }
 
@@ -109,7 +121,7 @@ func TestValidateFallsThroughForOpaqueKey(t *testing.T) {
 	defer srv.Close()
 	v := newTestValidator(t, srv.URL)
 
-	err := v.Validate(key.Request{APIKey: "chat_abcdef"})
+	err := validateErr(v, key.Request{APIKey: "chat_abcdef"})
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -121,7 +133,7 @@ func TestValidateFallsThroughForDottedOpaqueKey(t *testing.T) {
 	defer srv.Close()
 	v := newTestValidator(t, srv.URL)
 
-	err := v.Validate(key.Request{APIKey: "opaque.with.dots"})
+	err := validateErr(v, key.Request{APIKey: "opaque.with.dots"})
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -136,7 +148,7 @@ func TestValidateRejectsWrongAudience(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Audience = josejwt.Audience{"https://example.com"}
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsExpired(t *testing.T) {
@@ -146,7 +158,7 @@ func TestValidateRejectsExpired(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now().Add(-time.Hour)), RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsMissingExpiration(t *testing.T) {
@@ -158,7 +170,7 @@ func TestValidateRejectsMissingExpiration(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Expiry = nil
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsMissingScope(t *testing.T) {
@@ -168,7 +180,7 @@ func TestValidateRejectsMissingScope(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), "models:read")
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusForbidden)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusForbidden)
 }
 
 func TestValidateRejectsWrongIssuer(t *testing.T) {
@@ -180,7 +192,7 @@ func TestValidateRejectsWrongIssuer(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Issuer = "https://evil.example.com"
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateFallsThroughForWrongType(t *testing.T) {
@@ -190,7 +202,7 @@ func TestValidateFallsThroughForWrongType(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "JWT", validClaims(time.Now()), RequiredScope)
-	err := v.Validate(chatRequest(token))
+	err := validateErr(v, chatRequest(token))
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -206,7 +218,7 @@ func TestValidateRejectsForeignSignature(t *testing.T) {
 	// verification against the published key must fail.
 	_, foreignPriv, _ := ed25519.GenerateKey(nil)
 	token := mintToken(t, foreignPriv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
@@ -217,7 +229,7 @@ func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
 
 	// RFC 9068 / RFC 7515 permit the media type with an "application/" prefix.
 	token := mintToken(t, priv, testKID, "application/at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(chatRequest(token)); err != nil {
+	if err := validateErr(v, chatRequest(token)); err != nil {
 		t.Fatalf("expected application/at+jwt to be accepted, got %v", err)
 	}
 }
@@ -231,7 +243,7 @@ func TestValidateAcceptsNonChatPath(t *testing.T) {
 	// The inference:api scope authorizes every inference endpoint, not just
 	// chat completions, so a non-chat path must validate.
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(key.Request{APIKey: token, Path: "/v1/embeddings"}); err != nil {
+	if err := validateErr(v, key.Request{APIKey: token, Path: "/v1/embeddings"}); err != nil {
 		t.Fatalf("expected non-chat path to be accepted, got %v", err)
 	}
 }
@@ -310,7 +322,7 @@ func TestValidateRefreshesUnknownKidAfterRecentSuccess(t *testing.T) {
 	useSecond.Store(true)
 
 	token := mintToken(t, secondPriv, "test-key-2", "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(chatRequest(token)); err != nil {
+	if err := validateErr(v, chatRequest(token)); err != nil {
 		t.Fatalf("expected unknown kid to refresh immediately, got %v", err)
 	}
 }
@@ -344,7 +356,7 @@ func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(chatRequest(token)); err == nil {
+	if err := validateErr(v, chatRequest(token)); err == nil {
 		t.Fatal("expected rejection while no signing keys are cached")
 	}
 
@@ -355,7 +367,7 @@ func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
 	v.keys.lastAttempt = time.Now().Add(-2 * minRefreshInterval)
 	v.keys.mu.Unlock()
 
-	if err := v.Validate(chatRequest(token)); err != nil {
+	if err := validateErr(v, chatRequest(token)); err != nil {
 		t.Fatalf("expected token to validate after JWKS became available, got %v", err)
 	}
 }

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -88,7 +88,7 @@ func expectStatus(t *testing.T, err error, want int) {
 }
 
 func chatRequest(token string) key.Request {
-	return key.Request{APIKey: token, Path: chatCompletionsPath}
+	return key.Request{APIKey: token, Path: "/v1/chat/completions"}
 }
 
 func TestValidateAcceptsValidToken(t *testing.T) {
@@ -222,14 +222,18 @@ func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
 	}
 }
 
-func TestValidateRejectsChatTokenOnNonChatPath(t *testing.T) {
+func TestValidateAcceptsNonChatPath(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	srv := jwksServer(t, pub, testKID)
 	defer srv.Close()
 	v := newTestValidator(t, srv.URL)
 
+	// The inference:api scope authorizes every inference endpoint, not just
+	// chat completions, so a non-chat path must validate.
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	expectStatus(t, v.Validate(key.Request{APIKey: token, Path: "/v1/embeddings"}), http.StatusForbidden)
+	if err := v.Validate(key.Request{APIKey: token, Path: "/v1/embeddings"}); err != nil {
+		t.Fatalf("expected non-chat path to be accepted, got %v", err)
+	}
 }
 
 func TestRefreshIfAllowedThrottlesFailedAttempts(t *testing.T) {

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -91,14 +91,6 @@ func chatRequest(token string) key.Request {
 	return key.Request{APIKey: token, Path: "/v1/chat/completions"}
 }
 
-// validateErr runs the validator and returns only the error, for the many
-// rejection cases that do not care about the Result. The accepted-token tests
-// call Validate directly to assert the surfaced subject.
-func validateErr(val *Validator, req key.Request) error {
-	_, err := val.Validate(req)
-	return err
-}
-
 func TestValidateAcceptsValidToken(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	srv := jwksServer(t, pub, testKID)
@@ -106,12 +98,8 @@ func TestValidateAcceptsValidToken(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	res, err := v.Validate(chatRequest(token))
-	if err != nil {
+	if err := v.Validate(chatRequest(token)); err != nil {
 		t.Fatalf("expected valid token, got %v", err)
-	}
-	if res.Subject != "user_1" {
-		t.Fatalf("Subject = %q, want user_1", res.Subject)
 	}
 }
 
@@ -121,7 +109,7 @@ func TestValidateFallsThroughForOpaqueKey(t *testing.T) {
 	defer srv.Close()
 	v := newTestValidator(t, srv.URL)
 
-	err := validateErr(v, key.Request{APIKey: "chat_abcdef"})
+	err := v.Validate(key.Request{APIKey: "chat_abcdef"})
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -133,7 +121,7 @@ func TestValidateFallsThroughForDottedOpaqueKey(t *testing.T) {
 	defer srv.Close()
 	v := newTestValidator(t, srv.URL)
 
-	err := validateErr(v, key.Request{APIKey: "opaque.with.dots"})
+	err := v.Validate(key.Request{APIKey: "opaque.with.dots"})
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -148,7 +136,7 @@ func TestValidateRejectsWrongAudience(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Audience = josejwt.Audience{"https://example.com"}
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsExpired(t *testing.T) {
@@ -158,7 +146,7 @@ func TestValidateRejectsExpired(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now().Add(-time.Hour)), RequiredScope)
-	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsMissingExpiration(t *testing.T) {
@@ -170,7 +158,7 @@ func TestValidateRejectsMissingExpiration(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Expiry = nil
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsMissingScope(t *testing.T) {
@@ -180,7 +168,7 @@ func TestValidateRejectsMissingScope(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), "models:read")
-	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusForbidden)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusForbidden)
 }
 
 func TestValidateRejectsWrongIssuer(t *testing.T) {
@@ -192,7 +180,7 @@ func TestValidateRejectsWrongIssuer(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Issuer = "https://evil.example.com"
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateFallsThroughForWrongType(t *testing.T) {
@@ -202,7 +190,7 @@ func TestValidateFallsThroughForWrongType(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "JWT", validClaims(time.Now()), RequiredScope)
-	err := validateErr(v, chatRequest(token))
+	err := v.Validate(chatRequest(token))
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -218,7 +206,7 @@ func TestValidateRejectsForeignSignature(t *testing.T) {
 	// verification against the published key must fail.
 	_, foreignPriv, _ := ed25519.GenerateKey(nil)
 	token := mintToken(t, foreignPriv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
@@ -229,7 +217,7 @@ func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
 
 	// RFC 9068 / RFC 7515 permit the media type with an "application/" prefix.
 	token := mintToken(t, priv, testKID, "application/at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := validateErr(v, chatRequest(token)); err != nil {
+	if err := v.Validate(chatRequest(token)); err != nil {
 		t.Fatalf("expected application/at+jwt to be accepted, got %v", err)
 	}
 }
@@ -243,7 +231,7 @@ func TestValidateAcceptsNonChatPath(t *testing.T) {
 	// The inference:api scope authorizes every inference endpoint, not just
 	// chat completions, so a non-chat path must validate.
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := validateErr(v, key.Request{APIKey: token, Path: "/v1/embeddings"}); err != nil {
+	if err := v.Validate(key.Request{APIKey: token, Path: "/v1/embeddings"}); err != nil {
 		t.Fatalf("expected non-chat path to be accepted, got %v", err)
 	}
 }
@@ -322,7 +310,7 @@ func TestValidateRefreshesUnknownKidAfterRecentSuccess(t *testing.T) {
 	useSecond.Store(true)
 
 	token := mintToken(t, secondPriv, "test-key-2", "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := validateErr(v, chatRequest(token)); err != nil {
+	if err := v.Validate(chatRequest(token)); err != nil {
 		t.Fatalf("expected unknown kid to refresh immediately, got %v", err)
 	}
 }
@@ -356,7 +344,7 @@ func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := validateErr(v, chatRequest(token)); err == nil {
+	if err := v.Validate(chatRequest(token)); err == nil {
 		t.Fatal("expected rejection while no signing keys are cached")
 	}
 
@@ -367,7 +355,7 @@ func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
 	v.keys.lastAttempt = time.Now().Add(-2 * minRefreshInterval)
 	v.keys.mu.Unlock()
 
-	if err := validateErr(v, chatRequest(token)); err != nil {
+	if err := v.Validate(chatRequest(token)); err != nil {
 		t.Fatalf("expected token to validate after JWKS became available, got %v", err)
 	}
 }

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -1,0 +1,182 @@
+package jwt
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+
+	"tinfoil/internal/key"
+)
+
+const (
+	testIssuer = "https://api.tinfoil.sh"
+	testKID    = "test-key-1"
+)
+
+func mintToken(t *testing.T, priv ed25519.PrivateKey, kid, typ string, claims josejwt.Claims, scope string) string {
+	t.Helper()
+	signingKey := jose.JSONWebKey{Key: priv, KeyID: kid, Algorithm: string(jose.EdDSA)}
+	opts := &jose.SignerOptions{}
+	if typ != "" {
+		opts = opts.WithType(jose.ContentType(typ))
+	}
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.EdDSA, Key: signingKey}, opts)
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	token, err := josejwt.Signed(signer).
+		Claims(claims).
+		Claims(map[string]interface{}{"scope": scope}).
+		Serialize()
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+	return token
+}
+
+func jwksServer(t *testing.T, pub ed25519.PublicKey, kid string) *httptest.Server {
+	t.Helper()
+	set := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:       pub,
+		KeyID:     kid,
+		Algorithm: string(jose.EdDSA),
+		Use:       "sig",
+	}}}
+	body, err := json.Marshal(set)
+	if err != nil {
+		t.Fatalf("marshal jwks: %v", err)
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+}
+
+func validClaims(now time.Time) josejwt.Claims {
+	return josejwt.Claims{
+		Issuer:   testIssuer,
+		Subject:  "user_1",
+		Audience: josejwt.Audience{AccessTokenAudience},
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(15 * time.Minute)),
+		ID:       "jti-1",
+	}
+}
+
+func newTestValidator(t *testing.T, jwksURL string) *Validator {
+	t.Helper()
+	v, err := NewValidator(jwksURL, testIssuer, AccessTokenAudience, RequiredScope)
+	if err != nil {
+		t.Fatalf("new validator: %v", err)
+	}
+	return v
+}
+
+func expectStatus(t *testing.T, err error, want int) {
+	t.Helper()
+	var ve *key.ValidationError
+	if !errors.As(err, &ve) {
+		t.Fatalf("expected ValidationError, got %v", err)
+	}
+	if ve.StatusCode != want {
+		t.Fatalf("status = %d, want %d", ve.StatusCode, want)
+	}
+}
+
+func TestValidateAcceptsValidToken(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
+	if err := v.Validate(key.Request{APIKey: token}); err != nil {
+		t.Fatalf("expected valid token, got %v", err)
+	}
+}
+
+func TestValidateFallsThroughForOpaqueKey(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	err := v.Validate(key.Request{APIKey: "chat_abcdef"})
+	if !errors.Is(err, key.ErrUnsupportedToken) {
+		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
+	}
+}
+
+func TestValidateRejectsWrongAudience(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	claims := validClaims(time.Now())
+	claims.Audience = josejwt.Audience{"https://example.com"}
+	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
+	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+}
+
+func TestValidateRejectsExpired(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now().Add(-time.Hour)), RequiredScope)
+	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+}
+
+func TestValidateRejectsMissingScope(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), "models:read")
+	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusForbidden)
+}
+
+func TestValidateRejectsWrongIssuer(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	claims := validClaims(time.Now())
+	claims.Issuer = "https://evil.example.com"
+	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
+	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+}
+
+func TestValidateRejectsWrongType(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	token := mintToken(t, priv, testKID, "JWT", validClaims(time.Now()), RequiredScope)
+	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+}
+
+func TestValidateRejectsForeignSignature(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(nil)
+	srv := jwksServer(t, pub, testKID)
+	defer srv.Close()
+	v := newTestValidator(t, srv.URL)
+
+	// Signed by a different key but advertising the served kid: signature
+	// verification against the published key must fail.
+	_, foreignPriv, _ := ed25519.GenerateKey(nil)
+	token := mintToken(t, foreignPriv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
+	expectStatus(t, v.Validate(key.Request{APIKey: token}), http.StatusUnauthorized)
+}

--- a/tinfoil/internal/key/key.go
+++ b/tinfoil/internal/key/key.go
@@ -14,19 +14,8 @@ type Request struct {
 	Path          string `json:"path,omitempty"`
 }
 
-// Result is the non-secret outcome of a successful validation. It lets the shim
-// forward the authenticated principal to the upstream workload so the workload
-// can attribute usage and rate limits to a stable identity instead of the
-// (rotating) bearer credential.
-type Result struct {
-	// Subject is the authenticated principal — the JWT `sub` — when the
-	// credential is a locally-verified JWT access token. It is empty for opaque
-	// API keys, whose subject is known only to the control plane.
-	Subject string
-}
-
 type Validator interface {
-	Validate(req Request) (Result, error)
+	Validate(req Request) error
 }
 
 // ErrUnsupportedToken signals that a Validator cannot handle the presented
@@ -55,14 +44,13 @@ func NewChain(validators ...Validator) *Chain {
 	return &Chain{validators: validators}
 }
 
-func (c *Chain) Validate(req Request) (Result, error) {
-	var res Result
+func (c *Chain) Validate(req Request) error {
 	var err error
 	for _, v := range c.validators {
-		res, err = v.Validate(req)
+		err = v.Validate(req)
 		if !errors.Is(err, ErrUnsupportedToken) {
-			return res, err
+			return err
 		}
 	}
-	return res, err
+	return err
 }

--- a/tinfoil/internal/key/key.go
+++ b/tinfoil/internal/key/key.go
@@ -14,8 +14,19 @@ type Request struct {
 	Path          string `json:"path,omitempty"`
 }
 
+// Result is the non-secret outcome of a successful validation. It lets the shim
+// forward the authenticated principal to the upstream workload so the workload
+// can attribute usage and rate limits to a stable identity instead of the
+// (rotating) bearer credential.
+type Result struct {
+	// Subject is the authenticated principal — the JWT `sub` — when the
+	// credential is a locally-verified JWT access token. It is empty for opaque
+	// API keys, whose subject is known only to the control plane.
+	Subject string
+}
+
 type Validator interface {
-	Validate(req Request) error
+	Validate(req Request) (Result, error)
 }
 
 // ErrUnsupportedToken signals that a Validator cannot handle the presented
@@ -44,13 +55,14 @@ func NewChain(validators ...Validator) *Chain {
 	return &Chain{validators: validators}
 }
 
-func (c *Chain) Validate(req Request) error {
+func (c *Chain) Validate(req Request) (Result, error) {
+	var res Result
 	var err error
 	for _, v := range c.validators {
-		err = v.Validate(req)
+		res, err = v.Validate(req)
 		if !errors.Is(err, ErrUnsupportedToken) {
-			return err
+			return res, err
 		}
 	}
-	return err
+	return res, err
 }

--- a/tinfoil/internal/key/key.go
+++ b/tinfoil/internal/key/key.go
@@ -1,5 +1,10 @@
 package key
 
+import (
+	"errors"
+	"net/http"
+)
+
 // Request is the payload sent to the control plane for API key validation.
 // Domain, RequestedHost, and Path are optional policy inputs for the control plane.
 type Request struct {
@@ -11,4 +16,41 @@ type Request struct {
 
 type Validator interface {
 	Validate(req Request) error
+}
+
+// ErrUnsupportedToken signals that a Validator cannot handle the presented
+// credential's format, so a Chain should advance to the next validator.
+var ErrUnsupportedToken = errors.New("unsupported token format")
+
+// ValidationError is returned when a credential is rejected. It carries only an
+// HTTP status code so internal validator details never leak to callers.
+type ValidationError struct {
+	StatusCode int
+}
+
+func (e *ValidationError) Error() string {
+	return http.StatusText(e.StatusCode)
+}
+
+// Chain tries validators in order, advancing to the next only when one reports
+// ErrUnsupportedToken. The first definitive result (a success or a
+// ValidationError) is returned to the caller.
+type Chain struct {
+	validators []Validator
+}
+
+// NewChain returns a Validator that consults each validator in turn.
+func NewChain(validators ...Validator) *Chain {
+	return &Chain{validators: validators}
+}
+
+func (c *Chain) Validate(req Request) error {
+	var err error
+	for _, v := range c.validators {
+		err = v.Validate(req)
+		if !errors.Is(err, ErrUnsupportedToken) {
+			return err
+		}
+	}
+	return err
 }

--- a/tinfoil/internal/key/key_test.go
+++ b/tinfoil/internal/key/key_test.go
@@ -1,0 +1,63 @@
+package key
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+type stubValidator struct {
+	err    error
+	called *int
+}
+
+func (s stubValidator) Validate(Request) error {
+	if s.called != nil {
+		*s.called++
+	}
+	return s.err
+}
+
+func TestChainFallsThroughOnUnsupported(t *testing.T) {
+	var firstCalls, secondCalls int
+	chain := NewChain(
+		stubValidator{err: ErrUnsupportedToken, called: &firstCalls},
+		stubValidator{err: nil, called: &secondCalls},
+	)
+	if err := chain.Validate(Request{APIKey: "x"}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if firstCalls != 1 || secondCalls != 1 {
+		t.Fatalf("calls: first=%d second=%d", firstCalls, secondCalls)
+	}
+}
+
+func TestChainReturnsValidationErrorImmediately(t *testing.T) {
+	var secondCalls int
+	chain := NewChain(
+		stubValidator{err: &ValidationError{StatusCode: http.StatusUnauthorized}},
+		stubValidator{err: nil, called: &secondCalls},
+	)
+	err := chain.Validate(Request{APIKey: "x"})
+	var ve *ValidationError
+	if !errors.As(err, &ve) || ve.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 ValidationError, got %v", err)
+	}
+	if secondCalls != 0 {
+		t.Fatalf("second validator should not be consulted, calls=%d", secondCalls)
+	}
+}
+
+func TestChainShortCircuitsOnSuccess(t *testing.T) {
+	var secondCalls int
+	chain := NewChain(
+		stubValidator{err: nil},
+		stubValidator{err: ErrUnsupportedToken, called: &secondCalls},
+	)
+	if err := chain.Validate(Request{APIKey: "x"}); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if secondCalls != 0 {
+		t.Fatalf("second validator should not be consulted, calls=%d", secondCalls)
+	}
+}

--- a/tinfoil/internal/key/key_test.go
+++ b/tinfoil/internal/key/key_test.go
@@ -7,15 +7,16 @@ import (
 )
 
 type stubValidator struct {
+	result Result
 	err    error
 	called *int
 }
 
-func (s stubValidator) Validate(Request) error {
+func (s stubValidator) Validate(Request) (Result, error) {
 	if s.called != nil {
 		*s.called++
 	}
-	return s.err
+	return s.result, s.err
 }
 
 func TestChainFallsThroughOnUnsupported(t *testing.T) {
@@ -24,7 +25,7 @@ func TestChainFallsThroughOnUnsupported(t *testing.T) {
 		stubValidator{err: ErrUnsupportedToken, called: &firstCalls},
 		stubValidator{err: nil, called: &secondCalls},
 	)
-	if err := chain.Validate(Request{APIKey: "x"}); err != nil {
+	if _, err := chain.Validate(Request{APIKey: "x"}); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 	if firstCalls != 1 || secondCalls != 1 {
@@ -38,7 +39,7 @@ func TestChainReturnsValidationErrorImmediately(t *testing.T) {
 		stubValidator{err: &ValidationError{StatusCode: http.StatusUnauthorized}},
 		stubValidator{err: nil, called: &secondCalls},
 	)
-	err := chain.Validate(Request{APIKey: "x"})
+	_, err := chain.Validate(Request{APIKey: "x"})
 	var ve *ValidationError
 	if !errors.As(err, &ve) || ve.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401 ValidationError, got %v", err)
@@ -54,10 +55,27 @@ func TestChainShortCircuitsOnSuccess(t *testing.T) {
 		stubValidator{err: nil},
 		stubValidator{err: ErrUnsupportedToken, called: &secondCalls},
 	)
-	if err := chain.Validate(Request{APIKey: "x"}); err != nil {
+	if _, err := chain.Validate(Request{APIKey: "x"}); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 	if secondCalls != 0 {
 		t.Fatalf("second validator should not be consulted, calls=%d", secondCalls)
+	}
+}
+
+// TestChainPropagatesSubject verifies the Result from the validator that
+// handled the request (here the second, after the first falls through) is
+// returned to the caller, so the shim can forward the verified subject.
+func TestChainPropagatesSubject(t *testing.T) {
+	chain := NewChain(
+		stubValidator{err: ErrUnsupportedToken},
+		stubValidator{result: Result{Subject: "user_42"}, err: nil},
+	)
+	res, err := chain.Validate(Request{APIKey: "x"})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if res.Subject != "user_42" {
+		t.Fatalf("Subject = %q, want user_42", res.Subject)
 	}
 }

--- a/tinfoil/internal/key/key_test.go
+++ b/tinfoil/internal/key/key_test.go
@@ -7,16 +7,15 @@ import (
 )
 
 type stubValidator struct {
-	result Result
 	err    error
 	called *int
 }
 
-func (s stubValidator) Validate(Request) (Result, error) {
+func (s stubValidator) Validate(Request) error {
 	if s.called != nil {
 		*s.called++
 	}
-	return s.result, s.err
+	return s.err
 }
 
 func TestChainFallsThroughOnUnsupported(t *testing.T) {
@@ -25,7 +24,7 @@ func TestChainFallsThroughOnUnsupported(t *testing.T) {
 		stubValidator{err: ErrUnsupportedToken, called: &firstCalls},
 		stubValidator{err: nil, called: &secondCalls},
 	)
-	if _, err := chain.Validate(Request{APIKey: "x"}); err != nil {
+	if err := chain.Validate(Request{APIKey: "x"}); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 	if firstCalls != 1 || secondCalls != 1 {
@@ -39,7 +38,7 @@ func TestChainReturnsValidationErrorImmediately(t *testing.T) {
 		stubValidator{err: &ValidationError{StatusCode: http.StatusUnauthorized}},
 		stubValidator{err: nil, called: &secondCalls},
 	)
-	_, err := chain.Validate(Request{APIKey: "x"})
+	err := chain.Validate(Request{APIKey: "x"})
 	var ve *ValidationError
 	if !errors.As(err, &ve) || ve.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401 ValidationError, got %v", err)
@@ -55,27 +54,10 @@ func TestChainShortCircuitsOnSuccess(t *testing.T) {
 		stubValidator{err: nil},
 		stubValidator{err: ErrUnsupportedToken, called: &secondCalls},
 	)
-	if _, err := chain.Validate(Request{APIKey: "x"}); err != nil {
+	if err := chain.Validate(Request{APIKey: "x"}); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 	if secondCalls != 0 {
 		t.Fatalf("second validator should not be consulted, calls=%d", secondCalls)
-	}
-}
-
-// TestChainPropagatesSubject verifies the Result from the validator that
-// handled the request (here the second, after the first falls through) is
-// returned to the caller, so the shim can forward the verified subject.
-func TestChainPropagatesSubject(t *testing.T) {
-	chain := NewChain(
-		stubValidator{err: ErrUnsupportedToken},
-		stubValidator{result: Result{Subject: "user_42"}, err: nil},
-	)
-	res, err := chain.Validate(Request{APIKey: "x"})
-	if err != nil {
-		t.Fatalf("expected success, got %v", err)
-	}
-	if res.Subject != "user_42" {
-		t.Fatalf("Subject = %q, want user_42", res.Subject)
 	}
 }

--- a/tinfoil/internal/key/online/online_test.go
+++ b/tinfoil/internal/key/online/online_test.go
@@ -40,17 +40,19 @@ func TestVerifyOnline(t *testing.T) {
 	v, err := NewValidator("https://localhost:8080/validate")
 	assert.Nil(t, err)
 
-	assert.Nil(t, v.Validate(key.Request{
+	_, err = v.Validate(key.Request{
 		APIKey:        "good-key",
 		Domain:        "model.example.com",
 		RequestedHost: "realtime-model.model.example.com",
 		Path:          "/v1/chat/completions",
-	}))
+	})
+	assert.Nil(t, err)
 	assert.Equal(t, "model.example.com", lastReq.Domain)
 	assert.Equal(t, "realtime-model.model.example.com", lastReq.RequestedHost)
 	assert.Equal(t, "/v1/chat/completions", lastReq.Path)
 
-	assert.NotNil(t, v.Validate(key.Request{APIKey: "bad-key"}))
+	_, badErr := v.Validate(key.Request{APIKey: "bad-key"})
+	assert.NotNil(t, badErr)
 }
 
 func TestRejectHTTP(t *testing.T) {
@@ -68,7 +70,7 @@ func TestValidationErrorCarriesOnlyStatus(t *testing.T) {
 	v, err := NewValidator("https://localhost:8080/validate")
 	assert.Nil(t, err)
 
-	err = v.Validate(key.Request{APIKey: "bad-key"})
+	_, err = v.Validate(key.Request{APIKey: "bad-key"})
 	if assert.NotNil(t, err) {
 		validationErr, ok := err.(*key.ValidationError)
 		if assert.True(t, ok) {

--- a/tinfoil/internal/key/online/online_test.go
+++ b/tinfoil/internal/key/online/online_test.go
@@ -70,7 +70,7 @@ func TestValidationErrorCarriesOnlyStatus(t *testing.T) {
 
 	err = v.Validate(key.Request{APIKey: "bad-key"})
 	if assert.NotNil(t, err) {
-		validationErr, ok := err.(*ValidationError)
+		validationErr, ok := err.(*key.ValidationError)
 		if assert.True(t, ok) {
 			assert.Equal(t, http.StatusUnauthorized, validationErr.StatusCode)
 			assert.NotContains(t, validationErr.Error(), "internal validator details")

--- a/tinfoil/internal/key/online/online_test.go
+++ b/tinfoil/internal/key/online/online_test.go
@@ -40,19 +40,17 @@ func TestVerifyOnline(t *testing.T) {
 	v, err := NewValidator("https://localhost:8080/validate")
 	assert.Nil(t, err)
 
-	_, err = v.Validate(key.Request{
+	assert.Nil(t, v.Validate(key.Request{
 		APIKey:        "good-key",
 		Domain:        "model.example.com",
 		RequestedHost: "realtime-model.model.example.com",
 		Path:          "/v1/chat/completions",
-	})
-	assert.Nil(t, err)
+	}))
 	assert.Equal(t, "model.example.com", lastReq.Domain)
 	assert.Equal(t, "realtime-model.model.example.com", lastReq.RequestedHost)
 	assert.Equal(t, "/v1/chat/completions", lastReq.Path)
 
-	_, badErr := v.Validate(key.Request{APIKey: "bad-key"})
-	assert.NotNil(t, badErr)
+	assert.NotNil(t, v.Validate(key.Request{APIKey: "bad-key"}))
 }
 
 func TestRejectHTTP(t *testing.T) {
@@ -70,7 +68,7 @@ func TestValidationErrorCarriesOnlyStatus(t *testing.T) {
 	v, err := NewValidator("https://localhost:8080/validate")
 	assert.Nil(t, err)
 
-	_, err = v.Validate(key.Request{APIKey: "bad-key"})
+	err = v.Validate(key.Request{APIKey: "bad-key"})
 	if assert.NotNil(t, err) {
 		validationErr, ok := err.(*key.ValidationError)
 		if assert.True(t, ok) {

--- a/tinfoil/internal/key/online/verify.go
+++ b/tinfoil/internal/key/online/verify.go
@@ -28,25 +28,23 @@ func NewValidator(server string) (*Validator, error) {
 	}, nil
 }
 
-func (v *Validator) Validate(req key.Request) (key.Result, error) {
+func (v *Validator) Validate(req key.Request) error {
 	body, err := json.Marshal(req)
 	if err != nil {
-		return key.Result{}, fmt.Errorf("marshalling validation request: %w", err)
+		return fmt.Errorf("marshalling validation request: %w", err)
 	}
 
 	resp, err := v.client.Post(v.server, "application/json", bytes.NewReader(body))
 	if err != nil {
-		return key.Result{}, fmt.Errorf("validation request failed: %w", err)
+		return fmt.Errorf("validation request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
-	// The control plane knows the subject for opaque keys but does not return
-	// it here; the upstream attributes opaque-key usage by the key itself.
 	if resp.StatusCode == http.StatusOK {
-		return key.Result{}, nil
+		return nil
 	}
 
-	return key.Result{}, &key.ValidationError{
+	return &key.ValidationError{
 		StatusCode: resp.StatusCode,
 	}
 }

--- a/tinfoil/internal/key/online/verify.go
+++ b/tinfoil/internal/key/online/verify.go
@@ -28,14 +28,6 @@ func NewValidator(server string) (*Validator, error) {
 	}, nil
 }
 
-type ValidationError struct {
-	StatusCode int
-}
-
-func (e *ValidationError) Error() string {
-	return http.StatusText(e.StatusCode)
-}
-
 func (v *Validator) Validate(req key.Request) error {
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -52,7 +44,7 @@ func (v *Validator) Validate(req key.Request) error {
 		return nil
 	}
 
-	return &ValidationError{
+	return &key.ValidationError{
 		StatusCode: resp.StatusCode,
 	}
 }

--- a/tinfoil/internal/key/online/verify.go
+++ b/tinfoil/internal/key/online/verify.go
@@ -28,23 +28,25 @@ func NewValidator(server string) (*Validator, error) {
 	}, nil
 }
 
-func (v *Validator) Validate(req key.Request) error {
+func (v *Validator) Validate(req key.Request) (key.Result, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
-		return fmt.Errorf("marshalling validation request: %w", err)
+		return key.Result{}, fmt.Errorf("marshalling validation request: %w", err)
 	}
 
 	resp, err := v.client.Post(v.server, "application/json", bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("validation request failed: %w", err)
+		return key.Result{}, fmt.Errorf("validation request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
+	// The control plane knows the subject for opaque keys but does not return
+	// it here; the upstream attributes opaque-key usage by the key itself.
 	if resp.StatusCode == http.StatusOK {
-		return nil
+		return key.Result{}, nil
 	}
 
-	return &key.ValidationError{
+	return key.Result{}, &key.ValidationError{
 		StatusCode: resp.StatusCode,
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Verify OAuth JWT access tokens inside the enclave using the control plane JWKS to remove per-request round trips and cut latency. Tokens now use the stable audience `https://inference.tinfoil.sh` and the `inference:api` scope; opaque API keys still validate online.

- New Features
  - Added `tinfoil/internal/key/jwt` for in-enclave OAuth access-token validation against `.well-known/jwks.json`, with best-effort boot fetch, periodic refresh, throttled on-demand refresh (by last attempt), a 10s timeout, and unknown-kid retry; self-heals after startup outages.
  - Enforces EdDSA and claims (issuer, audience=`https://inference.tinfoil.sh`, typ=`at+jwt` or `application/at+jwt`), requires `inference:api`, and rejects tokens missing `sub`, `iat`, `jti`, or `client_id`.
  - Chained with the online validator so JWTs validate locally; opaque keys (or JWKS gaps) fall back online.

- Refactors
  - Introduced `key.ErrUnsupportedToken`, `key.ValidationError`, and `key.NewChain`; migrated the online validator and shim to use `key.ValidationError`.
  - Promoted `github.com/go-jose/go-jose/v4` to a direct dependency.

<sup>Written for commit 3c69850eca388e40b457de99d908100ee7da506d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

