### PR TITLE
feat(shim): forward verified JWT subject to upstream as X-Tinfoil-Subject

### DIFF
--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -88,6 +88,13 @@ const (
 	errTypeServer            = "server_error"
 )
 
+// subjectHeader carries the authenticated principal (JWT `sub`) from the shim to
+// the upstream workload after a JWT access token is verified in-enclave. The
+// upstream trusts it because the shim is the only path to it and unconditionally
+// strips any client-supplied value before setting its own. Must match the header
+// the upstream (confidential-model-router) reads.
+const subjectHeader = "X-Tinfoil-Subject"
+
 // Client-facing error messages, aligned with OpenAI's standard error messages
 // where applicable. See https://platform.openai.com/docs/guides/error-codes
 const (
@@ -214,7 +221,20 @@ func NewShimServer(
 	}
 
 	proxyHandler := ehbpMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Never trust a client-supplied identity header: the shim is the sole
+		// authority for subjectHeader and (re)sets it only after verifying a
+		// JWT below. Strip it unconditionally, including on unauthenticated
+		// paths, so a forged value can never reach the upstream.
+		r.Header.Del(subjectHeader)
+
 		apiKey := extractBearerToken(r.Header.Get("Authorization"))
+
+		// rateLimitID identifies the caller for the shim's local rate limiter.
+		// It defaults to the bearer credential and is replaced with the verified
+		// JWT subject when available, so a user's bucket is stable across the
+		// short-lived token's refreshes (and across multiple tokens).
+		rateLimitID := apiKey
+
 		if validator != nil && requiresAuth(config.AuthenticatedEndpoints, r.URL.Path) {
 			if len(apiKey) == 0 {
 				writeJSONError(w, errMsgAPIKeyRequired, errTypeInvalidRequest, http.StatusUnauthorized)
@@ -228,10 +248,19 @@ func NewShimServer(
 				Path:          r.URL.Path,
 			}
 
-			if err := validator.Validate(validationReq); err != nil {
+			res, err := validator.Validate(validationReq)
+			if err != nil {
 				log.Printf("Warning: failed to validate API key: %v", err)
 				writeValidationFailure(w, err)
 				return
+			}
+
+			// Forward the verified principal to the upstream so it can attribute
+			// usage and rate limits to a stable identity rather than the
+			// rotating bearer token. Empty for opaque keys (online validator).
+			if res.Subject != "" {
+				r.Header.Set(subjectHeader, res.Subject)
+				rateLimitID = res.Subject
 			}
 		}
 
@@ -240,7 +269,7 @@ func NewShimServer(
 				writeJSONError(w, errMsgAPIKeyRequired, errTypeInvalidRequest, http.StatusUnauthorized)
 				return
 			}
-			limiter := rateLimiter.Limit(apiKey)
+			limiter := rateLimiter.Limit(rateLimitID)
 			if !limiter.Allow() {
 				writeJSONError(w, errMsgRateLimited, errTypeInvalidRequest, http.StatusTooManyRequests)
 				return

--- a/tinfoil/internal/key/jwt/jwt.go
+++ b/tinfoil/internal/key/jwt/jwt.go
@@ -171,14 +171,14 @@ func NewValidator(jwksURL, issuer, audience, requiredScope string) *Validator {
 	}
 }
 
-func (v *Validator) Validate(req key.Request) error {
+func (v *Validator) Validate(req key.Request) (key.Result, error) {
 	if !isAccessTokenJWT(req.APIKey) {
-		return key.ErrUnsupportedToken
+		return key.Result{}, key.ErrUnsupportedToken
 	}
 
 	token, err := josejwt.ParseSigned(req.APIKey, []jose.SignatureAlgorithm{jose.EdDSA})
 	if err != nil || len(token.Headers) == 0 {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	// RFC 9068 registers the access-token type as "at+jwt"; RFC 7515 also
@@ -186,7 +186,7 @@ func (v *Validator) Validate(req key.Request) error {
 	// accept both forms case-insensitively.
 	typ, _ := token.Headers[0].ExtraHeaders[jose.HeaderType].(string)
 	if normalizeType(typ) != accessTokenType {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	signingKey, ok := v.keys.lookup(token.Headers[0].KeyID)
@@ -194,17 +194,17 @@ func (v *Validator) Validate(req key.Request) error {
 		v.keys.refreshIfAllowed()
 		signingKey, ok = v.keys.lookup(token.Headers[0].KeyID)
 		if !ok {
-			return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+			return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 		}
 	}
 
 	var claims josejwt.Claims
 	var ext accessTokenClaims
 	if err := token.Claims(signingKey, &claims, &ext); err != nil {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 	if claims.Subject == "" || claims.Expiry == nil || claims.IssuedAt == nil || claims.ID == "" || ext.ClientID == "" {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	if err := claims.Validate(josejwt.Expected{
@@ -212,14 +212,16 @@ func (v *Validator) Validate(req key.Request) error {
 		AnyAudience: josejwt.Audience{v.audience},
 		Time:        time.Now(),
 	}); err != nil {
-		return &key.ValidationError{StatusCode: http.StatusUnauthorized}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusUnauthorized}
 	}
 
 	if !scopeContains(ext.Scope, v.scope) {
-		return &key.ValidationError{StatusCode: http.StatusForbidden}
+		return key.Result{}, &key.ValidationError{StatusCode: http.StatusForbidden}
 	}
 
-	return nil
+	// The verified subject lets the shim forward a stable identity to the
+	// upstream so usage/rate limits attach to the user, not the rotating token.
+	return key.Result{Subject: claims.Subject}, nil
 }
 
 // isAccessTokenJWT reports whether s is explicitly typed as an access-token

--- a/tinfoil/internal/key/jwt/jwt_test.go
+++ b/tinfoil/internal/key/jwt/jwt_test.go
@@ -91,6 +91,14 @@ func chatRequest(token string) key.Request {
 	return key.Request{APIKey: token, Path: "/v1/chat/completions"}
 }
 
+// validateErr runs the validator and returns only the error, for the many
+// rejection cases that do not care about the Result. The accepted-token tests
+// call Validate directly to assert the surfaced subject.
+func validateErr(val *Validator, req key.Request) error {
+	_, err := val.Validate(req)
+	return err
+}
+
 func TestValidateAcceptsValidToken(t *testing.T) {
 	pub, priv, _ := ed25519.GenerateKey(nil)
 	srv := jwksServer(t, pub, testKID)
@@ -98,8 +106,12 @@ func TestValidateAcceptsValidToken(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(chatRequest(token)); err != nil {
+	res, err := v.Validate(chatRequest(token))
+	if err != nil {
 		t.Fatalf("expected valid token, got %v", err)
+	}
+	if res.Subject != "user_1" {
+		t.Fatalf("Subject = %q, want user_1", res.Subject)
 	}
 }
 
@@ -109,7 +121,7 @@ func TestValidateFallsThroughForOpaqueKey(t *testing.T) {
 	defer srv.Close()
 	v := newTestValidator(t, srv.URL)
 
-	err := v.Validate(key.Request{APIKey: "chat_abcdef"})
+	err := validateErr(v, key.Request{APIKey: "chat_abcdef"})
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -121,7 +133,7 @@ func TestValidateFallsThroughForDottedOpaqueKey(t *testing.T) {
 	defer srv.Close()
 	v := newTestValidator(t, srv.URL)
 
-	err := v.Validate(key.Request{APIKey: "opaque.with.dots"})
+	err := validateErr(v, key.Request{APIKey: "opaque.with.dots"})
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -136,7 +148,7 @@ func TestValidateRejectsWrongAudience(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Audience = josejwt.Audience{"https://example.com"}
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsExpired(t *testing.T) {
@@ -146,7 +158,7 @@ func TestValidateRejectsExpired(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now().Add(-time.Hour)), RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsMissingExpiration(t *testing.T) {
@@ -158,7 +170,7 @@ func TestValidateRejectsMissingExpiration(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Expiry = nil
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateRejectsMissingScope(t *testing.T) {
@@ -168,7 +180,7 @@ func TestValidateRejectsMissingScope(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), "models:read")
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusForbidden)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusForbidden)
 }
 
 func TestValidateRejectsWrongIssuer(t *testing.T) {
@@ -180,7 +192,7 @@ func TestValidateRejectsWrongIssuer(t *testing.T) {
 	claims := validClaims(time.Now())
 	claims.Issuer = "https://evil.example.com"
 	token := mintToken(t, priv, testKID, "at+jwt", claims, RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateFallsThroughForWrongType(t *testing.T) {
@@ -190,7 +202,7 @@ func TestValidateFallsThroughForWrongType(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "JWT", validClaims(time.Now()), RequiredScope)
-	err := v.Validate(chatRequest(token))
+	err := validateErr(v, chatRequest(token))
 	if !errors.Is(err, key.ErrUnsupportedToken) {
 		t.Fatalf("expected ErrUnsupportedToken, got %v", err)
 	}
@@ -206,7 +218,7 @@ func TestValidateRejectsForeignSignature(t *testing.T) {
 	// verification against the published key must fail.
 	_, foreignPriv, _ := ed25519.GenerateKey(nil)
 	token := mintToken(t, foreignPriv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	expectStatus(t, v.Validate(chatRequest(token)), http.StatusUnauthorized)
+	expectStatus(t, validateErr(v, chatRequest(token)), http.StatusUnauthorized)
 }
 
 func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
@@ -217,7 +229,7 @@ func TestValidateAcceptsApplicationPrefixType(t *testing.T) {
 
 	// RFC 9068 / RFC 7515 permit the media type with an "application/" prefix.
 	token := mintToken(t, priv, testKID, "application/at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(chatRequest(token)); err != nil {
+	if err := validateErr(v, chatRequest(token)); err != nil {
 		t.Fatalf("expected application/at+jwt to be accepted, got %v", err)
 	}
 }
@@ -231,7 +243,7 @@ func TestValidateAcceptsNonChatPath(t *testing.T) {
 	// The inference:api scope authorizes every inference endpoint, not just
 	// chat completions, so a non-chat path must validate.
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(key.Request{APIKey: token, Path: "/v1/embeddings"}); err != nil {
+	if err := validateErr(v, key.Request{APIKey: token, Path: "/v1/embeddings"}); err != nil {
 		t.Fatalf("expected non-chat path to be accepted, got %v", err)
 	}
 }
@@ -310,7 +322,7 @@ func TestValidateRefreshesUnknownKidAfterRecentSuccess(t *testing.T) {
 	useSecond.Store(true)
 
 	token := mintToken(t, secondPriv, "test-key-2", "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(chatRequest(token)); err != nil {
+	if err := validateErr(v, chatRequest(token)); err != nil {
 		t.Fatalf("expected unknown kid to refresh immediately, got %v", err)
 	}
 }
@@ -344,7 +356,7 @@ func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
 	v := newTestValidator(t, srv.URL)
 
 	token := mintToken(t, priv, testKID, "at+jwt", validClaims(time.Now()), RequiredScope)
-	if err := v.Validate(chatRequest(token)); err == nil {
+	if err := validateErr(v, chatRequest(token)); err == nil {
 		t.Fatal("expected rejection while no signing keys are cached")
 	}
 
@@ -355,7 +367,7 @@ func TestNewValidatorRecoversWhenJWKSStartsUnavailable(t *testing.T) {
 	v.keys.lastAttempt = time.Now().Add(-2 * minRefreshInterval)
 	v.keys.mu.Unlock()
 
-	if err := v.Validate(chatRequest(token)); err != nil {
+	if err := validateErr(v, chatRequest(token)); err != nil {
 		t.Fatalf("expected token to validate after JWKS became available, got %v", err)
 	}
 }

--- a/tinfoil/internal/key/key.go
+++ b/tinfoil/internal/key/key.go
@@ -14,8 +14,19 @@ type Request struct {
 	Path          string `json:"path,omitempty"`
 }
 
+// Result is the non-secret outcome of a successful validation. It lets the shim
+// forward the authenticated principal to the upstream workload so the workload
+// can attribute usage and rate limits to a stable identity instead of the
+// (rotating) bearer credential.
+type Result struct {
+	// Subject is the authenticated principal — the JWT `sub` — when the
+	// credential is a locally-verified JWT access token. It is empty for opaque
+	// API keys, whose subject is known only to the control plane.
+	Subject string
+}
+
 type Validator interface {
-	Validate(req Request) error
+	Validate(req Request) (Result, error)
 }
 
 // ErrUnsupportedToken signals that a Validator cannot handle the presented
@@ -44,13 +55,14 @@ func NewChain(validators ...Validator) *Chain {
 	return &Chain{validators: validators}
 }
 
-func (c *Chain) Validate(req Request) error {
+func (c *Chain) Validate(req Request) (Result, error) {
+	var res Result
 	var err error
 	for _, v := range c.validators {
-		err = v.Validate(req)
+		res, err = v.Validate(req)
 		if !errors.Is(err, ErrUnsupportedToken) {
-			return err
+			return res, err
 		}
 	}
-	return err
+	return res, err
 }

--- a/tinfoil/internal/key/key_test.go
+++ b/tinfoil/internal/key/key_test.go
@@ -7,15 +7,16 @@ import (
 )
 
 type stubValidator struct {
+	result Result
 	err    error
 	called *int
 }
 
-func (s stubValidator) Validate(Request) error {
+func (s stubValidator) Validate(Request) (Result, error) {
 	if s.called != nil {
 		*s.called++
 	}
-	return s.err
+	return s.result, s.err
 }
 
 func TestChainFallsThroughOnUnsupported(t *testing.T) {
@@ -24,7 +25,7 @@ func TestChainFallsThroughOnUnsupported(t *testing.T) {
 		stubValidator{err: ErrUnsupportedToken, called: &firstCalls},
 		stubValidator{err: nil, called: &secondCalls},
 	)
-	if err := chain.Validate(Request{APIKey: "x"}); err != nil {
+	if _, err := chain.Validate(Request{APIKey: "x"}); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 	if firstCalls != 1 || secondCalls != 1 {
@@ -38,7 +39,7 @@ func TestChainReturnsValidationErrorImmediately(t *testing.T) {
 		stubValidator{err: &ValidationError{StatusCode: http.StatusUnauthorized}},
 		stubValidator{err: nil, called: &secondCalls},
 	)
-	err := chain.Validate(Request{APIKey: "x"})
+	_, err := chain.Validate(Request{APIKey: "x"})
 	var ve *ValidationError
 	if !errors.As(err, &ve) || ve.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("expected 401 ValidationError, got %v", err)
@@ -54,10 +55,27 @@ func TestChainShortCircuitsOnSuccess(t *testing.T) {
 		stubValidator{err: nil},
 		stubValidator{err: ErrUnsupportedToken, called: &secondCalls},
 	)
-	if err := chain.Validate(Request{APIKey: "x"}); err != nil {
+	if _, err := chain.Validate(Request{APIKey: "x"}); err != nil {
 		t.Fatalf("expected success, got %v", err)
 	}
 	if secondCalls != 0 {
 		t.Fatalf("second validator should not be consulted, calls=%d", secondCalls)
+	}
+}
+
+// TestChainPropagatesSubject verifies the Result from the validator that
+// handled the request (here the second, after the first falls through) is
+// returned to the caller, so the shim can forward the verified subject.
+func TestChainPropagatesSubject(t *testing.T) {
+	chain := NewChain(
+		stubValidator{err: ErrUnsupportedToken},
+		stubValidator{result: Result{Subject: "user_42"}, err: nil},
+	)
+	res, err := chain.Validate(Request{APIKey: "x"})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if res.Subject != "user_42" {
+		t.Fatalf("Subject = %q, want user_42", res.Subject)
 	}
 }

--- a/tinfoil/internal/key/online/online_test.go
+++ b/tinfoil/internal/key/online/online_test.go
@@ -40,17 +40,19 @@ func TestVerifyOnline(t *testing.T) {
 	v, err := NewValidator("https://localhost:8080/validate")
 	assert.Nil(t, err)
 
-	assert.Nil(t, v.Validate(key.Request{
+	_, err = v.Validate(key.Request{
 		APIKey:        "good-key",
 		Domain:        "model.example.com",
 		RequestedHost: "realtime-model.model.example.com",
 		Path:          "/v1/chat/completions",
-	}))
+	})
+	assert.Nil(t, err)
 	assert.Equal(t, "model.example.com", lastReq.Domain)
 	assert.Equal(t, "realtime-model.model.example.com", lastReq.RequestedHost)
 	assert.Equal(t, "/v1/chat/completions", lastReq.Path)
 
-	assert.NotNil(t, v.Validate(key.Request{APIKey: "bad-key"}))
+	_, badErr := v.Validate(key.Request{APIKey: "bad-key"})
+	assert.NotNil(t, badErr)
 }
 
 func TestRejectHTTP(t *testing.T) {
@@ -68,7 +70,7 @@ func TestValidationErrorCarriesOnlyStatus(t *testing.T) {
 	v, err := NewValidator("https://localhost:8080/validate")
 	assert.Nil(t, err)
 
-	err = v.Validate(key.Request{APIKey: "bad-key"})
+	_, err = v.Validate(key.Request{APIKey: "bad-key"})
 	if assert.NotNil(t, err) {
 		validationErr, ok := err.(*key.ValidationError)
 		if assert.True(t, ok) {

--- a/tinfoil/internal/key/online/verify.go
+++ b/tinfoil/internal/key/online/verify.go
@@ -28,23 +28,25 @@ func NewValidator(server string) (*Validator, error) {
 	}, nil
 }
 
-func (v *Validator) Validate(req key.Request) error {
+func (v *Validator) Validate(req key.Request) (key.Result, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
-		return fmt.Errorf("marshalling validation request: %w", err)
+		return key.Result{}, fmt.Errorf("marshalling validation request: %w", err)
 	}
 
 	resp, err := v.client.Post(v.server, "application/json", bytes.NewReader(body))
 	if err != nil {
-		return fmt.Errorf("validation request failed: %w", err)
+		return key.Result{}, fmt.Errorf("validation request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
+	// The control plane knows the subject for opaque keys but does not return
+	// it here; the upstream attributes opaque-key usage by the key itself.
 	if resp.StatusCode == http.StatusOK {
-		return nil
+		return key.Result{}, nil
 	}
 
-	return &key.ValidationError{
+	return key.Result{}, &key.ValidationError{
 		StatusCode: resp.StatusCode,
 	}
 }


### PR DESCRIPTION
Stacked on #156 (base: `feat/jwt-tokens`). Merge #156 first.

## Why
PR #156 verifies OAuth JWT access tokens in-enclave but discards the verified identity. The upstream workload (confidential-model-router) keys its per-user rate limiter — and other identity-scoped logic — off the raw `Authorization: Bearer` string. A JWT access token is **not a stable identity**: it rotates on every ~15-minute refresh, and a user can mint several concurrently. So per-user keying silently degrades for JWT traffic (e.g. the fairness/priority throttle resets at every refresh and can be evaded by re-minting).

This surfaces the verified `sub` and forwards it to the upstream as a trusted header so downstream logic can attach to a stable principal.

## What
- **`key.Validator` now returns `(Result, error)`.** `Result.Subject` carries the JWT `sub`. `Chain` propagates the `Result` from whichever validator handled the request.
- **`jwt.Validator`** returns `Result{Subject: claims.Subject}` on success.
- **`online.Validator`** returns an empty subject — opaque-key subjects are known only to the control plane, so opaque traffic continues to be keyed by the key itself.
- **Shim (`api.go` proxyHandler):**
  - **Unconditionally strips** any client-supplied `X-Tinfoil-Subject` at the top of the handler (including on unauthenticated paths) — the shim is the sole authority for this header, so a forged inbound value can never reach the upstream.
  - After a successful JWT verification, **sets `X-Tinfoil-Subject` to the verified `sub`** and re-keys the shim's own local rate limiter on it.

## Trust model
The upstream trusts `X-Tinfoil-Subject` because the shim is the only network path to it and strips any inbound value before setting its own. The companion model-router PR keys its rate limiter on this header and documents the same assumption.

## Explicitly unchanged
- **Billing.** The control plane attributes JWT usage by verifying the raw token itself (`looksLikeJWT` → `Subject()`), so billing stays keyed on the raw JWT in usage events — swapping in the bare `sub` would break that detection. Out of scope here.

## Tests
- `jwt`: accepted-token test asserts the surfaced `sub`; all rejection cases updated to the new signature.
- `key`: new `TestChainPropagatesSubject` confirms the handling validator's `Result` reaches the caller.
- Full `tinfoil` module builds, vets, and tests green.
- Note: an end-to-end shim test of the header strip/inject is blocked by the EHBP identity middleware fronting the proxy handler (plain requests are rejected before reaching it); coverage is via the validator unit tests + the single-line unconditional strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward the verified JWT subject to upstream as `X-Tinfoil-Subject` and re-key local rate limiting on it, giving downstream a stable per-user identity instead of the rotating bearer token. The shim strips any client-supplied header and sets its own after in-enclave verification.

- **New Features**
  - Shim unconditionally strips inbound `X-Tinfoil-Subject`, then sets it to the verified JWT `sub` and uses it for rate limiting when available; opaque keys stay keyed by the token.

- **Migration**
  - `key.Validator.Validate` now returns `(Result, error)`; read `res.Subject` when present.
  - `key.Chain.Validate` propagates `Result`.
  - `jwt.Validator` populates `Result.Subject`; `online.Validator` returns an empty subject.

<sup>Written for commit 5396ebc8f69858c681d6f15705a8b7cce10b50b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

