### PR TITLE
feat: add support for b300

### DIFF
--- a/mkosi.extra/etc/systemd/system/tinfoil-boot.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-boot.service
@@ -14,7 +14,6 @@ StandardOutput=journal+console
 StandardError=journal+console
 NoNewPrivileges=yes
 RestrictSUIDSGID=yes
-ProtectHome=yes
 LockPersonality=yes
 RestrictRealtime=yes
 SystemCallArchitectures=native

--- a/tinfoil/cmd/boot/gpuattest.go
+++ b/tinfoil/cmd/boot/gpuattest.go
@@ -22,6 +22,7 @@ const (
 	gpuDeviceIDH100 = "0x2331"
 	gpuDeviceIDH200 = "0x2335"
 	gpuDeviceIDB200 = "0x2901"
+	gpuDeviceIDB300 = "0x3182"
 )
 
 // forEachNVIDIAGPU iterates over PCI devices that are NVIDIA GPUs
@@ -75,6 +76,8 @@ func detectGPUArch() (string, error) {
 			arch = "h200"
 		case gpuDeviceIDB200:
 			arch = "b200"
+		case gpuDeviceIDB300:
+			arch = "b300"
 		default:
 			return true
 		}
@@ -235,9 +238,9 @@ func verifyGPUAttestation(expectedGPUs int) (*GPURawEvidence, error) {
 			return nil, fmt.Errorf("detecting GPU arch: %w", err)
 		}
 		switch arch {
-		case "b200":
-			// B200 MPT: NVSwitches are not exposed to the guest.
-			log.Printf("HGX B200 MPT: no in-guest NVSwitch evidence")
+		case "b200", "b300":
+			// Blackwell MPT: NVSwitches are not exposed to the guest.
+			log.Printf("HGX Blackwell MPT: no in-guest NVSwitch evidence")
 
 		case "h100", "h200", "":
 			if err := runNvattest("nvswitch"); err != nil {

--- a/tinfoil/cmd/boot/gpuattest.go
+++ b/tinfoil/cmd/boot/gpuattest.go
@@ -60,7 +60,7 @@ func detectGPUCount() (int, error) {
 	return count, nil
 }
 
-// detectGPUArch returns "h100", "h200", "b200", or "" from the first GPU.
+// detectGPUArch returns "h100", "h200", "b200", "b300", or "" from the first GPU.
 func detectGPUArch() (string, error) {
 	const pciPath = "/sys/bus/pci/devices"
 	var arch string


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add B300 (Blackwell) GPU support to attestation: detect PCI ID 0x3182, report arch "b300", and handle Blackwell MPT (B200/B300) by skipping in-guest NVSwitch evidence with updated log text. Also remove ProtectHome from `tinfoil-boot.service` to avoid blocking needed access during boot.

<sup>Written for commit f99b5ed9cbd8ba86a5e28425dea46445be87dd6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

