### PR TITLE
feat: support for empk models

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -62,35 +62,10 @@ func (n *NetworkSpec) UnmarshalYAML(node *yaml.Node) error {
 
 // ModelSpec represents a model pack specification.
 type ModelSpec struct {
-	Name string                  `yaml:"name,omitempty"`
-	MPK  string                  `yaml:"mpk,omitempty"`
-	EMPK *EncryptedModelPackSpec `yaml:"empk,omitempty"`
-}
-
-// EncryptedModelPackSpec represents an encrypted model pack.
-//
-// The encrypted block device is opened with raw dm-crypt first. dm-verity is
-// then opened over the decrypted mapper and mounted read-only, matching the
-// public MPK mount contract exposed to containers under /tinfoil/mpk.
-type EncryptedModelPackSpec struct {
-	Device string `yaml:"device"`
-
-	RootHash   string `yaml:"root-hash"`
-	HashOffset string `yaml:"hash-offset"`
-	UUID       string `yaml:"uuid,omitempty"`
-
-	KeySecret string `yaml:"key-secret"`
-
-	Cipher     string `yaml:"cipher,omitempty"`
-	KeySize    int    `yaml:"key-size,omitempty"`
-	SectorSize int    `yaml:"sector-size,omitempty"`
-
-	EncryptedSHA256       string `yaml:"encrypted-sha256,omitempty"`
-	VerifyEncryptedSHA256 bool   `yaml:"verify-encrypted-sha256,omitempty"`
-
-	DataBlockSize int    `yaml:"data-block-size,omitempty"`
-	HashBlockSize int    `yaml:"hash-block-size,omitempty"`
-	DataBlocks    string `yaml:"data-blocks,omitempty"`
+	Name      string `yaml:"name,omitempty"`
+	MPK       string `yaml:"mpk,omitempty"`
+	EMPK      string `yaml:"empk,omitempty"`
+	KeySecret string `yaml:"key-secret,omitempty"`
 }
 
 // Container represents a container to run (Docker Compose-compatible subset)

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -60,9 +60,37 @@ func (n *NetworkSpec) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-// ModelSpec represents a model pack specification
+// ModelSpec represents a model pack specification.
 type ModelSpec struct {
-	MPK string `yaml:"mpk"`
+	Name string                  `yaml:"name,omitempty"`
+	MPK  string                  `yaml:"mpk,omitempty"`
+	EMPK *EncryptedModelPackSpec `yaml:"empk,omitempty"`
+}
+
+// EncryptedModelPackSpec represents an encrypted model pack.
+//
+// The encrypted block device is opened with raw dm-crypt first. dm-verity is
+// then opened over the decrypted mapper and mounted read-only, matching the
+// public MPK mount contract exposed to containers under /tinfoil/mpk.
+type EncryptedModelPackSpec struct {
+	Device string `yaml:"device"`
+
+	RootHash   string `yaml:"root-hash"`
+	HashOffset string `yaml:"hash-offset"`
+	UUID       string `yaml:"uuid,omitempty"`
+
+	KeySecret string `yaml:"key-secret"`
+
+	Cipher     string `yaml:"cipher,omitempty"`
+	KeySize    int    `yaml:"key-size,omitempty"`
+	SectorSize int    `yaml:"sector-size,omitempty"`
+
+	EncryptedSHA256       string `yaml:"encrypted-sha256,omitempty"`
+	VerifyEncryptedSHA256 bool   `yaml:"verify-encrypted-sha256,omitempty"`
+
+	DataBlockSize int    `yaml:"data-block-size,omitempty"`
+	HashBlockSize int    `yaml:"hash-block-size,omitempty"`
+	DataBlocks    string `yaml:"data-blocks,omitempty"`
 }
 
 // Container represents a container to run (Docker Compose-compatible subset)

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -63,8 +63,9 @@ func (n *NetworkSpec) UnmarshalYAML(node *yaml.Node) error {
 // ModelSpec represents a model pack specification.
 type ModelSpec struct {
 	Name      string `yaml:"name,omitempty"`
-	MPK       string `yaml:"mpk,omitempty"`
-	EMPK      string `yaml:"empk,omitempty"`
+	MPK       string `yaml:"mpk,omitempty"` // Legacy alias for mwp.
+	MWP       string `yaml:"mwp,omitempty"`
+	EMWP      string `yaml:"emwp,omitempty"`
 	KeySecret string `yaml:"key-secret,omitempty"`
 }
 

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -169,11 +169,10 @@ func run() error {
 	start = time.Now()
 	log.Println("Mounting models")
 	if err := mountModels(config, externalConfig); err != nil {
-		log.Printf("Warning: model mount failed: %v", err)
-		tracker.Record("models", boot.StatusWarning, time.Since(start), err.Error())
-	} else {
-		tracker.Record("models", boot.StatusOK, time.Since(start), "")
+		tracker.Record("models", boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("model mount failed: %w", err)
 	}
+	tracker.Record("models", boot.StatusOK, time.Since(start), "")
 
 	// 9. Containers + health checks
 	log.Println("Launching containers")

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -54,8 +54,13 @@ func runSubcommand(cmd string) error {
 		log.Println("Launching containers")
 		return launchContainers(config)
 	case "models":
+		externalConfig, err := getExternalConfig()
+		if err != nil {
+			log.Printf("Warning: external config not available, using defaults: %v", err)
+			externalConfig = &shimconfig.ExternalConfig{}
+		}
 		log.Println("Mounting models")
-		return mountModels(config)
+		return mountModels(config, externalConfig)
 	}
 	return nil
 }
@@ -163,7 +168,7 @@ func run() error {
 	// 8. Models
 	start = time.Now()
 	log.Println("Mounting models")
-	if err := mountModels(config); err != nil {
+	if err := mountModels(config, externalConfig); err != nil {
 		log.Printf("Warning: model mount failed: %v", err)
 		tracker.Record("models", boot.StatusWarning, time.Since(start), err.Error())
 	} else {

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -1,27 +1,15 @@
 package main
 
 import (
-	"crypto/hkdf"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
-	"strconv"
-	"strings"
+
+	"github.com/tinfoilsh/modelwrap"
+	"github.com/tinfoilsh/modelwrap/unwrap"
 
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
-)
-
-const (
-	defaultEMWPCipher     = "aes-xts-plain64"
-	defaultEMWPKeySize    = 512
-	defaultEMWPSectorSize = 4096
-	modelMountOptions     = "ro,nodev,nosuid,noexec"
-	modelFilesystemType   = "erofs"
-	emwpKeyDeriveInfo     = "tinfoil/emwp/dm-crypt-key/v1"
 )
 
 // mountModels mounts all model packs from the config
@@ -103,28 +91,15 @@ func mountEncryptedModelPack(model ModelSpec, externalConfig *shimconfig.Externa
 	if err := createLegacyModelPackAlias(spec); err != nil {
 		return err
 	}
-	cryptCmd := exec.Command(
-		"cryptsetup", "open",
-		"--type", "plain",
-		"--cipher", defaultEMWPCipher,
-		"--key-size", strconv.Itoa(defaultEMWPKeySize),
-		"--sector-size", strconv.Itoa(defaultEMWPSectorSize),
-		"--key-file", keyFile,
-		"--readonly",
-		diskByPARTUUID(spec.UUID),
-		cryptName,
-	)
-	cryptCmd.Stdout = os.Stdout
-	cryptCmd.Stderr = os.Stderr
-	if err := cryptCmd.Run(); err != nil {
+	if err := unwrap.OpenCrypt(diskByPARTUUID(spec.UUID), cryptName, keyFile); err != nil {
 		removeLegacyModelPackAlias(spec)
-		return fmt.Errorf("cryptsetup open: %w", err)
+		return err
 	}
 
 	cryptDevice := "/dev/mapper/" + cryptName
 	if err := openAndMountVerity(cryptDevice, verityName, spec.RootHash, spec.HashOffset, mountPoint); err != nil {
 		removeLegacyModelPackAlias(spec)
-		closeCryptMapper(cryptName)
+		unwrap.CloseCrypt(cryptName)
 		return err
 	}
 
@@ -164,7 +139,7 @@ func writePersistentModelKey(spec *modelPackRef, key []byte) (string, error) {
 	if err := os.Chmod(boot.ModelKeyDir, 0700); err != nil {
 		return "", fmt.Errorf("setting model key directory permissions: %w", err)
 	}
-	keyFile := fmt.Sprintf("%s/%s.key", boot.ModelKeyDir, spec.artifactID())
+	keyFile := fmt.Sprintf("%s/%s.key", boot.ModelKeyDir, spec.ArtifactID())
 	if err := os.WriteFile(keyFile, key, 0600); err != nil {
 		return "", fmt.Errorf("writing model key file: %w", err)
 	}
@@ -218,11 +193,11 @@ func modelPackRefForModel(model ModelSpec) (*modelPackRef, modelKind, error) {
 	return spec, modelKindEncrypted, nil
 }
 
+// modelPackRef wraps the shared artifact reference with cvmimage mount
+// layout policy (mapper names, mount points, legacy aliases).
 type modelPackRef struct {
-	raw        string
-	RootHash   string
-	HashOffset string
-	UUID       string
+	*modelwrap.ArtifactRef
+	raw string
 }
 
 func (r *modelPackRef) mapperName() string {
@@ -237,32 +212,12 @@ func (r *modelPackRef) legacyMountPoint() string {
 	return boot.MPKDir + "/mpk-" + r.RootHash
 }
 
-func (r *modelPackRef) artifactID() string {
-	return r.RootHash + "_" + r.UUID
-}
-
 func parseModelPackRef(ref string) (*modelPackRef, error) {
-	parts := strings.Split(ref, "_")
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("expected rootHash_hashOffset_uuid")
+	parsed, err := modelwrap.ParseRef(ref)
+	if err != nil {
+		return nil, err
 	}
-
-	spec := &modelPackRef{
-		raw:        ref,
-		RootHash:   parts[0],
-		HashOffset: parts[1],
-		UUID:       parts[2],
-	}
-	if !hexHashPattern.MatchString(spec.RootHash) {
-		return nil, fmt.Errorf("invalid root hash format: %s", spec.RootHash)
-	}
-	if !offsetPattern.MatchString(spec.HashOffset) {
-		return nil, fmt.Errorf("invalid hash offset format: %s", spec.HashOffset)
-	}
-	if !uuidPattern.MatchString(spec.UUID) {
-		return nil, fmt.Errorf("invalid UUID format: %s", spec.UUID)
-	}
-	return spec, nil
+	return &modelPackRef{ArtifactRef: parsed, raw: ref}, nil
 }
 
 func encryptedModelKey(keySecret string, spec *modelPackRef, externalConfig *shimconfig.ExternalConfig) ([]byte, error) {
@@ -276,51 +231,21 @@ func encryptedModelKey(keySecret string, spec *modelPackRef, externalConfig *shi
 	if secret == "" {
 		return nil, fmt.Errorf("encrypted model key secret %q not found", keySecret)
 	}
-	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(secret))
+	key, err := modelwrap.ParseMasterKey(secret)
 	if err != nil {
-		return nil, fmt.Errorf("decoding encrypted model key secret %q as base64: %w", keySecret, err)
+		return nil, fmt.Errorf("encrypted model key secret %q: %w", keySecret, err)
 	}
-	if len(key) != defaultEMWPKeySize/8 {
-		return nil, fmt.Errorf("encrypted model key secret %q decoded to %d bytes, want %d", keySecret, len(key), defaultEMWPKeySize/8)
-	}
-	return hkdf.Key(sha256.New, key, []byte(spec.artifactID()), emwpKeyDeriveInfo, defaultEMWPKeySize/8)
+	return modelwrap.DeriveKey(key, spec.ArtifactRef)
 }
 
 func openAndMountVerity(sourceDevice, deviceName, rootHash, hashOffset, mountPoint string) error {
-	// Using veritysetup as there's no good pure-Go dm-verity library.
-	cmd := exec.Command(
-		"veritysetup", "open",
-		sourceDevice,
-		deviceName,
-		sourceDevice,
-		rootHash,
-		"--hash-offset="+hashOffset,
-	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("veritysetup open: %w", err)
+	if err := unwrap.OpenVerity(sourceDevice, deviceName, rootHash, hashOffset); err != nil {
+		return err
 	}
-
-	if err := os.MkdirAll(mountPoint, 0755); err != nil {
-		closeVerityMapper(deviceName)
-		return fmt.Errorf("creating mount point: %w", err)
+	if err := unwrap.Mount("/dev/mapper/"+deviceName, mountPoint); err != nil {
+		unwrap.CloseVerity(deviceName)
+		return err
 	}
-
-	mountCmd := exec.Command(
-		"mount",
-		"-t", modelFilesystemType,
-		"-o", modelMountOptions,
-		"/dev/mapper/"+deviceName,
-		mountPoint,
-	)
-	mountCmd.Stdout = os.Stdout
-	mountCmd.Stderr = os.Stderr
-	if err := mountCmd.Run(); err != nil {
-		closeVerityMapper(deviceName)
-		return fmt.Errorf("mounting verity device: %w", err)
-	}
-
 	return nil
 }
 
@@ -330,14 +255,6 @@ func diskByUUID(uuid string) string {
 
 func diskByPARTUUID(uuid string) string {
 	return fmt.Sprintf("/dev/disk/by-partuuid/%s", uuid)
-}
-
-func closeVerityMapper(name string) {
-	_ = exec.Command("veritysetup", "close", name).Run()
-}
-
-func closeCryptMapper(name string) {
-	_ = exec.Command("cryptsetup", "close", name).Run()
 }
 
 func modelLogName(name, rootHash string) string {

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -1,17 +1,29 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"tinfoil/internal/boot"
+	shimconfig "tinfoil/internal/config"
+)
+
+const (
+	defaultEMPKCipher     = "aes-xts-plain64"
+	defaultEMPKKeySize    = 512
+	defaultEMPKSectorSize = 4096
 )
 
 // mountModels mounts all model packs from the config
-func mountModels(config *Config) error {
+func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) error {
 	if len(config.Models) == 0 {
 		log.Println("No models to mount")
 		return nil
@@ -19,8 +31,19 @@ func mountModels(config *Config) error {
 
 	log.Printf("Mounting %d model packs", len(config.Models))
 	for _, model := range config.Models {
-		if err := mountModelPack(model.MPK); err != nil {
-			return fmt.Errorf("mounting model pack %s: %w", model.MPK, err)
+		switch {
+		case model.MPK != "" && model.EMPK != nil:
+			return fmt.Errorf("model %q specifies both mpk and empk", model.Name)
+		case model.MPK != "":
+			if err := mountModelPack(model.MPK); err != nil {
+				return fmt.Errorf("mounting model pack %s: %w", model.MPK, err)
+			}
+		case model.EMPK != nil:
+			if err := mountEncryptedModelPack(model.Name, model.EMPK, externalConfig); err != nil {
+				return fmt.Errorf("mounting encrypted model pack %q: %w", model.Name, err)
+			}
+		default:
+			return fmt.Errorf("model %q specifies neither mpk nor empk", model.Name)
 		}
 	}
 
@@ -93,4 +116,213 @@ func mountModelPack(mpk string) error {
 
 	log.Printf("Mounted model pack %s at %s", deviceName, mountPoint)
 	return nil
+}
+
+// mountEncryptedModelPack mounts an encrypted model pack using dm-crypt below
+// dm-verity. The decrypted mapper contains the same plaintext layout as an MPK:
+// a read-only filesystem followed by its dm-verity hash tree.
+func mountEncryptedModelPack(name string, spec *EncryptedModelPackSpec, externalConfig *shimconfig.ExternalConfig) error {
+	if err := validateEncryptedModelPack(spec); err != nil {
+		return err
+	}
+
+	key, err := encryptedModelKey(spec, externalConfig)
+	if err != nil {
+		return err
+	}
+
+	if spec.VerifyEncryptedSHA256 {
+		if err := verifyEncryptedDeviceSHA256(spec.Device, spec.EncryptedSHA256); err != nil {
+			return err
+		}
+	}
+
+	if err := os.MkdirAll(boot.ModelKeyDir, 0700); err != nil {
+		return fmt.Errorf("creating model key directory: %w", err)
+	}
+	keyFile := fmt.Sprintf("%s/%s.key", boot.ModelKeyDir, spec.RootHash)
+	if err := os.WriteFile(keyFile, key, 0600); err != nil {
+		return fmt.Errorf("writing model key file: %w", err)
+	}
+	defer os.Remove(keyFile)
+
+	cryptName := fmt.Sprintf("empk-%s-crypt", spec.RootHash)
+	verityName := fmt.Sprintf("mpk-%s", spec.RootHash)
+	mountPoint := fmt.Sprintf("%s/%s", boot.MPKDir, verityName)
+
+	log.Printf("Opening encrypted model pack %s (device=%s)", modelLogName(name, spec.RootHash), spec.Device)
+	cryptCmd := exec.Command(
+		"cryptsetup", "open",
+		"--type", "plain",
+		"--cipher", encryptedModelCipher(spec),
+		"--key-size", strconv.Itoa(encryptedModelKeySize(spec)),
+		"--sector-size", strconv.Itoa(encryptedModelSectorSize(spec)),
+		"--key-file", keyFile,
+		spec.Device,
+		cryptName,
+	)
+	cryptCmd.Stdout = os.Stdout
+	cryptCmd.Stderr = os.Stderr
+	if err := cryptCmd.Run(); err != nil {
+		return fmt.Errorf("cryptsetup open: %w", err)
+	}
+
+	cryptDevice := "/dev/mapper/" + cryptName
+	verityArgs := []string{
+		"open",
+		cryptDevice,
+		verityName,
+		cryptDevice,
+		spec.RootHash,
+		"--hash-offset=" + spec.HashOffset,
+	}
+	if spec.DataBlockSize != 0 {
+		verityArgs = append(verityArgs, "--data-block-size="+strconv.Itoa(spec.DataBlockSize))
+	}
+	if spec.HashBlockSize != 0 {
+		verityArgs = append(verityArgs, "--hash-block-size="+strconv.Itoa(spec.HashBlockSize))
+	}
+	if spec.DataBlocks != "" {
+		verityArgs = append(verityArgs, "--data-blocks="+spec.DataBlocks)
+	}
+
+	verityCmd := exec.Command("veritysetup", verityArgs...)
+	verityCmd.Stdout = os.Stdout
+	verityCmd.Stderr = os.Stderr
+	if err := verityCmd.Run(); err != nil {
+		_ = exec.Command("cryptsetup", "close", cryptName).Run()
+		return fmt.Errorf("veritysetup open: %w", err)
+	}
+
+	if err := os.MkdirAll(mountPoint, 0755); err != nil {
+		_ = exec.Command("veritysetup", "close", verityName).Run()
+		_ = exec.Command("cryptsetup", "close", cryptName).Run()
+		return fmt.Errorf("creating mount point: %w", err)
+	}
+
+	mountCmd := exec.Command(
+		"mount", "-o", "ro",
+		"/dev/mapper/"+verityName,
+		mountPoint,
+	)
+	mountCmd.Stdout = os.Stdout
+	mountCmd.Stderr = os.Stderr
+	if err := mountCmd.Run(); err != nil {
+		_ = exec.Command("veritysetup", "close", verityName).Run()
+		_ = exec.Command("cryptsetup", "close", cryptName).Run()
+		return fmt.Errorf("mounting verity device: %w", err)
+	}
+
+	log.Printf("Mounted encrypted model pack %s at %s", modelLogName(name, spec.RootHash), mountPoint)
+	return nil
+}
+
+func validateEncryptedModelPack(spec *EncryptedModelPackSpec) error {
+	if spec == nil {
+		return fmt.Errorf("missing empk spec")
+	}
+	if !devicePathPattern.MatchString(spec.Device) {
+		return fmt.Errorf("invalid encrypted model device path: %s", spec.Device)
+	}
+	if !hexHashPattern.MatchString(spec.RootHash) {
+		return fmt.Errorf("invalid root hash format: %s", spec.RootHash)
+	}
+	if !offsetPattern.MatchString(spec.HashOffset) {
+		return fmt.Errorf("invalid hash offset format: %s", spec.HashOffset)
+	}
+	if spec.UUID != "" && !uuidPattern.MatchString(spec.UUID) {
+		return fmt.Errorf("invalid UUID format: %s", spec.UUID)
+	}
+	if !secretNamePattern.MatchString(spec.KeySecret) {
+		return fmt.Errorf("invalid key secret name: %s", spec.KeySecret)
+	}
+	if cipher := encryptedModelCipher(spec); cipher != defaultEMPKCipher {
+		return fmt.Errorf("unsupported encrypted model cipher: %s", cipher)
+	}
+	if keySize := encryptedModelKeySize(spec); keySize != defaultEMPKKeySize {
+		return fmt.Errorf("unsupported encrypted model key size: %d", keySize)
+	}
+	if sectorSize := encryptedModelSectorSize(spec); sectorSize != defaultEMPKSectorSize {
+		return fmt.Errorf("unsupported encrypted model sector size: %d", sectorSize)
+	}
+	if spec.EncryptedSHA256 != "" && !hexHashPattern.MatchString(spec.EncryptedSHA256) {
+		return fmt.Errorf("invalid encrypted image sha256 format: %s", spec.EncryptedSHA256)
+	}
+	if spec.VerifyEncryptedSHA256 && spec.EncryptedSHA256 == "" {
+		return fmt.Errorf("verify-encrypted-sha256 requires encrypted-sha256")
+	}
+	if spec.DataBlockSize != 0 && spec.DataBlockSize != 4096 {
+		return fmt.Errorf("unsupported dm-verity data block size: %d", spec.DataBlockSize)
+	}
+	if spec.HashBlockSize != 0 && spec.HashBlockSize != 4096 {
+		return fmt.Errorf("unsupported dm-verity hash block size: %d", spec.HashBlockSize)
+	}
+	if spec.DataBlocks != "" && !offsetPattern.MatchString(spec.DataBlocks) {
+		return fmt.Errorf("invalid dm-verity data blocks format: %s", spec.DataBlocks)
+	}
+	return nil
+}
+
+func encryptedModelKey(spec *EncryptedModelPackSpec, externalConfig *shimconfig.ExternalConfig) ([]byte, error) {
+	if externalConfig == nil {
+		return nil, fmt.Errorf("external config is required for encrypted model key %q", spec.KeySecret)
+	}
+	secret := externalConfig.GetSecret(spec.KeySecret)
+	if secret == "" {
+		return nil, fmt.Errorf("encrypted model key secret %q not found", spec.KeySecret)
+	}
+	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(secret))
+	if err != nil {
+		return nil, fmt.Errorf("decoding encrypted model key secret %q as base64: %w", spec.KeySecret, err)
+	}
+	if len(key) != defaultEMPKKeySize/8 {
+		return nil, fmt.Errorf("encrypted model key secret %q decoded to %d bytes, want %d", spec.KeySecret, len(key), defaultEMPKKeySize/8)
+	}
+	return key, nil
+}
+
+func verifyEncryptedDeviceSHA256(device, expected string) error {
+	f, err := os.Open(device)
+	if err != nil {
+		return fmt.Errorf("opening encrypted model device for sha256: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("hashing encrypted model device: %w", err)
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+	if actual != expected {
+		return fmt.Errorf("encrypted model device sha256 mismatch: got %s want %s", actual, expected)
+	}
+	return nil
+}
+
+func encryptedModelCipher(spec *EncryptedModelPackSpec) string {
+	if spec.Cipher == "" {
+		return defaultEMPKCipher
+	}
+	return spec.Cipher
+}
+
+func encryptedModelKeySize(spec *EncryptedModelPackSpec) int {
+	if spec.KeySize == 0 {
+		return defaultEMPKKeySize
+	}
+	return spec.KeySize
+}
+
+func encryptedModelSectorSize(spec *EncryptedModelPackSpec) int {
+	if spec.SectorSize == 0 {
+		return defaultEMPKSectorSize
+	}
+	return spec.SectorSize
+}
+
+func modelLogName(name, rootHash string) string {
+	if name != "" {
+		return name
+	}
+	return "mpk-" + rootHash
 }

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -32,14 +29,14 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 	log.Printf("Mounting %d model packs", len(config.Models))
 	for _, model := range config.Models {
 		switch {
-		case model.MPK != "" && model.EMPK != nil:
+		case model.MPK != "" && model.EMPK != "":
 			return fmt.Errorf("model %q specifies both mpk and empk", model.Name)
 		case model.MPK != "":
 			if err := mountModelPack(model.MPK); err != nil {
 				return fmt.Errorf("mounting model pack %s: %w", model.MPK, err)
 			}
-		case model.EMPK != nil:
-			if err := mountEncryptedModelPack(model.Name, model.EMPK, externalConfig); err != nil {
+		case model.EMPK != "":
+			if err := mountEncryptedModelPack(model, externalConfig); err != nil {
 				return fmt.Errorf("mounting encrypted model pack %q: %w", model.Name, err)
 			}
 		default:
@@ -53,65 +50,17 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 // mountModelPack mounts a model pack using dm-verity
 // MPK format: rootHash_hashOffset_uuid
 func mountModelPack(mpk string) error {
-	parts := strings.Split(mpk, "_")
-	if len(parts) != 3 {
-		return fmt.Errorf("invalid MPK format: %s (expected rootHash_offset_uuid)", mpk)
+	spec, err := parseModelPackRef(mpk)
+	if err != nil {
+		return fmt.Errorf("invalid MPK format: %s: %w", mpk, err)
 	}
 
-	rootHash := parts[0]
-	offset := parts[1]
-	uuid := parts[2]
-
-	// Validate components to prevent injection/traversal attacks
-	if !hexHashPattern.MatchString(rootHash) {
-		return fmt.Errorf("invalid root hash format: %s", rootHash)
-	}
-	if !offsetPattern.MatchString(offset) {
-		return fmt.Errorf("invalid offset format: %s", offset)
-	}
-	if !uuidPattern.MatchString(uuid) {
-		return fmt.Errorf("invalid UUID format: %s", uuid)
-	}
-
-	blockDevice := fmt.Sprintf("/dev/disk/by-uuid/%s", uuid)
-	deviceName := fmt.Sprintf("mpk-%s", rootHash)
+	deviceName := fmt.Sprintf("mpk-%s", spec.RootHash)
 	mountPoint := fmt.Sprintf("%s/%s", boot.MPKDir, deviceName)
 
-	log.Printf("Opening verity device %s (uuid=%s)", deviceName, uuid)
-
-	// Open dm-verity device
-	// Using veritysetup as there's no good pure-Go dm-verity library
-	cmd := exec.Command(
-		"veritysetup", "open",
-		blockDevice,
-		deviceName,
-		blockDevice,
-		rootHash,
-		"--hash-offset="+offset,
-	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("veritysetup open: %w", err)
-	}
-
-	// Create mount point
-	if err := os.MkdirAll(mountPoint, 0755); err != nil {
-		return fmt.Errorf("creating mount point: %w", err)
-	}
-
-	// Mount the verified device read-only
-	mountCmd := exec.Command(
-		"mount", "-o", "ro",
-		"/dev/mapper/"+deviceName,
-		mountPoint,
-	)
-	mountCmd.Stdout = os.Stdout
-	mountCmd.Stderr = os.Stderr
-
-	if err := mountCmd.Run(); err != nil {
-		return fmt.Errorf("mounting verity device: %w", err)
+	log.Printf("Opening verity device %s (uuid=%s)", deviceName, spec.UUID)
+	if err := openAndMountVerity(diskByUUID(spec.UUID), deviceName, spec.RootHash, spec.HashOffset, mountPoint); err != nil {
+		return err
 	}
 
 	log.Printf("Mounted model pack %s at %s", deviceName, mountPoint)
@@ -121,20 +70,15 @@ func mountModelPack(mpk string) error {
 // mountEncryptedModelPack mounts an encrypted model pack using dm-crypt below
 // dm-verity. The decrypted mapper contains the same plaintext layout as an MPK:
 // a read-only filesystem followed by its dm-verity hash tree.
-func mountEncryptedModelPack(name string, spec *EncryptedModelPackSpec, externalConfig *shimconfig.ExternalConfig) error {
-	if err := validateEncryptedModelPack(spec); err != nil {
-		return err
+func mountEncryptedModelPack(model ModelSpec, externalConfig *shimconfig.ExternalConfig) error {
+	spec, err := parseModelPackRef(model.EMPK)
+	if err != nil {
+		return fmt.Errorf("invalid EMPK format: %s: %w", model.EMPK, err)
 	}
 
-	key, err := encryptedModelKey(spec, externalConfig)
+	key, err := encryptedModelKey(model.KeySecret, externalConfig)
 	if err != nil {
 		return err
-	}
-
-	if spec.VerifyEncryptedSHA256 {
-		if err := verifyEncryptedDeviceSHA256(spec.Device, spec.EncryptedSHA256); err != nil {
-			return err
-		}
 	}
 
 	if err := os.MkdirAll(boot.ModelKeyDir, 0700); err != nil {
@@ -144,21 +88,20 @@ func mountEncryptedModelPack(name string, spec *EncryptedModelPackSpec, external
 	if err := os.WriteFile(keyFile, key, 0600); err != nil {
 		return fmt.Errorf("writing model key file: %w", err)
 	}
-	defer os.Remove(keyFile)
 
 	cryptName := fmt.Sprintf("empk-%s-crypt", spec.RootHash)
 	verityName := fmt.Sprintf("mpk-%s", spec.RootHash)
 	mountPoint := fmt.Sprintf("%s/%s", boot.MPKDir, verityName)
 
-	log.Printf("Opening encrypted model pack %s (device=%s)", modelLogName(name, spec.RootHash), spec.Device)
+	log.Printf("Opening encrypted model pack %s (uuid=%s)", modelLogName(model.Name, spec.RootHash), spec.UUID)
 	cryptCmd := exec.Command(
 		"cryptsetup", "open",
 		"--type", "plain",
-		"--cipher", encryptedModelCipher(spec),
-		"--key-size", strconv.Itoa(encryptedModelKeySize(spec)),
-		"--sector-size", strconv.Itoa(encryptedModelSectorSize(spec)),
+		"--cipher", defaultEMPKCipher,
+		"--key-size", strconv.Itoa(defaultEMPKKeySize),
+		"--sector-size", strconv.Itoa(defaultEMPKSectorSize),
 		"--key-file", keyFile,
-		spec.Device,
+		diskByUUID(spec.UUID),
 		cryptName,
 	)
 	cryptCmd.Stdout = os.Stdout
@@ -168,156 +111,111 @@ func mountEncryptedModelPack(name string, spec *EncryptedModelPackSpec, external
 	}
 
 	cryptDevice := "/dev/mapper/" + cryptName
-	verityArgs := []string{
-		"open",
-		cryptDevice,
-		verityName,
-		cryptDevice,
-		spec.RootHash,
-		"--hash-offset=" + spec.HashOffset,
-	}
-	if spec.DataBlockSize != 0 {
-		verityArgs = append(verityArgs, "--data-block-size="+strconv.Itoa(spec.DataBlockSize))
-	}
-	if spec.HashBlockSize != 0 {
-		verityArgs = append(verityArgs, "--hash-block-size="+strconv.Itoa(spec.HashBlockSize))
-	}
-	if spec.DataBlocks != "" {
-		verityArgs = append(verityArgs, "--data-blocks="+spec.DataBlocks)
+	if err := openAndMountVerity(cryptDevice, verityName, spec.RootHash, spec.HashOffset, mountPoint); err != nil {
+		closeCryptMapper(cryptName)
+		return err
 	}
 
-	verityCmd := exec.Command("veritysetup", verityArgs...)
-	verityCmd.Stdout = os.Stdout
-	verityCmd.Stderr = os.Stderr
-	if err := verityCmd.Run(); err != nil {
-		_ = exec.Command("cryptsetup", "close", cryptName).Run()
+	log.Printf("Mounted encrypted model pack %s at %s", modelLogName(model.Name, spec.RootHash), mountPoint)
+	return nil
+}
+
+type modelPackRef struct {
+	RootHash   string
+	HashOffset string
+	UUID       string
+}
+
+func parseModelPackRef(ref string) (*modelPackRef, error) {
+	parts := strings.Split(ref, "_")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("expected rootHash_hashOffset_uuid")
+	}
+
+	spec := &modelPackRef{
+		RootHash:   parts[0],
+		HashOffset: parts[1],
+		UUID:       parts[2],
+	}
+	if !hexHashPattern.MatchString(spec.RootHash) {
+		return nil, fmt.Errorf("invalid root hash format: %s", spec.RootHash)
+	}
+	if !offsetPattern.MatchString(spec.HashOffset) {
+		return nil, fmt.Errorf("invalid hash offset format: %s", spec.HashOffset)
+	}
+	if !uuidPattern.MatchString(spec.UUID) {
+		return nil, fmt.Errorf("invalid UUID format: %s", spec.UUID)
+	}
+	return spec, nil
+}
+
+func encryptedModelKey(keySecret string, externalConfig *shimconfig.ExternalConfig) ([]byte, error) {
+	if !secretNamePattern.MatchString(keySecret) {
+		return nil, fmt.Errorf("invalid key secret name: %s", keySecret)
+	}
+	if externalConfig == nil {
+		return nil, fmt.Errorf("external config is required for encrypted model key %q", keySecret)
+	}
+	secret := externalConfig.GetSecret(keySecret)
+	if secret == "" {
+		return nil, fmt.Errorf("encrypted model key secret %q not found", keySecret)
+	}
+	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(secret))
+	if err != nil {
+		return nil, fmt.Errorf("decoding encrypted model key secret %q as base64: %w", keySecret, err)
+	}
+	if len(key) != defaultEMPKKeySize/8 {
+		return nil, fmt.Errorf("encrypted model key secret %q decoded to %d bytes, want %d", keySecret, len(key), defaultEMPKKeySize/8)
+	}
+	return key, nil
+}
+
+func openAndMountVerity(sourceDevice, deviceName, rootHash, hashOffset, mountPoint string) error {
+	// Using veritysetup as there's no good pure-Go dm-verity library.
+	cmd := exec.Command(
+		"veritysetup", "open",
+		sourceDevice,
+		deviceName,
+		sourceDevice,
+		rootHash,
+		"--hash-offset="+hashOffset,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("veritysetup open: %w", err)
 	}
 
 	if err := os.MkdirAll(mountPoint, 0755); err != nil {
-		_ = exec.Command("veritysetup", "close", verityName).Run()
-		_ = exec.Command("cryptsetup", "close", cryptName).Run()
+		closeVerityMapper(deviceName)
 		return fmt.Errorf("creating mount point: %w", err)
 	}
 
 	mountCmd := exec.Command(
 		"mount", "-o", "ro",
-		"/dev/mapper/"+verityName,
+		"/dev/mapper/"+deviceName,
 		mountPoint,
 	)
 	mountCmd.Stdout = os.Stdout
 	mountCmd.Stderr = os.Stderr
 	if err := mountCmd.Run(); err != nil {
-		_ = exec.Command("veritysetup", "close", verityName).Run()
-		_ = exec.Command("cryptsetup", "close", cryptName).Run()
+		closeVerityMapper(deviceName)
 		return fmt.Errorf("mounting verity device: %w", err)
 	}
 
-	log.Printf("Mounted encrypted model pack %s at %s", modelLogName(name, spec.RootHash), mountPoint)
 	return nil
 }
 
-func validateEncryptedModelPack(spec *EncryptedModelPackSpec) error {
-	if spec == nil {
-		return fmt.Errorf("missing empk spec")
-	}
-	if !devicePathPattern.MatchString(spec.Device) {
-		return fmt.Errorf("invalid encrypted model device path: %s", spec.Device)
-	}
-	if !hexHashPattern.MatchString(spec.RootHash) {
-		return fmt.Errorf("invalid root hash format: %s", spec.RootHash)
-	}
-	if !offsetPattern.MatchString(spec.HashOffset) {
-		return fmt.Errorf("invalid hash offset format: %s", spec.HashOffset)
-	}
-	if spec.UUID != "" && !uuidPattern.MatchString(spec.UUID) {
-		return fmt.Errorf("invalid UUID format: %s", spec.UUID)
-	}
-	if !secretNamePattern.MatchString(spec.KeySecret) {
-		return fmt.Errorf("invalid key secret name: %s", spec.KeySecret)
-	}
-	if cipher := encryptedModelCipher(spec); cipher != defaultEMPKCipher {
-		return fmt.Errorf("unsupported encrypted model cipher: %s", cipher)
-	}
-	if keySize := encryptedModelKeySize(spec); keySize != defaultEMPKKeySize {
-		return fmt.Errorf("unsupported encrypted model key size: %d", keySize)
-	}
-	if sectorSize := encryptedModelSectorSize(spec); sectorSize != defaultEMPKSectorSize {
-		return fmt.Errorf("unsupported encrypted model sector size: %d", sectorSize)
-	}
-	if spec.EncryptedSHA256 != "" && !hexHashPattern.MatchString(spec.EncryptedSHA256) {
-		return fmt.Errorf("invalid encrypted image sha256 format: %s", spec.EncryptedSHA256)
-	}
-	if spec.VerifyEncryptedSHA256 && spec.EncryptedSHA256 == "" {
-		return fmt.Errorf("verify-encrypted-sha256 requires encrypted-sha256")
-	}
-	if spec.DataBlockSize != 0 && spec.DataBlockSize != 4096 {
-		return fmt.Errorf("unsupported dm-verity data block size: %d", spec.DataBlockSize)
-	}
-	if spec.HashBlockSize != 0 && spec.HashBlockSize != 4096 {
-		return fmt.Errorf("unsupported dm-verity hash block size: %d", spec.HashBlockSize)
-	}
-	if spec.DataBlocks != "" && !offsetPattern.MatchString(spec.DataBlocks) {
-		return fmt.Errorf("invalid dm-verity data blocks format: %s", spec.DataBlocks)
-	}
-	return nil
+func diskByUUID(uuid string) string {
+	return fmt.Sprintf("/dev/disk/by-uuid/%s", uuid)
 }
 
-func encryptedModelKey(spec *EncryptedModelPackSpec, externalConfig *shimconfig.ExternalConfig) ([]byte, error) {
-	if externalConfig == nil {
-		return nil, fmt.Errorf("external config is required for encrypted model key %q", spec.KeySecret)
-	}
-	secret := externalConfig.GetSecret(spec.KeySecret)
-	if secret == "" {
-		return nil, fmt.Errorf("encrypted model key secret %q not found", spec.KeySecret)
-	}
-	key, err := base64.StdEncoding.DecodeString(strings.TrimSpace(secret))
-	if err != nil {
-		return nil, fmt.Errorf("decoding encrypted model key secret %q as base64: %w", spec.KeySecret, err)
-	}
-	if len(key) != defaultEMPKKeySize/8 {
-		return nil, fmt.Errorf("encrypted model key secret %q decoded to %d bytes, want %d", spec.KeySecret, len(key), defaultEMPKKeySize/8)
-	}
-	return key, nil
+func closeVerityMapper(name string) {
+	_ = exec.Command("veritysetup", "close", name).Run()
 }
 
-func verifyEncryptedDeviceSHA256(device, expected string) error {
-	f, err := os.Open(device)
-	if err != nil {
-		return fmt.Errorf("opening encrypted model device for sha256: %w", err)
-	}
-	defer f.Close()
-
-	h := sha256.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return fmt.Errorf("hashing encrypted model device: %w", err)
-	}
-	actual := hex.EncodeToString(h.Sum(nil))
-	if actual != expected {
-		return fmt.Errorf("encrypted model device sha256 mismatch: got %s want %s", actual, expected)
-	}
-	return nil
-}
-
-func encryptedModelCipher(spec *EncryptedModelPackSpec) string {
-	if spec.Cipher == "" {
-		return defaultEMPKCipher
-	}
-	return spec.Cipher
-}
-
-func encryptedModelKeySize(spec *EncryptedModelPackSpec) int {
-	if spec.KeySize == 0 {
-		return defaultEMPKKeySize
-	}
-	return spec.KeySize
-}
-
-func encryptedModelSectorSize(spec *EncryptedModelPackSpec) int {
-	if spec.SectorSize == 0 {
-		return defaultEMPKSectorSize
-	}
-	return spec.SectorSize
+func closeCryptMapper(name string) {
+	_ = exec.Command("cryptsetup", "close", name).Run()
 }
 
 func modelLogName(name, rootHash string) string {

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/hkdf"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"log"
@@ -14,9 +16,12 @@ import (
 )
 
 const (
-	defaultEMPKCipher     = "aes-xts-plain64"
-	defaultEMPKKeySize    = 512
-	defaultEMPKSectorSize = 4096
+	defaultEMWPCipher     = "aes-xts-plain64"
+	defaultEMWPKeySize    = 512
+	defaultEMWPSectorSize = 4096
+	modelMountOptions     = "ro,nodev,nosuid,noexec"
+	modelFilesystemType   = "erofs"
+	emwpKeyDeriveInfo     = "tinfoil/emwp/dm-crypt-key/v1"
 )
 
 // mountModels mounts all model packs from the config
@@ -27,39 +32,43 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 	}
 
 	log.Printf("Mounting %d model packs", len(config.Models))
+	seen := map[string]struct{}{}
 	for _, model := range config.Models {
-		switch {
-		case model.MPK != "" && model.EMPK != "":
-			return fmt.Errorf("model %q specifies both mpk and empk", model.Name)
-		case model.MPK != "":
-			if err := mountModelPack(model.MPK); err != nil {
-				return fmt.Errorf("mounting model pack %s: %w", model.MPK, err)
+		ref, kind, err := modelPackRefForModel(model)
+		if err != nil {
+			return err
+		}
+		if _, ok := seen[ref.mapperName()]; ok {
+			return fmt.Errorf("duplicate model pack root hash: %s", ref.RootHash)
+		}
+		seen[ref.mapperName()] = struct{}{}
+
+		switch kind {
+		case modelKindPlaintext:
+			if err := mountModelPack(ref); err != nil {
+				return fmt.Errorf("mounting model pack %s: %w", ref.raw, err)
 			}
-		case model.EMPK != "":
+		case modelKindEncrypted:
 			if err := mountEncryptedModelPack(model, externalConfig); err != nil {
 				return fmt.Errorf("mounting encrypted model pack %q: %w", model.Name, err)
 			}
-		default:
-			return fmt.Errorf("model %q specifies neither mpk nor empk", model.Name)
 		}
 	}
 
 	return nil
 }
 
-// mountModelPack mounts a model pack using dm-verity
-// MPK format: rootHash_hashOffset_uuid
-func mountModelPack(mpk string) error {
-	spec, err := parseModelPackRef(mpk)
-	if err != nil {
-		return fmt.Errorf("invalid MPK format: %s: %w", mpk, err)
-	}
-
-	deviceName := fmt.Sprintf("mpk-%s", spec.RootHash)
-	mountPoint := fmt.Sprintf("%s/%s", boot.MPKDir, deviceName)
+// mountModelPack mounts a plaintext model wrap using dm-verity.
+func mountModelPack(spec *modelPackRef) error {
+	deviceName := spec.mapperName()
+	mountPoint := spec.mountPoint()
 
 	log.Printf("Opening verity device %s (uuid=%s)", deviceName, spec.UUID)
+	if err := createLegacyModelPackAlias(spec); err != nil {
+		return err
+	}
 	if err := openAndMountVerity(diskByUUID(spec.UUID), deviceName, spec.RootHash, spec.HashOffset, mountPoint); err != nil {
+		removeLegacyModelPackAlias(spec)
 		return err
 	}
 
@@ -67,39 +76,39 @@ func mountModelPack(mpk string) error {
 	return nil
 }
 
-// mountEncryptedModelPack mounts an encrypted model pack using dm-crypt below
-// dm-verity. The decrypted mapper contains the same plaintext layout as an MPK:
+// mountEncryptedModelPack mounts an encrypted model wrap using dm-crypt below
+// dm-verity. The decrypted mapper contains the same plaintext layout as an MWP:
 // a read-only filesystem followed by its dm-verity hash tree.
 func mountEncryptedModelPack(model ModelSpec, externalConfig *shimconfig.ExternalConfig) error {
-	spec, err := parseModelPackRef(model.EMPK)
+	spec, err := parseModelPackRef(model.EMWP)
 	if err != nil {
-		return fmt.Errorf("invalid EMPK format: %s: %w", model.EMPK, err)
+		return fmt.Errorf("invalid EMWP format: %s: %w", model.EMWP, err)
 	}
 
-	key, err := encryptedModelKey(model.KeySecret, externalConfig)
+	key, err := encryptedModelKey(model.KeySecret, spec, externalConfig)
 	if err != nil {
 		return err
 	}
 
-	if err := os.MkdirAll(boot.ModelKeyDir, 0700); err != nil {
-		return fmt.Errorf("creating model key directory: %w", err)
-	}
-	keyFile := fmt.Sprintf("%s/%s.key", boot.ModelKeyDir, spec.RootHash)
-	if err := os.WriteFile(keyFile, key, 0600); err != nil {
-		return fmt.Errorf("writing model key file: %w", err)
+	keyFile, err := writePersistentModelKey(spec, key)
+	if err != nil {
+		return err
 	}
 
-	cryptName := fmt.Sprintf("empk-%s-crypt", spec.RootHash)
-	verityName := fmt.Sprintf("mpk-%s", spec.RootHash)
-	mountPoint := fmt.Sprintf("%s/%s", boot.MPKDir, verityName)
+	cryptName := fmt.Sprintf("emwp-%s-crypt", spec.RootHash)
+	verityName := spec.mapperName()
+	mountPoint := spec.mountPoint()
 
 	log.Printf("Opening encrypted model pack %s (uuid=%s)", modelLogName(model.Name, spec.RootHash), spec.UUID)
+	if err := createLegacyModelPackAlias(spec); err != nil {
+		return err
+	}
 	cryptCmd := exec.Command(
 		"cryptsetup", "open",
 		"--type", "plain",
-		"--cipher", defaultEMPKCipher,
-		"--key-size", strconv.Itoa(defaultEMPKKeySize),
-		"--sector-size", strconv.Itoa(defaultEMPKSectorSize),
+		"--cipher", defaultEMWPCipher,
+		"--key-size", strconv.Itoa(defaultEMWPKeySize),
+		"--sector-size", strconv.Itoa(defaultEMWPSectorSize),
 		"--key-file", keyFile,
 		diskByUUID(spec.UUID),
 		cryptName,
@@ -107,11 +116,13 @@ func mountEncryptedModelPack(model ModelSpec, externalConfig *shimconfig.Externa
 	cryptCmd.Stdout = os.Stdout
 	cryptCmd.Stderr = os.Stderr
 	if err := cryptCmd.Run(); err != nil {
+		removeLegacyModelPackAlias(spec)
 		return fmt.Errorf("cryptsetup open: %w", err)
 	}
 
 	cryptDevice := "/dev/mapper/" + cryptName
 	if err := openAndMountVerity(cryptDevice, verityName, spec.RootHash, spec.HashOffset, mountPoint); err != nil {
+		removeLegacyModelPackAlias(spec)
 		closeCryptMapper(cryptName)
 		return err
 	}
@@ -120,10 +131,113 @@ func mountEncryptedModelPack(model ModelSpec, externalConfig *shimconfig.Externa
 	return nil
 }
 
+func createLegacyModelPackAlias(spec *modelPackRef) error {
+	if err := os.MkdirAll(boot.MPKDir, 0755); err != nil {
+		return fmt.Errorf("creating legacy model pack alias directory: %w", err)
+	}
+	aliasPath := spec.legacyMountPoint()
+	if fi, err := os.Lstat(aliasPath); err == nil {
+		if fi.Mode()&os.ModeSymlink == 0 {
+			return fmt.Errorf("legacy model pack alias path exists and is not a symlink: %s", aliasPath)
+		}
+		if err := os.Remove(aliasPath); err != nil {
+			return fmt.Errorf("removing stale legacy model pack alias: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking legacy model pack alias: %w", err)
+	}
+	if err := os.Symlink("../mwp/"+spec.mapperName(), aliasPath); err != nil {
+		return fmt.Errorf("creating legacy model pack alias: %w", err)
+	}
+	return nil
+}
+
+func removeLegacyModelPackAlias(spec *modelPackRef) {
+	_ = os.Remove(spec.legacyMountPoint())
+}
+
+func writePersistentModelKey(spec *modelPackRef, key []byte) (string, error) {
+	if err := os.MkdirAll(boot.ModelKeyDir, 0700); err != nil {
+		return "", fmt.Errorf("creating model key directory: %w", err)
+	}
+	if err := os.Chmod(boot.ModelKeyDir, 0700); err != nil {
+		return "", fmt.Errorf("setting model key directory permissions: %w", err)
+	}
+	keyFile := fmt.Sprintf("%s/%s.key", boot.ModelKeyDir, spec.artifactID())
+	if err := os.WriteFile(keyFile, key, 0600); err != nil {
+		return "", fmt.Errorf("writing model key file: %w", err)
+	}
+	if err := os.Chmod(keyFile, 0600); err != nil {
+		return "", fmt.Errorf("setting model key file permissions: %w", err)
+	}
+	return keyFile, nil
+}
+
+type modelKind string
+
+const (
+	modelKindPlaintext modelKind = "plaintext"
+	modelKindEncrypted modelKind = "encrypted"
+)
+
+func modelPackRefForModel(model ModelSpec) (*modelPackRef, modelKind, error) {
+	refs := 0
+	if model.MPK != "" {
+		refs++
+	}
+	if model.MWP != "" {
+		refs++
+	}
+	if model.EMWP != "" {
+		refs++
+	}
+	if refs != 1 {
+		return nil, "", fmt.Errorf("model %q must specify exactly one of mpk, mwp, or emwp", model.Name)
+	}
+
+	if model.MPK != "" {
+		spec, err := parseModelPackRef(model.MPK)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid legacy MPK format: %s: %w", model.MPK, err)
+		}
+		return spec, modelKindPlaintext, nil
+	}
+	if model.MWP != "" {
+		spec, err := parseModelPackRef(model.MWP)
+		if err != nil {
+			return nil, "", fmt.Errorf("invalid MWP format: %s: %w", model.MWP, err)
+		}
+		return spec, modelKindPlaintext, nil
+	}
+
+	spec, err := parseModelPackRef(model.EMWP)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid EMWP format: %s: %w", model.EMWP, err)
+	}
+	return spec, modelKindEncrypted, nil
+}
+
 type modelPackRef struct {
+	raw        string
 	RootHash   string
 	HashOffset string
 	UUID       string
+}
+
+func (r *modelPackRef) mapperName() string {
+	return "mwp-" + r.RootHash
+}
+
+func (r *modelPackRef) mountPoint() string {
+	return boot.MWPDir + "/" + r.mapperName()
+}
+
+func (r *modelPackRef) legacyMountPoint() string {
+	return boot.MPKDir + "/mpk-" + r.RootHash
+}
+
+func (r *modelPackRef) artifactID() string {
+	return r.RootHash + "_" + r.UUID
 }
 
 func parseModelPackRef(ref string) (*modelPackRef, error) {
@@ -133,6 +247,7 @@ func parseModelPackRef(ref string) (*modelPackRef, error) {
 	}
 
 	spec := &modelPackRef{
+		raw:        ref,
 		RootHash:   parts[0],
 		HashOffset: parts[1],
 		UUID:       parts[2],
@@ -149,7 +264,7 @@ func parseModelPackRef(ref string) (*modelPackRef, error) {
 	return spec, nil
 }
 
-func encryptedModelKey(keySecret string, externalConfig *shimconfig.ExternalConfig) ([]byte, error) {
+func encryptedModelKey(keySecret string, spec *modelPackRef, externalConfig *shimconfig.ExternalConfig) ([]byte, error) {
 	if !secretNamePattern.MatchString(keySecret) {
 		return nil, fmt.Errorf("invalid key secret name: %s", keySecret)
 	}
@@ -164,10 +279,10 @@ func encryptedModelKey(keySecret string, externalConfig *shimconfig.ExternalConf
 	if err != nil {
 		return nil, fmt.Errorf("decoding encrypted model key secret %q as base64: %w", keySecret, err)
 	}
-	if len(key) != defaultEMPKKeySize/8 {
-		return nil, fmt.Errorf("encrypted model key secret %q decoded to %d bytes, want %d", keySecret, len(key), defaultEMPKKeySize/8)
+	if len(key) != defaultEMWPKeySize/8 {
+		return nil, fmt.Errorf("encrypted model key secret %q decoded to %d bytes, want %d", keySecret, len(key), defaultEMWPKeySize/8)
 	}
-	return key, nil
+	return hkdf.Key(sha256.New, key, []byte(spec.artifactID()), emwpKeyDeriveInfo, defaultEMWPKeySize/8)
 }
 
 func openAndMountVerity(sourceDevice, deviceName, rootHash, hashOffset, mountPoint string) error {
@@ -192,7 +307,9 @@ func openAndMountVerity(sourceDevice, deviceName, rootHash, hashOffset, mountPoi
 	}
 
 	mountCmd := exec.Command(
-		"mount", "-o", "ro",
+		"mount",
+		"-t", modelFilesystemType,
+		"-o", modelMountOptions,
 		"/dev/mapper/"+deviceName,
 		mountPoint,
 	)
@@ -222,5 +339,5 @@ func modelLogName(name, rootHash string) string {
 	if name != "" {
 		return name
 	}
-	return "mpk-" + rootHash
+	return "mwp-" + rootHash
 }

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -110,7 +110,8 @@ func mountEncryptedModelPack(model ModelSpec, externalConfig *shimconfig.Externa
 		"--key-size", strconv.Itoa(defaultEMWPKeySize),
 		"--sector-size", strconv.Itoa(defaultEMWPSectorSize),
 		"--key-file", keyFile,
-		diskByUUID(spec.UUID),
+		"--readonly",
+		diskByPARTUUID(spec.UUID),
 		cryptName,
 	)
 	cryptCmd.Stdout = os.Stdout
@@ -325,6 +326,10 @@ func openAndMountVerity(sourceDevice, deviceName, rootHash, hashOffset, mountPoi
 
 func diskByUUID(uuid string) string {
 	return fmt.Sprintf("/dev/disk/by-uuid/%s", uuid)
+}
+
+func diskByPARTUUID(uuid string) string {
+	return fmt.Sprintf("/dev/disk/by-partuuid/%s", uuid)
 }
 
 func closeVerityMapper(name string) {

--- a/tinfoil/cmd/boot/models_integration_test.go
+++ b/tinfoil/cmd/boot/models_integration_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/tinfoilsh/modelwrap/unwrap"
+
+	shimconfig "tinfoil/internal/config"
+)
+
+func TestMountEncryptedModelPackIntegration(t *testing.T) {
+	if os.Getenv("TINFOIL_EMWP_INTEGRATION") != "1" {
+		t.Skip("set TINFOIL_EMWP_INTEGRATION=1 to run")
+	}
+
+	ref := os.Getenv("TINFOIL_EMWP_REF")
+	key := os.Getenv("TINFOIL_EMWP_KEY_B64")
+	if ref == "" || key == "" {
+		t.Fatal("TINFOIL_EMWP_REF and TINFOIL_EMWP_KEY_B64 are required")
+	}
+
+	spec, err := parseModelPackRef(ref)
+	if err != nil {
+		t.Fatalf("parsing EMWP ref: %v", err)
+	}
+	cleanupEMWPIntegration(spec)
+	t.Cleanup(func() {
+		cleanupEMWPIntegration(spec)
+	})
+
+	err = mountEncryptedModelPack(ModelSpec{
+		Name:      "emwp-integration",
+		EMWP:      ref,
+		KeySecret: "PRIVATE_MODEL_KEY",
+	}, &shimconfig.ExternalConfig{
+		Secrets: map[string]string{"PRIVATE_MODEL_KEY": key},
+	})
+	if err != nil {
+		t.Fatalf("mounting EMWP: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(spec.mountPoint(), "config.json")); err != nil {
+		t.Fatalf("checking mounted file: %v", err)
+	}
+	if _, err := os.Lstat(spec.legacyMountPoint()); err != nil {
+		t.Fatalf("checking legacy mount alias: %v", err)
+	}
+}
+
+func cleanupEMWPIntegration(spec *modelPackRef) {
+	_ = exec.Command("umount", spec.mountPoint()).Run()
+	unwrap.CloseVerity(spec.mapperName())
+	unwrap.CloseCrypt(fmt.Sprintf("emwp-%s-crypt", spec.RootHash))
+	removeLegacyModelPackAlias(spec)
+}

--- a/tinfoil/cmd/boot/models_test.go
+++ b/tinfoil/cmd/boot/models_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+)
+
+func TestValidateEncryptedModelPack(t *testing.T) {
+	valid := &EncryptedModelPackSpec{
+		Device:          "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_tinfoil-private-model1",
+		RootHash:        strings.Repeat("a", 64),
+		HashOffset:      "4096",
+		UUID:            "0eefa619-50b7-588f-a072-d405fb439d36",
+		KeySecret:       "PRIVATE_MODEL_KEY",
+		EncryptedSHA256: strings.Repeat("b", 64),
+		DataBlockSize:   4096,
+		HashBlockSize:   4096,
+		DataBlocks:      "123",
+	}
+	if err := validateEncryptedModelPack(valid); err != nil {
+		t.Fatalf("expected valid encrypted model pack: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*EncryptedModelPackSpec)
+	}{
+		{
+			name: "device outside by-id",
+			mutate: func(s *EncryptedModelPackSpec) {
+				s.Device = "/tmp/model.img"
+			},
+		},
+		{
+			name: "bad root hash",
+			mutate: func(s *EncryptedModelPackSpec) {
+				s.RootHash = "not-a-root"
+			},
+		},
+		{
+			name: "bad key secret",
+			mutate: func(s *EncryptedModelPackSpec) {
+				s.KeySecret = "PRIVATE-MODEL-KEY"
+			},
+		},
+		{
+			name: "unsupported cipher",
+			mutate: func(s *EncryptedModelPackSpec) {
+				s.Cipher = "aes-cbc-plain"
+			},
+		},
+		{
+			name: "unsupported key size",
+			mutate: func(s *EncryptedModelPackSpec) {
+				s.KeySize = 256
+			},
+		},
+		{
+			name: "unsupported sector size",
+			mutate: func(s *EncryptedModelPackSpec) {
+				s.SectorSize = 512
+			},
+		},
+		{
+			name: "verify requires sha",
+			mutate: func(s *EncryptedModelPackSpec) {
+				s.EncryptedSHA256 = ""
+				s.VerifyEncryptedSHA256 = true
+			},
+		},
+		{
+			name: "unsupported data block size",
+			mutate: func(s *EncryptedModelPackSpec) {
+				s.DataBlockSize = 8192
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := *valid
+			tt.mutate(&spec)
+			if err := validateEncryptedModelPack(&spec); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+}
+
+func TestEncryptedModelKey(t *testing.T) {
+	key := strings.Repeat("k", defaultEMPKKeySize/8)
+	ext := &shimconfig.ExternalConfig{
+		Secrets: map[string]string{
+			"PRIVATE_MODEL_KEY": base64.StdEncoding.EncodeToString([]byte(key)),
+		},
+	}
+	spec := &EncryptedModelPackSpec{KeySecret: "PRIVATE_MODEL_KEY"}
+
+	got, err := encryptedModelKey(spec, ext)
+	if err != nil {
+		t.Fatalf("expected decoded key: %v", err)
+	}
+	if string(got) != key {
+		t.Fatalf("decoded key mismatch")
+	}
+
+	for _, tc := range []struct {
+		name string
+		ext  *shimconfig.ExternalConfig
+	}{
+		{name: "missing external config"},
+		{name: "missing secret", ext: &shimconfig.ExternalConfig{Secrets: map[string]string{}}},
+		{name: "bad base64", ext: &shimconfig.ExternalConfig{Secrets: map[string]string{"PRIVATE_MODEL_KEY": "!"}}},
+		{name: "short key", ext: &shimconfig.ExternalConfig{Secrets: map[string]string{"PRIVATE_MODEL_KEY": base64.StdEncoding.EncodeToString([]byte("short"))}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := encryptedModelKey(spec, tc.ext); err == nil {
+				t.Fatal("expected key decode error")
+			}
+		})
+	}
+}

--- a/tinfoil/cmd/boot/models_test.go
+++ b/tinfoil/cmd/boot/models_test.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"strings"
 	"testing"
 
+	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 )
 
@@ -16,6 +18,18 @@ func TestParseModelPackRef(t *testing.T) {
 	}
 	if got.RootHash != strings.Repeat("a", 64) || got.HashOffset != "4096" || got.UUID != "0eefa619-50b7-588f-a072-d405fb439d36" {
 		t.Fatalf("parsed ref mismatch: %+v", got)
+	}
+	if got.mapperName() != "mwp-"+strings.Repeat("a", 64) {
+		t.Fatalf("mapper name mismatch: %s", got.mapperName())
+	}
+	if got.mountPoint() != boot.MWPDir+"/mwp-"+strings.Repeat("a", 64) {
+		t.Fatalf("mount point mismatch: %s", got.mountPoint())
+	}
+	if got.legacyMountPoint() != boot.MPKDir+"/mpk-"+strings.Repeat("a", 64) {
+		t.Fatalf("legacy mount point mismatch: %s", got.legacyMountPoint())
+	}
+	if got.artifactID() != strings.Repeat("a", 64)+"_0eefa619-50b7-588f-a072-d405fb439d36" {
+		t.Fatalf("artifact ID mismatch: %s", got.artifactID())
 	}
 
 	tests := []struct {
@@ -49,19 +63,85 @@ func TestParseModelPackRef(t *testing.T) {
 	}
 }
 
+func TestModelPackRefForModel(t *testing.T) {
+	ref := strings.Repeat("a", 64) + "_4096_0eefa619-50b7-588f-a072-d405fb439d36"
+
+	for _, tt := range []struct {
+		name     string
+		model    ModelSpec
+		wantKind modelKind
+	}{
+		{name: "legacy mpk", model: ModelSpec{Name: "legacy", MPK: ref}, wantKind: modelKindPlaintext},
+		{name: "mwp", model: ModelSpec{Name: "plain", MWP: ref}, wantKind: modelKindPlaintext},
+		{name: "emwp", model: ModelSpec{Name: "encrypted", EMWP: ref}, wantKind: modelKindEncrypted},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, kind, err := modelPackRefForModel(tt.model)
+			if err != nil {
+				t.Fatalf("expected model ref: %v", err)
+			}
+			if got.raw != ref {
+				t.Fatalf("raw ref mismatch: got %q want %q", got.raw, ref)
+			}
+			if kind != tt.wantKind {
+				t.Fatalf("kind mismatch: got %q want %q", kind, tt.wantKind)
+			}
+		})
+	}
+
+	for _, tt := range []struct {
+		name  string
+		model ModelSpec
+	}{
+		{name: "missing model ref", model: ModelSpec{Name: "missing"}},
+		{name: "both mpk and mwp", model: ModelSpec{Name: "both", MPK: ref, MWP: ref}},
+		{name: "both mwp and emwp", model: ModelSpec{Name: "both", MWP: ref, EMWP: ref}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, _, err := modelPackRefForModel(tt.model); err == nil {
+				t.Fatal("expected model ref error")
+			}
+		})
+	}
+}
+
 func TestEncryptedModelKey(t *testing.T) {
-	key := strings.Repeat("k", defaultEMPKKeySize/8)
+	key := strings.Repeat("k", defaultEMWPKeySize/8)
+	spec := &modelPackRef{
+		RootHash:   strings.Repeat("a", 64),
+		HashOffset: "4096",
+		UUID:       "0eefa619-50b7-588f-a072-d405fb439d36",
+	}
 	ext := &shimconfig.ExternalConfig{
 		Secrets: map[string]string{
 			"PRIVATE_MODEL_KEY": base64.StdEncoding.EncodeToString([]byte(key)),
 		},
 	}
-	got, err := encryptedModelKey("PRIVATE_MODEL_KEY", ext)
+	got, err := encryptedModelKey("PRIVATE_MODEL_KEY", spec, ext)
 	if err != nil {
-		t.Fatalf("expected decoded key: %v", err)
+		t.Fatalf("expected derived key: %v", err)
 	}
-	if string(got) != key {
-		t.Fatalf("decoded key mismatch")
+	if len(got) != defaultEMWPKeySize/8 {
+		t.Fatalf("derived key length: got %d, want %d", len(got), defaultEMWPKeySize/8)
+	}
+	if bytes.Equal(got, []byte(key)) {
+		t.Fatal("derived key should differ from external master key")
+	}
+	gotAgain, err := encryptedModelKey("PRIVATE_MODEL_KEY", spec, ext)
+	if err != nil {
+		t.Fatalf("expected repeat derived key: %v", err)
+	}
+	if !bytes.Equal(got, gotAgain) {
+		t.Fatal("derived key should be deterministic for the same artifact")
+	}
+	otherSpec := *spec
+	otherSpec.UUID = "1eefa619-50b7-588f-a072-d405fb439d36"
+	otherGot, err := encryptedModelKey("PRIVATE_MODEL_KEY", &otherSpec, ext)
+	if err != nil {
+		t.Fatalf("expected other derived key: %v", err)
+	}
+	if bytes.Equal(got, otherGot) {
+		t.Fatal("derived key should differ across artifacts")
 	}
 
 	for _, tc := range []struct {
@@ -74,7 +154,7 @@ func TestEncryptedModelKey(t *testing.T) {
 		{name: "short key", ext: &shimconfig.ExternalConfig{Secrets: map[string]string{"PRIVATE_MODEL_KEY": base64.StdEncoding.EncodeToString([]byte("short"))}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := encryptedModelKey("PRIVATE_MODEL_KEY", tc.ext); err == nil {
+			if _, err := encryptedModelKey("PRIVATE_MODEL_KEY", spec, tc.ext); err == nil {
 				t.Fatal("expected key decode error")
 			}
 		})

--- a/tinfoil/cmd/boot/models_test.go
+++ b/tinfoil/cmd/boot/models_test.go
@@ -6,11 +6,15 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tinfoilsh/modelwrap"
+
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 )
 
-func TestParseModelPackRef(t *testing.T) {
+// Reference syntax validation is covered by the modelwrap module tests;
+// this only checks the cvmimage mount layout policy built on top of it.
+func TestModelPackRefLayout(t *testing.T) {
 	ref := strings.Repeat("a", 64) + "_4096_0eefa619-50b7-588f-a072-d405fb439d36"
 	got, err := parseModelPackRef(ref)
 	if err != nil {
@@ -28,38 +32,11 @@ func TestParseModelPackRef(t *testing.T) {
 	if got.legacyMountPoint() != boot.MPKDir+"/mpk-"+strings.Repeat("a", 64) {
 		t.Fatalf("legacy mount point mismatch: %s", got.legacyMountPoint())
 	}
-	if got.artifactID() != strings.Repeat("a", 64)+"_0eefa619-50b7-588f-a072-d405fb439d36" {
-		t.Fatalf("artifact ID mismatch: %s", got.artifactID())
+	if got.ArtifactID() != strings.Repeat("a", 64)+"_0eefa619-50b7-588f-a072-d405fb439d36" {
+		t.Fatalf("artifact ID mismatch: %s", got.ArtifactID())
 	}
-
-	tests := []struct {
-		name string
-		ref  string
-	}{
-		{
-			name: "missing parts",
-			ref:  strings.Repeat("a", 64) + "_4096",
-		},
-		{
-			name: "bad UUID",
-			ref:  strings.Repeat("a", 64) + "_4096_not-a-uuid",
-		},
-		{
-			name: "bad root hash",
-			ref:  "not-a-root_4096_0eefa619-50b7-588f-a072-d405fb439d36",
-		},
-		{
-			name: "bad offset",
-			ref:  strings.Repeat("a", 64) + "_not-an-offset_0eefa619-50b7-588f-a072-d405fb439d36",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, err := parseModelPackRef(tt.ref); err == nil {
-				t.Fatal("expected validation error")
-			}
-		})
+	if _, err := parseModelPackRef("not-a-ref"); err == nil {
+		t.Fatal("expected validation error to propagate from modelwrap")
 	}
 }
 
@@ -116,11 +93,13 @@ func TestDiskLocators(t *testing.T) {
 }
 
 func TestEncryptedModelKey(t *testing.T) {
-	key := strings.Repeat("k", defaultEMWPKeySize/8)
+	key := strings.Repeat("k", modelwrap.EMWPMasterKeyBytes)
 	spec := &modelPackRef{
-		RootHash:   strings.Repeat("a", 64),
-		HashOffset: "4096",
-		UUID:       "0eefa619-50b7-588f-a072-d405fb439d36",
+		ArtifactRef: &modelwrap.ArtifactRef{
+			RootHash:   strings.Repeat("a", 64),
+			HashOffset: "4096",
+			UUID:       "0eefa619-50b7-588f-a072-d405fb439d36",
+		},
 	}
 	ext := &shimconfig.ExternalConfig{
 		Secrets: map[string]string{
@@ -131,8 +110,8 @@ func TestEncryptedModelKey(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected derived key: %v", err)
 	}
-	if len(got) != defaultEMWPKeySize/8 {
-		t.Fatalf("derived key length: got %d, want %d", len(got), defaultEMWPKeySize/8)
+	if len(got) != modelwrap.EMWPKeyBytes {
+		t.Fatalf("derived key length: got %d, want %d", len(got), modelwrap.EMWPKeyBytes)
 	}
 	if bytes.Equal(got, []byte(key)) {
 		t.Fatal("derived key should differ from external master key")
@@ -144,9 +123,10 @@ func TestEncryptedModelKey(t *testing.T) {
 	if !bytes.Equal(got, gotAgain) {
 		t.Fatal("derived key should be deterministic for the same artifact")
 	}
-	otherSpec := *spec
-	otherSpec.UUID = "1eefa619-50b7-588f-a072-d405fb439d36"
-	otherGot, err := encryptedModelKey("PRIVATE_MODEL_KEY", &otherSpec, ext)
+	otherRef := *spec.ArtifactRef
+	otherRef.UUID = "1eefa619-50b7-588f-a072-d405fb439d36"
+	otherSpec := &modelPackRef{ArtifactRef: &otherRef}
+	otherGot, err := encryptedModelKey("PRIVATE_MODEL_KEY", otherSpec, ext)
 	if err != nil {
 		t.Fatalf("expected other derived key: %v", err)
 	}

--- a/tinfoil/cmd/boot/models_test.go
+++ b/tinfoil/cmd/boot/models_test.go
@@ -105,6 +105,16 @@ func TestModelPackRefForModel(t *testing.T) {
 	}
 }
 
+func TestDiskLocators(t *testing.T) {
+	id := "0eefa619-50b7-588f-a072-d405fb439d36"
+	if got := diskByUUID(id); got != "/dev/disk/by-uuid/"+id {
+		t.Fatalf("disk by UUID mismatch: %s", got)
+	}
+	if got := diskByPARTUUID(id); got != "/dev/disk/by-partuuid/"+id {
+		t.Fatalf("disk by PARTUUID mismatch: %s", got)
+	}
+}
+
 func TestEncryptedModelKey(t *testing.T) {
 	key := strings.Repeat("k", defaultEMWPKeySize/8)
 	spec := &modelPackRef{

--- a/tinfoil/cmd/boot/models_test.go
+++ b/tinfoil/cmd/boot/models_test.go
@@ -8,82 +8,41 @@ import (
 	shimconfig "tinfoil/internal/config"
 )
 
-func TestValidateEncryptedModelPack(t *testing.T) {
-	valid := &EncryptedModelPackSpec{
-		Device:          "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_tinfoil-private-model1",
-		RootHash:        strings.Repeat("a", 64),
-		HashOffset:      "4096",
-		UUID:            "0eefa619-50b7-588f-a072-d405fb439d36",
-		KeySecret:       "PRIVATE_MODEL_KEY",
-		EncryptedSHA256: strings.Repeat("b", 64),
-		DataBlockSize:   4096,
-		HashBlockSize:   4096,
-		DataBlocks:      "123",
+func TestParseModelPackRef(t *testing.T) {
+	ref := strings.Repeat("a", 64) + "_4096_0eefa619-50b7-588f-a072-d405fb439d36"
+	got, err := parseModelPackRef(ref)
+	if err != nil {
+		t.Fatalf("expected valid model pack ref: %v", err)
 	}
-	if err := validateEncryptedModelPack(valid); err != nil {
-		t.Fatalf("expected valid encrypted model pack: %v", err)
+	if got.RootHash != strings.Repeat("a", 64) || got.HashOffset != "4096" || got.UUID != "0eefa619-50b7-588f-a072-d405fb439d36" {
+		t.Fatalf("parsed ref mismatch: %+v", got)
 	}
 
 	tests := []struct {
-		name   string
-		mutate func(*EncryptedModelPackSpec)
+		name string
+		ref  string
 	}{
 		{
-			name: "device outside by-id",
-			mutate: func(s *EncryptedModelPackSpec) {
-				s.Device = "/tmp/model.img"
-			},
+			name: "missing parts",
+			ref:  strings.Repeat("a", 64) + "_4096",
+		},
+		{
+			name: "bad UUID",
+			ref:  strings.Repeat("a", 64) + "_4096_not-a-uuid",
 		},
 		{
 			name: "bad root hash",
-			mutate: func(s *EncryptedModelPackSpec) {
-				s.RootHash = "not-a-root"
-			},
+			ref:  "not-a-root_4096_0eefa619-50b7-588f-a072-d405fb439d36",
 		},
 		{
-			name: "bad key secret",
-			mutate: func(s *EncryptedModelPackSpec) {
-				s.KeySecret = "PRIVATE-MODEL-KEY"
-			},
-		},
-		{
-			name: "unsupported cipher",
-			mutate: func(s *EncryptedModelPackSpec) {
-				s.Cipher = "aes-cbc-plain"
-			},
-		},
-		{
-			name: "unsupported key size",
-			mutate: func(s *EncryptedModelPackSpec) {
-				s.KeySize = 256
-			},
-		},
-		{
-			name: "unsupported sector size",
-			mutate: func(s *EncryptedModelPackSpec) {
-				s.SectorSize = 512
-			},
-		},
-		{
-			name: "verify requires sha",
-			mutate: func(s *EncryptedModelPackSpec) {
-				s.EncryptedSHA256 = ""
-				s.VerifyEncryptedSHA256 = true
-			},
-		},
-		{
-			name: "unsupported data block size",
-			mutate: func(s *EncryptedModelPackSpec) {
-				s.DataBlockSize = 8192
-			},
+			name: "bad offset",
+			ref:  strings.Repeat("a", 64) + "_not-an-offset_0eefa619-50b7-588f-a072-d405fb439d36",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			spec := *valid
-			tt.mutate(&spec)
-			if err := validateEncryptedModelPack(&spec); err == nil {
+			if _, err := parseModelPackRef(tt.ref); err == nil {
 				t.Fatal("expected validation error")
 			}
 		})
@@ -97,9 +56,7 @@ func TestEncryptedModelKey(t *testing.T) {
 			"PRIVATE_MODEL_KEY": base64.StdEncoding.EncodeToString([]byte(key)),
 		},
 	}
-	spec := &EncryptedModelPackSpec{KeySecret: "PRIVATE_MODEL_KEY"}
-
-	got, err := encryptedModelKey(spec, ext)
+	got, err := encryptedModelKey("PRIVATE_MODEL_KEY", ext)
 	if err != nil {
 		t.Fatalf("expected decoded key: %v", err)
 	}
@@ -117,7 +74,7 @@ func TestEncryptedModelKey(t *testing.T) {
 		{name: "short key", ext: &shimconfig.ExternalConfig{Secrets: map[string]string{"PRIVATE_MODEL_KEY": base64.StdEncoding.EncodeToString([]byte("short"))}}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if _, err := encryptedModelKey(spec, tc.ext); err == nil {
+			if _, err := encryptedModelKey("PRIVATE_MODEL_KEY", tc.ext); err == nil {
 				t.Fatal("expected key decode error")
 			}
 		})

--- a/tinfoil/cmd/boot/validation.go
+++ b/tinfoil/cmd/boot/validation.go
@@ -8,10 +8,12 @@ import (
 
 // Input validation patterns
 var (
-	hexHashPattern  = regexp.MustCompile(`^[a-f0-9]{64}$`)                        // SHA256 hex strings
-	uuidPattern     = regexp.MustCompile(`^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`)
-	offsetPattern   = regexp.MustCompile(`^[0-9]+$`)                              // Numeric offset
-	registryPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`) // Registry hostnames
+	hexHashPattern    = regexp.MustCompile(`^[a-f0-9]{64}$`) // SHA256 hex strings
+	uuidPattern       = regexp.MustCompile(`^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`)
+	offsetPattern     = regexp.MustCompile(`^[0-9]+$`) // Numeric offset
+	devicePathPattern = regexp.MustCompile(`^/dev/disk/by-id/[A-Za-z0-9._:+-]+$`)
+	registryPattern   = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`) // Registry hostnames
+	secretNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 )
 
 // sha256Hash computes the SHA256 hash of data and returns hex string

--- a/tinfoil/cmd/boot/validation.go
+++ b/tinfoil/cmd/boot/validation.go
@@ -10,8 +10,7 @@ import (
 var (
 	hexHashPattern    = regexp.MustCompile(`^[a-f0-9]{64}$`) // SHA256 hex strings
 	uuidPattern       = regexp.MustCompile(`^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$`)
-	offsetPattern     = regexp.MustCompile(`^[0-9]+$`) // Numeric offset
-	devicePathPattern = regexp.MustCompile(`^/dev/disk/by-id/[A-Za-z0-9._:+-]+$`)
+	offsetPattern     = regexp.MustCompile(`^[0-9]+$`)                         // Numeric offset
 	registryPattern   = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`) // Registry hostnames
 	secretNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 )

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.1.7
+	github.com/tinfoilsh/modelwrap v0.2.0
 	github.com/tinfoilsh/tinfoil-go/verifier v0.12.0
 	golang.org/x/net v0.48.0
 	golang.org/x/time v0.14.0

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -128,6 +128,8 @@ github.com/theupdateframework/go-tuf/v2 v2.4.1 h1:K6ewW064rKZCPkRo1W/CTbTtm/+IB4
 github.com/theupdateframework/go-tuf/v2 v2.4.1/go.mod h1:Nex2enPVYDFCklrnbTzl3OVwD7fgIAj0J5++z/rvCj8=
 github.com/tinfoilsh/encrypted-http-body-protocol v0.1.7 h1:wx0fOuWYr6WmEd75Q+LIZCcxOOGFbFw35CXNcE54nHs=
 github.com/tinfoilsh/encrypted-http-body-protocol v0.1.7/go.mod h1:0rBBhKu3L0rasEdlLg2auq9UKgg7CY0jhhZpzFxWFp0=
+github.com/tinfoilsh/modelwrap v0.2.0 h1:j0+ez9WidhmH+9q5Hyj0XO0wBI/bfs2ZW0jfZYolaQ8=
+github.com/tinfoilsh/modelwrap v0.2.0/go.mod h1:PpW6+CvwIz9MoFueyU2YjYHnrHNzMGCMq+7Ai8DbxEA=
 github.com/tinfoilsh/tinfoil-go/verifier v0.12.0 h1:xg0/euV/uEGDhKXgxD6L5UpN4LCR6jcUIpEak9/WAbQ=
 github.com/tinfoilsh/tinfoil-go/verifier v0.12.0/go.mod h1:1iPX7k1r9To22RBdod/UdaA0mXR1THjl/f7RpReZ2PE=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -22,6 +22,7 @@ const (
 	ExternalConfigPath = PrivateDir + "/external-config.yml"
 	DockerConfigDir    = PrivateDir + "/docker-config"
 	DockerConfigPath   = DockerConfigDir + "/config.json"
+	ModelKeyDir        = PrivateDir + "/model-keys"
 	GCloudKeyPath      = PrivateDir + "/gcloud_key.json"
 	CacheDir           = PrivateDir + "/tfshim-cache"
 	StatePath          = PrivateDir + "/boot-state.json"

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -9,7 +9,8 @@ const (
 	ConfigPath          = PublicDir + "/config.yml"
 	AttestationPath     = PublicDir + "/attestation.json"
 	ContainerStatusPath = PublicDir + "/container-status.json"
-	MPKDir              = PublicDir + "/mpk"
+	MWPDir              = PublicDir + "/mwp"
+	MPKDir              = PublicDir + "/mpk" // Legacy alias directory for MWP mounts.
 
 	// Private — only accessible to boot, egress, and shim processes (mode 0700).
 	// Holds CVM-level secrets and material that must never reach a container.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds encrypted model wraps (EMWP) with dm-crypt under dm-verity, and unifies model config to `mwp` (plaintext) or `emwp` (encrypted); `mpk` stays as a legacy alias. Uses `github.com/tinfoilsh/modelwrap` for ref parsing and key derivation, and mounts models read-only with a stable layout and legacy symlink.

- New Features
  - `ModelSpec` supports `name` (optional), `mpk` (alias), `mwp`, `emwp`, and `key-secret`.
  - Plaintext: dm-verity on `/dev/disk/by-uuid/<uuid>`; mounted at `/mwp/mwp-<root>` with a legacy symlink at `/mpk/mpk-<root>`.
  - Encrypted: dm-crypt on `/dev/disk/by-partuuid/<uuid>` then dm-verity on the decrypted device. Keys are base64-decoded from `external-config`, HKDF-derived per artifact with `modelwrap`, and written to `ModelKeyDir`.
  - Validates root-hash, hash-offset, UUID, and secret name; rejects multiple refs per model and duplicate root hashes.
  - Boot now fails if model mounting fails. Integration and unit tests added.
  - Switched to `github.com/tinfoilsh/modelwrap v0.2.0` and `github.com/tinfoilsh/modelwrap/unwrap` for parsing, key derivation, and device ops.

- Migration
  - In external config, add a base64-encoded 64-byte key for `key-secret`.
  - In boot config, set `mwp: <root_hash>_<hash_offset>_<uuid>` for plaintext, or `emwp: <...>` plus `key-secret: <SECRET_NAME>`; `name` is optional.
  - Existing `mpk` configs and paths continue to work via the alias.

<sup>Written for commit fc7fc5c42281fa2b48af1263153e53d8990853b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

