### PR TITLE
Include tls-exporter in the attestation report

### DIFF
--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -383,10 +383,26 @@ func registerObservabilityHandlers(
 				}
 			}
 
+			// RFC 9266 tls-exporter channel binding for the TLS session this
+			// request arrived over.
+			var tlsExporter []byte
+			if r.TLS != nil {
+				if exporter, exErr := r.TLS.ExportKeyingMaterial(
+					tinfoilattestation.TLSExporterLabel,
+					nil,
+					tinfoilattestation.TLSExporterSize,
+				); exErr == nil {
+					tlsExporter = exporter
+				} else {
+					log.Printf("tls-exporter channel binding unavailable: %v", exErr)
+				}
+			}
+
 			fresh, err := tinfoilattestation.BuildAttestation(
 				identityBody.TLSKeyFP,
 				identityBody.HPKEKey,
 				nonce,
+				tlsExporter,
 				deviceEvidence,
 				collateral,
 			)

--- a/tinfoil/internal/attestation/attestation.go
+++ b/tinfoil/internal/attestation/attestation.go
@@ -135,6 +135,46 @@ func DummyReport(userData [64]byte) *legacy.Document {
 	}
 }
 
+const (
+	// TLSExporterLabel is the RFC 9266 channel-binding exporter label.
+	TLSExporterLabel = "EXPORTER-Channel-Binding"
+	// TLSExporterSize is the channel-binding value size emitted in v3 documents.
+	TLSExporterSize = 32
+
+	tlsExporterCryptoMaterialID       = "tls-exporter"
+	tlsExporterCryptoMaterialV1Format = "https://tinfoil.sh/format/tls-exporter/v1"
+)
+
+func buildCryptoMaterialSection(tlsKeyFP, hpkeKey [32]byte, tlsExporter []byte) (envelope.CryptoMaterialSection, error) {
+	items := []envelope.CryptoMaterialItem{
+		{
+			ID:     envelope.CryptoMaterialIDTLS,
+			Format: envelope.KeySPKIFPSHA256V1Format,
+			Data:   hex.EncodeToString(tlsKeyFP[:]),
+		},
+		{
+			ID:     envelope.CryptoMaterialIDHPKE,
+			Format: envelope.KeyX25519HPKEV1Format,
+			Data:   hex.EncodeToString(hpkeKey[:]),
+		},
+	}
+	if len(tlsExporter) != 0 {
+		if len(tlsExporter) != TLSExporterSize {
+			return envelope.CryptoMaterialSection{}, fmt.Errorf("tls exporter must be %d bytes, got %d", TLSExporterSize, len(tlsExporter))
+		}
+		items = append(items, envelope.CryptoMaterialItem{
+			ID:     tlsExporterCryptoMaterialID,
+			Format: tlsExporterCryptoMaterialV1Format,
+			Data:   hex.EncodeToString(tlsExporter),
+		})
+	}
+
+	return envelope.CryptoMaterialSection{
+		Format: envelope.CryptoMaterialV1Format,
+		Items:  items,
+	}, nil
+}
+
 // BuildAttestation assembles a fresh v3 attestation document: it serializes
 // the two endorsed sections exactly once, derives REPORT_DATA from their
 // hashes and the nonce, obtains a hardware quote over that REPORT_DATA, and
@@ -145,6 +185,7 @@ func BuildAttestation(
 	tlsKeyFP [32]byte,
 	hpkeKey [32]byte,
 	nonce []byte,
+	tlsExporter []byte,
 	deviceEvidence []envelope.DeviceEvidenceItem,
 	collateral []envelope.CollateralEntry,
 ) (*envelope.Document, error) {
@@ -158,20 +199,12 @@ func BuildAttestation(
 		collateral = []envelope.CollateralEntry{}
 	}
 
-	cryptoMaterial := envelope.CryptoMaterialSection{
-		Format: envelope.CryptoMaterialV1Format,
-		Items: []envelope.CryptoMaterialItem{
-			{
-				ID:     envelope.CryptoMaterialIDTLS,
-				Format: envelope.KeySPKIFPSHA256V1Format,
-				Data:   hex.EncodeToString(tlsKeyFP[:]),
-			},
-			{
-				ID:     envelope.CryptoMaterialIDHPKE,
-				Format: envelope.KeyX25519HPKEV1Format,
-				Data:   hex.EncodeToString(hpkeKey[:]),
-			},
-		},
+	// The TLS exporter is carried in the endorsed crypto-material section, so
+	// report-data/v1 binds it through that section's hash without changing the
+	// verifier's REPORT_DATA derivation.
+	cryptoMaterial, err := buildCryptoMaterialSection(tlsKeyFP, hpkeKey, tlsExporter)
+	if err != nil {
+		return nil, err
 	}
 	deviceSection := envelope.DeviceEvidenceSection{
 		Format: envelope.DeviceEvidenceV1Format,

--- a/tinfoil/internal/attestation/attestation_test.go
+++ b/tinfoil/internal/attestation/attestation_test.go
@@ -1,0 +1,87 @@
+package attestation
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/tinfoilsh/tinfoil-go/verifier/envelope"
+)
+
+func TestTLSExporterIsBoundIntoV3CryptoMaterial(t *testing.T) {
+	var tlsKeyFP, hpkeKey [32]byte
+	copy(tlsKeyFP[:], bytes.Repeat([]byte{0xaa}, len(tlsKeyFP)))
+	copy(hpkeKey[:], bytes.Repeat([]byte{0xbb}, len(hpkeKey)))
+	tlsExporter := bytes.Repeat([]byte{0xcc}, TLSExporterSize)
+
+	cryptoMaterial, err := buildCryptoMaterialSection(tlsKeyFP, hpkeKey, tlsExporter)
+	if err != nil {
+		t.Fatalf("building crypto material: %v", err)
+	}
+	cryptoBytes, err := json.Marshal(cryptoMaterial)
+	if err != nil {
+		t.Fatalf("marshaling crypto material: %v", err)
+	}
+	deviceBytes, err := json.Marshal(envelope.DeviceEvidenceSection{
+		Format: envelope.DeviceEvidenceV1Format,
+		Items:  []envelope.DeviceEvidenceItem{},
+	})
+	if err != nil {
+		t.Fatalf("marshaling device evidence: %v", err)
+	}
+
+	nonce := bytes.Repeat([]byte{0xdd}, envelope.NonceSize)
+	cryptoHash := sha256.Sum256(cryptoBytes)
+	deviceHash := sha256.Sum256(deviceBytes)
+	reportData, err := envelope.ComputeReportData(nonce, cryptoHash[:], deviceHash[:])
+	if err != nil {
+		t.Fatalf("computing report data: %v", err)
+	}
+	docBytes, err := json.Marshal(envelope.Document{
+		Format: envelope.AttestationV3Format,
+		Challenge: envelope.Challenge{
+			Nonce:               hex.EncodeToString(nonce),
+			ReportData:          hex.EncodeToString(reportData[:]),
+			ReportDataAlgorithm: envelope.ReportDataV1Algorithm,
+		},
+		CPUEvidence: envelope.CPUEvidence{
+			Format:       envelope.TDXQuoteV1Format,
+			ReportBase64: base64.StdEncoding.EncodeToString([]byte{0x01}),
+			Endorsed: envelope.EndorsedHashes{
+				CryptoMaterialHash: hex.EncodeToString(cryptoHash[:]),
+				DeviceEvidenceHash: hex.EncodeToString(deviceHash[:]),
+			},
+		},
+		CryptoMaterial: base64.StdEncoding.EncodeToString(cryptoBytes),
+		DeviceEvidence: base64.StdEncoding.EncodeToString(deviceBytes),
+		Collateral:     []envelope.CollateralEntry{},
+	})
+	if err != nil {
+		t.Fatalf("marshaling document: %v", err)
+	}
+
+	parsed, _, err := envelope.Check(docBytes, nonce)
+	if err != nil {
+		t.Fatalf("checking v3 envelope: %v", err)
+	}
+	item, ok := parsed.CryptoMaterialItem(tlsExporterCryptoMaterialID)
+	if !ok {
+		t.Fatal("v3 envelope does not contain TLS exporter crypto material")
+	}
+	if item.Format != tlsExporterCryptoMaterialV1Format {
+		t.Fatalf("TLS exporter format = %q, want %q", item.Format, tlsExporterCryptoMaterialV1Format)
+	}
+	if item.Data != hex.EncodeToString(tlsExporter) {
+		t.Fatalf("TLS exporter data = %q, want %q", item.Data, hex.EncodeToString(tlsExporter))
+	}
+}
+
+func TestBuildCryptoMaterialSectionRejectsInvalidTLSExporterSize(t *testing.T) {
+	_, err := buildCryptoMaterialSection([32]byte{}, [32]byte{}, []byte{0x01})
+	if err == nil {
+		t.Fatal("expected an error for a TLS exporter with the wrong size")
+	}
+}


### PR DESCRIPTION
This implements [RFC 9266](https://datatracker.ietf.org/doc/html/rfc9266) tls-exporter channel binding for the attestation request. Binding the report to the TLS session lets a client detect a MITM that could otherwise relay attestation requests undetected.