### PR TITLE
fix: b300 attestation for v3

### DIFF
--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -291,6 +291,10 @@ func wrapShimMux(config *config.Config, att *attestation.Document, mux *http.Ser
 	return corsMiddleware(config, globalMiddleware(mux))
 }
 
+func requiresNVSwitchEvidence(expectedGPUs int, gpuEvidence *tinfoilattestation.GPUEvidenceCollection) bool {
+	return expectedGPUs == 8 && gpuEvidence.HasArch(tinfoilattestation.GPUArchHopper)
+}
+
 func registerObservabilityHandlers(
 	mux *http.ServeMux,
 	ehbpMiddleware func(http.Handler) http.Handler,
@@ -329,7 +333,7 @@ func registerObservabilityHandlers(
 					return
 				}
 				gpuJSON, _ = json.Marshal(gpuEvidence)
-				if expectedGPUs >= 8 {
+				if requiresNVSwitchEvidence(expectedGPUs, gpuEvidence) {
 					nvswitchJSON, err = tinfoilattestation.CollectNVSwitchEvidence(nonce32)
 					if err != nil {
 						log.Printf("NVSwitch evidence collection failed: %v", err)

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -189,6 +189,38 @@ func TestWriteValidationFailureDoesNotLeakInternalError(t *testing.T) {
 	}
 }
 
+func TestRequiresNVSwitchEvidence(t *testing.T) {
+	evidence := func(arches ...string) *tinfoilattestation.GPUEvidenceCollection {
+		collection := &tinfoilattestation.GPUEvidenceCollection{}
+		for _, arch := range arches {
+			collection.Evidences = append(collection.Evidences, tinfoilattestation.GPUEvidence{Arch: arch})
+		}
+		return collection
+	}
+
+	tests := []struct {
+		name         string
+		expectedGPUs int
+		evidence     *tinfoilattestation.GPUEvidenceCollection
+		want         bool
+	}{
+		{"single GPU never requires switch evidence", 1, evidence(tinfoilattestation.GPUArchHopper), false},
+		{"nil evidence does not require switch evidence", 8, nil, false},
+		{"blackwell 8 GPU skips switch evidence", 8, evidence(tinfoilattestation.GPUArchBlackwell), false},
+		{"hopper 8 GPU requires switch evidence", 8, evidence(tinfoilattestation.GPUArchHopper), true},
+		{"hopper non-8 GPU skips switch evidence", 4, evidence(tinfoilattestation.GPUArchHopper), false},
+		{"unknown 8 GPU skips switch evidence", 8, evidence("UNKNOWN_123"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := requiresNVSwitchEvidence(tt.expectedGPUs, tt.evidence); got != tt.want {
+				t.Fatalf("requiresNVSwitchEvidence(%d, %+v) = %v, want %v", tt.expectedGPUs, tt.evidence, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNoPathsConfigured_AllPathsAllowed(t *testing.T) {
 	handler := testServer(t, nil, 9999)
 

--- a/tinfoil/internal/attestation/gpu.go
+++ b/tinfoil/internal/attestation/gpu.go
@@ -25,9 +25,26 @@ type GPUEvidenceCollection struct {
 	Evidences []GPUEvidence `json:"evidences"`
 }
 
+const (
+	GPUArchHopper    = "HOPPER"
+	GPUArchBlackwell = "BLACKWELL"
+)
+
 var archNames = map[nvml.DeviceArchitecture]string{
-	nvml.DEVICE_ARCH_HOPPER:    "HOPPER",
-	nvml.DEVICE_ARCH_BLACKWELL: "BLACKWELL",
+	nvml.DEVICE_ARCH_HOPPER:    GPUArchHopper,
+	nvml.DEVICE_ARCH_BLACKWELL: GPUArchBlackwell,
+}
+
+func (c *GPUEvidenceCollection) HasArch(arch string) bool {
+	if c == nil {
+		return false
+	}
+	for _, evidence := range c.Evidences {
+		if evidence.Arch == arch {
+			return true
+		}
+	}
+	return false
 }
 
 // CollectGPUEvidence collects fresh attestation evidence from all GPUs using


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes B300 v3 attestation by collecting NVSwitch evidence only on 8x Hopper systems and skipping it for Blackwell and other configs. Adds safe handling for nil GPU evidence and standardizes GPU arch constants.

- **Bug Fixes**
  - Only collect NVSwitch evidence when expected GPUs is 8 and `tinfoilattestation` evidence includes Hopper.
  - Avoid nil dereference by handling nil GPU evidence in the decision path.

- **Refactors**
  - Introduced `GPUArchHopper` and `GPUArchBlackwell` constants and `GPUEvidenceCollection.HasArch`.
  - Added unit tests for `requiresNVSwitchEvidence` covering Hopper, Blackwell, nil, and unknown cases.

<sup>Written for commit e6b4468ccc74f35e9d15b600833dae2a35da053c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

