### PR TITLE
ci: skip repo version bump on prerelease

### DIFF
--- a/.github/workflows/update-config-repos.yml
+++ b/.github/workflows/update-config-repos.yml
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   prepare:
     runs-on: ubuntu-latest
+    if: github.event_name != 'release' || !github.event.release.prerelease
     permissions:
       contents: read
     outputs:


### PR DESCRIPTION
Adds a prerelease check on `update-config-repos`.

`release.yml` already detects prerelease tags  and passes `--prerelease` when creating the release. we use this.

`workflow_dispatch` runs are unaffected — the `github.event_name != 'release'` clause keeps manual invocations working.
