### PR TITLE
feat: forward client cert in header for mTLS

### DIFF
--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
@@ -190,6 +191,15 @@ func NewShimServer(
 			req.Header.Set("Host", "localhost")
 			req.Host = "localhost"
 			req.Header.Del(ehbpProtocol.EncapsulatedKeyHeader)
+
+			// Forward the TLS peer certificate (if any) to the upstream so
+			// the app can perform attested-client verification itself.
+			//
+			// We use the standard X-Forwarded-Client-Cert (XFCC) header.
+			if req.TLS != nil && len(req.TLS.PeerCertificates) > 0 {
+				peerDER := req.TLS.PeerCertificates[0].Raw
+				req.Header.Set("X-Forwarded-Client-Cert", base64.StdEncoding.EncodeToString(peerDER))
+			}
 
 			// Forward original host and protocol to the upstream
 			req.Header.Del("Forwarded")

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -63,6 +63,7 @@ func main() {
 		GetCertificate: func(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
 			return cert.Load(), nil
 		},
+		ClientAuth: tls.RequestClientCert,
 	}
 
 	srv := &http.Server{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Forwards the client TLS certificate to the upstream using the X-Forwarded-Client-Cert header and enables requesting client certs, so apps can perform their own attested-client checks.

- **New Features**
  - If a client certificate is present, set X-Forwarded-Client-Cert to the base64-encoded DER of the peer certificate (first in chain).
  - Configure server TLS to request client certificates with `tls.RequestClientCert` (backward-compatible for non-mTLS clients).

<sup>Written for commit 0ff8d79b03834bc229be93e3b8c06fbc82d018c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

