### PR TITLE
feat: add virtio_net driver for better performance

### DIFF
--- a/mkosi.extra/etc/systemd/network/20-enp0s2.link
+++ b/mkosi.extra/etc/systemd/network/20-enp0s2.link
@@ -1,0 +1,8 @@
+[Match]
+Driver=virtio_net
+
+[Link]
+NamePolicy=keep kernel database onboard slot path
+AlternativeNamesPolicy=database onboard slot path
+MACAddressPolicy=persistent
+CombinedChannels=max


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a systemd .link for `virtio_net` to improve network throughput and keep stable interface identities. It sets CombinedChannels=max, persistent MAC, and predictable name policies for consistent naming and better performance.

<sup>Written for commit ef71c5f4b5cce88db27bfc435e5f873d6015eef6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

