### PR TITLE
fix: stream chat responses without buffering or truncation

### DIFF
--- a/tinfoil/cmd/shim/openai_proxy.go
+++ b/tinfoil/cmd/shim/openai_proxy.go
@@ -2,17 +2,33 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"crypto/rand"
 	"encoding/json"
-	"fmt"
+	"errors"
 	"io"
 	"math/big"
+	"mime"
 	"net/http"
 	"strings"
+	"sync"
 
 	"log"
 )
+
+const (
+	initialSSEBufferSize = 64 * 1024
+	maxSSELineBytes      = 4 * 1024 * 1024
+)
+
+// isEventStreamContentType reports whether the Content-Type header identifies
+// an SSE response, ignoring parameters such as charset.
+func isEventStreamContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	return mediaType == "text/event-stream"
+}
 
 // addPaddingToStreamChunk adds a random padding field to the delta object in a streaming chunk
 // without parsing the entire response structure
@@ -62,17 +78,30 @@ func addPaddingToStreamChunk(data string) (string, error) {
 	return string(modified), nil
 }
 
-type chatRequest struct {
-	Model    string `json:"model"`
-	Stream   bool   `json:"stream"`
-	Messages []struct {
-		Role    string `json:"role"`
-		Content any    `json:"content"` // String or array of content parts
-	} `json:"messages"`
-}
-
 type streamTransport struct {
 	base http.RoundTripper
+}
+
+type closeOnceReadCloser struct {
+	io.ReadCloser
+	once sync.Once
+	err  error
+}
+
+func (c *closeOnceReadCloser) Close() error {
+	c.once.Do(func() {
+		c.err = c.ReadCloser.Close()
+	})
+	return c.err
+}
+
+type streamResponseBody struct {
+	*io.PipeReader
+	upstream io.Closer
+}
+
+func (b *streamResponseBody) Close() error {
+	return errors.Join(b.PipeReader.Close(), b.upstream.Close())
 }
 
 func (t *streamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -80,32 +109,13 @@ func (t *streamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return t.base.RoundTrip(req)
 	}
 
-	var cr chatRequest
-
-	if req.Body == nil {
-		resp := &http.Response{
-			StatusCode: http.StatusBadRequest,
-			Body:       io.NopCloser(bytes.NewReader([]byte("chat completions request body is empty"))),
-		}
-		return resp, nil
-	}
-
-	body, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read request body: %w", err)
-	}
-	if err := json.Unmarshal(body, &cr); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal request body: %w", err)
-	}
-	req.Body = io.NopCloser(bytes.NewReader(body))
-
 	// Make the actual request
 	resp, err := t.base.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}
 
-	if !cr.Stream {
+	if !isEventStreamContentType(resp.Header.Get("Content-Type")) {
 		return resp, nil
 	}
 
@@ -113,34 +123,40 @@ func (t *streamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp.Header.Set("Cache-Control", "no-cache")
 	resp.Header.Set("Connection", "keep-alive")
 	resp.Header.Del("Content-Length")
+	resp.ContentLength = -1
 
 	// Create a pipe to modify the response stream
 	pr, pw := io.Pipe()
-	originalBody := resp.Body
-	resp.Body = pr
+	originalBody := &closeOnceReadCloser{ReadCloser: resp.Body}
+	resp.Body = &streamResponseBody{PipeReader: pr, upstream: originalBody}
 
 	go func() {
 		defer originalBody.Close()
-		defer pw.Close()
 
 		scanner := bufio.NewScanner(originalBody)
-		scanner.Buffer(make([]byte, 0, bufio.MaxScanTokenSize), 1024*1024)
+		scanner.Buffer(make([]byte, 0, initialSSEBufferSize), maxSSELineBytes)
 		for scanner.Scan() {
 			line := scanner.Text()
+			out := line + "\n"
 			if strings.HasPrefix(line, "data: ") && line != "data: [DONE]" {
 				data := strings.TrimPrefix(line, "data: ")
 				modifiedData, err := addPaddingToStreamChunk(data)
 				if err != nil {
 					log.Printf("Warning: failed to add padding to chunk: %v", err)
-					pw.Write([]byte(line + "\n"))
-					continue
+				} else {
+					out = "data: " + modifiedData + "\n"
 				}
-				pw.Write([]byte("data: " + modifiedData + "\n"))
-			} else {
-				pw.Write([]byte(line + "\n"))
+			}
+			if _, err := io.WriteString(pw, out); err != nil {
+				pw.CloseWithError(err)
+				return
 			}
 		}
-
+		if err := scanner.Err(); err != nil {
+			pw.CloseWithError(err)
+			return
+		}
+		pw.Close()
 	}()
 
 	return resp, nil

--- a/tinfoil/cmd/shim/openai_proxy_test.go
+++ b/tinfoil/cmd/shim/openai_proxy_test.go
@@ -2,9 +2,273 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+type trackingReadCloser struct {
+	reader io.Reader
+	reads  int
+}
+
+func (r *trackingReadCloser) Read(p []byte) (int, error) {
+	r.reads++
+	return r.reader.Read(p)
+}
+
+func (r *trackingReadCloser) Close() error { return nil }
+
+func TestStreamTransportDoesNotBufferRequestBody(t *testing.T) {
+	body := &trackingReadCloser{reader: strings.NewReader("not-json")}
+	transport := &streamTransport{base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Body != body {
+			t.Fatal("request body was replaced before forwarding")
+		}
+		if body.reads != 0 {
+			t.Fatal("request body was read before forwarding")
+		}
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("upstream response")),
+		}, nil
+	})}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.test/v1/chat/completions", body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := transport.RoundTrip(req); err != nil {
+		t.Fatalf("non-JSON request should be forwarded without local buffering: %v", err)
+	}
+}
+
+func TestStreamTransportDetectsStreamingResponse(t *testing.T) {
+	transport := &streamTransport{base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type":   []string{"text/event-stream; charset=utf-8"},
+				"Content-Length": []string{"123"},
+			},
+			ContentLength: 123,
+			Body: io.NopCloser(strings.NewReader(
+				"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n",
+			)),
+		}, nil
+	})}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.test/v1/chat/completions", strings.NewReader(`{"stream":false}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), `"p":`) {
+		t.Fatalf("stream chunk was not padded: %s", body)
+	}
+	if resp.Header.Get("Content-Length") != "" || resp.ContentLength != -1 {
+		t.Fatal("transformed stream retained stale content-length metadata")
+	}
+}
+
+func TestStreamTransportForwardsOversizedEvents(t *testing.T) {
+	largeContent := strings.Repeat("a", 2*1024*1024)
+	event := `data: {"choices":[{"delta":{"content":"` + largeContent + `"}}]}` + "\n\ndata: [DONE]\n\n"
+	transport := &streamTransport{base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(event)),
+		}, nil
+	})}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.test/v1/chat/completions", strings.NewReader(`{"stream":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), largeContent) {
+		t.Fatal("oversized stream event was truncated")
+	}
+	if !strings.Contains(string(body), "data: [DONE]") {
+		t.Fatal("events after an oversized event were dropped")
+	}
+}
+
+func TestStreamTransportRejectsUnboundedEvents(t *testing.T) {
+	event := "data: " + strings.Repeat("a", maxSSELineBytes+1)
+	transport := &streamTransport{base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       io.NopCloser(strings.NewReader(event)),
+		}, nil
+	})}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.test/v1/chat/completions", strings.NewReader(`{"stream":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.ReadAll(resp.Body); err == nil {
+		t.Fatal("oversized stream event was accepted without a bounded-memory error")
+	}
+}
+
+type errorAfterReader struct {
+	reader io.Reader
+	err    error
+}
+
+func (r *errorAfterReader) Read(p []byte) (int, error) {
+	n, err := r.reader.Read(p)
+	if err == io.EOF {
+		return n, r.err
+	}
+	return n, err
+}
+
+func (r *errorAfterReader) Close() error { return nil }
+
+func TestStreamTransportPropagatesUpstreamReadErrors(t *testing.T) {
+	upstreamErr := errors.New("upstream connection reset")
+	transport := &streamTransport{base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body: &errorAfterReader{
+				reader: strings.NewReader("data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n"),
+				err:    upstreamErr,
+			},
+		}, nil
+	})}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.test/v1/chat/completions", strings.NewReader(`{"stream":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if _, err := io.ReadAll(resp.Body); !errors.Is(err, upstreamErr) {
+		t.Fatalf("upstream read error was not preserved: %v", err)
+	}
+}
+
+func TestStreamTransportIgnoresNonSSEMediaTypes(t *testing.T) {
+	body := io.NopCloser(strings.NewReader(`{"choices":[{"delta":{"content":"hi"}}]}`))
+	transport := &streamTransport{base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header: http.Header{
+				"Content-Type":   []string{"text/event-streaming"},
+				"Content-Length": []string{"42"},
+			},
+			ContentLength: 42,
+			Body:          body,
+		}, nil
+	})}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.test/v1/chat/completions", strings.NewReader(`{"stream":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Body != body {
+		t.Fatal("non-SSE response body should pass through untouched")
+	}
+	if resp.Header.Get("Content-Length") != "42" || resp.ContentLength != 42 {
+		t.Fatal("non-SSE response content-length metadata was changed")
+	}
+}
+
+type blockingReadCloser struct {
+	started   chan struct{}
+	closed    chan struct{}
+	startOnce sync.Once
+	closeOnce sync.Once
+}
+
+func newBlockingReadCloser() *blockingReadCloser {
+	return &blockingReadCloser{
+		started: make(chan struct{}),
+		closed:  make(chan struct{}),
+	}
+}
+
+func (r *blockingReadCloser) Read([]byte) (int, error) {
+	r.startOnce.Do(func() { close(r.started) })
+	<-r.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (r *blockingReadCloser) Close() error {
+	r.closeOnce.Do(func() { close(r.closed) })
+	return nil
+}
+
+func TestStreamTransportClosesUpstreamOnDownstreamDisconnect(t *testing.T) {
+	upstream := newBlockingReadCloser()
+	transport := &streamTransport{base: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+			Body:       upstream,
+		}, nil
+	})}
+	req, err := http.NewRequest(http.MethodPost, "https://upstream.test/v1/chat/completions", strings.NewReader(`{"stream":true}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-upstream.started:
+	case <-time.After(time.Second):
+		t.Fatal("stream producer did not begin reading upstream")
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-upstream.closed:
+	case <-time.After(time.Second):
+		t.Fatal("closing the downstream body did not close upstream")
+	}
+}
 
 func TestAddPaddingToStreamChunk(t *testing.T) {
 	tests := []struct {
@@ -57,15 +321,15 @@ func TestAddPaddingToStreamChunk(t *testing.T) {
 			},
 		},
 		{
-		name:  "chunk with empty string finish_reason",
-		input: `{"id":"chatcmpl-456","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":""}]}`,
-		validate: func(t *testing.T, output string) {
-			var result map[string]interface{}
-			if err := json.Unmarshal([]byte(output), &result); err != nil {
-				t.Fatalf("Failed to unmarshal output: %v", err)
-			}
+			name:  "chunk with empty string finish_reason",
+			input: `{"id":"chatcmpl-456","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":""}]}`,
+			validate: func(t *testing.T, output string) {
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					t.Fatalf("Failed to unmarshal output: %v", err)
+				}
 
-			choices := result["choices"].([]interface{})
+				choices := result["choices"].([]interface{})
 				choice := choices[0].(map[string]interface{})
 
 				// Empty string should be preserved
@@ -75,15 +339,15 @@ func TestAddPaddingToStreamChunk(t *testing.T) {
 			},
 		},
 		{
-		name:  "chunk with stop finish_reason",
-		input: `{"id":"chatcmpl-789","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}`,
-		validate: func(t *testing.T, output string) {
-			var result map[string]interface{}
-			if err := json.Unmarshal([]byte(output), &result); err != nil {
-				t.Fatalf("Failed to unmarshal output: %v", err)
-			}
+			name:  "chunk with stop finish_reason",
+			input: `{"id":"chatcmpl-789","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}`,
+			validate: func(t *testing.T, output string) {
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					t.Fatalf("Failed to unmarshal output: %v", err)
+				}
 
-			choices := result["choices"].([]interface{})
+				choices := result["choices"].([]interface{})
 				choice := choices[0].(map[string]interface{})
 
 				// stop should be preserved
@@ -103,16 +367,16 @@ func TestAddPaddingToStreamChunk(t *testing.T) {
 			},
 		},
 		{
-		name:  "chunk without delta",
-		input: `{"id":"chatcmpl-nodelta","choices":[{"index":0,"message":{"content":"test"}}]}`,
-		validate: func(t *testing.T, output string) {
-			// Should return unchanged when no delta
-			var result map[string]interface{}
-			if err := json.Unmarshal([]byte(output), &result); err != nil {
-				t.Fatalf("Failed to unmarshal output: %v", err)
-			}
+			name:  "chunk without delta",
+			input: `{"id":"chatcmpl-nodelta","choices":[{"index":0,"message":{"content":"test"}}]}`,
+			validate: func(t *testing.T, output string) {
+				// Should return unchanged when no delta
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					t.Fatalf("Failed to unmarshal output: %v", err)
+				}
 
-			choices := result["choices"].([]interface{})
+				choices := result["choices"].([]interface{})
 				choice := choices[0].(map[string]interface{})
 
 				if _, hasDelta := choice["delta"]; hasDelta {
@@ -126,15 +390,15 @@ func TestAddPaddingToStreamChunk(t *testing.T) {
 			shouldError: true,
 		},
 		{
-		name:  "complex nested structure preservation",
-		input: `{"id":"complex","choices":[{"index":0,"delta":{"role":"assistant","content":"Test","tool_calls":[{"id":"call_123","type":"function","function":{"name":"test","arguments":"{}"}}]},"finish_reason":null,"logprobs":{"content":[{"token":"Test","logprob":-0.5}]}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
-		validate: func(t *testing.T, output string) {
-			var result map[string]interface{}
-			if err := json.Unmarshal([]byte(output), &result); err != nil {
-				t.Fatalf("Failed to unmarshal output: %v", err)
-			}
+			name:  "complex nested structure preservation",
+			input: `{"id":"complex","choices":[{"index":0,"delta":{"role":"assistant","content":"Test","tool_calls":[{"id":"call_123","type":"function","function":{"name":"test","arguments":"{}"}}]},"finish_reason":null,"logprobs":{"content":[{"token":"Test","logprob":-0.5}]}}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+			validate: func(t *testing.T, output string) {
+				var result map[string]interface{}
+				if err := json.Unmarshal([]byte(output), &result); err != nil {
+					t.Fatalf("Failed to unmarshal output: %v", err)
+				}
 
-			// Check that complex nested structures are preserved
+				// Check that complex nested structures are preserved
 				choices := result["choices"].([]interface{})
 				choice := choices[0].(map[string]interface{})
 				delta := choice["delta"].(map[string]interface{})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes chat response streaming by detecting SSE via Content-Type (ignoring parameters) and forwarding chunks line-by-line with a bounded scanner—no buffering or truncation. Request bodies are untouched; transformed streams clear Content-Length; upstream errors and client disconnects are handled correctly.

- **Bug Fixes**
  - Stop reading/parsing request bodies; forward as-is.
  - Only stream when Content-Type is text/event-stream; pass others through.
  - Use a line-based bufio.Scanner with increased limits (4MB/line) to preserve large events and `data: [DONE]`, while rejecting unbounded lines safely.
  - Propagate upstream read errors and close upstream when the client closes the response body.

<sup>Written for commit bc3e611478987c7a08e479c2a5b75af679c03f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

