### PR TITLE
Validate /metrics online-only in the shim

### DIFF
--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -71,6 +71,22 @@ func requiresAuth(authenticatedEndpoints *[]string, path string) bool {
 	return pathAllowed(*authenticatedEndpoints, path)
 }
 
+// metricsValidator validates /metrics online-only: the local JWT leg accepts
+// any inference-scoped token without consulting the control plane, which would
+// bypass its admin-key requirement for /metrics. All other paths use the full
+// chain.
+type metricsValidator struct {
+	online key.Validator
+	chain  key.Validator
+}
+
+func (v *metricsValidator) Validate(req key.Request) error {
+	if req.Path == "/metrics" {
+		return v.online.Validate(req)
+	}
+	return v.chain.Validate(req)
+}
+
 // extractBearerToken returns the token portion of an Authorization header,
 // accepting any capitalization of the "Bearer" scheme.
 func extractBearerToken(header string) string {

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -14,7 +14,39 @@ import (
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 	tinfoilattestation "tinfoil/internal/attestation"
 	"tinfoil/internal/config"
+	"tinfoil/internal/key"
 )
+
+type fakeValidator struct {
+	err   error
+	calls []key.Request
+}
+
+func (f *fakeValidator) Validate(req key.Request) error {
+	f.calls = append(f.calls, req)
+	return f.err
+}
+
+func testAuthServer(t *testing.T, validator key.Validator, authenticatedEndpoints []string) http.Handler {
+	t.Helper()
+
+	id, err := identity.NewIdentity()
+	if err != nil {
+		t.Fatalf("creating identity: %v", err)
+	}
+
+	cfg := &config.Config{
+		UpstreamPort:           9999,
+		AuthenticatedEndpoints: &authenticatedEndpoints,
+	}
+	extCfg := &config.ExternalConfig{}
+	att := &attestation.Document{
+		Format: "https://tinfoil.sh/predicate/dummy/v2",
+		Body:   "deadbeef",
+	}
+
+	return NewShimServer(validator, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, "127.0.0.1:9999")
+}
 
 func testServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
 	t.Helper()
@@ -141,6 +173,77 @@ func TestRequiresAuth(t *testing.T) {
 				t.Errorf("requiresAuth(%v, %q) = %v, want %v", tt.authenticatedEndpoints, tt.path, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMetricsValidation_JWTGoesOnline(t *testing.T) {
+	// The local JWT leg accepts any inference-scoped token; /metrics must not
+	// be satisfiable by it, so the online validator's verdict is final.
+	jwt := &fakeValidator{err: nil}
+	online := &fakeValidator{err: &key.ValidationError{StatusCode: http.StatusForbidden}}
+	validator := &metricsValidator{online: online, chain: key.NewChain(jwt, online)}
+
+	handler := testAuthServer(t, validator, []string{"/metrics", "/v1/chat/completions"})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJFZERTQSJ9.e30.sig")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 from online validator, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(jwt.calls) != 0 {
+		t.Fatalf("local JWT validator must not be consulted for /metrics, calls=%d", len(jwt.calls))
+	}
+	if len(online.calls) != 1 || online.calls[0].Path != "/metrics" {
+		t.Fatalf("online validator calls = %+v, want one call with path /metrics", online.calls)
+	}
+}
+
+func TestMetricsValidation_OpaqueKeyGoesOnline(t *testing.T) {
+	jwt := &fakeValidator{err: key.ErrUnsupportedToken}
+	online := &fakeValidator{err: nil}
+	validator := &metricsValidator{online: online, chain: key.NewChain(jwt, online)}
+
+	handler := testAuthServer(t, validator, []string{"/metrics"})
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer tk-admin-key")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusForbidden {
+		t.Fatalf("online-accepted key should pass validation, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(online.calls) != 1 {
+		t.Fatalf("online validator calls = %d, want 1", len(online.calls))
+	}
+	if got := online.calls[0]; got.APIKey != "tk-admin-key" || got.Path != "/metrics" {
+		t.Fatalf("online validation request = %+v", got)
+	}
+}
+
+func TestMetricsValidation_OtherPathsKeepChain(t *testing.T) {
+	jwt := &fakeValidator{err: nil}
+	online := &fakeValidator{err: &key.ValidationError{StatusCode: http.StatusForbidden}}
+	validator := &metricsValidator{online: online, chain: key.NewChain(jwt, online)}
+
+	handler := testAuthServer(t, validator, []string{"/metrics", "/v1/chat/completions"})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer eyJhbGciOiJFZERTQSJ9.e30.sig")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusUnauthorized || rec.Code == http.StatusForbidden {
+		t.Fatalf("locally-validated JWT should pass on inference paths, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(jwt.calls) != 1 {
+		t.Fatalf("jwt validator calls = %d, want 1", len(jwt.calls))
+	}
+	if len(online.calls) != 0 {
+		t.Fatalf("online validator must not be consulted when JWT leg succeeds, calls=%d", len(online.calls))
 	}
 }
 

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -211,7 +211,10 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 				jwksURL := controlPlaneURL.JoinPath(".well-known", "jwks.json").String()
 				jwtValidator := localjwt.NewValidator(jwksURL, config.ControlPlane, localjwt.AccessTokenAudience, localjwt.RequiredScope)
 				log.Println("Local JWT validation enabled (OAuth access tokens verified in-enclave)")
-				validator = key.NewChain(jwtValidator, onlineValidator)
+				validator = &metricsValidator{
+					online: onlineValidator,
+					chain:  key.NewChain(jwtValidator, onlineValidator),
+				}
 			} else {
 				log.Println("Warning: API key verification disabled (unauthenticated endpoint)")
 			}


### PR DESCRIPTION
Routes /metrics authentication through the online validator only, so locally-verified OAuth access tokens can no longer satisfy it and the control plane's admin-key policy for /metrics (tinfoilsh/controlplane#499) is authoritative. Every other authenticated path keeps the existing JWT-then-online chain, and configs that don't list /metrics in authenticated-endpoints see no change at all.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces online-only validation for /metrics so locally validated OAuth access tokens no longer work, making the control plane’s admin-key policy authoritative. Other authenticated paths keep the JWT→online chain; setups that don’t list /metrics in authenticated endpoints are unaffected.

- **Migration**
  - Use an admin key for /metrics requests; OAuth access tokens will be rejected.

<sup>Written for commit f174424817fbef9bd0c5b2280df40aee3544c3ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

