### PR TITLE
Extract minimal device-mapper API

### DIFF
--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/tinfoilsh/modelwrap v0.2.0
 	github.com/tinfoilsh/tinfoil-go/verifier v0.12.0
 	golang.org/x/net v0.48.0
+	golang.org/x/sys v0.40.0
 	golang.org/x/time v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -72,7 +73,6 @@ require (
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
-	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect

--- a/tinfoil/internal/devicemapper/devicemapper.go
+++ b/tinfoil/internal/devicemapper/devicemapper.go
@@ -92,25 +92,28 @@ func OpenControl() (*os.File, error) {
 
 // EnsureControlNode creates /dev/mapper/control from its sysfs device number.
 func EnsureControlNode() error {
-	if isCharDevice(ControlNode) {
-		return nil
-	}
 	deadline := time.Now().Add(5 * time.Second)
 	var lastErr error
 	for {
 		major, minor, err := readMajorMinor(controlDevicePath)
 		if err == nil {
+			dev := unix.Mkdev(major, minor)
+			if deviceNodeMatches(ControlNode, true, dev) {
+				return nil
+			}
 			if err := os.MkdirAll(filepath.Dir(ControlNode), 0755); err != nil {
 				return err
 			}
-			dev := int(unix.Mkdev(major, minor))
-			if err := unix.Mknod(ControlNode, unix.S_IFCHR|0600, dev); err != nil && !errors.Is(err, unix.EEXIST) {
+			if err := removeStaleNode(ControlNode); err != nil {
+				return fmt.Errorf("removing stale %s: %w", ControlNode, err)
+			}
+			if err := unix.Mknod(ControlNode, unix.S_IFCHR|0600, int(dev)); err != nil && !errors.Is(err, unix.EEXIST) {
 				return fmt.Errorf("creating %s: %w", ControlNode, err)
 			}
-			if isCharDevice(ControlNode) {
+			if deviceNodeMatches(ControlNode, true, dev) {
 				return nil
 			}
-			lastErr = fmt.Errorf("%s was created but is not a character device", ControlNode)
+			lastErr = fmt.Errorf("%s does not match device-mapper device %d:%d", ControlNode, major, minor)
 		} else {
 			lastErr = err
 		}
@@ -126,22 +129,17 @@ func EnsureBlockNode(path string, dev uint64) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	if info, err := os.Stat(path); err == nil {
-		if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
-			if stat, ok := info.Sys().(*syscall.Stat_t); ok &&
-				unix.Major(stat.Rdev) == unix.Major(dev) &&
-				unix.Minor(stat.Rdev) == unix.Minor(dev) {
-				return nil
-			}
-		}
-		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("removing stale %s: %w", path, err)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return err
+	if deviceNodeMatches(path, false, dev) {
+		return nil
+	}
+	if err := removeStaleNode(path); err != nil {
+		return fmt.Errorf("removing stale %s: %w", path, err)
 	}
 	if err := unix.Mknod(path, unix.S_IFBLK|0600, int(dev)); err != nil {
 		return fmt.Errorf("creating %s: %w", path, err)
+	}
+	if !deviceNodeMatches(path, false, dev) {
+		return fmt.Errorf("%s does not match device-mapper block device %d:%d", path, unix.Major(dev), unix.Minor(dev))
 	}
 	return nil
 }
@@ -252,8 +250,11 @@ func baseBuffer(size int, name string) []byte {
 }
 
 func tableLoadBuffer(name string, lengthSectors uint64, targetType, params string) ([]byte, error) {
-	if targetType == "" || len(targetType) >= 16 {
+	if targetType == "" || len(targetType) >= 16 || strings.IndexByte(targetType, 0) >= 0 {
 		return nil, fmt.Errorf("invalid device-mapper target type %q", targetType)
+	}
+	if strings.IndexByte(params, 0) >= 0 {
+		return nil, fmt.Errorf("device-mapper target parameters contain NUL")
 	}
 	targetSize := align(targetSpecSize+len(params)+1, targetSpecAlign)
 	buf := baseBuffer(ioctlSize+targetSize, name)
@@ -302,9 +303,31 @@ func align(value, alignment int) int {
 	return (value + alignment - 1) &^ (alignment - 1)
 }
 
-func isCharDevice(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
+func deviceNodeMatches(path string, charDevice bool, dev uint64) bool {
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 {
+		return false
+	}
+	if charDevice {
+		if info.Mode()&os.ModeCharDevice == 0 {
+			return false
+		}
+	} else if info.Mode()&os.ModeDevice == 0 || info.Mode()&os.ModeCharDevice != 0 {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	return ok &&
+		unix.Major(stat.Rdev) == unix.Major(dev) &&
+		unix.Minor(stat.Rdev) == unix.Minor(dev)
+}
+
+func removeStaleNode(path string) error {
+	if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+		return nil
+	} else if err != nil {
+		return err
+	}
+	return os.Remove(path)
 }
 
 func readMajorMinor(path string) (uint32, uint32, error) {

--- a/tinfoil/internal/devicemapper/devicemapper.go
+++ b/tinfoil/internal/devicemapper/devicemapper.go
@@ -1,0 +1,327 @@
+// Package devicemapper provides the minimal device-mapper ioctl operations
+// needed to create and activate a read-only mapping.
+package devicemapper
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	ControlNode = "/dev/mapper/control"
+
+	controlDevicePath = "/sys/class/misc/device-mapper/dev"
+	ioctlSize         = 312
+	ioctlDataStart    = ioctlSize
+	targetSpecSize    = 40
+	nameOffset        = 48
+	devOffset         = 40
+	targetSpecAlign   = 8
+	maxNameLen        = 127
+
+	versionMajor = 4
+	versionMinor = 0
+	versionPatch = 0
+
+	versionCmd    = 0
+	devCreateCmd  = 3
+	devSuspendCmd = 6
+	devStatusCmd  = 7
+	tableLoadCmd  = 9
+
+	readOnlyFlag      = 1 << 0
+	existsFlag        = 0x00000004
+	activePresentFlag = 1 << 5
+	ioctlMagic        = 0xfd
+	ioctlReadWrite    = 3
+)
+
+const (
+	versionIOCTL    = uintptr((ioctlReadWrite << 30) | (ioctlSize << 16) | (ioctlMagic << 8) | versionCmd)
+	devCreateIOCTL  = uintptr((ioctlReadWrite << 30) | (ioctlSize << 16) | (ioctlMagic << 8) | devCreateCmd)
+	devSuspendIOCTL = uintptr((ioctlReadWrite << 30) | (ioctlSize << 16) | (ioctlMagic << 8) | devSuspendCmd)
+	devStatusIOCTL  = uintptr((ioctlReadWrite << 30) | (ioctlSize << 16) | (ioctlMagic << 8) | devStatusCmd)
+	tableLoadIOCTL  = uintptr((ioctlReadWrite << 30) | (ioctlSize << 16) | (ioctlMagic << 8) | tableLoadCmd)
+)
+
+// Version is the device-mapper ioctl protocol version reported by the kernel.
+type Version struct {
+	Major uint32
+	Minor uint32
+	Patch uint32
+}
+
+// Info is the device state returned by create and status ioctls.
+type Info struct {
+	Dev         uint64
+	Flags       uint32
+	OpenCount   int32
+	TargetCount uint32
+}
+
+// Active reports whether the device has an active table.
+func (info Info) Active() bool {
+	return info.Flags&activePresentFlag != 0
+}
+
+// ReadOnly reports whether the device is read-only.
+func (info Info) ReadOnly() bool {
+	return info.Flags&readOnlyFlag != 0
+}
+
+// OpenControl ensures the control node exists and opens it for ioctls.
+func OpenControl() (*os.File, error) {
+	if err := EnsureControlNode(); err != nil {
+		return nil, err
+	}
+	control, err := os.OpenFile(ControlNode, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", ControlNode, err)
+	}
+	return control, nil
+}
+
+// EnsureControlNode creates /dev/mapper/control from its sysfs device number.
+func EnsureControlNode() error {
+	if isCharDevice(ControlNode) {
+		return nil
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
+	for {
+		major, minor, err := readMajorMinor(controlDevicePath)
+		if err == nil {
+			if err := os.MkdirAll(filepath.Dir(ControlNode), 0755); err != nil {
+				return err
+			}
+			dev := int(unix.Mkdev(major, minor))
+			if err := unix.Mknod(ControlNode, unix.S_IFCHR|0600, dev); err != nil && !errors.Is(err, unix.EEXIST) {
+				return fmt.Errorf("creating %s: %w", ControlNode, err)
+			}
+			if isCharDevice(ControlNode) {
+				return nil
+			}
+			lastErr = fmt.Errorf("%s was created but is not a character device", ControlNode)
+		} else {
+			lastErr = err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("device-mapper control node not ready: %w", lastErr)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// EnsureBlockNode creates path for the block device returned by device-mapper.
+func EnsureBlockNode(path string, dev uint64) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	if info, err := os.Stat(path); err == nil {
+		if info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
+			if stat, ok := info.Sys().(*syscall.Stat_t); ok &&
+				unix.Major(stat.Rdev) == unix.Major(dev) &&
+				unix.Minor(stat.Rdev) == unix.Minor(dev) {
+				return nil
+			}
+		}
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("removing stale %s: %w", path, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := unix.Mknod(path, unix.S_IFBLK|0600, int(dev)); err != nil {
+		return fmt.Errorf("creating %s: %w", path, err)
+	}
+	return nil
+}
+
+// CheckVersion verifies and returns the kernel's ioctl protocol version.
+func CheckVersion(control *os.File) (Version, error) {
+	buf := baseBuffer(ioctlSize, "")
+	if err := ioctl(control, versionIOCTL, buf); err != nil {
+		return Version{}, fmt.Errorf("device-mapper version ioctl failed: %w", err)
+	}
+	version := Version{
+		Major: binary.LittleEndian.Uint32(buf[0:4]),
+		Minor: binary.LittleEndian.Uint32(buf[4:8]),
+		Patch: binary.LittleEndian.Uint32(buf[8:12]),
+	}
+	if version.Major != versionMajor {
+		return Version{}, fmt.Errorf("unsupported device-mapper ioctl major version %d", version.Major)
+	}
+	return version, nil
+}
+
+// CreateReadOnly creates an empty read-only device-mapper device.
+func CreateReadOnly(control *os.File, name string) (Info, error) {
+	if err := validateName(name); err != nil {
+		return Info{}, err
+	}
+	buf := baseBuffer(16*1024, name)
+	setFlags(buf, readOnlyFlag|existsFlag)
+	if err := ioctl(control, devCreateIOCTL, buf); err != nil {
+		return Info{}, fmt.Errorf("device-mapper create %s failed: %w", name, err)
+	}
+	return infoFromBuffer(buf), nil
+}
+
+// LoadReadOnlyTable loads one read-only target covering lengthSectors.
+func LoadReadOnlyTable(control *os.File, name string, lengthSectors uint64, targetType, params string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	buf, err := tableLoadBuffer(name, lengthSectors, targetType, params)
+	if err != nil {
+		return err
+	}
+	if err := ioctl(control, tableLoadIOCTL, buf); err != nil {
+		return fmt.Errorf("device-mapper table load %s failed: %w", name, err)
+	}
+	return nil
+}
+
+// ResumeReadOnly activates a loaded read-only table.
+func ResumeReadOnly(control *os.File, name string) error {
+	if err := validateName(name); err != nil {
+		return err
+	}
+	buf := baseBuffer(2*1024, name)
+	setFlags(buf, readOnlyFlag|existsFlag)
+	if err := ioctl(control, devSuspendIOCTL, buf); err != nil {
+		return fmt.Errorf("device-mapper resume %s failed: %w", name, err)
+	}
+	return nil
+}
+
+// Status returns the current device state.
+func Status(control *os.File, name string) (Info, error) {
+	if err := validateName(name); err != nil {
+		return Info{}, err
+	}
+	buf := baseBuffer(16*1024, name)
+	setFlags(buf, existsFlag)
+	if err := ioctl(control, devStatusIOCTL, buf); err != nil {
+		return Info{}, fmt.Errorf("device-mapper status %s failed: %w", name, err)
+	}
+	info := infoFromBuffer(buf)
+	if info.Flags&existsFlag == 0 {
+		return Info{}, fmt.Errorf("device-mapper device %s does not exist", name)
+	}
+	return info, nil
+}
+
+func validateName(name string) error {
+	if name == "" || len(name) > maxNameLen {
+		return fmt.Errorf("invalid device-mapper name length for %q", name)
+	}
+	for _, char := range name {
+		if char >= 'a' && char <= 'z' ||
+			char >= 'A' && char <= 'Z' ||
+			char >= '0' && char <= '9' ||
+			strings.ContainsRune("-_.+", char) {
+			continue
+		}
+		return fmt.Errorf("invalid character %q in device-mapper name %q", char, name)
+	}
+	return nil
+}
+
+func baseBuffer(size int, name string) []byte {
+	if size < ioctlSize {
+		size = ioctlSize
+	}
+	buf := make([]byte, size)
+	binary.LittleEndian.PutUint32(buf[0:4], versionMajor)
+	binary.LittleEndian.PutUint32(buf[4:8], versionMinor)
+	binary.LittleEndian.PutUint32(buf[8:12], versionPatch)
+	binary.LittleEndian.PutUint32(buf[12:16], uint32(len(buf)))
+	binary.LittleEndian.PutUint32(buf[16:20], ioctlDataStart)
+	putCString(buf[nameOffset:nameOffset+128], name)
+	return buf
+}
+
+func tableLoadBuffer(name string, lengthSectors uint64, targetType, params string) ([]byte, error) {
+	if targetType == "" || len(targetType) >= 16 {
+		return nil, fmt.Errorf("invalid device-mapper target type %q", targetType)
+	}
+	targetSize := align(targetSpecSize+len(params)+1, targetSpecAlign)
+	buf := baseBuffer(ioctlSize+targetSize, name)
+	setFlags(buf, readOnlyFlag|existsFlag)
+	binary.LittleEndian.PutUint32(buf[20:24], 1)
+
+	spec := buf[ioctlSize : ioctlSize+targetSpecSize]
+	binary.LittleEndian.PutUint64(spec[0:8], 0)
+	binary.LittleEndian.PutUint64(spec[8:16], lengthSectors)
+	binary.LittleEndian.PutUint32(spec[20:24], uint32(targetSize))
+	putCString(spec[24:40], targetType)
+	putCString(buf[ioctlSize+targetSpecSize:ioctlSize+targetSize], params)
+	return buf, nil
+}
+
+func setFlags(buf []byte, flags uint32) {
+	binary.LittleEndian.PutUint32(buf[28:32], flags)
+}
+
+func infoFromBuffer(buf []byte) Info {
+	return Info{
+		Dev:         binary.LittleEndian.Uint64(buf[devOffset : devOffset+8]),
+		Flags:       binary.LittleEndian.Uint32(buf[28:32]),
+		OpenCount:   int32(binary.LittleEndian.Uint32(buf[24:28])),
+		TargetCount: binary.LittleEndian.Uint32(buf[20:24]),
+	}
+}
+
+func ioctl(control *os.File, request uintptr, buf []byte) error {
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, control.Fd(), request, uintptr(unsafe.Pointer(&buf[0])))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+func putCString(dst []byte, value string) {
+	if len(dst) == 0 {
+		return
+	}
+	n := copy(dst[:len(dst)-1], value)
+	dst[n] = 0
+}
+
+func align(value, alignment int) int {
+	return (value + alignment - 1) &^ (alignment - 1)
+}
+
+func isCharDevice(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+func readMajorMinor(path string) (uint32, uint32, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	majorText, minorText, ok := strings.Cut(strings.TrimSpace(string(data)), ":")
+	if !ok {
+		return 0, 0, fmt.Errorf("invalid device number in %s", path)
+	}
+	var major, minor uint32
+	if _, err := fmt.Sscanf(majorText, "%d", &major); err != nil {
+		return 0, 0, fmt.Errorf("invalid major in %s: %w", path, err)
+	}
+	if _, err := fmt.Sscanf(minorText, "%d", &minor); err != nil {
+		return 0, 0, fmt.Errorf("invalid minor in %s: %w", path, err)
+	}
+	return major, minor, nil
+}

--- a/tinfoil/internal/devicemapper/devicemapper_test.go
+++ b/tinfoil/internal/devicemapper/devicemapper_test.go
@@ -1,0 +1,107 @@
+package devicemapper
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIoctlConstants(t *testing.T) {
+	if ioctlSize != 312 || targetSpecSize != 40 {
+		t.Fatalf("unexpected dm ioctl layout: ioctl=%d target=%d", ioctlSize, targetSpecSize)
+	}
+	for name, tc := range map[string]struct {
+		got  uintptr
+		want uintptr
+	}{
+		"version":    {versionIOCTL, 0xc138fd00},
+		"create":     {devCreateIOCTL, 0xc138fd03},
+		"resume":     {devSuspendIOCTL, 0xc138fd06},
+		"status":     {devStatusIOCTL, 0xc138fd07},
+		"table load": {tableLoadIOCTL, 0xc138fd09},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Fatalf("unexpected ioctl number: got %#x want %#x", tc.got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTableLoadBuffer(t *testing.T) {
+	buf, err := tableLoadBuffer("root", 6291456, "verity", "1 8:1 8:2 4096 4096 786432 1 sha256 abcdef 012345")
+	if err != nil {
+		t.Fatalf("tableLoadBuffer: %v", err)
+	}
+	if binary.LittleEndian.Uint32(buf[0:4]) != 4 ||
+		binary.LittleEndian.Uint32(buf[12:16]) != uint32(len(buf)) ||
+		binary.LittleEndian.Uint32(buf[16:20]) != ioctlDataStart ||
+		binary.LittleEndian.Uint32(buf[20:24]) != 1 ||
+		binary.LittleEndian.Uint32(buf[28:32]) != readOnlyFlag|existsFlag {
+		t.Fatalf("unexpected dm ioctl header")
+	}
+	if got := cString(buf[nameOffset : nameOffset+128]); got != "root" {
+		t.Fatalf("unexpected dm name %q", got)
+	}
+
+	spec := buf[ioctlSize : ioctlSize+targetSpecSize]
+	if binary.LittleEndian.Uint64(spec[0:8]) != 0 ||
+		binary.LittleEndian.Uint64(spec[8:16]) != 6291456 {
+		t.Fatalf("unexpected target range")
+	}
+	next := binary.LittleEndian.Uint32(spec[20:24])
+	if next%targetSpecAlign != 0 || int(next) != len(buf)-ioctlSize {
+		t.Fatalf("unexpected next target offset %d for len %d", next, len(buf))
+	}
+	if got := cString(spec[24:40]); got != "verity" {
+		t.Fatalf("unexpected target type %q", got)
+	}
+	if got := cString(buf[ioctlSize+targetSpecSize:]); got != "1 8:1 8:2 4096 4096 786432 1 sha256 abcdef 012345" {
+		t.Fatalf("unexpected target params %q", got)
+	}
+}
+
+func TestReadMajorMinor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "dev")
+	if err := os.WriteFile(path, []byte("10:236\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	major, minor, err := readMajorMinor(path)
+	if err != nil {
+		t.Fatalf("readMajorMinor: %v", err)
+	}
+	if major != 10 || minor != 236 {
+		t.Fatalf("unexpected major/minor %d:%d", major, minor)
+	}
+}
+
+func TestValidateName(t *testing.T) {
+	for _, name := range []string{"root", "model.sha256-dead_beef+1"} {
+		if err := validateName(name); err != nil {
+			t.Fatalf("valid name %q rejected: %v", name, err)
+		}
+	}
+	for _, name := range []string{"", "name/with/slash", strings.Repeat("x", maxNameLen+1)} {
+		if err := validateName(name); err == nil {
+			t.Fatalf("invalid name %q accepted", name)
+		}
+	}
+}
+
+func TestPutCStringAlwaysTerminates(t *testing.T) {
+	buf := bytes.Repeat([]byte{0xff}, 4)
+	putCString(buf, "longer-than-buffer")
+	if !bytes.Equal(buf, []byte{'l', 'o', 'n', 0}) {
+		t.Fatalf("putCString result = %v, want truncated NUL-terminated string", buf)
+	}
+}
+
+func cString(buf []byte) string {
+	if index := bytes.IndexByte(buf, 0); index >= 0 {
+		buf = buf[:index]
+	}
+	return string(buf)
+}

--- a/tinfoil/internal/devicemapper/devicemapper_test.go
+++ b/tinfoil/internal/devicemapper/devicemapper_test.go
@@ -6,7 +6,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestIoctlConstants(t *testing.T) {
@@ -64,6 +67,22 @@ func TestTableLoadBuffer(t *testing.T) {
 	}
 }
 
+func TestTableLoadBufferRejectsEmbeddedNUL(t *testing.T) {
+	for name, tc := range map[string]struct {
+		targetType string
+		params     string
+	}{
+		"target type": {targetType: "ver\x00ity", params: "valid"},
+		"parameters":  {targetType: "verity", params: "valid\x00ignored"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := tableLoadBuffer("root", 1, tc.targetType, tc.params); err == nil {
+				t.Fatal("embedded NUL accepted")
+			}
+		})
+	}
+}
+
 func TestReadMajorMinor(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "dev")
 	if err := os.WriteFile(path, []byte("10:236\n"), 0644); err != nil {
@@ -75,6 +94,35 @@ func TestReadMajorMinor(t *testing.T) {
 	}
 	if major != 10 || minor != 236 {
 		t.Fatalf("unexpected major/minor %d:%d", major, minor)
+	}
+}
+
+func TestDeviceNodeMatchesTypeAndDeviceNumber(t *testing.T) {
+	info, err := os.Lstat("/dev/null")
+	if err != nil {
+		t.Skipf("/dev/null unavailable: %v", err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		t.Fatal("/dev/null stat has unexpected type")
+	}
+	if !deviceNodeMatches("/dev/null", true, stat.Rdev) {
+		t.Fatal("matching character device rejected")
+	}
+	wrongDev := unix.Mkdev(unix.Major(stat.Rdev), unix.Minor(stat.Rdev)+1)
+	if deviceNodeMatches("/dev/null", true, wrongDev) {
+		t.Fatal("wrong device number accepted")
+	}
+	if deviceNodeMatches("/dev/null", false, stat.Rdev) {
+		t.Fatal("character device accepted as block device")
+	}
+
+	link := filepath.Join(t.TempDir(), "null")
+	if err := os.Symlink("/dev/null", link); err != nil {
+		t.Fatal(err)
+	}
+	if deviceNodeMatches(link, true, stat.Rdev) {
+		t.Fatal("symlink accepted as device node")
 	}
 }
 


### PR DESCRIPTION
## Why

The measured-root initrd needs a small auditable device-mapper mechanism. This isolates only the required ioctl encoding before any boot-path consumer is introduced.

## Changes

- add create, read-only table load, resume, and status operations
- create the control/block device nodes from kernel-reported device numbers
- validate mapping names and C-string termination
- test ioctl constants and encoded table layout directly
- make the existing `x/sys` dependency direct

## Non-goals

No current command imports this package. This PR does not add dm-verity policy, an initrd, image wiring, or runtime behavior.

## Review surface

435 additions, 1 deletion across three files. The entire production surface is the single `internal/devicemapper` implementation.

## Validation

- `go build ./...`
- `go test ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal device-mapper API to create and activate read-only mappings, plus helpers to create required device nodes. It also hardens node handling and ioctl inputs, isolating the measured-root boot path behind a small, auditable package.

- **New Features**
  - Introduces `internal/devicemapper` with create, read-only table load, resume, and status ioctls.
  - Creates `/dev/mapper/control` and block nodes from sysfs device numbers, waits until ready, removes stale/mismatched nodes, enforces device type, and rejects symlinks.
  - Validates mapping names and ensures C-string termination; rejects embedded NUL in target types/params.
  - Tests ioctl numbers and encoded table layout.

- **Dependencies**
  - Makes `golang.org/x/sys` a direct dependency.

<sup>Written for commit f2c773ba307d64a70fd68eaa4060be100cdf8648. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

