### PR TITLE
Consume fixed guest topology and external network

### DIFF
--- a/mkosi.extra/etc/systemd/network/20-enp0s2.network
+++ b/mkosi.extra/etc/systemd/network/20-enp0s2.network
@@ -1,6 +1,7 @@
 [Match]
-Name=enp0s2
+Path=pci-0000:00:02.0
 
-[Network]
-DHCP=yes
-IPv6AcceptRA=no
+[Link]
+# tinfoil-boot exclusively owns this measured NIC and applies the validated
+# external_config.network contract. networkd must not start or renew DHCP.
+Unmanaged=yes

--- a/mkosi.extra/etc/systemd/system/tinfoil-boot.service
+++ b/mkosi.extra/etc/systemd/system/tinfoil-boot.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Tinfoil Boot Service
-After=network-online.target docker.service containerd.service nvidia-persistenced.service nvidia-fabricmanager.service nvidia-cdi-refresh.service nftables.service
-Requires=network-online.target docker.service containerd.service nftables.service
+After=systemd-resolved.service docker.service containerd.service nvidia-persistenced.service nvidia-fabricmanager.service nvidia-cdi-refresh.service nftables.service
+Requires=systemd-resolved.service docker.service containerd.service nftables.service
 Wants=nvidia-persistenced.service nvidia-fabricmanager.service nvidia-cdi-refresh.service
 
 [Service]

--- a/tinfoil/cmd/boot/auth.go
+++ b/tinfoil/cmd/boot/auth.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"tinfoil/internal/boot"
+	shimconfig "tinfoil/internal/config"
 )
 
 const (
@@ -28,11 +29,9 @@ type DockerAuth struct {
 // Supports:
 //   - REGISTRY_<HOST>_USER/TOKEN (e.g., REGISTRY_GHCR_IO_TOKEN)
 //   - GCLOUD_KEY/GCLOUD_REGISTRY (GCP service account for Artifact Registry)
-func setupRegistryAuth() error {
+func setupRegistryAuth(ext *shimconfig.ExternalConfig) error {
 	os.Setenv("DOCKER_CONFIG", boot.DockerConfigDir)
-
-	ext, err := getExternalConfig()
-	if err != nil || ext.Secrets == nil {
+	if ext == nil || ext.Secrets == nil {
 		log.Println("No external config, skipping registry auth")
 		return nil
 	}
@@ -108,4 +107,3 @@ func setupRegistryAuth() error {
 	}
 	return nil
 }
-

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -147,9 +147,6 @@ func validateExternalNetwork(config *shimconfig.ExternalNetworkConfig) error {
 	if config == nil {
 		return fmt.Errorf("network section is required")
 	}
-	if config.Version != 2 {
-		return fmt.Errorf("unsupported external network version %d", config.Version)
-	}
 	prefix, err := netip.ParsePrefix(config.Address)
 	if err != nil || !prefix.Addr().Is4() {
 		return fmt.Errorf("invalid IPv4 address %q", config.Address)
@@ -160,20 +157,6 @@ func validateExternalNetwork(config *shimconfig.ExternalNetworkConfig) error {
 	gateway, err := netip.ParseAddr(config.Gateway)
 	if err != nil || !gateway.Is4() {
 		return fmt.Errorf("invalid IPv4 gateway %q", config.Gateway)
-	}
-	if len(config.Nameservers) == 0 || len(config.Nameservers) > 3 {
-		return fmt.Errorf("external network requires 1 to 3 DNS servers")
-	}
-	seenNameservers := make(map[netip.Addr]struct{}, len(config.Nameservers))
-	for _, value := range config.Nameservers {
-		nameserver, err := netip.ParseAddr(value)
-		if err != nil || !nameserver.Is4() {
-			return fmt.Errorf("invalid IPv4 DNS server %q", value)
-		}
-		if _, duplicate := seenNameservers[nameserver]; duplicate {
-			return fmt.Errorf("duplicate DNS server %q", value)
-		}
-		seenNameservers[nameserver] = struct{}{}
 	}
 	if !prefix.Contains(gateway) {
 		return fmt.Errorf("gateway %s is outside address subnet %s", config.Gateway, config.Address)

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"log"
+	"net/netip"
 	"os"
 	"strings"
 
@@ -11,6 +13,7 @@ import (
 
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/device"
 )
 
 // Config represents the main configuration file
@@ -123,12 +126,8 @@ type Healthcheck struct {
 	StartPeriod string   `yaml:"start_period,omitempty"` // "60s"
 }
 
-const (
-	configDiskPath   = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_tinfoil-config"
-	externalDiskPath = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_tinfoil-ext-config"
-)
-
 const maxGPUCount = 8
+const maxDiskPayloadBytes = 1 << 20
 
 func validateGPUCount(count int) error {
 	if count < 0 || count > maxGPUCount {
@@ -137,14 +136,62 @@ func validateGPUCount(count int) error {
 	return nil
 }
 
-// loadAndVerifyConfig reads the config from disk and verifies its hash
-func loadAndVerifyConfig() (*Config, error) {
-	if _, err := os.Stat(configDiskPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("config disk not found at %s", configDiskPath)
+func validateModelCount(count int) error {
+	if count < 0 || count > device.MaxModelDisks {
+		return fmt.Errorf("models must contain at most %d entries (got %d)", device.MaxModelDisks, count)
+	}
+	return nil
+}
+
+func validateExternalNetwork(config *shimconfig.ExternalNetworkConfig) error {
+	if config == nil {
+		return fmt.Errorf("network section is required")
+	}
+	if config.Version != 1 {
+		return fmt.Errorf("unsupported external network version %d", config.Version)
+	}
+	prefix, err := netip.ParsePrefix(config.Address)
+	if err != nil || !prefix.Addr().Is4() {
+		return fmt.Errorf("invalid IPv4 address %q", config.Address)
+	}
+	gateway, err := netip.ParseAddr(config.Gateway)
+	if err != nil || !gateway.Is4() {
+		return fmt.Errorf("invalid IPv4 gateway %q", config.Gateway)
+	}
+	if !prefix.Contains(gateway) {
+		return fmt.Errorf("gateway %s is outside address subnet %s", config.Gateway, config.Address)
 	}
 
-	// Read config from disk device (strip null bytes)
-	configData, err := readDiskAndStripNulls(configDiskPath)
+	address := prefix.Addr()
+	network := prefix.Masked().Addr()
+	broadcast := ipv4Broadcast(prefix)
+	if gateway == network || gateway == broadcast {
+		return fmt.Errorf("gateway %s is reserved in subnet %s", gateway, prefix)
+	}
+	if address == network ||
+		address == broadcast ||
+		address == gateway {
+		return fmt.Errorf("address %s is reserved in subnet %s", address, prefix)
+	}
+	return nil
+}
+
+func ipv4Broadcast(prefix netip.Prefix) netip.Addr {
+	broadcast := prefix.Masked().Addr().As4()
+	for bit := prefix.Bits(); bit < 32; bit++ {
+		broadcast[bit/8] |= 1 << (7 - bit%8)
+	}
+	return netip.AddrFrom4(broadcast)
+}
+
+// loadAndVerifyConfig reads the config from disk and verifies its hash
+func loadAndVerifyConfig() (*Config, error) {
+	configDiskPath, err := device.ConfigDisk()
+	if err != nil {
+		return nil, fmt.Errorf("finding config disk: %w", err)
+	}
+
+	configData, err := readDiskPayload(configDiskPath, maxDiskPayloadBytes)
 	if err != nil {
 		return nil, fmt.Errorf("reading config disk: %w", err)
 	}
@@ -169,13 +216,15 @@ func loadAndVerifyConfig() (*Config, error) {
 		return nil, fmt.Errorf("writing config to ramdisk: %w", err)
 	}
 
-	// Parse config
 	var config Config
 	if err := yaml.Unmarshal(configData, &config); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
 	if err := validateGPUCount(config.GPUs); err != nil {
+		return nil, err
+	}
+	if err := validateModelCount(len(config.Models)); err != nil {
 		return nil, err
 	}
 
@@ -207,7 +256,7 @@ func loadAndVerifyConfig() (*Config, error) {
 	}
 
 	if err := loadExternalConfig(); err != nil {
-		log.Printf("Warning: external config not loaded: %v", err)
+		return nil, err
 	}
 
 	return &config, nil
@@ -252,6 +301,9 @@ func loadConfigFromRamdisk() (*Config, error) {
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
+	if err := validateModelCount(len(config.Models)); err != nil {
+		return nil, err
+	}
 
 	shimCfg, err := shimconfig.Decode(&config.ShimRaw)
 	if err != nil {
@@ -268,13 +320,17 @@ func loadConfigFromRamdisk() (*Config, error) {
 }
 
 func loadExternalConfig() error {
-	if _, err := os.Stat(externalDiskPath); os.IsNotExist(err) {
-		return fmt.Errorf("external config disk not found at %s", externalDiskPath)
+	externalDiskPath, err := device.ExternalConfigDisk()
+	if err != nil {
+		return fmt.Errorf("finding external config disk: %w", err)
 	}
 
-	data, err := readDiskAndStripNulls(externalDiskPath)
+	data, err := readDiskPayload(externalDiskPath, maxDiskPayloadBytes)
 	if err != nil {
 		return fmt.Errorf("reading external config disk: %w", err)
+	}
+	if _, err := decodeExternalConfig(data); err != nil {
+		return err
 	}
 
 	if err := os.WriteFile(boot.ExternalConfigPath, data, 0600); err != nil {
@@ -290,21 +346,44 @@ func getExternalConfig() (*shimconfig.ExternalConfig, error) {
 		return nil, fmt.Errorf("reading external config: %w", err)
 	}
 
-	var config shimconfig.ExternalConfig
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("parsing external config: %w", err)
-	}
-	return &config, nil
+	return decodeExternalConfig(data)
 }
 
-// readDiskAndStripNulls reads a disk device and strips trailing null bytes
-func readDiskAndStripNulls(path string) ([]byte, error) {
-	data, err := os.ReadFile(path)
+func decodeExternalConfig(data []byte) (*shimconfig.ExternalConfig, error) {
+	config, err := shimconfig.DecodeExternal(data)
+	if err != nil {
+		return nil, fmt.Errorf("parsing external config: %w", err)
+	}
+	if err := validateExternalNetwork(config.Network); err != nil {
+		return nil, fmt.Errorf("external network config: %w", err)
+	}
+	return config, nil
+}
+
+// readDiskPayload reads a NUL-padded config disk without reading its full
+// capacity into memory. Embedded non-NUL bytes after padding are rejected.
+func readDiskPayload(path string, maxBytes int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	defer file.Close()
+
+	data, err := io.ReadAll(io.LimitReader(file, maxBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
-
-	data = bytes.TrimRight(data, "\x00")
+	if padding := bytes.IndexByte(data, 0); padding >= 0 {
+		for _, value := range data[padding:] {
+			if value != 0 {
+				return nil, fmt.Errorf("%s contains data after NUL padding", path)
+			}
+		}
+		return data[:padding], nil
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("%s payload exceeds %d bytes", path, maxBytes)
+	}
 	return data, nil
 }
 

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -161,9 +161,19 @@ func validateExternalNetwork(config *shimconfig.ExternalNetworkConfig) error {
 	if err != nil || !gateway.Is4() {
 		return fmt.Errorf("invalid IPv4 gateway %q", config.Gateway)
 	}
-	dns, err := netip.ParseAddr(config.DNS)
-	if err != nil || !dns.Is4() {
-		return fmt.Errorf("invalid IPv4 DNS server %q", config.DNS)
+	if len(config.Nameservers) == 0 || len(config.Nameservers) > 3 {
+		return fmt.Errorf("external network requires 1 to 3 DNS servers")
+	}
+	seenNameservers := make(map[netip.Addr]struct{}, len(config.Nameservers))
+	for _, value := range config.Nameservers {
+		nameserver, err := netip.ParseAddr(value)
+		if err != nil || !nameserver.Is4() {
+			return fmt.Errorf("invalid IPv4 DNS server %q", value)
+		}
+		if _, duplicate := seenNameservers[nameserver]; duplicate {
+			return fmt.Errorf("duplicate DNS server %q", value)
+		}
+		seenNameservers[nameserver] = struct{}{}
 	}
 	if !prefix.Contains(gateway) {
 		return fmt.Errorf("gateway %s is outside address subnet %s", config.Gateway, config.Address)

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -147,7 +147,7 @@ func validateExternalNetwork(config *shimconfig.ExternalNetworkConfig) error {
 	if config == nil {
 		return fmt.Errorf("network section is required")
 	}
-	if config.Version != 1 {
+	if config.Version != 2 {
 		return fmt.Errorf("unsupported external network version %d", config.Version)
 	}
 	prefix, err := netip.ParsePrefix(config.Address)
@@ -160,6 +160,10 @@ func validateExternalNetwork(config *shimconfig.ExternalNetworkConfig) error {
 	gateway, err := netip.ParseAddr(config.Gateway)
 	if err != nil || !gateway.Is4() {
 		return fmt.Errorf("invalid IPv4 gateway %q", config.Gateway)
+	}
+	dns, err := netip.ParseAddr(config.DNS)
+	if err != nil || !dns.Is4() {
+		return fmt.Errorf("invalid IPv4 DNS server %q", config.DNS)
 	}
 	if !prefix.Contains(gateway) {
 		return fmt.Errorf("gateway %s is outside address subnet %s", config.Gateway, config.Address)

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -154,6 +154,9 @@ func validateExternalNetwork(config *shimconfig.ExternalNetworkConfig) error {
 	if err != nil || !prefix.Addr().Is4() {
 		return fmt.Errorf("invalid IPv4 address %q", config.Address)
 	}
+	if prefix.Bits() > 30 {
+		return fmt.Errorf("IPv4 prefix /%d has no distinct guest and gateway addresses", prefix.Bits())
+	}
 	gateway, err := netip.ParseAddr(config.Gateway)
 	if err != nil || !gateway.Is4() {
 		return fmt.Errorf("invalid IPv4 gateway %q", config.Gateway)

--- a/tinfoil/cmd/boot/config_test.go
+++ b/tinfoil/cmd/boot/config_test.go
@@ -38,41 +38,50 @@ func TestValidateModelCount(t *testing.T) {
 
 func TestValidateExternalNetwork(t *testing.T) {
 	valid := shimconfig.ExternalNetworkConfig{
-		Version: 1,
+		Version: 2,
 		Address: "100.64.0.42/20",
 		Gateway: "100.64.0.1",
+		DNS:     "1.1.1.1",
 	}
 	if err := validateExternalNetwork(&valid); err != nil {
 		t.Fatalf("valid network rejected: %v", err)
 	}
 
-	for name, config := range map[string]shimconfig.ExternalNetworkConfig{
-		"version zero": {Version: 0, Address: valid.Address, Gateway: valid.Gateway},
-		"version two":  {Version: 2, Address: valid.Address, Gateway: valid.Gateway},
-		"version negative": {
-			Version: -1, Address: valid.Address, Gateway: valid.Gateway,
+	for name, mutate := range map[string]func(*shimconfig.ExternalNetworkConfig){
+		"version zero":     func(c *shimconfig.ExternalNetworkConfig) { c.Version = 0 },
+		"version one":      func(c *shimconfig.ExternalNetworkConfig) { c.Version = 1 },
+		"version negative": func(c *shimconfig.ExternalNetworkConfig) { c.Version = -1 },
+		"IPv6": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Address, c.Gateway = "2001:db8::2/64", "2001:db8::1"
 		},
-		"IPv6": {Version: 1, Address: "2001:db8::2/64", Gateway: "2001:db8::1"},
-		"mapped IPv6": {
-			Version: 1, Address: "::ffff:100.64.0.42/120", Gateway: "::ffff:100.64.0.1",
+		"mapped IPv6": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Address, c.Gateway = "::ffff:100.64.0.42/120", "::ffff:100.64.0.1"
 		},
-		"missing prefix": {Version: 1, Address: "100.64.0.42", Gateway: valid.Gateway},
-		"point-to-point prefix": {
-			Version: 1, Address: "192.0.2.0/31", Gateway: "192.0.2.1",
+		"missing prefix": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Address = "100.64.0.42"
 		},
-		"host prefix": {Version: 1, Address: "192.0.2.1/32", Gateway: "192.0.2.1"},
-		"subnet":      {Version: 1, Address: valid.Address, Gateway: "192.0.2.1"},
-		"network":     {Version: 1, Address: "100.64.0.0/20", Gateway: valid.Gateway},
-		"broadcast":   {Version: 1, Address: "100.64.15.255/20", Gateway: valid.Gateway},
-		"gateway":     {Version: 1, Address: "100.64.0.1/20", Gateway: valid.Gateway},
-		"gateway network": {
-			Version: 1, Address: valid.Address, Gateway: "100.64.0.0",
+		"point-to-point prefix": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Address, c.Gateway = "192.0.2.0/31", "192.0.2.1"
 		},
-		"gateway broadcast": {
-			Version: 1, Address: valid.Address, Gateway: "100.64.15.255",
+		"host prefix": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Address, c.Gateway = "192.0.2.1/32", "192.0.2.1"
 		},
+		"subnet":    func(c *shimconfig.ExternalNetworkConfig) { c.Gateway = "192.0.2.1" },
+		"network":   func(c *shimconfig.ExternalNetworkConfig) { c.Address = "100.64.0.0/20" },
+		"broadcast": func(c *shimconfig.ExternalNetworkConfig) { c.Address = "100.64.15.255/20" },
+		"gateway":   func(c *shimconfig.ExternalNetworkConfig) { c.Address = "100.64.0.1/20" },
+		"gateway network": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Gateway = "100.64.0.0"
+		},
+		"gateway broadcast": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Gateway = "100.64.15.255"
+		},
+		"invalid DNS": func(c *shimconfig.ExternalNetworkConfig) { c.DNS = "not-an-ip" },
+		"IPv6 DNS":    func(c *shimconfig.ExternalNetworkConfig) { c.DNS = "2001:db8::53" },
 	} {
 		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
 			if err := validateExternalNetwork(&config); err == nil {
 				t.Fatalf("invalid network accepted: %+v", config)
 			}
@@ -86,9 +95,10 @@ func TestValidateExternalNetwork(t *testing.T) {
 func TestDecodeExternalConfigRequiresStrictNetwork(t *testing.T) {
 	valid := []byte(`
 network:
-  version: 1
+  version: 2
   address: 10.0.2.15/24
   gateway: 10.0.2.2
+  dns: 10.0.2.3
 secrets:
   API_KEY: secret
 `)
@@ -96,7 +106,7 @@ secrets:
 		t.Fatalf("valid external config rejected: %v", err)
 	}
 
-	unknown := strings.Replace(string(valid), "  gateway:", "  dns: 10.0.2.3\n  gateway:", 1)
+	unknown := strings.Replace(string(valid), "  gateway:", "  unexpected: true\n  gateway:", 1)
 	if _, err := decodeExternalConfig([]byte(unknown)); err == nil {
 		t.Fatal("decodeExternalConfig accepted an unknown network field")
 	}

--- a/tinfoil/cmd/boot/config_test.go
+++ b/tinfoil/cmd/boot/config_test.go
@@ -57,10 +57,14 @@ func TestValidateExternalNetwork(t *testing.T) {
 			Version: 1, Address: "::ffff:100.64.0.42/120", Gateway: "::ffff:100.64.0.1",
 		},
 		"missing prefix": {Version: 1, Address: "100.64.0.42", Gateway: valid.Gateway},
-		"subnet":         {Version: 1, Address: valid.Address, Gateway: "192.0.2.1"},
-		"network":        {Version: 1, Address: "100.64.0.0/20", Gateway: valid.Gateway},
-		"broadcast":      {Version: 1, Address: "100.64.15.255/20", Gateway: valid.Gateway},
-		"gateway":        {Version: 1, Address: "100.64.0.1/20", Gateway: valid.Gateway},
+		"point-to-point prefix": {
+			Version: 1, Address: "192.0.2.0/31", Gateway: "192.0.2.1",
+		},
+		"host prefix": {Version: 1, Address: "192.0.2.1/32", Gateway: "192.0.2.1"},
+		"subnet":      {Version: 1, Address: valid.Address, Gateway: "192.0.2.1"},
+		"network":     {Version: 1, Address: "100.64.0.0/20", Gateway: valid.Gateway},
+		"broadcast":   {Version: 1, Address: "100.64.15.255/20", Gateway: valid.Gateway},
+		"gateway":     {Version: 1, Address: "100.64.0.1/20", Gateway: valid.Gateway},
 		"gateway network": {
 			Version: 1, Address: valid.Address, Gateway: "100.64.0.0",
 		},

--- a/tinfoil/cmd/boot/config_test.go
+++ b/tinfoil/cmd/boot/config_test.go
@@ -38,10 +38,10 @@ func TestValidateModelCount(t *testing.T) {
 
 func TestValidateExternalNetwork(t *testing.T) {
 	valid := shimconfig.ExternalNetworkConfig{
-		Version: 2,
-		Address: "100.64.0.42/20",
-		Gateway: "100.64.0.1",
-		DNS:     "1.1.1.1",
+		Version:     2,
+		Address:     "100.64.0.42/20",
+		Gateway:     "100.64.0.1",
+		Nameservers: []string{"1.1.1.1", "1.0.0.1"},
 	}
 	if err := validateExternalNetwork(&valid); err != nil {
 		t.Fatalf("valid network rejected: %v", err)
@@ -76,8 +76,15 @@ func TestValidateExternalNetwork(t *testing.T) {
 		"gateway broadcast": func(c *shimconfig.ExternalNetworkConfig) {
 			c.Gateway = "100.64.15.255"
 		},
-		"invalid DNS": func(c *shimconfig.ExternalNetworkConfig) { c.DNS = "not-an-ip" },
-		"IPv6 DNS":    func(c *shimconfig.ExternalNetworkConfig) { c.DNS = "2001:db8::53" },
+		"missing DNS": func(c *shimconfig.ExternalNetworkConfig) { c.Nameservers = nil },
+		"invalid DNS": func(c *shimconfig.ExternalNetworkConfig) { c.Nameservers = []string{"not-an-ip"} },
+		"IPv6 DNS":    func(c *shimconfig.ExternalNetworkConfig) { c.Nameservers = []string{"2001:db8::53"} },
+		"duplicate DNS": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Nameservers = []string{"1.1.1.1", "1.1.1.1"}
+		},
+		"too many DNS servers": func(c *shimconfig.ExternalNetworkConfig) {
+			c.Nameservers = []string{"1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4"}
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := valid
@@ -98,7 +105,7 @@ network:
   version: 2
   address: 10.0.2.15/24
   gateway: 10.0.2.2
-  dns: 10.0.2.3
+  nameservers: [10.0.2.3]
 secrets:
   API_KEY: secret
 `)

--- a/tinfoil/cmd/boot/config_test.go
+++ b/tinfoil/cmd/boot/config_test.go
@@ -38,19 +38,14 @@ func TestValidateModelCount(t *testing.T) {
 
 func TestValidateExternalNetwork(t *testing.T) {
 	valid := shimconfig.ExternalNetworkConfig{
-		Version:     2,
-		Address:     "100.64.0.42/20",
-		Gateway:     "100.64.0.1",
-		Nameservers: []string{"1.1.1.1", "1.0.0.1"},
+		Address: "100.64.0.42/20",
+		Gateway: "100.64.0.1",
 	}
 	if err := validateExternalNetwork(&valid); err != nil {
 		t.Fatalf("valid network rejected: %v", err)
 	}
 
 	for name, mutate := range map[string]func(*shimconfig.ExternalNetworkConfig){
-		"version zero":     func(c *shimconfig.ExternalNetworkConfig) { c.Version = 0 },
-		"version one":      func(c *shimconfig.ExternalNetworkConfig) { c.Version = 1 },
-		"version negative": func(c *shimconfig.ExternalNetworkConfig) { c.Version = -1 },
 		"IPv6": func(c *shimconfig.ExternalNetworkConfig) {
 			c.Address, c.Gateway = "2001:db8::2/64", "2001:db8::1"
 		},
@@ -76,15 +71,6 @@ func TestValidateExternalNetwork(t *testing.T) {
 		"gateway broadcast": func(c *shimconfig.ExternalNetworkConfig) {
 			c.Gateway = "100.64.15.255"
 		},
-		"missing DNS": func(c *shimconfig.ExternalNetworkConfig) { c.Nameservers = nil },
-		"invalid DNS": func(c *shimconfig.ExternalNetworkConfig) { c.Nameservers = []string{"not-an-ip"} },
-		"IPv6 DNS":    func(c *shimconfig.ExternalNetworkConfig) { c.Nameservers = []string{"2001:db8::53"} },
-		"duplicate DNS": func(c *shimconfig.ExternalNetworkConfig) {
-			c.Nameservers = []string{"1.1.1.1", "1.1.1.1"}
-		},
-		"too many DNS servers": func(c *shimconfig.ExternalNetworkConfig) {
-			c.Nameservers = []string{"1.1.1.1", "1.0.0.1", "8.8.8.8", "8.8.4.4"}
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := valid
@@ -102,10 +88,8 @@ func TestValidateExternalNetwork(t *testing.T) {
 func TestDecodeExternalConfigRequiresStrictNetwork(t *testing.T) {
 	valid := []byte(`
 network:
-  version: 2
-  address: 10.0.2.15/24
-  gateway: 10.0.2.2
-  nameservers: [10.0.2.3]
+  address: 100.64.0.42/20
+  gateway: 100.64.0.1
 secrets:
   API_KEY: secret
 `)
@@ -116,6 +100,10 @@ secrets:
 	unknown := strings.Replace(string(valid), "  gateway:", "  unexpected: true\n  gateway:", 1)
 	if _, err := decodeExternalConfig([]byte(unknown)); err == nil {
 		t.Fatal("decodeExternalConfig accepted an unknown network field")
+	}
+	obsolete := strings.Replace(string(valid), "  address:", "  version: 1\n  address:", 1)
+	if _, err := decodeExternalConfig([]byte(obsolete)); err == nil {
+		t.Fatal("decodeExternalConfig accepted the obsolete versioned schema")
 	}
 	for name, document := range map[string]string{
 		"missing": "secrets: {}\n",

--- a/tinfoil/cmd/boot/config_test.go
+++ b/tinfoil/cmd/boot/config_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+)
 
 func TestValidateGPUCount(t *testing.T) {
 	for count := range maxGPUCount + 1 {
@@ -13,5 +20,120 @@ func TestValidateGPUCount(t *testing.T) {
 		if err := validateGPUCount(count); err == nil {
 			t.Fatalf("expected GPU count %d to be invalid", count)
 		}
+	}
+}
+
+func TestValidateModelCount(t *testing.T) {
+	for _, count := range []int{0, 1, 24} {
+		if err := validateModelCount(count); err != nil {
+			t.Fatalf("model count %d rejected: %v", count, err)
+		}
+	}
+	for _, count := range []int{-1, 25} {
+		if err := validateModelCount(count); err == nil {
+			t.Fatalf("model count %d accepted", count)
+		}
+	}
+}
+
+func TestValidateExternalNetwork(t *testing.T) {
+	valid := shimconfig.ExternalNetworkConfig{
+		Version: 1,
+		Address: "100.64.0.42/20",
+		Gateway: "100.64.0.1",
+	}
+	if err := validateExternalNetwork(&valid); err != nil {
+		t.Fatalf("valid network rejected: %v", err)
+	}
+
+	for name, config := range map[string]shimconfig.ExternalNetworkConfig{
+		"version zero": {Version: 0, Address: valid.Address, Gateway: valid.Gateway},
+		"version two":  {Version: 2, Address: valid.Address, Gateway: valid.Gateway},
+		"version negative": {
+			Version: -1, Address: valid.Address, Gateway: valid.Gateway,
+		},
+		"IPv6": {Version: 1, Address: "2001:db8::2/64", Gateway: "2001:db8::1"},
+		"mapped IPv6": {
+			Version: 1, Address: "::ffff:100.64.0.42/120", Gateway: "::ffff:100.64.0.1",
+		},
+		"missing prefix": {Version: 1, Address: "100.64.0.42", Gateway: valid.Gateway},
+		"subnet":         {Version: 1, Address: valid.Address, Gateway: "192.0.2.1"},
+		"network":        {Version: 1, Address: "100.64.0.0/20", Gateway: valid.Gateway},
+		"broadcast":      {Version: 1, Address: "100.64.15.255/20", Gateway: valid.Gateway},
+		"gateway":        {Version: 1, Address: "100.64.0.1/20", Gateway: valid.Gateway},
+		"gateway network": {
+			Version: 1, Address: valid.Address, Gateway: "100.64.0.0",
+		},
+		"gateway broadcast": {
+			Version: 1, Address: valid.Address, Gateway: "100.64.15.255",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateExternalNetwork(&config); err == nil {
+				t.Fatalf("invalid network accepted: %+v", config)
+			}
+		})
+	}
+	if err := validateExternalNetwork(nil); err == nil {
+		t.Fatal("missing external network accepted")
+	}
+}
+
+func TestDecodeExternalConfigRequiresStrictNetwork(t *testing.T) {
+	valid := []byte(`
+network:
+  version: 1
+  address: 10.0.2.15/24
+  gateway: 10.0.2.2
+secrets:
+  API_KEY: secret
+`)
+	if _, err := decodeExternalConfig(valid); err != nil {
+		t.Fatalf("valid external config rejected: %v", err)
+	}
+
+	unknown := strings.Replace(string(valid), "  gateway:", "  dns: 10.0.2.3\n  gateway:", 1)
+	if _, err := decodeExternalConfig([]byte(unknown)); err == nil {
+		t.Fatal("decodeExternalConfig accepted an unknown network field")
+	}
+	for name, document := range map[string]string{
+		"missing": "secrets: {}\n",
+		"null":    "network: null\n",
+		"empty":   "network: {}\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := decodeExternalConfig([]byte(document)); err == nil {
+				t.Fatalf("decodeExternalConfig accepted %s network", name)
+			}
+		})
+	}
+}
+
+func TestReadDiskPayloadIsBoundedAndRequiresZeroPadding(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	if err := os.WriteFile(path, append([]byte("gpus: 0\n"), make([]byte, 32)...), 0644); err != nil {
+		t.Fatal(err)
+	}
+	data, err := readDiskPayload(path, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "gpus: 0\n" {
+		t.Fatalf("payload = %q", data)
+	}
+
+	if err := os.WriteFile(path, []byte("valid\x00hidden"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readDiskPayload(path, 16); err == nil {
+		t.Fatal("readDiskPayload accepted data after NUL padding")
+	}
+
+	if err := os.WriteFile(path, []byte(strings.Repeat("x", 17)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readDiskPayload(path, 16); err == nil {
+		t.Fatal("readDiskPayload accepted an oversized payload")
 	}
 }

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -60,7 +60,7 @@ func runSubcommand(cmd string) error {
 		}
 		log.Println("Setting up registry authentication")
 		if err := setupRegistryAuth(externalConfig); err != nil {
-			log.Printf("Warning: registry auth setup failed: %v", err)
+			return fmt.Errorf("registry auth setup failed: %w", err)
 		}
 		log.Println("Launching containers")
 		return launchContainers(config, externalConfig)
@@ -183,11 +183,10 @@ func run() error {
 	start = time.Now()
 	log.Println("Setting up registry authentication")
 	if err := setupRegistryAuth(externalConfig); err != nil {
-		log.Printf("Warning: registry auth setup failed: %v", err)
-		tracker.Record("registry-auth", boot.StatusWarning, time.Since(start), err.Error())
-	} else {
-		tracker.Record("registry-auth", boot.StatusOK, time.Since(start), "")
+		tracker.Record("registry-auth", boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("registry auth setup failed: %w", err)
 	}
+	tracker.Record("registry-auth", boot.StatusOK, time.Since(start), "")
 
 	// 9. Firewall
 	start = time.Now()

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -1,13 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"os"
 	"time"
 
 	"tinfoil/internal/boot"
-	shimconfig "tinfoil/internal/config"
 )
 
 func init() {
@@ -49,8 +49,7 @@ func runSubcommand(cmd string) error {
 	case "containers":
 		externalConfig, err := getExternalConfig()
 		if err != nil {
-			log.Printf("Warning: external config not available, using defaults: %v", err)
-			externalConfig = &shimconfig.ExternalConfig{}
+			return fmt.Errorf("loading external config: %w", err)
 		}
 		// Manual re-run must fetch vault secrets, they're not persisted on disk.
 		if config.VaultURL != "" {
@@ -60,7 +59,7 @@ func runSubcommand(cmd string) error {
 			}
 		}
 		log.Println("Setting up registry authentication")
-		if err := setupRegistryAuth(); err != nil {
+		if err := setupRegistryAuth(externalConfig); err != nil {
 			log.Printf("Warning: registry auth setup failed: %v", err)
 		}
 		log.Println("Launching containers")
@@ -68,8 +67,7 @@ func runSubcommand(cmd string) error {
 	case "models":
 		externalConfig, err := getExternalConfig()
 		if err != nil {
-			log.Printf("Warning: external config not available, using defaults: %v", err)
-			externalConfig = &shimconfig.ExternalConfig{}
+			return fmt.Errorf("loading external config: %w", err)
 		}
 		log.Println("Mounting models")
 		return mountModels(config, externalConfig)
@@ -90,12 +88,22 @@ func run() error {
 	}
 	externalConfig, err := getExternalConfig()
 	if err != nil {
-		log.Printf("Warning: external config not available, using defaults: %v", err)
-		externalConfig = &shimconfig.ExternalConfig{}
+		tracker.Record("config", boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("loading external config: %w", err)
 	}
 	tracker.Record("config", boot.StatusOK, time.Since(start), "")
 
-	// 2. Identity
+	// 2. Network
+	start = time.Now()
+	log.Println("Configuring guest network")
+	networkDetail, err := configureGuestNetwork(context.Background(), externalConfig.Network)
+	if err != nil {
+		tracker.Record(boot.StageNetwork, boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("network configuration failed: %w", err)
+	}
+	tracker.Record(boot.StageNetwork, boot.StatusOK, time.Since(start), networkDetail)
+
+	// 3. Identity
 	start = time.Now()
 	log.Println("Generating node identity")
 	nodeID, err := generateIdentity(config.ShimCfg, externalConfig)
@@ -105,7 +113,7 @@ func run() error {
 	}
 	tracker.Record("identity", boot.StatusOK, time.Since(start), nodeID.Domain)
 
-	// 3. CPU attestation
+	// 4. CPU attestation
 	start = time.Now()
 	log.Println("Fetching CPU attestation")
 	cpuAtt, err := fetchCPUAttestation(nodeID, config.ShimCfg)
@@ -115,7 +123,7 @@ func run() error {
 	}
 	tracker.Record("cpu-attestation", boot.StatusOK, time.Since(start), string(cpuAtt.V2Doc.Format))
 
-	// 4. GPU attestation
+	// 5. GPU attestation
 	start = time.Now()
 	gpuCount := config.GPUs
 	if gpuCount == 0 {
@@ -149,7 +157,7 @@ func run() error {
 		tracker.Record("gpu-attestation", boot.StatusSkipped, time.Since(start), "no GPUs")
 	}
 
-	// 5. Certificate
+	// 6. Certificate
 	start = time.Now()
 	log.Println("Obtaining TLS certificate")
 	if err := obtainCertificate(nodeID, cpuAtt.V2Doc, config.ShimCfg, externalConfig); err != nil {
@@ -158,7 +166,7 @@ func run() error {
 	}
 	tracker.Record("certificate", boot.StatusOK, time.Since(start), "")
 
-	// 6. Fetch any external vault secrets.
+	// 7. Fetch any external vault secrets.
 	start = time.Now()
 	if config.VaultURL == "" {
 		tracker.Record(boot.StageVaultSecrets, boot.StatusSkipped, time.Since(start), "no vault configured")
@@ -171,17 +179,17 @@ func run() error {
 		tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), config.VaultURL)
 	}
 
-	// 7. Registry auth
+	// 8. Registry auth
 	start = time.Now()
 	log.Println("Setting up registry authentication")
-	if err := setupRegistryAuth(); err != nil {
+	if err := setupRegistryAuth(externalConfig); err != nil {
 		log.Printf("Warning: registry auth setup failed: %v", err)
 		tracker.Record("registry-auth", boot.StatusWarning, time.Since(start), err.Error())
 	} else {
 		tracker.Record("registry-auth", boot.StatusOK, time.Since(start), "")
 	}
 
-	// 8. Firewall
+	// 9. Firewall
 	start = time.Now()
 	log.Println("Configuring firewall")
 	if err := setupFirewall(config); err != nil {
@@ -190,7 +198,7 @@ func run() error {
 	}
 	tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
 
-	// 9. Models
+	// 10. Models
 	start = time.Now()
 	log.Println("Mounting models")
 	if err := mountModels(config, externalConfig); err != nil {
@@ -199,7 +207,7 @@ func run() error {
 	}
 	tracker.Record("models", boot.StatusOK, time.Since(start), "")
 
-	// 10. Containers + health checks
+	// 11. Containers + health checks
 	log.Println("Launching containers")
 	if err := launchContainersAndWaitHealthy(tracker, config, externalConfig); err != nil {
 		return err

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -10,6 +10,7 @@ import (
 
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/device"
 )
 
 // mountModels mounts all model packs from the config
@@ -21,7 +22,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 
 	log.Printf("Mounting %d model packs", len(config.Models))
 	seen := map[string]struct{}{}
-	for _, model := range config.Models {
+	for index, model := range config.Models {
 		ref, kind, err := modelPackRefForModel(model)
 		if err != nil {
 			return err
@@ -33,11 +34,19 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 
 		switch kind {
 		case modelKindPlaintext:
-			if err := mountModelPack(ref); err != nil {
+			sourceDevice, err := device.ModelDisk(index)
+			if err != nil {
+				return fmt.Errorf("finding model disk %d: %w", index, err)
+			}
+			if err := mountModelPack(ref, sourceDevice); err != nil {
 				return fmt.Errorf("mounting model pack %s: %w", ref.raw, err)
 			}
 		case modelKindEncrypted:
-			if err := mountEncryptedModelPack(model, externalConfig); err != nil {
+			sourceDevice, err := device.ModelPartition(index, device.EMWPPayloadPartition)
+			if err != nil {
+				return fmt.Errorf("finding encrypted model partition %d: %w", index, err)
+			}
+			if err := mountEncryptedModelPack(model, externalConfig, sourceDevice); err != nil {
 				return fmt.Errorf("mounting encrypted model pack %q: %w", model.Name, err)
 			}
 		}
@@ -47,7 +56,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 }
 
 // mountModelPack mounts a plaintext model wrap using dm-verity.
-func mountModelPack(spec *modelPackRef) error {
+func mountModelPack(spec *modelPackRef, sourceDevice string) error {
 	deviceName := spec.mapperName()
 	mountPoint := spec.mountPoint()
 
@@ -55,7 +64,7 @@ func mountModelPack(spec *modelPackRef) error {
 	if err := createLegacyModelPackAlias(spec); err != nil {
 		return err
 	}
-	if err := openAndMountVerity(diskByUUID(spec.UUID), deviceName, spec.RootHash, spec.HashOffset, mountPoint); err != nil {
+	if err := openAndMountVerity(sourceDevice, deviceName, spec.RootHash, spec.HashOffset, mountPoint); err != nil {
 		removeLegacyModelPackAlias(spec)
 		return err
 	}
@@ -67,7 +76,11 @@ func mountModelPack(spec *modelPackRef) error {
 // mountEncryptedModelPack mounts an encrypted model wrap using dm-crypt below
 // dm-verity. The decrypted mapper contains the same plaintext layout as an MWP:
 // a read-only filesystem followed by its dm-verity hash tree.
-func mountEncryptedModelPack(model ModelSpec, externalConfig *shimconfig.ExternalConfig) error {
+func mountEncryptedModelPack(
+	model ModelSpec,
+	externalConfig *shimconfig.ExternalConfig,
+	sourceDevice string,
+) error {
 	spec, err := parseModelPackRef(model.EMWP)
 	if err != nil {
 		return fmt.Errorf("invalid EMWP format: %s: %w", model.EMWP, err)
@@ -91,7 +104,7 @@ func mountEncryptedModelPack(model ModelSpec, externalConfig *shimconfig.Externa
 	if err := createLegacyModelPackAlias(spec); err != nil {
 		return err
 	}
-	if err := unwrap.OpenCrypt(diskByPARTUUID(spec.UUID), cryptName, keyFile); err != nil {
+	if err := unwrap.OpenCrypt(sourceDevice, cryptName, keyFile); err != nil {
 		removeLegacyModelPackAlias(spec)
 		return err
 	}
@@ -247,14 +260,6 @@ func openAndMountVerity(sourceDevice, deviceName, rootHash, hashOffset, mountPoi
 		return err
 	}
 	return nil
-}
-
-func diskByUUID(uuid string) string {
-	return fmt.Sprintf("/dev/disk/by-uuid/%s", uuid)
-}
-
-func diskByPARTUUID(uuid string) string {
-	return fmt.Sprintf("/dev/disk/by-partuuid/%s", uuid)
 }
 
 func modelLogName(name, rootHash string) string {

--- a/tinfoil/cmd/boot/models_integration_test.go
+++ b/tinfoil/cmd/boot/models_integration_test.go
@@ -21,8 +21,9 @@ func TestMountEncryptedModelPackIntegration(t *testing.T) {
 
 	ref := os.Getenv("TINFOIL_EMWP_REF")
 	key := os.Getenv("TINFOIL_EMWP_KEY_B64")
-	if ref == "" || key == "" {
-		t.Fatal("TINFOIL_EMWP_REF and TINFOIL_EMWP_KEY_B64 are required")
+	device := os.Getenv("TINFOIL_EMWP_DEVICE")
+	if ref == "" || key == "" || device == "" {
+		t.Fatal("TINFOIL_EMWP_REF, TINFOIL_EMWP_KEY_B64, and TINFOIL_EMWP_DEVICE are required")
 	}
 
 	spec, err := parseModelPackRef(ref)
@@ -40,7 +41,7 @@ func TestMountEncryptedModelPackIntegration(t *testing.T) {
 		KeySecret: "PRIVATE_MODEL_KEY",
 	}, &shimconfig.ExternalConfig{
 		Secrets: map[string]string{"PRIVATE_MODEL_KEY": key},
-	})
+	}, device)
 	if err != nil {
 		t.Fatalf("mounting EMWP: %v", err)
 	}

--- a/tinfoil/cmd/boot/models_test.go
+++ b/tinfoil/cmd/boot/models_test.go
@@ -82,16 +82,6 @@ func TestModelPackRefForModel(t *testing.T) {
 	}
 }
 
-func TestDiskLocators(t *testing.T) {
-	id := "0eefa619-50b7-588f-a072-d405fb439d36"
-	if got := diskByUUID(id); got != "/dev/disk/by-uuid/"+id {
-		t.Fatalf("disk by UUID mismatch: %s", got)
-	}
-	if got := diskByPARTUUID(id); got != "/dev/disk/by-partuuid/"+id {
-		t.Fatalf("disk by PARTUUID mismatch: %s", got)
-	}
-}
-
 func TestEncryptedModelKey(t *testing.T) {
 	key := strings.Repeat("k", modelwrap.EMWPMasterKeyBytes)
 	spec := &modelPackRef{

--- a/tinfoil/cmd/boot/network_ready.go
+++ b/tinfoil/cmd/boot/network_ready.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"path/filepath"
@@ -15,10 +16,13 @@ import (
 
 const (
 	networkReadyTimeout = 90 * time.Second
+	networkPollInterval = 100 * time.Millisecond
 	ipBinary            = "/usr/sbin/ip"
+	resolvectlBinary    = "/usr/bin/resolvectl"
 )
 
 var sysBusPCIDevices = "/sys/bus/pci/devices"
+var errNetworkInterfaceNotFound = errors.New("network interface not found")
 
 type commandRunner func(context.Context, string, ...string) ([]byte, error)
 
@@ -30,7 +34,12 @@ func configureGuestNetwork(ctx context.Context, config *shimconfig.ExternalNetwo
 	ctx, cancel := context.WithTimeout(ctx, networkReadyTimeout)
 	defer cancel()
 
-	iface, err := networkInterfaceAtPCI(sysBusPCIDevices, boot.ExternalNICPCIAddress)
+	iface, err := waitForNetworkInterface(
+		ctx,
+		sysBusPCIDevices,
+		boot.ExternalNICPCIAddress,
+		networkPollInterval,
+	)
 	if err != nil {
 		return "", err
 	}
@@ -38,9 +47,33 @@ func configureGuestNetwork(ctx context.Context, config *shimconfig.ExternalNetwo
 		return "", err
 	}
 	return fmt.Sprintf(
-		"static network configured; interface=%s address=%s gateway=%s",
-		iface, config.Address, config.Gateway,
+		"static network configured; interface=%s address=%s gateway=%s dns=%s",
+		iface, config.Address, config.Gateway, config.DNS,
 	), nil
+}
+
+func waitForNetworkInterface(
+	ctx context.Context,
+	sysBusPCI string,
+	pciAddress string,
+	pollInterval time.Duration,
+) (string, error) {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	for {
+		iface, err := networkInterfaceAtPCI(sysBusPCI, pciAddress)
+		if err == nil {
+			return iface, nil
+		}
+		if !errors.Is(err, errNetworkInterfaceNotFound) {
+			return "", err
+		}
+		select {
+		case <-ctx.Done():
+			return "", fmt.Errorf("waiting for network interface at PCI device %s: %w", pciAddress, ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func networkInterfaceAtPCI(sysBusPCI, pciAddress string) (string, error) {
@@ -57,13 +90,17 @@ func networkInterfaceAtPCI(sysBusPCI, pciAddress string) (string, error) {
 	}
 	sort.Strings(matches)
 	matches = compactStrings(matches)
-	if len(matches) != 1 {
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("%w at PCI device %s", errNetworkInterfaceNotFound, pciAddress)
+	case 1:
+		return filepath.Base(matches[0]), nil
+	default:
 		return "", fmt.Errorf(
 			"expected one network interface at PCI device %s, found %d",
 			pciAddress, len(matches),
 		)
 	}
-	return filepath.Base(matches[0]), nil
 }
 
 func compactStrings(values []string) []string {
@@ -85,21 +122,29 @@ func applyStaticNetwork(
 	config *shimconfig.ExternalNetworkConfig,
 	run commandRunner,
 ) error {
-	commands := [][]string{
-		{"link", "set", "dev", iface, "up"},
-		{"addr", "replace", config.Address, "dev", iface},
-		{"route", "replace", "default", "via", config.Gateway, "dev", iface},
+	commands := []struct {
+		name string
+		args []string
+	}{
+		{ipBinary, []string{"link", "set", "dev", iface, "up"}},
+		{ipBinary, []string{"addr", "flush", "dev", iface}},
+		{ipBinary, []string{"route", "flush", "dev", iface}},
+		{ipBinary, []string{"addr", "replace", config.Address, "dev", iface}},
+		{ipBinary, []string{"route", "replace", "default", "via", config.Gateway, "dev", iface}},
+		{resolvectlBinary, []string{"dns", iface, config.DNS}},
+		{resolvectlBinary, []string{"domain", iface, "~."}},
+		{resolvectlBinary, []string{"default-route", iface, "yes"}},
 	}
-	for _, args := range commands {
-		output, err := run(ctx, ipBinary, args...)
+	for _, command := range commands {
+		output, err := run(ctx, command.name, command.args...)
 		if err == nil {
 			continue
 		}
 		detail := strings.TrimSpace(string(output))
 		if detail != "" {
-			return fmt.Errorf("ip %s: %w: %s", strings.Join(args, " "), err, detail)
+			return fmt.Errorf("%s %s: %w: %s", command.name, strings.Join(command.args, " "), err, detail)
 		}
-		return fmt.Errorf("ip %s: %w", strings.Join(args, " "), err)
+		return fmt.Errorf("%s %s: %w", command.name, strings.Join(command.args, " "), err)
 	}
 	return nil
 }

--- a/tinfoil/cmd/boot/network_ready.go
+++ b/tinfoil/cmd/boot/network_ready.go
@@ -19,6 +19,8 @@ const (
 	networkPollInterval = 100 * time.Millisecond
 	ipBinary            = "/usr/sbin/ip"
 	resolvectlBinary    = "/usr/bin/resolvectl"
+	primaryNameserver   = "1.1.1.1"
+	secondaryNameserver = "1.0.0.1"
 )
 
 var sysBusPCIDevices = "/sys/bus/pci/devices"
@@ -48,7 +50,7 @@ func configureGuestNetwork(ctx context.Context, config *shimconfig.ExternalNetwo
 	}
 	return fmt.Sprintf(
 		"static network configured; interface=%s address=%s gateway=%s dns=%s",
-		iface, config.Address, config.Gateway, strings.Join(config.Nameservers, ","),
+		iface, config.Address, config.Gateway, primaryNameserver+","+secondaryNameserver,
 	), nil
 }
 
@@ -122,7 +124,7 @@ func applyStaticNetwork(
 	config *shimconfig.ExternalNetworkConfig,
 	run commandRunner,
 ) error {
-	dnsArgs := append([]string{"dns", iface}, config.Nameservers...)
+	dnsArgs := []string{"dns", iface, primaryNameserver, secondaryNameserver}
 	commands := []struct {
 		name string
 		args []string

--- a/tinfoil/cmd/boot/network_ready.go
+++ b/tinfoil/cmd/boot/network_ready.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"tinfoil/internal/boot"
+	shimconfig "tinfoil/internal/config"
+)
+
+const (
+	networkReadyTimeout = 90 * time.Second
+	ipBinary            = "/usr/sbin/ip"
+)
+
+var sysBusPCIDevices = "/sys/bus/pci/devices"
+
+type commandRunner func(context.Context, string, ...string) ([]byte, error)
+
+func runCommand(ctx context.Context, name string, args ...string) ([]byte, error) {
+	return exec.CommandContext(ctx, name, args...).CombinedOutput()
+}
+
+func configureGuestNetwork(ctx context.Context, config *shimconfig.ExternalNetworkConfig) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, networkReadyTimeout)
+	defer cancel()
+
+	iface, err := networkInterfaceAtPCI(sysBusPCIDevices, boot.ExternalNICPCIAddress)
+	if err != nil {
+		return "", err
+	}
+	if err := applyStaticNetwork(ctx, iface, config, runCommand); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(
+		"static network configured; interface=%s address=%s gateway=%s",
+		iface, config.Address, config.Gateway,
+	), nil
+}
+
+func networkInterfaceAtPCI(sysBusPCI, pciAddress string) (string, error) {
+	var matches []string
+	for _, pattern := range []string{
+		filepath.Join(sysBusPCI, pciAddress, "net", "*"),
+		filepath.Join(sysBusPCI, pciAddress, "virtio*", "net", "*"),
+	} {
+		found, err := filepath.Glob(pattern)
+		if err != nil {
+			return "", err
+		}
+		matches = append(matches, found...)
+	}
+	sort.Strings(matches)
+	matches = compactStrings(matches)
+	if len(matches) != 1 {
+		return "", fmt.Errorf(
+			"expected one network interface at PCI device %s, found %d",
+			pciAddress, len(matches),
+		)
+	}
+	return filepath.Base(matches[0]), nil
+}
+
+func compactStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func applyStaticNetwork(
+	ctx context.Context,
+	iface string,
+	config *shimconfig.ExternalNetworkConfig,
+	run commandRunner,
+) error {
+	commands := [][]string{
+		{"link", "set", "dev", iface, "up"},
+		{"addr", "replace", config.Address, "dev", iface},
+		{"route", "replace", "default", "via", config.Gateway, "dev", iface},
+	}
+	for _, args := range commands {
+		output, err := run(ctx, ipBinary, args...)
+		if err == nil {
+			continue
+		}
+		detail := strings.TrimSpace(string(output))
+		if detail != "" {
+			return fmt.Errorf("ip %s: %w: %s", strings.Join(args, " "), err, detail)
+		}
+		return fmt.Errorf("ip %s: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}

--- a/tinfoil/cmd/boot/network_ready.go
+++ b/tinfoil/cmd/boot/network_ready.go
@@ -48,7 +48,7 @@ func configureGuestNetwork(ctx context.Context, config *shimconfig.ExternalNetwo
 	}
 	return fmt.Sprintf(
 		"static network configured; interface=%s address=%s gateway=%s dns=%s",
-		iface, config.Address, config.Gateway, config.DNS,
+		iface, config.Address, config.Gateway, strings.Join(config.Nameservers, ","),
 	), nil
 }
 
@@ -122,6 +122,7 @@ func applyStaticNetwork(
 	config *shimconfig.ExternalNetworkConfig,
 	run commandRunner,
 ) error {
+	dnsArgs := append([]string{"dns", iface}, config.Nameservers...)
 	commands := []struct {
 		name string
 		args []string
@@ -131,7 +132,7 @@ func applyStaticNetwork(
 		{ipBinary, []string{"route", "flush", "dev", iface}},
 		{ipBinary, []string{"addr", "replace", config.Address, "dev", iface}},
 		{ipBinary, []string{"route", "replace", "default", "via", config.Gateway, "dev", iface}},
-		{resolvectlBinary, []string{"dns", iface, config.DNS}},
+		{resolvectlBinary, dnsArgs},
 		{resolvectlBinary, []string{"domain", iface, "~."}},
 		{resolvectlBinary, []string{"default-route", iface, "yes"}},
 	}

--- a/tinfoil/cmd/boot/network_ready_test.go
+++ b/tinfoil/cmd/boot/network_ready_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	shimconfig "tinfoil/internal/config"
 )
@@ -46,6 +47,31 @@ func TestNetworkInterfaceAtPCIRejectsAmbiguousTopology(t *testing.T) {
 	}
 }
 
+func TestWaitForNetworkInterfacePollsUntilSysfsAppears(t *testing.T) {
+	root := t.TempDir()
+	createErr := make(chan error, 1)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		createErr <- os.MkdirAll(
+			filepath.Join(root, "0000:00:02.0", "virtio0", "net", "ens2"),
+			0755,
+		)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, err := waitForNetworkInterface(ctx, root, "0000:00:02.0", 5*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := <-createErr; err != nil {
+		t.Fatal(err)
+	}
+	if got != "ens2" {
+		t.Fatalf("waitForNetworkInterface() = %q, want ens2", got)
+	}
+}
+
 func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 	var calls []string
 	run := func(_ context.Context, name string, args ...string) ([]byte, error) {
@@ -53,17 +79,23 @@ func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 		return nil, nil
 	}
 	config := shimconfig.ExternalNetworkConfig{
-		Version: 1,
+		Version: 2,
 		Address: "100.64.0.42/20",
 		Gateway: "100.64.0.1",
+		DNS:     "1.1.1.1",
 	}
 	if err := applyStaticNetwork(context.Background(), "ens2", &config, run); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
 		"/usr/sbin/ip link set dev ens2 up",
+		"/usr/sbin/ip addr flush dev ens2",
+		"/usr/sbin/ip route flush dev ens2",
 		"/usr/sbin/ip addr replace 100.64.0.42/20 dev ens2",
 		"/usr/sbin/ip route replace default via 100.64.0.1 dev ens2",
+		"/usr/bin/resolvectl dns ens2 1.1.1.1",
+		"/usr/bin/resolvectl domain ens2 ~.",
+		"/usr/bin/resolvectl default-route ens2 yes",
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %v, want %v", calls, want)
@@ -72,9 +104,10 @@ func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 
 func TestApplyStaticNetworkPropagatesCommandFailure(t *testing.T) {
 	config := &shimconfig.ExternalNetworkConfig{
-		Version: 1,
+		Version: 2,
 		Address: "100.64.0.42/20",
 		Gateway: "100.64.0.1",
+		DNS:     "1.1.1.1",
 	}
 	run := func(_ context.Context, _ string, _ ...string) ([]byte, error) {
 		return []byte("permission denied"), errors.New("exit status 2")
@@ -82,5 +115,28 @@ func TestApplyStaticNetworkPropagatesCommandFailure(t *testing.T) {
 	err := applyStaticNetwork(context.Background(), "ens2", config, run)
 	if err == nil || !strings.Contains(err.Error(), "permission denied") {
 		t.Fatalf("command failure = %v", err)
+	}
+}
+
+func TestImageNetworkWiringLeavesNICToTinfoilBoot(t *testing.T) {
+	networkdConfig, err := os.ReadFile(
+		"../../../mkosi.extra/etc/systemd/network/20-enp0s2.network",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(networkdConfig), "Unmanaged=yes") ||
+		strings.Contains(string(networkdConfig), "DHCP=") {
+		t.Fatalf("networkd still owns guest addressing:\n%s", networkdConfig)
+	}
+
+	bootUnit, err := os.ReadFile(
+		"../../../mkosi.extra/etc/systemd/system/tinfoil-boot.service",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(bootUnit), "network-online.target") {
+		t.Fatalf("tinfoil-boot still waits for network-online.target:\n%s", bootUnit)
 	}
 }

--- a/tinfoil/cmd/boot/network_ready_test.go
+++ b/tinfoil/cmd/boot/network_ready_test.go
@@ -79,10 +79,10 @@ func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 		return nil, nil
 	}
 	config := shimconfig.ExternalNetworkConfig{
-		Version: 2,
-		Address: "100.64.0.42/20",
-		Gateway: "100.64.0.1",
-		DNS:     "1.1.1.1",
+		Version:     2,
+		Address:     "100.64.0.42/20",
+		Gateway:     "100.64.0.1",
+		Nameservers: []string{"1.1.1.1", "1.0.0.1"},
 	}
 	if err := applyStaticNetwork(context.Background(), "ens2", &config, run); err != nil {
 		t.Fatal(err)
@@ -93,7 +93,7 @@ func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 		"/usr/sbin/ip route flush dev ens2",
 		"/usr/sbin/ip addr replace 100.64.0.42/20 dev ens2",
 		"/usr/sbin/ip route replace default via 100.64.0.1 dev ens2",
-		"/usr/bin/resolvectl dns ens2 1.1.1.1",
+		"/usr/bin/resolvectl dns ens2 1.1.1.1 1.0.0.1",
 		"/usr/bin/resolvectl domain ens2 ~.",
 		"/usr/bin/resolvectl default-route ens2 yes",
 	}
@@ -104,10 +104,10 @@ func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 
 func TestApplyStaticNetworkPropagatesCommandFailure(t *testing.T) {
 	config := &shimconfig.ExternalNetworkConfig{
-		Version: 2,
-		Address: "100.64.0.42/20",
-		Gateway: "100.64.0.1",
-		DNS:     "1.1.1.1",
+		Version:     2,
+		Address:     "100.64.0.42/20",
+		Gateway:     "100.64.0.1",
+		Nameservers: []string{"1.1.1.1"},
 	}
 	run := func(_ context.Context, _ string, _ ...string) ([]byte, error) {
 		return []byte("permission denied"), errors.New("exit status 2")

--- a/tinfoil/cmd/boot/network_ready_test.go
+++ b/tinfoil/cmd/boot/network_ready_test.go
@@ -79,10 +79,8 @@ func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 		return nil, nil
 	}
 	config := shimconfig.ExternalNetworkConfig{
-		Version:     2,
-		Address:     "100.64.0.42/20",
-		Gateway:     "100.64.0.1",
-		Nameservers: []string{"1.1.1.1", "1.0.0.1"},
+		Address: "100.64.0.42/20",
+		Gateway: "100.64.0.1",
 	}
 	if err := applyStaticNetwork(context.Background(), "ens2", &config, run); err != nil {
 		t.Fatal(err)
@@ -104,10 +102,8 @@ func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 
 func TestApplyStaticNetworkPropagatesCommandFailure(t *testing.T) {
 	config := &shimconfig.ExternalNetworkConfig{
-		Version:     2,
-		Address:     "100.64.0.42/20",
-		Gateway:     "100.64.0.1",
-		Nameservers: []string{"1.1.1.1"},
+		Address: "100.64.0.42/20",
+		Gateway: "100.64.0.1",
 	}
 	run := func(_ context.Context, _ string, _ ...string) ([]byte, error) {
 		return []byte("permission denied"), errors.New("exit status 2")

--- a/tinfoil/cmd/boot/network_ready_test.go
+++ b/tinfoil/cmd/boot/network_ready_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+)
+
+func TestNetworkInterfaceAtPCIFollowsMeasuredDevice(t *testing.T) {
+	root := t.TempDir()
+	netDir := filepath.Join(root, "0000:00:02.0", "virtio0", "net", "ens2")
+	if err := os.MkdirAll(netDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "0000:00:03.0", "virtio1", "net", "ens3"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := networkInterfaceAtPCI(root, "0000:00:02.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "ens2" {
+		t.Fatalf("networkInterfaceAtPCI() = %q, want ens2", got)
+	}
+}
+
+func TestNetworkInterfaceAtPCIRejectsAmbiguousTopology(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{"ens2", "ens3"} {
+		if err := os.MkdirAll(
+			filepath.Join(root, "0000:00:02.0", "virtio0", "net", name),
+			0755,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := networkInterfaceAtPCI(root, "0000:00:02.0"); err == nil {
+		t.Fatal("networkInterfaceAtPCI() accepted ambiguous topology")
+	}
+}
+
+func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
+	var calls []string
+	run := func(_ context.Context, name string, args ...string) ([]byte, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return nil, nil
+	}
+	config := shimconfig.ExternalNetworkConfig{
+		Version: 1,
+		Address: "100.64.0.42/20",
+		Gateway: "100.64.0.1",
+	}
+	if err := applyStaticNetwork(context.Background(), "ens2", &config, run); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"/usr/sbin/ip link set dev ens2 up",
+		"/usr/sbin/ip addr replace 100.64.0.42/20 dev ens2",
+		"/usr/sbin/ip route replace default via 100.64.0.1 dev ens2",
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestApplyStaticNetworkPropagatesCommandFailure(t *testing.T) {
+	config := &shimconfig.ExternalNetworkConfig{
+		Version: 1,
+		Address: "100.64.0.42/20",
+		Gateway: "100.64.0.1",
+	}
+	run := func(_ context.Context, _ string, _ ...string) ([]byte, error) {
+		return []byte("permission denied"), errors.New("exit status 2")
+	}
+	err := applyStaticNetwork(context.Background(), "ens2", config, run)
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("command failure = %v", err)
+	}
+}

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -38,4 +38,8 @@ const (
 
 	// InitBinary is PID 1 after the measured root replaces the initrd.
 	InitBinary = "/usr/bin/tinfoil-init"
+
+	// ExternalNICPCIAddress is the measured virtio-net topology ABI. It MUST
+	// match tinfoild/admin/guest_topology.go.
+	ExternalNICPCIAddress = "0000:00:02.0"
 )

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -33,6 +33,7 @@ const (
 
 const (
 	StageConfig         = "config"
+	StageNetwork        = "network"
 	StageIdentity       = "identity"
 	StageCPUAttestation = "cpu-attestation"
 	StageGPUAttestation = "gpu-attestation"
@@ -48,7 +49,7 @@ const (
 // InitialStages is the ordered list of stages known at boot time.
 // Both boot and shim use this as the starting point.
 var InitialStages = []string{
-	StageConfig, StageIdentity, StageCPUAttestation, StageGPUAttestation, StageCertificate,
+	StageConfig, StageNetwork, StageIdentity, StageCPUAttestation, StageGPUAttestation, StageCertificate,
 	StageVaultSecrets, StageRegistryAuth, StageFirewall, StageModels, StageContainers, StageShim,
 }
 

--- a/tinfoil/internal/boot/state_test.go
+++ b/tinfoil/internal/boot/state_test.go
@@ -11,6 +11,11 @@ func TestNetworkStagePrecedesIdentityAndAttestation(t *testing.T) {
 	for index, stage := range InitialStages {
 		positions[stage] = index
 	}
+	for _, stage := range []string{StageNetwork, StageIdentity, StageCPUAttestation} {
+		if _, ok := positions[stage]; !ok {
+			t.Fatalf("required stage %q is missing: %v", stage, InitialStages)
+		}
+	}
 	if positions[StageNetwork] >= positions[StageIdentity] ||
 		positions[StageNetwork] >= positions[StageCPUAttestation] {
 		t.Fatalf("network stage must precede network-dependent boot work: %v", InitialStages)

--- a/tinfoil/internal/boot/state_test.go
+++ b/tinfoil/internal/boot/state_test.go
@@ -6,6 +6,17 @@ import (
 	"testing"
 )
 
+func TestNetworkStagePrecedesIdentityAndAttestation(t *testing.T) {
+	positions := make(map[string]int, len(InitialStages))
+	for index, stage := range InitialStages {
+		positions[stage] = index
+	}
+	if positions[StageNetwork] >= positions[StageIdentity] ||
+		positions[StageNetwork] >= positions[StageCPUAttestation] {
+		t.Fatalf("network stage must precede network-dependent boot work: %v", InitialStages)
+	}
+}
+
 func TestWriteStateAtomic(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "boot-state.json")

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 
@@ -52,21 +54,34 @@ const (
 )
 
 type Metadata struct {
-	ID     string `yaml:"id"`
-	Domain string `yaml:"domain"`
-	Image  string `yaml:"image"`
-	GPU    string `yaml:"gpu"`
-	Repo   string `yaml:"repo,omitempty"`
-	Digest string `yaml:"digest,omitempty"`
+	ID     string               `yaml:"id"`
+	Domain string               `yaml:"domain"`
+	Image  string               `yaml:"image"`
+	CPU    string               `yaml:"cpu"`
+	GPU    string               `yaml:"gpu"`
+	Repo   string               `yaml:"repo,omitempty"`
+	Digest string               `yaml:"digest,omitempty"`
+	Extra  map[string]yaml.Node `yaml:",inline"`
+}
+
+type ExternalNetworkConfig struct {
+	Version int    `yaml:"version"`
+	Address string `yaml:"address"`
+	Gateway string `yaml:"gateway"`
 }
 
 type ExternalConfig struct {
-	MetricsAPIKey string
-	ACPIAPIKey    string
-	Env           map[string]string `yaml:"env"`
-	Secrets       map[string]string `yaml:"secrets"`
-	Metadata      Metadata          `yaml:"metadata"`
-	VaultToken    string            `yaml:"vault-token,omitempty"`
+	MetricsAPIKey string                 `yaml:"-"`
+	ACPIAPIKey    string                 `yaml:"-"`
+	Env           map[string]string      `yaml:"env"`
+	Secrets       map[string]string      `yaml:"secrets"`
+	Metadata      Metadata               `yaml:"metadata"`
+	VaultToken    string                 `yaml:"vault-token,omitempty"`
+	Network       *ExternalNetworkConfig `yaml:"network"`
+
+	// tinfoild preserves operator-owned top-level external data. Keep accepting
+	// those unrelated keys while KnownFields rejects unknown network fields.
+	Extra map[string]yaml.Node `yaml:",inline"`
 }
 
 func (e *ExternalConfig) GetSecret(key string) string {
@@ -78,6 +93,31 @@ func (e *ExternalConfig) GetSecret(key string) string {
 		return ""
 	}
 	return v
+}
+
+// DecodeExternal strictly decodes typed external-config sections. Unknown
+// operator-owned top-level keys remain opaque through ExternalConfig.Extra.
+func DecodeExternal(data []byte) (*ExternalConfig, error) {
+	var config ExternalConfig
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to decode external config: %v", err)
+	}
+	var trailing yaml.Node
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("failed to decode external config: multiple YAML documents")
+		}
+		return nil, fmt.Errorf("failed to decode external config: %v", err)
+	}
+	if err := defaults.Set(&config); err != nil {
+		return nil, fmt.Errorf("failed to set external config defaults: %v", err)
+	}
+
+	config.MetricsAPIKey = config.GetSecret(SecretMetricsAPIKey)
+	config.ACPIAPIKey = config.GetSecret(SecretACPIAPIKey)
+	return &config, nil
 }
 
 // Decode populates a Config from a yaml.Node (a parsed YAML subtree),
@@ -135,16 +175,9 @@ func Load(configFile, externalConfigFile string) (*Config, *ExternalConfig, erro
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read external config file: %v", err)
 	}
-	var externalConfig ExternalConfig
-	if err := yaml.Unmarshal(externalConfigBytes, &externalConfig); err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal external config: %v", err)
+	externalConfig, err := DecodeExternal(externalConfigBytes)
+	if err != nil {
+		return nil, nil, err
 	}
-	if err := defaults.Set(&externalConfig); err != nil {
-		return nil, nil, fmt.Errorf("failed to set defaults: %v", err)
-	}
-
-	externalConfig.MetricsAPIKey = externalConfig.GetSecret(SecretMetricsAPIKey)
-	externalConfig.ACPIAPIKey = externalConfig.GetSecret(SecretACPIAPIKey)
-
-	return config, &externalConfig, nil
+	return config, externalConfig, nil
 }

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -67,10 +67,8 @@ type Metadata struct {
 }
 
 type ExternalNetworkConfig struct {
-	Version     int      `yaml:"version"`
-	Address     string   `yaml:"address"`
-	Gateway     string   `yaml:"gateway"`
-	Nameservers []string `yaml:"nameservers"`
+	Address string `yaml:"address"`
+	Gateway string `yaml:"gateway"`
 }
 
 type ExternalConfig struct {

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -67,10 +67,10 @@ type Metadata struct {
 }
 
 type ExternalNetworkConfig struct {
-	Version int    `yaml:"version"`
-	Address string `yaml:"address"`
-	Gateway string `yaml:"gateway"`
-	DNS     string `yaml:"dns"`
+	Version     int      `yaml:"version"`
+	Address     string   `yaml:"address"`
+	Gateway     string   `yaml:"gateway"`
+	Nameservers []string `yaml:"nameservers"`
 }
 
 type ExternalConfig struct {

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -70,6 +70,7 @@ type ExternalNetworkConfig struct {
 	Version int    `yaml:"version"`
 	Address string `yaml:"address"`
 	Gateway string `yaml:"gateway"`
+	DNS     string `yaml:"dns"`
 }
 
 type ExternalConfig struct {

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -54,14 +54,16 @@ const (
 )
 
 type Metadata struct {
-	ID     string               `yaml:"id"`
-	Domain string               `yaml:"domain"`
-	Image  string               `yaml:"image"`
-	CPU    string               `yaml:"cpu"`
-	GPU    string               `yaml:"gpu"`
-	Repo   string               `yaml:"repo,omitempty"`
-	Digest string               `yaml:"digest,omitempty"`
-	Extra  map[string]yaml.Node `yaml:",inline"`
+	ID     string `yaml:"id"`
+	Domain string `yaml:"domain"`
+	Image  string `yaml:"image"`
+	CPU    string `yaml:"cpu"`
+	GPU    string `yaml:"gpu"`
+	Repo   string `yaml:"repo,omitempty"`
+	Digest string `yaml:"digest,omitempty"`
+	// Extra preserves operator metadata that tinfoild merges into this
+	// unmeasured document. Only the security-sensitive network block is closed.
+	Extra map[string]yaml.Node `yaml:",inline"`
 }
 
 type ExternalNetworkConfig struct {

--- a/tinfoil/internal/config/config_test.go
+++ b/tinfoil/internal/config/config_test.go
@@ -32,9 +32,10 @@ func TestGetSecret(t *testing.T) {
 func TestDecodeExternalStrictNetwork(t *testing.T) {
 	config, err := DecodeExternal([]byte(`
 network:
-  version: 1
+  version: 2
   address: 100.64.0.42/20
   gateway: 100.64.0.1
+  dns: 1.1.1.1
 secrets:
   METRICS_API_KEY: metrics-secret
 metadata:
@@ -47,9 +48,10 @@ operator-extension:
 		t.Fatal(err)
 	}
 	if config.Network == nil ||
-		config.Network.Version != 1 ||
+		config.Network.Version != 2 ||
 		config.Network.Address != "100.64.0.42/20" ||
-		config.Network.Gateway != "100.64.0.1" {
+		config.Network.Gateway != "100.64.0.1" ||
+		config.Network.DNS != "1.1.1.1" {
 		t.Fatalf("unexpected network config: %+v", config.Network)
 	}
 	if config.Metadata.CPU != "amd" {
@@ -69,10 +71,11 @@ operator-extension:
 func TestDecodeExternalRejectsUnknownNetworkField(t *testing.T) {
 	_, err := DecodeExternal([]byte(`
 network:
-  version: 1
+  version: 2
   address: 10.0.2.15/24
   gateway: 10.0.2.2
   dns: 10.0.2.3
+  unexpected: true
 `))
 	if err == nil {
 		t.Fatal("DecodeExternal accepted an unknown network field")

--- a/tinfoil/internal/config/config_test.go
+++ b/tinfoil/internal/config/config_test.go
@@ -1,13 +1,15 @@
 package config
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestGetSecret(t *testing.T) {
 	tests := []struct {
-		name    string
-		config  *ExternalConfig
-		key     string
-		want    string
+		name   string
+		config *ExternalConfig
+		key    string
+		want   string
 	}{
 		{"nil receiver", nil, "KEY", ""},
 		{"nil secrets map", &ExternalConfig{}, "KEY", ""},
@@ -24,5 +26,57 @@ func TestGetSecret(t *testing.T) {
 				t.Errorf("GetSecret(%q) = %q, want %q", tt.key, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDecodeExternalStrictNetwork(t *testing.T) {
+	config, err := DecodeExternal([]byte(`
+network:
+  version: 1
+  address: 100.64.0.42/20
+  gateway: 100.64.0.1
+secrets:
+  METRICS_API_KEY: metrics-secret
+metadata:
+  cpu: amd
+operator-extension:
+  retained: true
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Network == nil ||
+		config.Network.Version != 1 ||
+		config.Network.Address != "100.64.0.42/20" ||
+		config.Network.Gateway != "100.64.0.1" {
+		t.Fatalf("unexpected network config: %+v", config.Network)
+	}
+	if config.Metadata.CPU != "amd" {
+		t.Fatalf("metadata CPU = %q", config.Metadata.CPU)
+	}
+	if config.MetricsAPIKey != "metrics-secret" {
+		t.Fatalf("MetricsAPIKey = %q", config.MetricsAPIKey)
+	}
+	if _, ok := config.Extra["operator-extension"]; !ok {
+		t.Fatal("operator-owned top-level extension was not retained")
+	}
+}
+
+func TestDecodeExternalRejectsUnknownNetworkField(t *testing.T) {
+	_, err := DecodeExternal([]byte(`
+network:
+  version: 1
+  address: 10.0.2.15/24
+  gateway: 10.0.2.2
+  dns: 10.0.2.3
+`))
+	if err == nil {
+		t.Fatal("DecodeExternal accepted an unknown network field")
+	}
+}
+
+func TestDecodeExternalRejectsMultipleDocuments(t *testing.T) {
+	if _, err := DecodeExternal([]byte("{}\n---\n{}\n")); err == nil {
+		t.Fatal("DecodeExternal accepted multiple YAML documents")
 	}
 }

--- a/tinfoil/internal/config/config_test.go
+++ b/tinfoil/internal/config/config_test.go
@@ -35,7 +35,7 @@ network:
   version: 2
   address: 100.64.0.42/20
   gateway: 100.64.0.1
-  dns: 1.1.1.1
+  nameservers: [1.1.1.1, 1.0.0.1]
 secrets:
   METRICS_API_KEY: metrics-secret
 metadata:
@@ -51,7 +51,9 @@ operator-extension:
 		config.Network.Version != 2 ||
 		config.Network.Address != "100.64.0.42/20" ||
 		config.Network.Gateway != "100.64.0.1" ||
-		config.Network.DNS != "1.1.1.1" {
+		len(config.Network.Nameservers) != 2 ||
+		config.Network.Nameservers[0] != "1.1.1.1" ||
+		config.Network.Nameservers[1] != "1.0.0.1" {
 		t.Fatalf("unexpected network config: %+v", config.Network)
 	}
 	if config.Metadata.CPU != "amd" {
@@ -74,7 +76,7 @@ network:
   version: 2
   address: 10.0.2.15/24
   gateway: 10.0.2.2
-  dns: 10.0.2.3
+  nameservers: [10.0.2.3]
   unexpected: true
 `))
 	if err == nil {

--- a/tinfoil/internal/config/config_test.go
+++ b/tinfoil/internal/config/config_test.go
@@ -32,10 +32,8 @@ func TestGetSecret(t *testing.T) {
 func TestDecodeExternalStrictNetwork(t *testing.T) {
 	config, err := DecodeExternal([]byte(`
 network:
-  version: 2
   address: 100.64.0.42/20
   gateway: 100.64.0.1
-  nameservers: [1.1.1.1, 1.0.0.1]
 secrets:
   METRICS_API_KEY: metrics-secret
 metadata:
@@ -48,12 +46,8 @@ operator-extension:
 		t.Fatal(err)
 	}
 	if config.Network == nil ||
-		config.Network.Version != 2 ||
 		config.Network.Address != "100.64.0.42/20" ||
-		config.Network.Gateway != "100.64.0.1" ||
-		len(config.Network.Nameservers) != 2 ||
-		config.Network.Nameservers[0] != "1.1.1.1" ||
-		config.Network.Nameservers[1] != "1.0.0.1" {
+		config.Network.Gateway != "100.64.0.1" {
 		t.Fatalf("unexpected network config: %+v", config.Network)
 	}
 	if config.Metadata.CPU != "amd" {
@@ -73,10 +67,8 @@ operator-extension:
 func TestDecodeExternalRejectsUnknownNetworkField(t *testing.T) {
 	_, err := DecodeExternal([]byte(`
 network:
-  version: 2
-  address: 10.0.2.15/24
-  gateway: 10.0.2.2
-  nameservers: [10.0.2.3]
+  address: 100.64.0.42/20
+  gateway: 100.64.0.1
   unexpected: true
 `))
 	if err == nil {

--- a/tinfoil/internal/config/config_test.go
+++ b/tinfoil/internal/config/config_test.go
@@ -39,6 +39,7 @@ secrets:
   METRICS_API_KEY: metrics-secret
 metadata:
   cpu: amd
+  operator-label: retained
 operator-extension:
   retained: true
 `))
@@ -53,6 +54,9 @@ operator-extension:
 	}
 	if config.Metadata.CPU != "amd" {
 		t.Fatalf("metadata CPU = %q", config.Metadata.CPU)
+	}
+	if config.Metadata.Extra["operator-label"].Value != "retained" {
+		t.Fatalf("operator metadata not retained: %+v", config.Metadata.Extra)
 	}
 	if config.MetricsAPIKey != "metrics-secret" {
 		t.Fatalf("MetricsAPIKey = %q", config.MetricsAPIKey)

--- a/tinfoil/internal/device/topology.go
+++ b/tinfoil/internal/device/topology.go
@@ -1,0 +1,167 @@
+package device
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// These are the measured PCI addresses QEMU assigned before tinfoild made
+	// them explicit. They MUST match tinfoild/admin/guest_topology.go.
+	configDiskPCIAddress   = "0000:00:05.0"
+	externalDiskPCIAddress = "0000:00:06.0"
+	firstModelDiskPCISlot  = 7
+	lastUsableDiskPCISlot  = 30 // Q35 reserves slot 31 for ISA/SATA/SMBus.
+
+	EMWPPayloadPartition = 1
+	// MaxModelDisks is the number of Q35 slots reserved for model disks.
+	MaxModelDisks = lastUsableDiskPCISlot - firstModelDiskPCISlot + 1
+)
+
+var (
+	sysBusPCIDevices = "/sys/bus/pci/devices"
+	sysBlockDir      = "/sys/block"
+	devDir           = "/dev"
+
+	deviceWaitTimeout = 30 * time.Second
+	deviceWaitDelay   = 100 * time.Millisecond
+)
+
+// ConfigDisk returns the disk below the fixed config controller.
+func ConfigDisk() (string, error) {
+	return waitForDevice(func() (string, error) {
+		return findDiskByPCIAddress(configDiskPCIAddress)
+	})
+}
+
+// ExternalConfigDisk returns the disk below the fixed external-config
+// controller.
+func ExternalConfigDisk() (string, error) {
+	return waitForDevice(func() (string, error) {
+		return findDiskByPCIAddress(externalDiskPCIAddress)
+	})
+}
+
+// ModelDisk returns the disk at a model's fixed position in the config.
+func ModelDisk(index int) (string, error) {
+	pciAddress, err := modelDiskPCIAddress(index)
+	if err != nil {
+		return "", err
+	}
+	return waitForDevice(func() (string, error) {
+		return findDiskByPCIAddress(pciAddress)
+	})
+}
+
+// ModelPartition returns a numbered partition on a model's fixed disk.
+func ModelPartition(index, partition int) (string, error) {
+	pciAddress, err := modelDiskPCIAddress(index)
+	if err != nil {
+		return "", err
+	}
+	return waitForDevice(func() (string, error) {
+		disk, err := findDiskByPCIAddress(pciAddress)
+		if err != nil {
+			return "", err
+		}
+		return findPartition(disk, partition)
+	})
+}
+
+func modelDiskPCIAddress(index int) (string, error) {
+	slot := firstModelDiskPCISlot + index
+	if index < 0 || slot > lastUsableDiskPCISlot {
+		return "", fmt.Errorf("model index %d exceeds the measured PCI slot range", index)
+	}
+	return fmt.Sprintf("0000:00:%02x.0", slot), nil
+}
+
+func waitForDevice(find func() (string, error)) (string, error) {
+	deadline := time.Now().Add(deviceWaitTimeout)
+	var lastErr error
+	for {
+		path, err := find()
+		if err == nil {
+			return path, nil
+		}
+		lastErr = err
+		if time.Now().After(deadline) {
+			return "", lastErr
+		}
+		time.Sleep(deviceWaitDelay)
+	}
+}
+
+// findDiskByPCIAddress follows kernel topology only. It deliberately does not
+// parse serial/VPD bytes or disk contents as identity.
+func findDiskByPCIAddress(pciAddress string) (string, error) {
+	pattern := filepath.Join(
+		sysBusPCIDevices, pciAddress,
+		"virtio*", "host*", "target*", "*", "block", "*",
+	)
+	blockPaths, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", fmt.Errorf("finding disk below PCI device %s: %w", pciAddress, err)
+	}
+	var matches []string
+	for _, blockPath := range blockPaths {
+		path := filepath.Join(devDir, filepath.Base(blockPath))
+		if _, err := os.Stat(path); err == nil {
+			matches = append(matches, path)
+		}
+	}
+	sort.Strings(matches)
+	matches = compactPaths(matches)
+	if len(matches) == 1 {
+		return matches[0], nil
+	}
+	return "", fmt.Errorf(
+		"expected one disk below PCI device %s, found %d",
+		pciAddress, len(matches),
+	)
+}
+
+func compactPaths(paths []string) []string {
+	if len(paths) < 2 {
+		return paths
+	}
+	out := paths[:1]
+	for _, path := range paths[1:] {
+		if path != out[len(out)-1] {
+			out = append(out, path)
+		}
+	}
+	return out
+}
+
+func findPartition(diskPath string, partition int) (string, error) {
+	if partition <= 0 {
+		return "", fmt.Errorf("invalid partition number %d", partition)
+	}
+	disk := filepath.Base(diskPath)
+	entries, err := os.ReadDir(filepath.Join(sysBlockDir, disk))
+	if err != nil {
+		return "", fmt.Errorf("reading partitions for %s: %w", diskPath, err)
+	}
+	for _, entry := range entries {
+		data, err := os.ReadFile(filepath.Join(sysBlockDir, disk, entry.Name(), "partition"))
+		if err != nil {
+			continue
+		}
+		found, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil || found != partition {
+			continue
+		}
+		path := filepath.Join(devDir, entry.Name())
+		if _, err := os.Stat(path); err != nil {
+			return "", fmt.Errorf("partition node %s not ready: %w", path, err)
+		}
+		return path, nil
+	}
+	return "", fmt.Errorf("partition %d on %s not found", partition, diskPath)
+}

--- a/tinfoil/internal/device/topology_test.go
+++ b/tinfoil/internal/device/topology_test.go
@@ -1,0 +1,151 @@
+package device
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type deviceFixture struct {
+	pci string
+	sys string
+	dev string
+}
+
+func withFixture(t *testing.T) deviceFixture {
+	t.Helper()
+	root := t.TempDir()
+	fixture := deviceFixture{
+		pci: filepath.Join(root, "sys/bus/pci/devices"),
+		sys: filepath.Join(root, "sys/block"),
+		dev: filepath.Join(root, "dev"),
+	}
+	for _, path := range []string{fixture.pci, fixture.sys, fixture.dev} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	oldPCI, oldSys, oldDev := sysBusPCIDevices, sysBlockDir, devDir
+	oldTimeout, oldDelay := deviceWaitTimeout, deviceWaitDelay
+	sysBusPCIDevices, sysBlockDir, devDir = fixture.pci, fixture.sys, fixture.dev
+	deviceWaitTimeout, deviceWaitDelay = 0, 0
+	t.Cleanup(func() {
+		sysBusPCIDevices, sysBlockDir, devDir = oldPCI, oldSys, oldDev
+		deviceWaitTimeout, deviceWaitDelay = oldTimeout, oldDelay
+	})
+	return fixture
+}
+
+func TestConfigDiskUsesFixedController(t *testing.T) {
+	fixture := withFixture(t)
+	addPCIDisk(t, fixture, configDiskPCIAddress, "sda")
+
+	got, err := ConfigDisk()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(fixture.dev, "sda"); got != want {
+		t.Fatalf("ConfigDisk() = %q, want %q", got, want)
+	}
+}
+
+func TestExternalConfigDiskUsesFixedController(t *testing.T) {
+	fixture := withFixture(t)
+	addPCIDisk(t, fixture, externalDiskPCIAddress, "sdb")
+
+	got, err := ExternalConfigDisk()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(fixture.dev, "sdb"); got != want {
+		t.Fatalf("ExternalConfigDisk() = %q, want %q", got, want)
+	}
+}
+
+func TestConfigDiskRejectsWrongOrAmbiguousTopology(t *testing.T) {
+	t.Run("wrong controller", func(t *testing.T) {
+		fixture := withFixture(t)
+		addPCIDisk(t, fixture, "0000:00:04.0", "sda")
+		if _, err := ConfigDisk(); err == nil {
+			t.Fatal("ConfigDisk() accepted a disk below the root controller")
+		}
+	})
+	t.Run("ambiguous controller", func(t *testing.T) {
+		fixture := withFixture(t)
+		addPCIDisk(t, fixture, configDiskPCIAddress, "sda")
+		addPCIDisk(t, fixture, configDiskPCIAddress, "sdb")
+		if _, err := ConfigDisk(); err == nil {
+			t.Fatal("ConfigDisk() accepted an ambiguous controller")
+		}
+	})
+}
+
+func TestModelDiskAndPartitionUseConfigOrder(t *testing.T) {
+	fixture := withFixture(t)
+	addPCIDisk(t, fixture, "0000:00:07.0", "sdc")
+	partitionDir := filepath.Join(fixture.sys, "sdc", "sdc1")
+	mustMkdir(t, partitionDir)
+	mustWrite(t, filepath.Join(partitionDir, "partition"), "1\n")
+	mustWrite(t, filepath.Join(fixture.dev, "sdc1"), "")
+
+	disk, err := ModelDisk(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(fixture.dev, "sdc"); disk != want {
+		t.Fatalf("ModelDisk(0) = %q, want %q", disk, want)
+	}
+	partition, err := ModelPartition(0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(fixture.dev, "sdc1"); partition != want {
+		t.Fatalf("ModelPartition(0, 1) = %q, want %q", partition, want)
+	}
+}
+
+func TestModelDiskBounds(t *testing.T) {
+	for index, want := range map[int]string{
+		0:                 "0000:00:07.0",
+		MaxModelDisks - 1: "0000:00:1e.0",
+	} {
+		got, err := modelDiskPCIAddress(index)
+		if err != nil {
+			t.Fatalf("modelDiskPCIAddress(%d): %v", index, err)
+		}
+		if got != want {
+			t.Fatalf("modelDiskPCIAddress(%d) = %q, want %q", index, got, want)
+		}
+	}
+	for _, index := range []int{-1, lastUsableDiskPCISlot - firstModelDiskPCISlot + 1} {
+		if _, err := modelDiskPCIAddress(index); err == nil {
+			t.Fatalf("modelDiskPCIAddress(%d) succeeded", index)
+		}
+	}
+}
+
+func addPCIDisk(t *testing.T, fixture deviceFixture, controller, name string) {
+	t.Helper()
+	blockDir := filepath.Join(
+		fixture.pci, controller,
+		"virtio0", "host0", "target0:0:0", "0:0:0:0", "block", name,
+	)
+	mustMkdir(t, blockDir)
+	mustMkdir(t, filepath.Join(fixture.sys, name))
+	mustWrite(t, filepath.Join(fixture.dev, name), "")
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(path, 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustWrite(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary

- discover config, external-config, and model disks from the fixed Q35 PCI controller ABI shipped by tinfoild
- require a bounded external-config disk and strictly decode its bridge-only address/gateway subsection
- make `tinfoil-boot` the sole owner of the fixed NIC: disable networkd management and DHCP, clear prior address/route state, apply static IPv4, and configure the two fixed public resolvers
- poll the measured PCI path for delayed NIC enumeration
- mount plaintext and encrypted model disks by configuration order instead of filesystem UUID/PARTUUID aliases

## Trust boundary

`external_config.network` is deliberately unmeasured host-selected operational input and contains only `address` and `gateway`. Resolver policy stays compiled into the measured guest. The block has no schema version because there is only one new-image format; strict decoding rejects obsolete and unknown fields, while the cvmimage 0.11.0 compatibility boundary distinguishes legacy DHCP images.

The measured workload config and `tinfoil-config-hash` are unchanged. The guest validates the IPv4 prefix/gateway relationship, reserved addresses, PCI topology, model bounds, and disk payload size before use.

This branch is based directly on the small public recut, so it adds the fixed mechanisms rather than first landing and then deleting the DHCP, SCSI VPD/serial, and filesystem-superblock parsers from #172. It therefore prevents roughly 1,700 lines of legacy parser code from entering the replacement series even though the standalone diff is additive.

## Dependency and rollout

- fixed PCI producer: tinfoild #140
- bridge-only DHCP-free producer: tinfoild #141 must merge first
- release v0.6.7 is required only before final cvmimage 0.11.0 integration or release
- producer feature gate: cvmimage 0.11.0
- no fallback for older tinfoild; release compatibility must reject that pairing
- review-only: the final additive rootfs/image switch remains a later PR

## Review focus

- `tinfoil/internal/device/topology.go`: fixed PCI ABI and model slot bounds
- `tinfoil/internal/config/config.go`: strict minimal external network schema
- `tinfoil/cmd/boot/config.go`: bounded config-disk reads and fail-closed loading
- `tinfoil/cmd/boot/network_ready.go`: exact static address/route/resolver commands and delayed enumeration
- `mkosi.extra/etc/systemd/network/20-enp0s2.network`: explicit networkd non-ownership
- `mkosi.extra/etc/systemd/system/tinfoil-boot.service`: no pre-static-network `network-online` wait
- `tinfoil/cmd/boot/models.go`: positional model-device binding

## Validation

- `go test ./...`
- `go test -race ./cmd/boot ./internal/config ./internal/device`
- `go test -tags=integration ./cmd/boot`
- `go vet ./...`
- `git diff --check origin/jules/harden-tcb...HEAD`

A no-DHCP built-image boot remains a required gate before the later image-switch PR.