### PR TITLE
Add parser-free measured-root initrd

### DIFF
--- a/mkosi.conf
+++ b/mkosi.conf
@@ -9,6 +9,10 @@ Repositories=main restricted universe multiverse
 [Output]
 Format=disk
 Output=tinfoilcvm
+# systemd-repart derives the dm-verity salt as
+# HMAC-SHA256(Seed, "verity-salt"). Keep this synchronized with
+# tinfoil/cmd/initrd so no verity superblock fields enter the runtime TCB.
+Seed=48c56959-5579-5709-85af-f5393936a4d8
 
 [Content]
 Hostname=tinfoil

--- a/mkosi.repart/11-root-verity.conf
+++ b/mkosi.repart/11-root-verity.conf
@@ -2,4 +2,6 @@
 Type=root-verity
 Verity=hash
 VerityMatchKey=root
+VerityDataBlockSizeBytes=4096
+VerityHashBlockSizeBytes=4096
 SizeMinBytes=1.5G

--- a/tinfoil/cmd/initrd/main.go
+++ b/tinfoil/cmd/initrd/main.go
@@ -1,0 +1,449 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"tinfoil/internal/boot"
+	"tinfoil/internal/devicemapper"
+)
+
+const (
+	// systemd-repart derives this salt as
+	// HMAC-SHA256(repartSeed, "verity-salt"). mkosi.conf pins the same seed.
+	// This is build policy, not secret material.
+	repartSeed = "48c56959-5579-5709-85af-f5393936a4d8"
+	veritySalt = "d8f43870af05f2fb613c2bb571f911da45cfa46a77e6efeabbdd5ed760ebabde"
+
+	// These are the systemd-repart dm-verity format invariants used by
+	// mkosi.repart/10-root.conf and 11-root-verity.conf. A mismatch fails
+	// closed because the resulting tree cannot match the measured roothash.
+	verityTableVersion   = 1
+	verityDataBlockSize  = 4096
+	verityHashBlockSize  = 4096
+	verityHashAlgorithm  = "sha256"
+	verityHashStartBlock = 1
+
+	dmName     = "root"
+	dmRootNode = "/dev/mapper/root"
+	kmsgInfo   = "<6>"
+)
+
+var (
+	consoleMu     sync.Mutex
+	sysClassBlock = "/sys/class/block"
+)
+
+func main() {
+	log.SetFlags(0)
+	if err := run(); err != nil {
+		initrdLogf("fatal: %v", err)
+		for {
+			time.Sleep(time.Minute)
+		}
+	}
+}
+
+func run() error {
+	if err := mountInitrdFilesystems(); err != nil {
+		return err
+	}
+
+	roothash, err := cmdlineValue("roothash")
+	if err != nil || !isHex64(roothash) {
+		return errors.New("missing or invalid roothash")
+	}
+	roothash = strings.ToLower(roothash)
+
+	// systemd-repart assigns the data partition the first 128 bits of the
+	// roothash and the hash partition the final 128 bits.
+	rootHex32, verityHex32 := splitRoothash(roothash)
+	rootPartUUID := guidFromHex32(rootHex32)
+	verityPartUUID := guidFromHex32(verityHex32)
+
+	initrdLogf("waiting for root PARTUUID %s", rootPartUUID)
+	rootDevice, err := findPartUUID(rootPartUUID, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("root data partition not found: %w", err)
+	}
+	initrdLogf("waiting for verity PARTUUID %s", verityPartUUID)
+	verityDevice, err := findPartUUID(verityPartUUID, 30*time.Second)
+	if err != nil {
+		return fmt.Errorf("root verity partition not found: %w", err)
+	}
+
+	// Partition size comes from kernel sysfs. Every other verity parameter is
+	// fixed build policy; no verity superblock bytes are parsed at runtime.
+	dataBlocks, err := verityDataBlocks(rootDevice)
+	if err != nil {
+		return err
+	}
+	rootDevNumber, err := blockDevNumber(rootDevice)
+	if err != nil {
+		return err
+	}
+	verityDevNumber, err := blockDevNumber(verityDevice)
+	if err != nil {
+		return err
+	}
+	verityLengthSectors := dataBlocks * (verityDataBlockSize / 512)
+	verityParams := verityTableParams(rootDevNumber, verityDevNumber, dataBlocks, roothash)
+
+	info, err := createMeasuredRoot(verityLengthSectors, verityParams)
+	if err != nil {
+		return err
+	}
+	initrdLogf(
+		"measured root active: dev=%d:%d flags=0x%x targets=%d",
+		unix.Major(info.Dev),
+		unix.Minor(info.Dev),
+		info.Flags,
+		info.TargetCount,
+	)
+	if !isBlockDevice(dmRootNode) {
+		return fmt.Errorf("%s was not created", dmRootNode)
+	}
+
+	if err := os.MkdirAll("/sysroot", 0755); err != nil {
+		return err
+	}
+	if err := unix.Mount(dmRootNode, "/sysroot", "ext4", unix.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("mounting measured root: %w", err)
+	}
+	return switchRoot("/sysroot", boot.InitBinary)
+}
+
+func verityTableParams(rootDev, hashDev string, dataBlocks uint64, roothash string) string {
+	return fmt.Sprintf(
+		"%d %s %s %d %d %d %d %s %s %s",
+		verityTableVersion,
+		rootDev,
+		hashDev,
+		verityDataBlockSize,
+		verityHashBlockSize,
+		dataBlocks,
+		verityHashStartBlock,
+		verityHashAlgorithm,
+		roothash,
+		veritySalt,
+	)
+}
+
+func mountInitrdFilesystems() error {
+	mounts := []struct {
+		source string
+		target string
+		fstype string
+		flags  uintptr
+		data   string
+	}{
+		{"devtmpfs", "/dev", "devtmpfs", unix.MS_NOSUID, "mode=0755"},
+		{"proc", "/proc", "proc", unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC, ""},
+		{"sysfs", "/sys", "sysfs", unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC, ""},
+		{"tmpfs", "/run", "tmpfs", unix.MS_NOSUID | unix.MS_NODEV, "mode=0755"},
+	}
+	for _, mount := range mounts {
+		if err := mountIfNeeded(mount.source, mount.target, mount.fstype, mount.flags, mount.data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mountIfNeeded(source, target, fstype string, flags uintptr, data string) error {
+	if isMountPoint(target) {
+		return nil
+	}
+	if err := os.MkdirAll(target, 0755); err != nil {
+		return err
+	}
+	if err := unix.Mount(source, target, fstype, flags, data); err != nil {
+		if errors.Is(err, unix.EBUSY) {
+			return nil
+		}
+		return fmt.Errorf("mount %s on %s: %w", fstype, target, err)
+	}
+	return nil
+}
+
+func isMountPoint(target string) bool {
+	file, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 5 && fields[4] == target {
+			return true
+		}
+	}
+	return false
+}
+
+func cmdlineValue(name string) (string, error) {
+	data, err := os.ReadFile("/proc/cmdline")
+	if err != nil {
+		return "", err
+	}
+	return cmdlineValueFrom(string(data), name)
+}
+
+func cmdlineValueFrom(cmdline, name string) (string, error) {
+	prefix := name + "="
+	var value string
+	found := false
+	for _, field := range strings.Fields(cmdline) {
+		candidate, ok := strings.CutPrefix(field, prefix)
+		if !ok {
+			continue
+		}
+		if found {
+			return "", fmt.Errorf("duplicate kernel command-line parameter %s", name)
+		}
+		value = candidate
+		found = true
+	}
+	if !found {
+		return "", os.ErrNotExist
+	}
+	return value, nil
+}
+
+func isHex64(value string) bool {
+	if len(value) != 64 {
+		return false
+	}
+	for _, char := range value {
+		if (char < '0' || char > '9') &&
+			(char < 'a' || char > 'f') &&
+			(char < 'A' || char > 'F') {
+			return false
+		}
+	}
+	return true
+}
+
+func splitRoothash(roothash string) (string, string) {
+	return roothash[:32], roothash[32:]
+}
+
+func guidFromHex32(value string) string {
+	value = strings.ToLower(value)
+	return fmt.Sprintf(
+		"%s-%s-%s-%s-%s",
+		value[:8], value[8:12], value[12:16], value[16:20], value[20:],
+	)
+}
+
+func findPartUUID(want string, timeout time.Duration) (string, error) {
+	want = strings.ToLower(want)
+	deadline := time.Now().Add(timeout)
+	for {
+		var matches []string
+		uevents, _ := filepath.Glob("/sys/block/*/*/uevent")
+		for _, path := range uevents {
+			fields, err := readUevent(path)
+			if err != nil ||
+				fields["DEVTYPE"] != "partition" ||
+				strings.ToLower(fields["PARTUUID"]) != want {
+				continue
+			}
+			device := filepath.Join("/dev", fields["DEVNAME"])
+			if isBlockDevice(device) {
+				matches = append(matches, device)
+			}
+		}
+		sort.Strings(matches)
+		matches = compactStrings(matches)
+		switch len(matches) {
+		case 1:
+			return matches[0], nil
+		case 0:
+			if time.Now().After(deadline) {
+				return "", os.ErrNotExist
+			}
+			time.Sleep(100 * time.Millisecond)
+		default:
+			return "", fmt.Errorf("PARTUUID %s is ambiguous", want)
+		}
+	}
+}
+
+func compactStrings(values []string) []string {
+	if len(values) < 2 {
+		return values
+	}
+	out := values[:1]
+	for _, value := range values[1:] {
+		if value != out[len(out)-1] {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func readUevent(path string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	fields := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), "=")
+		if ok {
+			fields[key] = value
+		}
+	}
+	return fields, scanner.Err()
+}
+
+func isBlockDevice(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0
+}
+
+func createMeasuredRoot(lengthSectors uint64, params string) (devicemapper.Info, error) {
+	control, err := devicemapper.OpenControl()
+	if err != nil {
+		return devicemapper.Info{}, err
+	}
+	defer control.Close()
+
+	if _, err := devicemapper.CheckVersion(control); err != nil {
+		return devicemapper.Info{}, err
+	}
+	if _, err := devicemapper.CreateReadOnly(control, dmName); err != nil {
+		return devicemapper.Info{}, err
+	}
+	if err := devicemapper.LoadReadOnlyVerityTable(control, dmName, lengthSectors, params); err != nil {
+		return devicemapper.Info{}, err
+	}
+	if err := devicemapper.ResumeReadOnly(control, dmName); err != nil {
+		return devicemapper.Info{}, err
+	}
+
+	info, err := devicemapper.Status(control, dmName)
+	if err != nil {
+		return devicemapper.Info{}, err
+	}
+	if !info.Active() {
+		return devicemapper.Info{}, errors.New("measured root device has no active table")
+	}
+	if !info.ReadOnly() {
+		return devicemapper.Info{}, errors.New("measured root device is not read-only")
+	}
+	if err := devicemapper.EnsureBlockNode(dmRootNode, info.Dev); err != nil {
+		return devicemapper.Info{}, err
+	}
+	return info, nil
+}
+
+// verityDataBlocks derives geometry from the kernel's partition size instead
+// of trusting the host-controlled verity superblock.
+func verityDataBlocks(dataDevice string) (uint64, error) {
+	name := strings.TrimPrefix(dataDevice, "/dev/")
+	data, err := os.ReadFile(filepath.Join(sysClassBlock, name, "size"))
+	if err != nil {
+		return 0, fmt.Errorf("reading data partition size for %s: %w", dataDevice, err)
+	}
+	sectors, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parsing data partition size: %w", err)
+	}
+	const sectorsPerDataBlock = verityDataBlockSize / 512
+	if sectors == 0 || sectors%sectorsPerDataBlock != 0 {
+		return 0, fmt.Errorf(
+			"data partition size %d sectors is not a multiple of %d",
+			sectors, sectorsPerDataBlock,
+		)
+	}
+	return sectors / sectorsPerDataBlock, nil
+}
+
+func blockDevNumber(device string) (string, error) {
+	name := strings.TrimPrefix(device, "/dev/")
+	data, err := os.ReadFile(filepath.Join(sysClassBlock, name, "dev"))
+	if err != nil {
+		return "", fmt.Errorf("missing sysfs device number for %s: %w", device, err)
+	}
+	majorText, minorText, ok := strings.Cut(strings.TrimSpace(string(data)), ":")
+	if !ok {
+		return "", fmt.Errorf("invalid sysfs device number for %s", device)
+	}
+	major, majorErr := strconv.ParseUint(majorText, 10, 32)
+	minor, minorErr := strconv.ParseUint(minorText, 10, 32)
+	if majorErr != nil || minorErr != nil {
+		return "", fmt.Errorf("invalid sysfs device number for %s", device)
+	}
+	return fmt.Sprintf("%d:%d", major, minor), nil
+}
+
+func switchRoot(newRoot, initPath string) error {
+	if err := unix.Mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		return fmt.Errorf("making mounts private before root hand-off: %w", err)
+	}
+	for _, dir := range []string{"dev", "proc", "sys", "run"} {
+		source := "/" + dir
+		target := filepath.Join(newRoot, dir)
+		if err := os.MkdirAll(target, 0755); err != nil {
+			return err
+		}
+		if err := unix.Mount(source, target, "", unix.MS_MOVE, ""); err != nil {
+			return fmt.Errorf("moving %s into measured root: %w", source, err)
+		}
+	}
+
+	if err := unix.Chdir(newRoot); err != nil {
+		return err
+	}
+	if err := unix.Mount(newRoot, "/", "", unix.MS_MOVE, ""); err != nil {
+		return fmt.Errorf("moving measured root to /: %w", err)
+	}
+	if err := unix.Chroot("."); err != nil {
+		return err
+	}
+	if err := unix.Chdir("/"); err != nil {
+		return err
+	}
+	return unix.Exec(initPath, []string{initPath}, os.Environ())
+}
+
+func initrdLogf(format string, args ...any) {
+	message := fmt.Sprintf(format, args...)
+	consoleMu.Lock()
+	defer consoleMu.Unlock()
+	log.Print("tinfoil-initrd: " + message)
+	for _, path := range []string{"/dev/kmsg", "/dev/ttyS0", "/dev/console"} {
+		file, err := os.OpenFile(path, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+		if err != nil {
+			continue
+		}
+		if path == "/dev/kmsg" {
+			_, _ = fmt.Fprintf(file, kmsgInfo+"tinfoil-initrd: %s\n", message)
+		} else {
+			_, _ = fmt.Fprintf(file, "tinfoil-initrd: %s\n", message)
+		}
+		_ = file.Close()
+	}
+}

--- a/tinfoil/cmd/initrd/main.go
+++ b/tinfoil/cmd/initrd/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -268,8 +267,6 @@ func findPartUUID(want string, timeout time.Duration) (string, error) {
 				matches = append(matches, device)
 			}
 		}
-		sort.Strings(matches)
-		matches = compactStrings(matches)
 		switch len(matches) {
 		case 1:
 			return matches[0], nil
@@ -282,19 +279,6 @@ func findPartUUID(want string, timeout time.Duration) (string, error) {
 			return "", fmt.Errorf("PARTUUID %s is ambiguous", want)
 		}
 	}
-}
-
-func compactStrings(values []string) []string {
-	if len(values) < 2 {
-		return values
-	}
-	out := values[:1]
-	for _, value := range values[1:] {
-		if value != out[len(out)-1] {
-			out = append(out, value)
-		}
-	}
-	return out
 }
 
 func readUevent(path string) (map[string]string, error) {

--- a/tinfoil/cmd/initrd/main_test.go
+++ b/tinfoil/cmd/initrd/main_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPinnedVeritySaltMatchesRepartSeed(t *testing.T) {
+	seedBytes, err := hex.DecodeString(strings.ReplaceAll(repartSeed, "-", ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	mac := hmac.New(sha256.New, seedBytes)
+	if _, err := mac.Write([]byte("verity-salt")); err != nil {
+		t.Fatal(err)
+	}
+	if got := hex.EncodeToString(mac.Sum(nil)); got != veritySalt {
+		t.Fatalf("derived salt = %s, want %s", got, veritySalt)
+	}
+
+	mkosiConfig, err := os.ReadFile("../../../mkosi.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(mkosiConfig), "Seed="+repartSeed+"\n") {
+		t.Fatalf("mkosi.conf does not pin repart seed %s", repartSeed)
+	}
+
+	repartConfig, err := os.ReadFile("../../../mkosi.repart/11-root-verity.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, setting := range []string{
+		"VerityDataBlockSizeBytes=4096\n",
+		"VerityHashBlockSizeBytes=4096\n",
+	} {
+		if !strings.Contains(string(repartConfig), setting) {
+			t.Fatalf("root verity repart config is missing %s", strings.TrimSpace(setting))
+		}
+	}
+}
+
+func TestVerityTableParamsAreFullyPinned(t *testing.T) {
+	roothash := strings.Repeat("ab", 32)
+	got := verityTableParams("8:1", "8:2", 786432, roothash)
+	want := "1 8:1 8:2 4096 4096 786432 1 sha256 " + roothash + " " + veritySalt
+	if got != want {
+		t.Fatalf("verityTableParams() = %q, want %q", got, want)
+	}
+}
+
+func TestIsHex64(t *testing.T) {
+	valid := strings.Repeat("a", 64)
+	if !isHex64(valid) {
+		t.Fatal("valid roothash rejected")
+	}
+	for _, value := range []string{
+		valid[:63],
+		valid + "0",
+		"0123456789abcdefABCDEF0123456789abcdefABCDEF0123456789abcdez",
+	} {
+		if isHex64(value) {
+			t.Fatalf("invalid roothash accepted: %q", value)
+		}
+	}
+}
+
+func TestSplitRoothashAndGUID(t *testing.T) {
+	roothash := "0123456789abcdef0123456789abcdefabcDEF0123456789ABCDef0123456789"
+	root, verity := splitRoothash(roothash)
+	if root != "0123456789abcdef0123456789abcdef" {
+		t.Fatalf("root half = %q", root)
+	}
+	if verity != "abcDEF0123456789ABCDef0123456789" {
+		t.Fatalf("verity half = %q", verity)
+	}
+	if got := guidFromHex32(root); got != "01234567-89ab-cdef-0123-456789abcdef" {
+		t.Fatalf("root GUID = %q", got)
+	}
+	if got := guidFromHex32(verity); got != "abcdef01-2345-6789-abcd-ef0123456789" {
+		t.Fatalf("verity GUID = %q", got)
+	}
+}
+
+func TestCmdlineValueFromRejectsAmbiguity(t *testing.T) {
+	value, err := cmdlineValueFrom("console=hvc0 roothash=abcd", "roothash")
+	if err != nil || value != "abcd" {
+		t.Fatalf("cmdlineValueFrom() = %q, %v", value, err)
+	}
+	if _, err := cmdlineValueFrom("roothash=one roothash=two", "roothash"); err == nil {
+		t.Fatal("duplicate roothash accepted")
+	}
+	if _, err := cmdlineValueFrom("console=hvc0", "roothash"); !os.IsNotExist(err) {
+		t.Fatalf("missing roothash error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestVerityDataBlocksUsesKernelGeometry(t *testing.T) {
+	root := t.TempDir()
+	sizeDir := filepath.Join(root, "sdb1")
+	if err := os.MkdirAll(sizeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sizeDir, "size"), []byte("6291456\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	old := sysClassBlock
+	sysClassBlock = root
+	t.Cleanup(func() { sysClassBlock = old })
+
+	got, err := verityDataBlocks("/dev/sdb1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 786432 {
+		t.Fatalf("verityDataBlocks() = %d, want 786432", got)
+	}
+
+	if err := os.WriteFile(filepath.Join(sizeDir, "size"), []byte("6291455\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verityDataBlocks("/dev/sdb1"); err == nil {
+		t.Fatal("misaligned partition size accepted")
+	}
+
+	maxAlignedSectors := ^uint64(0) - 7
+	if err := os.WriteFile(
+		filepath.Join(sizeDir, "size"),
+		[]byte(strconv.FormatUint(maxAlignedSectors, 10)),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	got, err = verityDataBlocks("/dev/sdb1")
+	if err != nil {
+		t.Fatalf("maximum aligned sector count rejected: %v", err)
+	}
+	if want := maxAlignedSectors / 8; got != want {
+		t.Fatalf("maximum data block count = %d, want %d", got, want)
+	}
+}
+
+func TestBlockDevNumberValidatesSysfs(t *testing.T) {
+	root := t.TempDir()
+	devDir := filepath.Join(root, "sdb1")
+	if err := os.MkdirAll(devDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	old := sysClassBlock
+	sysClassBlock = root
+	t.Cleanup(func() { sysClassBlock = old })
+
+	path := filepath.Join(devDir, "dev")
+	if err := os.WriteFile(path, []byte("8:17\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := blockDevNumber("/dev/sdb1"); err != nil || got != "8:17" {
+		t.Fatalf("blockDevNumber() = %q, %v", got, err)
+	}
+	if err := os.WriteFile(path, []byte("8:17:1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := blockDevNumber("/dev/sdb1"); err == nil {
+		t.Fatal("malformed device number accepted")
+	}
+}

--- a/tinfoil/cmd/initrd/main_test.go
+++ b/tinfoil/cmd/initrd/main_test.go
@@ -101,6 +101,13 @@ func TestCmdlineValueFromRejectsAmbiguity(t *testing.T) {
 	}
 }
 
+func withSysClassBlock(t *testing.T, root string) {
+	t.Helper()
+	old := sysClassBlock
+	sysClassBlock = root
+	t.Cleanup(func() { sysClassBlock = old })
+}
+
 func TestVerityDataBlocksUsesKernelGeometry(t *testing.T) {
 	root := t.TempDir()
 	sizeDir := filepath.Join(root, "sdb1")
@@ -110,9 +117,7 @@ func TestVerityDataBlocksUsesKernelGeometry(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(sizeDir, "size"), []byte("6291456\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	old := sysClassBlock
-	sysClassBlock = root
-	t.Cleanup(func() { sysClassBlock = old })
+	withSysClassBlock(t, root)
 
 	got, err := verityDataBlocks("/dev/sdb1")
 	if err != nil {
@@ -152,9 +157,7 @@ func TestBlockDevNumberValidatesSysfs(t *testing.T) {
 	if err := os.MkdirAll(devDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	old := sysClassBlock
-	sysClassBlock = root
-	t.Cleanup(func() { sysClassBlock = old })
+	withSysClassBlock(t, root)
 
 	path := filepath.Join(devDir, "dev")
 	if err := os.WriteFile(path, []byte("8:17\n"), 0644); err != nil {

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -35,4 +35,7 @@ const (
 	// HTTPChallengePort is the plaintext-HTTP port served by tinfoil-boot
 	// during cert-proxy + tls-challenge.
 	HTTPChallengePort = 80
+
+	// InitBinary is PID 1 after the measured root replaces the initrd.
+	InitBinary = "/usr/bin/tinfoil-init"
 )

--- a/tinfoil/internal/devicemapper/devicemapper.go
+++ b/tinfoil/internal/devicemapper/devicemapper.go
@@ -174,12 +174,14 @@ func CreateReadOnly(control *os.File, name string) (Info, error) {
 	return infoFromBuffer(buf), nil
 }
 
-// LoadReadOnlyTable loads one read-only target covering lengthSectors.
-func LoadReadOnlyTable(control *os.File, name string, lengthSectors uint64, targetType, params string) error {
+// LoadReadOnlyVerityTable loads one read-only verity target covering
+// lengthSectors. The target type is fixed so callers cannot select a broader
+// device-mapper surface.
+func LoadReadOnlyVerityTable(control *os.File, name string, lengthSectors uint64, params string) error {
 	if err := validateName(name); err != nil {
 		return err
 	}
-	buf, err := tableLoadBuffer(name, lengthSectors, targetType, params)
+	buf, err := tableLoadBuffer(name, lengthSectors, "verity", params)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- add the small Go initrd that discovers root partitions from the measured roothash, creates a read-only dm-verity mapping, and hands off to `tinfoil-init`
- reuse #174's device-mapper ioctl package and narrow its exported table loader to the `verity` target
- derive only root geometry and device numbers from kernel sysfs; parse no verity-superblock bytes
- reuse the additive builder's fixed repart seed and hardcode systemd-repart v259's geometry-independent derived salt
- explicitly pin both verity block sizes to 4096 bytes
- carry no generic module loader and no module-mode kernel command-line parameter

## Build contract

The canonical seed already used by `codex/bazel-additive-stage1/2` is:

```
48c56959-5579-5709-85af-f5393936a4d8
```

systemd-repart v259 computes `HMAC-SHA256(seed, "verity-salt")`, yielding:

```
d8f43870af05f2fb613c2bb571f911da45cfa46a77e6efeabbdd5ed760ebabde
```

The unit test independently derives that value and verifies the matching `mkosi.conf` and repart policy settings.

## Dependency and rollout

- code dependency: merged #174
- merge/release dependency: #175 must provide built-in `DM_BUFIO` and `DM_VERITY`
- review-only: this PR does not assemble or select the additive initrd, wire the custom kernel, or switch the shipping image
- #173 is superseded because it still reads salt from the verity superblock

## Review focus

- `tinfoil/cmd/initrd/main.go`: roothash/PARTUUID handling, fixed verity table, read-only mount, and `switch_root`
- `mkosi.conf` and `mkosi.repart/11-root-verity.conf`: reproducible producer contract
- `tinfoil/internal/devicemapper/devicemapper.go`: verity-only exported table API

## Validation

- `go test ./...`
- `go test -race ./cmd/initrd ./internal/devicemapper`
- `go vet ./...`
- absence check for `readVeritySalt`, verity-superblock parsing, `FinitModule`, module manifests, and `tinfoil-initrd-modules`
- `git diff --check origin/jules/harden-tcb...HEAD`

A clean built-artifact smoke (including zeroing superblock block 0 while preserving hash-tree block 1) remains a gate for the later additive-initrd/image-switch PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a small Go initrd that boots a measured, read-only root via `dm-verity` without parsing the verity superblock. It derives geometry from sysfs, enforces fixed verity parameters, and hands off to `tinfoil-init`.

- New Features
  - New `tinfoil/cmd/initrd`: reads `roothash`, derives `PARTUUID`s, waits for devices, creates a read-only `dm-verity` mapping, mounts `/sysroot`, and `switch_root`s to `boot.InitBinary` (`/usr/bin/tinfoil-init`).
  - No superblock parsing: only partition size and device numbers come from sysfs; params are fixed (sha256, start=1, 4K data/hash blocks, salt from HMAC-SHA256(seed, "verity-salt")).
  - Producer settings pinned: `mkosi.conf` seeds `systemd-repart`; `mkosi.repart/11-root-verity.conf` sets 4096-byte blocks; tests verify seed, salt, and table params and simplify discovery/geometry helpers. `tinfoil/internal/devicemapper` is narrowed to `LoadReadOnlyVerityTable`.

- Migration
  - Kernel must include built-in `DM_BUFIO` and `DM_VERITY`.
  - Boot with `roothash=<64-hex>` on the kernel cmdline.
  - Build with `Seed=48c56959-5579-5709-85af-f5393936a4d8` in `mkosi.conf` and `Verity*BlockSizeBytes=4096` in `mkosi.repart/11-root-verity.conf`. No module loader or module-mode cmdline is supported.

<sup>Written for commit b3c3e05af945cc154c630a255d58602a53187513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

