### PR TITLE
Add bounded NVIDIA module loader

### DIFF
--- a/kernel/build-nvidia-open-local.sh
+++ b/kernel/build-nvidia-open-local.sh
@@ -13,7 +13,9 @@ kernel_out_dir="${TINFOIL_KERNEL_OUT_DIR:-$kernel_dir/out}"
 kernel_release="${TINFOIL_KERNEL_RELEASE:-$(tr -d '\n' < "$kernel_out_dir/kernel.release")}"
 kernel_source_dir="${TINFOIL_KERNEL_SOURCE_DIR:-$kernel_dir/build/linux-source-$kernel_source_version}"
 scratch_dir="${TINFOIL_NVIDIA_OPEN_BUILD_DIR:-$kernel_dir/build/nvidia-open-$nvidia_version}"
-stage_dir="${TINFOIL_NVIDIA_OPEN_STAGE_DIR:-$repo_dir/image/rootfs-overlay/usr/lib/modules/$kernel_release/updates/dkms}"
+# finit_module loads by file descriptor, so keep the three measured artifacts
+# at a fixed application-owned path instead of parsing uname at runtime.
+stage_dir="${TINFOIL_NVIDIA_OPEN_STAGE_DIR:-$repo_dir/image/rootfs-overlay/usr/lib/tinfoil/kernel-modules}"
 
 source_deb="nvidia-kernel-source-open_${nvidia_package_version}_amd64.deb"
 dkms_deb="nvidia-dkms-open_${nvidia_package_version}_amd64.deb"

--- a/tinfoil/internal/nvidia/modules.go
+++ b/tinfoil/internal/nvidia/modules.go
@@ -1,0 +1,177 @@
+// Package nvidia owns the fixed policy and mechanisms needed to initialize
+// NVIDIA hardware in a Tinfoil CVM.
+package nvidia
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	nvidiaModuleRoot = "/usr/lib/tinfoil/kernel-modules"
+	moduleSysfsRoot  = "/sys/module"
+
+	nvidiaCoreParameters = "NVreg_TemporaryFilePath=/var/tmp " +
+		"NVreg_EnableS0ixPowerManagement=1 " +
+		"NVreg_PreserveVideoMemoryAllocations=1"
+)
+
+type modulePolicy struct {
+	kernelName string
+	candidates [2]string
+	parameters string
+}
+
+var (
+	coreModule = modulePolicy{
+		kernelName: "nvidia",
+		candidates: [2]string{"nvidia.ko.zst", "nvidia.ko"},
+		parameters: nvidiaCoreParameters,
+	}
+	uvmModule = modulePolicy{
+		kernelName: "nvidia_uvm",
+		candidates: [2]string{"nvidia-uvm.ko.zst", "nvidia-uvm.ko"},
+	}
+	modesetModule = modulePolicy{
+		kernelName: "nvidia_modeset",
+		candidates: [2]string{"nvidia-modeset.ko.zst", "nvidia-modeset.ko"},
+	}
+)
+
+type dependencies struct {
+	moduleRoot      string
+	moduleSysfsRoot string
+	stat            func(string) (os.FileInfo, error)
+	finitModule     func(string, string, int) error
+}
+
+// LoadCoreKernelModules loads the fixed NVIDIA core module inventory.
+func LoadCoreKernelModules() error {
+	return loadInventory("core", systemDependencies(), coreModule)
+}
+
+// LoadUVMKernelModules loads the fixed NVIDIA core and UVM module inventory.
+func LoadUVMKernelModules() error {
+	return loadInventory("UVM", systemDependencies(), coreModule, uvmModule)
+}
+
+// LoadModesetKernelModules loads the fixed NVIDIA core and modeset inventory.
+func LoadModesetKernelModules() error {
+	return loadInventory("modeset", systemDependencies(), coreModule, modesetModule)
+}
+
+func systemDependencies() dependencies {
+	return dependencies{
+		moduleRoot:      nvidiaModuleRoot,
+		moduleSysfsRoot: moduleSysfsRoot,
+		stat:            os.Stat,
+		finitModule:     finitModule,
+	}
+}
+
+func loadInventory(name string, deps dependencies, inventory ...modulePolicy) error {
+	for _, policy := range inventory {
+		if err := loadModule(policy, deps); err != nil {
+			return fmt.Errorf("load NVIDIA %s modules: %w", name, err)
+		}
+	}
+	return nil
+}
+
+func loadModule(policy modulePolicy, deps dependencies) error {
+	loaded, err := moduleLoaded(policy.kernelName, deps)
+	if err != nil {
+		return fmt.Errorf("check whether %s is loaded: %w", policy.kernelName, err)
+	}
+	if loaded {
+		return nil
+	}
+
+	var missing []string
+	for _, candidate := range policy.candidates {
+		path, err := fixedModulePath(deps.moduleRoot, candidate)
+		if err != nil {
+			return fmt.Errorf("resolve fixed candidate for %s: %w", policy.kernelName, err)
+		}
+		if _, err := deps.stat(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				missing = append(missing, path)
+				continue
+			}
+			return fmt.Errorf("%s stat %s: %w", policy.kernelName, path, err)
+		}
+
+		flags := 0
+		if strings.HasSuffix(candidate, ".ko.zst") {
+			flags = unix.MODULE_INIT_COMPRESSED_FILE
+		}
+		err = deps.finitModule(path, policy.parameters, flags)
+		if err == nil || errors.Is(err, unix.EEXIST) {
+			return nil
+		}
+		return fmt.Errorf("%s finit_module %s: %w", policy.kernelName, path, err)
+	}
+
+	return fmt.Errorf(
+		"no fixed NVIDIA module candidate for %s under %s (missing: %s)",
+		policy.kernelName,
+		deps.moduleRoot,
+		strings.Join(missing, ", "),
+	)
+}
+
+func fixedModulePath(root, candidate string) (string, error) {
+	if !filepath.IsAbs(root) || filepath.Clean(root) != root {
+		return "", errors.New("invalid fixed NVIDIA module root")
+	}
+	if !fixedNVIDIACandidate(candidate) {
+		return "", fmt.Errorf("invalid fixed NVIDIA candidate %q", candidate)
+	}
+
+	path := filepath.Join(root, candidate)
+	relative, err := filepath.Rel(root, path)
+	if err != nil {
+		return "", fmt.Errorf("resolve NVIDIA module path: %w", err)
+	}
+	if relative != candidate {
+		return "", errors.New("NVIDIA module path escaped fixed module root")
+	}
+	return path, nil
+}
+
+func fixedNVIDIACandidate(candidate string) bool {
+	switch candidate {
+	case "nvidia.ko.zst", "nvidia.ko",
+		"nvidia-uvm.ko.zst", "nvidia-uvm.ko",
+		"nvidia-modeset.ko.zst", "nvidia-modeset.ko":
+		return true
+	default:
+		return false
+	}
+}
+
+func moduleLoaded(name string, deps dependencies) (bool, error) {
+	_, err := deps.stat(filepath.Join(deps.moduleSysfsRoot, name))
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+func finitModule(path, parameters string, flags int) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return unix.FinitModule(int(file.Fd()), parameters, flags)
+}

--- a/tinfoil/internal/nvidia/modules_test.go
+++ b/tinfoil/internal/nvidia/modules_test.go
@@ -1,0 +1,284 @@
+package nvidia
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+type finitCall struct {
+	path       string
+	parameters string
+	flags      int
+}
+
+func testDependencies(
+	loaded map[string]bool,
+	files map[string]bool,
+	loader func(string, string, int) error,
+) dependencies {
+	return dependencies{
+		moduleRoot:      "/modules",
+		moduleSysfsRoot: "/sys/module",
+		stat: func(path string) (os.FileInfo, error) {
+			if strings.HasPrefix(path, "/sys/module/") {
+				if loaded[filepath.Base(path)] {
+					return nil, nil
+				}
+				return nil, os.ErrNotExist
+			}
+			if files[path] {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		finitModule: loader,
+	}
+}
+
+func loadedName(path string) string {
+	switch filepath.Base(path) {
+	case "nvidia.ko", "nvidia.ko.zst":
+		return "nvidia"
+	case "nvidia-uvm.ko", "nvidia-uvm.ko.zst":
+		return "nvidia_uvm"
+	case "nvidia-modeset.ko", "nvidia-modeset.ko.zst":
+		return "nvidia_modeset"
+	default:
+		return ""
+	}
+}
+
+func TestFixedInventoriesLoadOnlyOrderedNVIDIAModules(t *testing.T) {
+	const coreParameters = "NVreg_TemporaryFilePath=/var/tmp " +
+		"NVreg_EnableS0ixPowerManagement=1 " +
+		"NVreg_PreserveVideoMemoryAllocations=1"
+
+	tests := []struct {
+		name      string
+		inventory []modulePolicy
+		want      []finitCall
+	}{
+		{
+			name:      "core",
+			inventory: []modulePolicy{coreModule},
+			want: []finitCall{{
+				path:       "/modules/nvidia.ko.zst",
+				parameters: coreParameters,
+				flags:      unix.MODULE_INIT_COMPRESSED_FILE,
+			}},
+		},
+		{
+			name:      "UVM",
+			inventory: []modulePolicy{coreModule, uvmModule},
+			want: []finitCall{
+				{
+					path:       "/modules/nvidia.ko.zst",
+					parameters: coreParameters,
+					flags:      unix.MODULE_INIT_COMPRESSED_FILE,
+				},
+				{
+					path:  "/modules/nvidia-uvm.ko.zst",
+					flags: unix.MODULE_INIT_COMPRESSED_FILE,
+				},
+			},
+		},
+		{
+			name:      "modeset",
+			inventory: []modulePolicy{coreModule, modesetModule},
+			want: []finitCall{
+				{
+					path:       "/modules/nvidia.ko.zst",
+					parameters: coreParameters,
+					flags:      unix.MODULE_INIT_COMPRESSED_FILE,
+				},
+				{
+					path:  "/modules/nvidia-modeset.ko.zst",
+					flags: unix.MODULE_INIT_COMPRESSED_FILE,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			loaded := map[string]bool{}
+			files := map[string]bool{
+				"/modules/nvidia.ko.zst":         true,
+				"/modules/nvidia-uvm.ko.zst":     true,
+				"/modules/nvidia-modeset.ko.zst": true,
+				"/modules/not-nvidia.ko.zst":     true,
+			}
+			var got []finitCall
+			deps := testDependencies(loaded, files, func(path, parameters string, flags int) error {
+				got = append(got, finitCall{path: path, parameters: parameters, flags: flags})
+				name := loadedName(path)
+				if name == "" {
+					t.Fatalf("attempted to load non-NVIDIA candidate %q", path)
+				}
+				loaded[name] = true
+				return nil
+			})
+
+			if err := loadInventory(test.name, deps, test.inventory...); err != nil {
+				t.Fatalf("loadInventory: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("finit_module calls = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestFinitModuleCompressionFlagAndCandidateOrder(t *testing.T) {
+	tests := []struct {
+		name      string
+		files     map[string]bool
+		wantPath  string
+		wantFlags int
+		wantStats []string
+	}{
+		{
+			name: "compressed preferred",
+			files: map[string]bool{
+				"/modules/nvidia.ko.zst": true,
+				"/modules/nvidia.ko":     true,
+			},
+			wantPath:  "/modules/nvidia.ko.zst",
+			wantFlags: unix.MODULE_INIT_COMPRESSED_FILE,
+			wantStats: []string{
+				"/modules/nvidia.ko.zst",
+			},
+		},
+		{
+			name: "uncompressed fallback",
+			files: map[string]bool{
+				"/modules/nvidia.ko": true,
+			},
+			wantPath:  "/modules/nvidia.ko",
+			wantFlags: 0,
+			wantStats: []string{
+				"/modules/nvidia.ko.zst",
+				"/modules/nvidia.ko",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var gotCall finitCall
+			var gotStats []string
+			deps := testDependencies(map[string]bool{}, test.files, func(path, parameters string, flags int) error {
+				gotCall = finitCall{path: path, parameters: parameters, flags: flags}
+				return nil
+			})
+			stat := deps.stat
+			deps.stat = func(path string) (os.FileInfo, error) {
+				if !strings.HasPrefix(path, "/sys/module/") {
+					gotStats = append(gotStats, path)
+				}
+				return stat(path)
+			}
+
+			if err := loadInventory("core", deps, coreModule); err != nil {
+				t.Fatalf("loadInventory: %v", err)
+			}
+			if gotCall.path != test.wantPath || gotCall.flags != test.wantFlags {
+				t.Fatalf("finit_module call = %#v, want path %q flags %d", gotCall, test.wantPath, test.wantFlags)
+			}
+			if !reflect.DeepEqual(gotStats, test.wantStats) {
+				t.Fatalf("candidate stat order = %q, want %q", gotStats, test.wantStats)
+			}
+		})
+	}
+}
+
+func TestFixedModulePathAllowsOnlyMeasuredInventory(t *testing.T) {
+	path, err := fixedModulePath(nvidiaModuleRoot, "nvidia-uvm.ko.zst")
+	if err != nil {
+		t.Fatalf("fixedModulePath: %v", err)
+	}
+	const want = "/usr/lib/tinfoil/kernel-modules/nvidia-uvm.ko.zst"
+	if path != want {
+		t.Fatalf("fixedModulePath = %q, want %q", path, want)
+	}
+
+	for _, candidate := range []string{
+		"evil.ko",
+		"../nvidia.ko",
+		"updates/dkms/nvidia.ko",
+		"nvidia-drm.ko",
+		"nvidia-peermem.ko.zst",
+	} {
+		t.Run(fmt.Sprintf("candidate_%q", candidate), func(t *testing.T) {
+			if _, err := fixedModulePath(nvidiaModuleRoot, candidate); err == nil {
+				t.Fatalf("fixedModulePath accepted non-inventory candidate %q", candidate)
+			}
+		})
+	}
+	if _, err := fixedModulePath("usr/lib/tinfoil/kernel-modules", "nvidia.ko"); err == nil {
+		t.Fatal("fixedModulePath accepted relative module root")
+	}
+}
+
+func TestAlreadyLoadedModulesAreSafe(t *testing.T) {
+	t.Run("loaded before call", func(t *testing.T) {
+		deps := testDependencies(map[string]bool{"nvidia": true}, nil, func(string, string, int) error {
+			t.Fatal("finit_module called for an already-loaded module")
+			return nil
+		})
+		if err := loadInventory("core", deps, coreModule); err != nil {
+			t.Fatalf("loadInventory: %v", err)
+		}
+	})
+
+	t.Run("finit reports already exists", func(t *testing.T) {
+		files := map[string]bool{
+			"/modules/nvidia.ko": true,
+		}
+		deps := testDependencies(map[string]bool{}, files, func(string, string, int) error {
+			return unix.EEXIST
+		})
+		if err := loadInventory("core", deps, coreModule); err != nil {
+			t.Fatalf("loadInventory: %v", err)
+		}
+	})
+}
+
+func TestLoadInventoryPropagatesFailuresInOrder(t *testing.T) {
+	loadErr := errors.New("bad vermagic")
+	files := map[string]bool{
+		"/modules/nvidia.ko.zst":     true,
+		"/modules/nvidia-uvm.ko.zst": true,
+	}
+	var calls []string
+	deps := testDependencies(map[string]bool{}, files, func(path, _ string, _ int) error {
+		calls = append(calls, path)
+		return loadErr
+	})
+
+	err := loadInventory("UVM", deps, coreModule, uvmModule)
+	if err == nil {
+		t.Fatal("loadInventory unexpectedly succeeded")
+	}
+	if !errors.Is(err, loadErr) {
+		t.Fatalf("loadInventory error %q does not wrap %q", err, loadErr)
+	}
+	for _, want := range []string{"load NVIDIA UVM modules", "nvidia", "finit_module", "bad vermagic"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("loadInventory error %q does not contain %q", err, want)
+		}
+	}
+	wantCalls := []string{
+		"/modules/nvidia.ko.zst",
+	}
+	if !reflect.DeepEqual(calls, wantCalls) {
+		t.Fatalf("finit_module calls after failure = %q, want %q", calls, wantCalls)
+	}
+}


### PR DESCRIPTION
## Summary

- add an NVIDIA-only module loader with fixed core, UVM, and modeset inventories
- load only measured-root DKMS artifacts from `/usr/lib/modules/<release>/updates/dkms`
- support the pinned `.ko.zst` artifact and an uncompressed `.ko` fallback via `finit_module`
- keep all non-NVIDIA prerequisites built into the minimized kernel from #175

## Trust boundary

The public API exposes only `LoadCoreKernelModules`, `LoadUVMKernelModules`, and `LoadModesetKernelModules`. Callers cannot supply module names, paths, parameters, or arbitrary inventories. The only runtime-derived path component is the bounded kernel release; module filenames and core parameters are compiled policy.

There is no directory scanning, `modules.dep`/`modules.builtin` parsing, `modprobe`, or generic runtime module-loader API. Already-loaded modules and `EEXIST` are accepted; all other load failures propagate.

## Scope

This is a source-only foundation and does not wire a new PID 1 or change image behavior. Later NVIDIA bootstrap PRs will own ordering, device setup, userspace services, and hardware validation.

## Review focus

- `tinfoil/internal/nvidia/modules.go`: fixed inventories, release validation, exact path construction, and `finit_module` flags
- `tinfoil/internal/nvidia/modules_test.go`: inventory/order constraints, compressed fallback, path rejection, already-loaded behavior, and fail-closed errors

## Validation

- `go test ./...`
- `go test -race ./internal/nvidia`
- `go vet ./...`
- `git diff --check origin/jules/harden-tcb...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded NVIDIA kernel module loader that initializes fixed core, UVM, and modeset inventories from an application-owned measured path. It uses a small, fail-closed API with `.ko.zst` support and `.ko` fallback via `unix.FinitModule`.

- **New Features**
  - Public API: `LoadCoreKernelModules`, `LoadUVMKernelModules`, `LoadModesetKernelModules`.
  - Loads only fixed candidates under `/usr/lib/tinfoil/kernel-modules`; no `uname`/`osrelease` parsing.
  - Prefers compressed artifacts; tolerates `EEXIST` for already-loaded modules.
  - No `modprobe`, no `modules.dep` parsing, no directory scans; core `nvidia` parameters are compiled policy.

- **Migration**
  - Source-only; artifacts are staged at `/usr/lib/tinfoil/kernel-modules` (replacing `/usr/lib/modules/<release>/updates/dkms`). No PID 1 or image behavior changes.

<sup>Written for commit 5561ec5ee16a87552e030af49544947e80103be1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

