### PR TITLE
Add PID 1 runtime filesystem setup

### DIFF
--- a/tinfoil/internal/pid1/runtime/setup.go
+++ b/tinfoil/internal/pid1/runtime/setup.go
@@ -1,0 +1,258 @@
+// Package runtime owns the filesystem and sysctl setup performed by PID 1.
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"tinfoil/internal/boot"
+)
+
+const (
+	// Ramdisk sizing preserves the legacy tinfoil-ramdisk policy: reserve
+	// 16 GiB for the OS on production-sized hosts and use a small fixed
+	// ramdisk on development hosts.
+	ramdiskMinRAMGB   = 32
+	ramdiskReserveGB  = 16
+	ramdiskFallbackGB = 4
+
+	tmpfs512M = "size=512M,mode=1777"
+)
+
+// LogFunc receives runtime setup diagnostics.
+type LogFunc func(format string, args ...any)
+
+type sysctlSetting struct {
+	path     string
+	value    string
+	optional bool
+}
+
+// sysctlPolicy is compiled into the measured PID 1 binary. Keeping the exact
+// procfs paths here avoids shipping a configuration-language parser.
+var sysctlPolicy = []sysctlSetting{
+	{path: "fs/protected_hardlinks", value: "1"},
+	{path: "fs/protected_symlinks", value: "1"},
+	{path: "fs/protected_regular", value: "2"},
+	{path: "fs/protected_fifos", value: "1"},
+	{path: "kernel/dmesg_restrict", value: "1"},
+	{path: "kernel/kptr_restrict", value: "1"},
+	{path: "kernel/printk", value: "4 4 1 7"},
+	{path: "kernel/sysrq", value: "0"},
+	{path: "kernel/yama/ptrace_scope", value: "1"},
+	{path: "net/core/default_qdisc", value: "fq_codel", optional: true},
+	{path: "net/ipv4/conf/default/rp_filter", value: "2"},
+	{path: "net/ipv4/conf/all/rp_filter", value: "2"},
+	{path: "vm/max_map_count", value: "1048576"},
+	{path: "vm/mmap_min_addr", value: "65536"},
+}
+
+// SetupFilesystems mounts the kernel-backed filesystems and creates the
+// runtime paths required before services start.
+func SetupFilesystems(log LogFunc) error {
+	if err := os.WriteFile("/proc/sys/kernel/hostname", []byte("tinfoil\n"), 0644); err != nil {
+		logf(log, "warning: setting hostname: %v", err)
+	}
+	mounts := []struct {
+		source string
+		target string
+		fstype string
+		flags  uintptr
+		data   string
+		fatal  bool
+	}{
+		{"tmpfs", "/dev/shm", "tmpfs", syscall.MS_NOSUID | syscall.MS_NODEV, "mode=1777,size=512M", true},
+		{"devpts", "/dev/pts", "devpts", syscall.MS_NOSUID | syscall.MS_NOEXEC, "mode=0620,ptmxmode=0666,newinstance", true},
+		{"mqueue", "/dev/mqueue", "mqueue", syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC, "", false},
+		{"hugetlbfs", "/dev/hugepages", "hugetlbfs", syscall.MS_NOSUID | syscall.MS_NODEV, "mode=1770,gid=0", false},
+		{"cgroup2", "/sys/fs/cgroup", "cgroup2", syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC, "", true},
+	}
+	for _, mount := range mounts {
+		if err := mountIfNeeded(mount.source, mount.target, mount.fstype, mount.flags, mount.data, log); err != nil {
+			if mount.fatal {
+				return err
+			}
+			logf(log, "optional mount skipped: %v", err)
+		}
+	}
+	if err := ensureSymlink("/dev/shm", "/run/shm"); err != nil {
+		logf(log, "warning: creating /run/shm compatibility symlink: %v", err)
+	}
+	for _, dir := range []struct {
+		path string
+		mode os.FileMode
+	}{
+		{"/run/lock", os.ModeSticky | 0777},
+		{"/run/cryptsetup", 0700},
+	} {
+		if err := ensureDir(dir.path, dir.mode); err != nil {
+			logf(log, "warning: creating runtime dir %s: %v", dir.path, err)
+		}
+	}
+	return nil
+}
+
+// SetupRamdisk mounts the workload ramdisk and private/public subdirectories.
+func SetupRamdisk(log LogFunc) error {
+	logf(log, "creating ramdisk")
+	memTotalKB, err := systemMemoryKB()
+	if err != nil {
+		return fmt.Errorf("reading system memory: %w", err)
+	}
+	sizeGB, fallback, err := ramdiskSizeGB(memTotalKB)
+	if err != nil {
+		return fmt.Errorf("sizing ramdisk: %w", err)
+	}
+	if fallback {
+		logf(log, "warning: not enough RAM for full ramdisk, falling back to %dG", sizeGB)
+	}
+
+	if err := mountIfNeeded("tmpfs", boot.RamdiskDir, "tmpfs", syscall.MS_NOSUID|syscall.MS_NODEV, fmt.Sprintf("size=%dG,mode=0755", sizeGB), log); err != nil {
+		return err
+	}
+	if err := ensureDir(boot.PrivateDir, 0700); err != nil {
+		return err
+	}
+	if err := ensureDir(boot.PublicDir, 0755); err != nil {
+		return err
+	}
+	if err := mountIfNeeded("tmpfs", "/tmp", "tmpfs", syscall.MS_NOSUID|syscall.MS_NODEV, tmpfs512M, log); err != nil {
+		return err
+	}
+	if err := mountIfNeeded("tmpfs", "/var/tmp", "tmpfs", syscall.MS_NOSUID|syscall.MS_NODEV, tmpfs512M, log); err != nil {
+		return err
+	}
+	logf(log, "ramdisk ready")
+	return nil
+}
+
+// ApplySysctls applies the measured runtime sysctl policy.
+func ApplySysctls(log LogFunc) error {
+	return applySysctls("/proc/sys", sysctlPolicy, log)
+}
+
+func systemMemoryKB() (uint64, error) {
+	var info unix.Sysinfo_t
+	if err := unix.Sysinfo(&info); err != nil {
+		return 0, err
+	}
+	return memoryKB(uint64(info.Totalram), uint64(info.Unit))
+}
+
+func memoryKB(totalRAM, unit uint64) (uint64, error) {
+	if totalRAM == 0 {
+		return 0, errors.New("total RAM is zero")
+	}
+	if unit == 0 {
+		unit = 1
+	}
+	if totalRAM > ^uint64(0)/unit {
+		return 0, errors.New("total RAM overflows bytes")
+	}
+	return totalRAM * unit / 1024, nil
+}
+
+func ramdiskSizeGB(memTotalKB uint64) (uint64, bool, error) {
+	if memTotalKB == 0 {
+		return 0, false, errors.New("MemTotal is zero")
+	}
+	ramGB := memTotalKB / 1024 / 1024
+	if ramGB < ramdiskMinRAMGB {
+		return ramdiskFallbackGB, true, nil
+	}
+	return ramGB - ramdiskReserveGB, false, nil
+}
+
+func mountIfNeeded(source, target, fstype string, flags uintptr, data string, log LogFunc) error {
+	if isMountPoint(target) {
+		return nil
+	}
+	if err := os.MkdirAll(target, 0755); err != nil {
+		return err
+	}
+	if err := syscall.Mount(source, target, fstype, flags, data); err != nil {
+		return fmt.Errorf("mount %s on %s: %w", fstype, target, err)
+	}
+	logf(log, "mounted %s on %s", fstype, target)
+	return nil
+}
+
+func ensureDir(path string, mode os.FileMode) error {
+	if err := os.MkdirAll(path, mode); err != nil {
+		return err
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("chmod %s: %w", path, err)
+	}
+	return nil
+}
+
+func ensureSymlink(target, linkPath string) error {
+	info, err := os.Lstat(linkPath)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			current, err := os.Readlink(linkPath)
+			if err != nil {
+				return fmt.Errorf("readlink %s: %w", linkPath, err)
+			}
+			if current == target {
+				return nil
+			}
+			if err := os.Remove(linkPath); err != nil {
+				return fmt.Errorf("remove stale symlink %s: %w", linkPath, err)
+			}
+		} else if err := os.Remove(linkPath); err != nil {
+			return fmt.Errorf("%s exists and is not removable: %w", linkPath, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0755); err != nil {
+		return err
+	}
+	if err := os.Symlink(target, linkPath); err != nil {
+		return fmt.Errorf("symlink %s -> %s: %w", linkPath, target, err)
+	}
+	return nil
+}
+
+func isMountPoint(target string) bool {
+	target = filepath.Clean(target)
+	parent := filepath.Dir(target)
+	var targetStat, parentStat unix.Statx_t
+	if err := unix.Statx(unix.AT_FDCWD, target, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &targetStat); err != nil {
+		return false
+	}
+	if err := unix.Statx(unix.AT_FDCWD, parent, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &parentStat); err != nil {
+		return false
+	}
+	return targetStat.Mask&unix.STATX_MNT_ID != 0 &&
+		parentStat.Mask&unix.STATX_MNT_ID != 0 &&
+		targetStat.Mnt_id != parentStat.Mnt_id
+}
+
+func applySysctls(procSysRoot string, policy []sysctlSetting, log LogFunc) error {
+	for _, setting := range policy {
+		procPath := filepath.Join(procSysRoot, setting.path)
+		if err := os.WriteFile(procPath, []byte(setting.value+"\n"), 0644); err != nil {
+			if setting.optional && errors.Is(err, os.ErrNotExist) {
+				logf(log, "optional sysctl %s skipped: %v", setting.path, err)
+				continue
+			}
+			return fmt.Errorf("setting sysctl %s: %w", setting.path, err)
+		}
+	}
+	logf(log, "applied sysctl policy")
+	return nil
+}
+
+func logf(log LogFunc, format string, args ...any) {
+	if log != nil {
+		log(format, args...)
+	}
+}

--- a/tinfoil/internal/pid1/runtime/setup.go
+++ b/tinfoil/internal/pid1/runtime/setup.go
@@ -169,7 +169,11 @@ func ramdiskSizeGB(memTotalKB uint64) (uint64, bool, error) {
 }
 
 func mountIfNeeded(source, target, fstype string, flags uintptr, data string, log LogFunc) error {
-	if isMountPoint(target) {
+	mounted, err := isMountPoint(target)
+	if err != nil {
+		return fmt.Errorf("check mount point %s: %w", target, err)
+	}
+	if mounted {
 		return nil
 	}
 	if err := os.MkdirAll(target, 0755); err != nil {
@@ -221,19 +225,35 @@ func ensureSymlink(target, linkPath string) error {
 	return nil
 }
 
-func isMountPoint(target string) bool {
+type statxFunc func(int, string, int, int, *unix.Statx_t) error
+
+func isMountPoint(target string) (bool, error) {
+	return isMountPointWith(target, unix.Statx)
+}
+
+func isMountPointWith(target string, statx statxFunc) (bool, error) {
 	target = filepath.Clean(target)
 	parent := filepath.Dir(target)
-	var targetStat, parentStat unix.Statx_t
-	if err := unix.Statx(unix.AT_FDCWD, target, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &targetStat); err != nil {
-		return false
+	targetID, err := mountID(target, statx)
+	if err != nil {
+		return false, err
 	}
-	if err := unix.Statx(unix.AT_FDCWD, parent, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &parentStat); err != nil {
-		return false
+	parentID, err := mountID(parent, statx)
+	if err != nil {
+		return false, err
 	}
-	return targetStat.Mask&unix.STATX_MNT_ID != 0 &&
-		parentStat.Mask&unix.STATX_MNT_ID != 0 &&
-		targetStat.Mnt_id != parentStat.Mnt_id
+	return targetID != parentID, nil
+}
+
+func mountID(path string, statx statxFunc) (uint64, error) {
+	var info unix.Statx_t
+	if err := statx(unix.AT_FDCWD, path, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &info); err != nil {
+		return 0, fmt.Errorf("statx %s: %w", path, err)
+	}
+	if info.Mask&unix.STATX_MNT_ID == 0 {
+		return 0, fmt.Errorf("statx %s did not report STATX_MNT_ID", path)
+	}
+	return info.Mnt_id, nil
 }
 
 func applySysctls(procSysRoot string, policy []sysctlSetting, log LogFunc) error {

--- a/tinfoil/internal/pid1/runtime/setup.go
+++ b/tinfoil/internal/pid1/runtime/setup.go
@@ -169,11 +169,7 @@ func ramdiskSizeGB(memTotalKB uint64) (uint64, bool, error) {
 }
 
 func mountIfNeeded(source, target, fstype string, flags uintptr, data string, log LogFunc) error {
-	mounted, err := isMountPoint(target)
-	if err != nil {
-		return fmt.Errorf("check mount point %s: %w", target, err)
-	}
-	if mounted {
+	if isMountPoint(target) {
 		return nil
 	}
 	if err := os.MkdirAll(target, 0755); err != nil {
@@ -225,35 +221,19 @@ func ensureSymlink(target, linkPath string) error {
 	return nil
 }
 
-type statxFunc func(int, string, int, int, *unix.Statx_t) error
-
-func isMountPoint(target string) (bool, error) {
-	return isMountPointWith(target, unix.Statx)
-}
-
-func isMountPointWith(target string, statx statxFunc) (bool, error) {
+func isMountPoint(target string) bool {
 	target = filepath.Clean(target)
 	parent := filepath.Dir(target)
-	targetID, err := mountID(target, statx)
-	if err != nil {
-		return false, err
+	var targetStat, parentStat unix.Statx_t
+	if err := unix.Statx(unix.AT_FDCWD, target, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &targetStat); err != nil {
+		return false
 	}
-	parentID, err := mountID(parent, statx)
-	if err != nil {
-		return false, err
+	if err := unix.Statx(unix.AT_FDCWD, parent, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &parentStat); err != nil {
+		return false
 	}
-	return targetID != parentID, nil
-}
-
-func mountID(path string, statx statxFunc) (uint64, error) {
-	var info unix.Statx_t
-	if err := statx(unix.AT_FDCWD, path, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &info); err != nil {
-		return 0, fmt.Errorf("statx %s: %w", path, err)
-	}
-	if info.Mask&unix.STATX_MNT_ID == 0 {
-		return 0, fmt.Errorf("statx %s did not report STATX_MNT_ID", path)
-	}
-	return info.Mnt_id, nil
+	return targetStat.Mask&unix.STATX_MNT_ID != 0 &&
+		parentStat.Mask&unix.STATX_MNT_ID != 0 &&
+		targetStat.Mnt_id != parentStat.Mnt_id
 }
 
 func applySysctls(procSysRoot string, policy []sysctlSetting, log LogFunc) error {

--- a/tinfoil/internal/pid1/runtime/setup_test.go
+++ b/tinfoil/internal/pid1/runtime/setup_test.go
@@ -1,0 +1,133 @@
+package runtime
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureSymlinkCreatesAndReplacesStaleLink(t *testing.T) {
+	linkPath := filepath.Join(t.TempDir(), "run", "shm")
+
+	if err := ensureSymlink("/dev/shm", linkPath); err != nil {
+		t.Fatalf("ensureSymlink create: %v", err)
+	}
+	if got, err := os.Readlink(linkPath); err != nil || got != "/dev/shm" {
+		t.Fatalf("symlink target = %q, %v; want /dev/shm", got, err)
+	}
+	if err := ensureSymlink("/dev/shm", linkPath); err != nil {
+		t.Fatalf("ensureSymlink idempotent: %v", err)
+	}
+	if err := os.Remove(linkPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("/stale", linkPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureSymlink("/dev/shm", linkPath); err != nil {
+		t.Fatalf("ensureSymlink replace stale: %v", err)
+	}
+	if got, err := os.Readlink(linkPath); err != nil || got != "/dev/shm" {
+		t.Fatalf("symlink target after replace = %q, %v; want /dev/shm", got, err)
+	}
+}
+
+func TestRamdiskSizeGB(t *testing.T) {
+	tests := []struct {
+		name     string
+		memGB    uint64
+		wantSize uint64
+		wantFB   bool
+	}{
+		{name: "large", memGB: 128, wantSize: 112},
+		{name: "minimum-full", memGB: 32, wantSize: 16},
+		{name: "below-minimum", memGB: 31, wantSize: 4, wantFB: true},
+		{name: "development", memGB: 16, wantSize: 4, wantFB: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotSize, gotFallback, err := ramdiskSizeGB(tt.memGB * 1024 * 1024)
+			if err != nil {
+				t.Fatalf("ramdiskSizeGB: %v", err)
+			}
+			if gotSize != tt.wantSize || gotFallback != tt.wantFB {
+				t.Fatalf("size,fallback = %d,%t; want %d,%t", gotSize, gotFallback, tt.wantSize, tt.wantFB)
+			}
+		})
+	}
+	if _, _, err := ramdiskSizeGB(0); err == nil {
+		t.Fatal("ramdiskSizeGB(0) succeeded")
+	}
+}
+
+func TestMemoryKBUsesKernelUnit(t *testing.T) {
+	got, err := memoryKB(64*1024*1024, 1024)
+	if err != nil || got != 64*1024*1024 {
+		t.Fatalf("memoryKB = %d, %v; want %d", got, err, uint64(64*1024*1024))
+	}
+	if got, err := memoryKB(1024, 0); err != nil || got != 1 {
+		t.Fatalf("memoryKB unit zero = %d, %v; want 1", got, err)
+	}
+	if _, err := memoryKB(0, 1); err == nil {
+		t.Fatal("memoryKB accepted zero RAM")
+	}
+	if _, err := memoryKB(^uint64(0), 2); err == nil {
+		t.Fatal("memoryKB accepted overflowing RAM")
+	}
+}
+
+func TestIsMountPointUsesKernelMountIDs(t *testing.T) {
+	if !isMountPoint("/proc") {
+		t.Fatal("/proc is not detected as a mount point")
+	}
+	if isMountPoint(t.TempDir()) {
+		t.Fatal("ordinary temporary directory detected as a mount point")
+	}
+}
+
+func TestApplySysctls(t *testing.T) {
+	root := t.TempDir()
+	procRoot := filepath.Join(root, "proc", "sys")
+	kptrPath := filepath.Join(procRoot, "kernel", "kptr_restrict")
+	mmapPath := filepath.Join(procRoot, "vm", "mmap_min_addr")
+	for _, path := range []string{kptrPath, mmapPath} {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	policy := []sysctlSetting{
+		{path: "kernel/kptr_restrict", value: "1"},
+		{path: "net/core/default_qdisc", value: "fq_codel", optional: true},
+		{path: "vm/mmap_min_addr", value: "65536"},
+	}
+
+	var logs []string
+	err := applySysctls(procRoot, policy, func(format string, args ...any) {
+		logs = append(logs, format)
+	})
+	if err != nil {
+		t.Fatalf("applySysctls: %v", err)
+	}
+	if got, err := os.ReadFile(kptrPath); err != nil || string(got) != "1\n" {
+		t.Fatalf("kptr_restrict = %q, %v; want 1", got, err)
+	}
+	if got, err := os.ReadFile(mmapPath); err != nil || string(got) != "65536\n" {
+		t.Fatalf("mmap_min_addr = %q, %v; want 65536", got, err)
+	}
+	if len(logs) != 2 {
+		t.Fatalf("log count = %d, want optional skip and completion", len(logs))
+	}
+}
+
+func TestApplySysctlsFailsClosed(t *testing.T) {
+	if err := applySysctls(
+		filepath.Join(t.TempDir(), "missing-proc"),
+		[]sysctlSetting{{path: "kernel/kptr_restrict", value: "1"}},
+		nil,
+	); err == nil {
+		t.Fatal("applySysctls accepted missing required key")
+	}
+}

--- a/tinfoil/internal/pid1/runtime/setup_test.go
+++ b/tinfoil/internal/pid1/runtime/setup_test.go
@@ -1,9 +1,12 @@
 package runtime
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestEnsureSymlinkCreatesAndReplacesStaleLink(t *testing.T) {
@@ -77,11 +80,37 @@ func TestMemoryKBUsesKernelUnit(t *testing.T) {
 }
 
 func TestIsMountPointUsesKernelMountIDs(t *testing.T) {
-	if !isMountPoint("/proc") {
+	mounted, err := isMountPoint("/proc")
+	if err != nil {
+		t.Fatalf("isMountPoint(/proc): %v", err)
+	}
+	if !mounted {
 		t.Fatal("/proc is not detected as a mount point")
 	}
-	if isMountPoint(t.TempDir()) {
+	mounted, err = isMountPoint(t.TempDir())
+	if err != nil {
+		t.Fatalf("isMountPoint(temp): %v", err)
+	}
+	if mounted {
 		t.Fatal("ordinary temporary directory detected as a mount point")
+	}
+}
+
+func TestIsMountPointFailsClosedWithoutKernelMountID(t *testing.T) {
+	noMountID := func(_ int, _ string, _, _ int, info *unix.Statx_t) error {
+		info.Mask = 0
+		return nil
+	}
+	if _, err := isMountPointWith("/target", noMountID); err == nil {
+		t.Fatal("isMountPointWith accepted missing STATX_MNT_ID")
+	}
+
+	statErr := errors.New("statx unavailable")
+	failing := func(_ int, _ string, _, _ int, _ *unix.Statx_t) error {
+		return statErr
+	}
+	if _, err := isMountPointWith("/target", failing); !errors.Is(err, statErr) {
+		t.Fatalf("isMountPointWith error = %v, want %v", err, statErr)
 	}
 }
 

--- a/tinfoil/internal/pid1/runtime/setup_test.go
+++ b/tinfoil/internal/pid1/runtime/setup_test.go
@@ -1,12 +1,9 @@
 package runtime
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"testing"
-
-	"golang.org/x/sys/unix"
 )
 
 func TestEnsureSymlinkCreatesAndReplacesStaleLink(t *testing.T) {
@@ -80,37 +77,11 @@ func TestMemoryKBUsesKernelUnit(t *testing.T) {
 }
 
 func TestIsMountPointUsesKernelMountIDs(t *testing.T) {
-	mounted, err := isMountPoint("/proc")
-	if err != nil {
-		t.Fatalf("isMountPoint(/proc): %v", err)
-	}
-	if !mounted {
+	if !isMountPoint("/proc") {
 		t.Fatal("/proc is not detected as a mount point")
 	}
-	mounted, err = isMountPoint(t.TempDir())
-	if err != nil {
-		t.Fatalf("isMountPoint(temp): %v", err)
-	}
-	if mounted {
+	if isMountPoint(t.TempDir()) {
 		t.Fatal("ordinary temporary directory detected as a mount point")
-	}
-}
-
-func TestIsMountPointFailsClosedWithoutKernelMountID(t *testing.T) {
-	noMountID := func(_ int, _ string, _, _ int, info *unix.Statx_t) error {
-		info.Mask = 0
-		return nil
-	}
-	if _, err := isMountPointWith("/target", noMountID); err == nil {
-		t.Fatal("isMountPointWith accepted missing STATX_MNT_ID")
-	}
-
-	statErr := errors.New("statx unavailable")
-	failing := func(_ int, _ string, _, _ int, _ *unix.Statx_t) error {
-		return statErr
-	}
-	if _, err := isMountPointWith("/target", failing); !errors.Is(err, statErr) {
-		t.Fatalf("isMountPointWith error = %v, want %v", err, statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add the isolated runtime-filesystem foundation for the future Tinfoil PID 1
- mount the required devpts, cgroup, shared-memory, queue, hugepage, workload, and temporary filesystems with fixed flags
- preserve the bounded workload-ramdisk sizing policy
- apply the exact minimal sysctl policy directly through procfs

## Parser reduction

This slice does not ship a sysctl configuration parser. The measured PID 1 binary owns a fixed list of procfs paths and values. It also uses `sysinfo(2)` instead of parsing `/proc/meminfo`, and `statx(2)` mount IDs instead of parsing `/proc/self/mountinfo`.

The policy includes the `fs.protected_*`, kernel visibility, ptrace, reverse-path filtering, mmap, and queue settings required after removing the stock sysctl.d inventory. Only `net/core/default_qdisc` is optional because the minimized kernel may omit that key.

## Scope

The code is an independently buildable `internal/pid1/runtime` package. It adds no placeholder `cmd/init`, changes no current image behavior, and does not include NVIDIA devices, service hardening, supervision, debug code, or rootfs pruning. A later lifecycle PR will compose this API into the real CPU-capable PID 1.

## Review focus

- exact mount types, flags, modes, and fatal/optional classification
- ramdisk sizing at the 32 GiB boundary
- fixed sysctl paths, values, and single optional setting
- `sysinfo` unit/overflow handling and `statx` mount-point detection

## Validation

- `go build ./...`
- `go test ./...`
- `go test -race ./internal/pid1/runtime`
- `go vet ./...`
- `git diff --check origin/jules/harden-tcb...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the isolated runtime filesystem and sysctl setup for the future PID 1. It mounts core kernel filesystems, sizes the workload ramdisk, applies a minimal fixed sysctl policy, and uses `statx(2)` mount IDs when available without failing closed.

- **New Features**
  - New `tinfoil/internal/pid1/runtime` package with PID 1 setup API; no changes to current images.
  - Filesystems: mount `/dev/shm` tmpfs (512M, 1777), `devpts` at `/dev/pts`, `cgroup2` at `/sys/fs/cgroup`; optional `mqueue` and `hugetlbfs`. Creates `/run/shm` symlink and runtime dirs.
  - Ramdisk: reserve 16 GiB when RAM ≥ 32 GiB; otherwise 4 GiB fallback. Mounts `/tmp` and `/var/tmp` as 512M tmpfs.
  - Sysctls: writes exact procfs keys (fs.protected_*, kernel dmesg/kptr/printk, sysrq, Yama ptrace, rp_filter, `vm/mmap_min_addr`, `vm/max_map_count`); optional `net/core/default_qdisc`. Uses `sysinfo(2)` and `statx(2)` mount IDs opportunistically.

<sup>Written for commit 5a07b4b1ecf00b9fc11c442e290b5e944bfb319e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

