### PR TITLE
Add fixed PID 1 service hardening policies

### DIFF
--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -1,0 +1,251 @@
+// Package hardening contains the fixed process-hardening policy used by the
+// Tinfoil PID 1. A later PID 1 wrapper applies a service policy in its
+// self-exec child immediately before replacing that child with the service.
+package hardening
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	maxCapability      = len([2]unix.CapUserData{})*32 - 1
+	runtimeNOFILEFloor = 524288
+)
+
+// Service identifies one of the fixed Tinfoil-owned service policies.
+type Service string
+
+const (
+	ServiceBoot            Service = "tinfoil-boot"
+	ServiceContainerStatus Service = "tinfoil-container-status"
+	ServiceEgress          Service = "tinfoil-egress"
+	ServiceShim            Service = "tinfoil-shim"
+)
+
+type servicePolicy struct {
+	noNewPrivileges   bool
+	boundCapabilities []int
+}
+
+// A nil boundCapabilities list deliberately preserves the inherited bounding
+// set. Boot still performs model-pack mounts and device-mapper and nftables
+// operations, so the current image does not establish a narrower safe set for
+// it. A non-nil empty list means that no capabilities are permitted.
+func policyFor(service Service) (servicePolicy, bool) {
+	switch service {
+	case ServiceBoot:
+		return servicePolicy{noNewPrivileges: true}, true
+	case ServiceContainerStatus:
+		return servicePolicy{
+			noNewPrivileges:   true,
+			boundCapabilities: []int{},
+		}, true
+	case ServiceEgress:
+		return servicePolicy{
+			noNewPrivileges:   true,
+			boundCapabilities: []int{unix.CAP_NET_ADMIN},
+		}, true
+	case ServiceShim:
+		return servicePolicy{
+			noNewPrivileges:   true,
+			boundCapabilities: []int{unix.CAP_NET_BIND_SERVICE},
+		}, true
+	default:
+		return servicePolicy{}, false
+	}
+}
+
+// ApplyService applies the fixed policy for service to the calling process.
+// It rejects unknown services. The caller must terminate the child instead of
+// executing the target service if ApplyService returns an error.
+func ApplyService(service Service) error {
+	return applyService(linuxServiceKernel{}, service)
+}
+
+type serviceKernel interface {
+	dropBoundingCapability(int) error
+	setCapabilities([2]unix.CapUserData) error
+	setNoNewPrivileges() error
+}
+
+func applyService(kernel serviceKernel, service Service) error {
+	policy, ok := policyFor(service)
+	if !ok {
+		return fmt.Errorf("unknown service hardening policy %q", service)
+	}
+
+	if policy.boundCapabilities != nil {
+		data, err := packCapabilities(policy.boundCapabilities)
+		if err != nil {
+			return fmt.Errorf("prepare capability set for %s: %w", service, err)
+		}
+
+		allowed := [maxCapability + 1]bool{}
+		for _, capability := range policy.boundCapabilities {
+			allowed[capability] = true
+		}
+		for capability := 0; capability <= maxCapability; capability++ {
+			if allowed[capability] {
+				continue
+			}
+			if err := kernel.dropBoundingCapability(capability); err != nil &&
+				!errors.Is(err, unix.EINVAL) {
+				return fmt.Errorf("drop capability %d from %s bounding set: %w", capability, service, err)
+			}
+		}
+		if err := kernel.setCapabilities(data); err != nil {
+			return fmt.Errorf("set capabilities for %s: %w", service, err)
+		}
+	}
+
+	if policy.noNewPrivileges {
+		if err := kernel.setNoNewPrivileges(); err != nil {
+			return fmt.Errorf("set no_new_privileges for %s: %w", service, err)
+		}
+	}
+	return nil
+}
+
+type linuxServiceKernel struct{}
+
+func (linuxServiceKernel) dropBoundingCapability(capability int) error {
+	return unix.Prctl(unix.PR_CAPBSET_DROP, uintptr(capability), 0, 0, 0)
+}
+
+func (linuxServiceKernel) setCapabilities(data [2]unix.CapUserData) error {
+	header := unix.CapUserHeader{
+		Version: unix.LINUX_CAPABILITY_VERSION_3,
+		Pid:     0,
+	}
+	return unix.Capset(&header, &data[0])
+}
+
+func (linuxServiceKernel) setNoNewPrivileges() error {
+	return unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0)
+}
+
+func packCapabilities(capabilities []int) ([2]unix.CapUserData, error) {
+	var data [2]unix.CapUserData
+	for _, capability := range capabilities {
+		if capability < 0 || capability > maxCapability {
+			return data, fmt.Errorf("capability %d is outside supported range 0..%d", capability, maxCapability)
+		}
+		index := capability / 32
+		bit := uint32(1) << uint(capability%32)
+		data[index].Effective |= bit
+		data[index].Permitted |= bit
+		data[index].Inheritable |= bit
+	}
+	return data, nil
+}
+
+type runtimeLimit struct {
+	name     string
+	resource int
+	floor    unix.Rlimit
+}
+
+var runtimeLimits = []runtimeLimit{
+	{
+		name:     "nofile",
+		resource: unix.RLIMIT_NOFILE,
+		floor: unix.Rlimit{
+			Cur: runtimeNOFILEFloor,
+			Max: runtimeNOFILEFloor,
+		},
+	},
+	{
+		name:     "memlock",
+		resource: unix.RLIMIT_MEMLOCK,
+		floor: unix.Rlimit{
+			Cur: unix.RLIM_INFINITY,
+			Max: unix.RLIM_INFINITY,
+		},
+	},
+}
+
+// ApplyRuntimeLimits raises the calling PID 1's NOFILE and MEMLOCK limits to
+// their runtime floors without lowering existing limits. It reads each value
+// back and fails if the kernel did not apply the requested floor.
+func ApplyRuntimeLimits() error {
+	return applyRuntimeLimits(linuxRlimitKernel{})
+}
+
+type rlimitKernel interface {
+	getRlimit(int) (unix.Rlimit, error)
+	setRlimit(int, unix.Rlimit) error
+}
+
+func applyRuntimeLimits(kernel rlimitKernel) error {
+	for _, limit := range runtimeLimits {
+		before, err := kernel.getRlimit(limit.resource)
+		if err != nil {
+			return fmt.Errorf("get rlimit %s: %w", limit.name, err)
+		}
+
+		desired := raisedRlimit(before, limit.floor)
+		if desired != before {
+			if err := kernel.setRlimit(limit.resource, desired); err != nil {
+				return fmt.Errorf(
+					"set rlimit %s soft=%s hard=%s: %w",
+					limit.name,
+					formatRlimit(desired.Cur),
+					formatRlimit(desired.Max),
+					err,
+				)
+			}
+		}
+
+		after, err := kernel.getRlimit(limit.resource)
+		if err != nil {
+			return fmt.Errorf("verify rlimit %s: %w", limit.name, err)
+		}
+		hardFloor := max(limit.floor.Cur, limit.floor.Max)
+		if after.Cur < limit.floor.Cur || after.Max < hardFloor {
+			return fmt.Errorf(
+				"rlimit %s stayed below requested floor: soft=%s hard=%s want soft>=%s hard>=%s",
+				limit.name,
+				formatRlimit(after.Cur),
+				formatRlimit(after.Max),
+				formatRlimit(limit.floor.Cur),
+				formatRlimit(hardFloor),
+			)
+		}
+	}
+	return nil
+}
+
+func raisedRlimit(current, floor unix.Rlimit) unix.Rlimit {
+	desired := current
+	hardFloor := max(floor.Cur, floor.Max)
+	if desired.Max < hardFloor {
+		desired.Max = hardFloor
+	}
+	if desired.Cur < floor.Cur {
+		desired.Cur = floor.Cur
+	}
+	return desired
+}
+
+func formatRlimit(value uint64) string {
+	if value == unix.RLIM_INFINITY {
+		return "infinity"
+	}
+	return strconv.FormatUint(value, 10)
+}
+
+type linuxRlimitKernel struct{}
+
+func (linuxRlimitKernel) getRlimit(resource int) (unix.Rlimit, error) {
+	var limit unix.Rlimit
+	err := unix.Getrlimit(resource, &limit)
+	return limit, err
+}
+
+func (linuxRlimitKernel) setRlimit(resource int, limit unix.Rlimit) error {
+	return unix.Setrlimit(resource, &limit)
+}

--- a/tinfoil/internal/pid1/hardening/hardening_test.go
+++ b/tinfoil/internal/pid1/hardening/hardening_test.go
@@ -1,0 +1,297 @@
+package hardening
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestServicePoliciesAreExact(t *testing.T) {
+	want := map[Service]servicePolicy{
+		ServiceBoot: {
+			noNewPrivileges: true,
+		},
+		ServiceContainerStatus: {
+			noNewPrivileges:   true,
+			boundCapabilities: []int{},
+		},
+		ServiceEgress: {
+			noNewPrivileges:   true,
+			boundCapabilities: []int{unix.CAP_NET_ADMIN},
+		},
+		ServiceShim: {
+			noNewPrivileges:   true,
+			boundCapabilities: []int{unix.CAP_NET_BIND_SERVICE},
+		},
+	}
+	for service, wantPolicy := range want {
+		got, ok := policyFor(service)
+		if !ok {
+			t.Fatalf("policyFor(%q) did not find policy", service)
+		}
+		if !reflect.DeepEqual(got, wantPolicy) {
+			t.Errorf("policyFor(%q) = %#v, want %#v", service, got, wantPolicy)
+		}
+	}
+	if _, ok := policyFor(Service("unknown")); ok {
+		t.Fatal("policyFor accepted unknown service")
+	}
+}
+
+func TestPackCapabilitiesPacksLowAndHighCapabilities(t *testing.T) {
+	data, err := packCapabilities([]int{unix.CAP_NET_BIND_SERVICE, 33, 63})
+	if err != nil {
+		t.Fatalf("packCapabilities: %v", err)
+	}
+
+	low := uint32(1) << uint(unix.CAP_NET_BIND_SERVICE)
+	high := uint32(1)<<1 | uint32(1)<<31
+	for _, field := range []struct {
+		name string
+		low  uint32
+		high uint32
+	}{
+		{name: "effective", low: data[0].Effective, high: data[1].Effective},
+		{name: "permitted", low: data[0].Permitted, high: data[1].Permitted},
+		{name: "inheritable", low: data[0].Inheritable, high: data[1].Inheritable},
+	} {
+		if field.low != low || field.high != high {
+			t.Errorf("%s words = %#x/%#x, want %#x/%#x", field.name, field.low, field.high, low, high)
+		}
+	}
+}
+
+func TestPackCapabilitiesRejectsOutOfRangeValues(t *testing.T) {
+	for _, capability := range []int{-1, maxCapability + 1} {
+		t.Run(fmt.Sprint(capability), func(t *testing.T) {
+			if _, err := packCapabilities([]int{capability}); err == nil {
+				t.Fatalf("packCapabilities(%d) succeeded", capability)
+			}
+		})
+	}
+}
+
+func TestApplyServiceAppliesExactBoundingSetThenNoNewPrivileges(t *testing.T) {
+	kernel := &fakeServiceKernel{last: 13}
+	if err := applyService(kernel, ServiceEgress); err != nil {
+		t.Fatalf("applyService: %v", err)
+	}
+
+	wantDropped := []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13}
+	if !reflect.DeepEqual(kernel.dropped, wantDropped) {
+		t.Fatalf("dropped capabilities = %v, want %v", kernel.dropped, wantDropped)
+	}
+	wantData, err := packCapabilities([]int{unix.CAP_NET_ADMIN})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kernel.capabilityData != wantData {
+		t.Fatalf("capability data = %#v, want %#v", kernel.capabilityData, wantData)
+	}
+	if got := kernel.calls[len(kernel.calls)-1]; got != "no-new-privileges" {
+		t.Fatalf("last call = %q, want no-new-privileges; all calls: %v", got, kernel.calls)
+	}
+}
+
+func TestApplyServiceBootOnlySetsNoNewPrivileges(t *testing.T) {
+	kernel := &fakeServiceKernel{last: 63}
+	if err := applyService(kernel, ServiceBoot); err != nil {
+		t.Fatalf("applyService: %v", err)
+	}
+	if want := []string{"no-new-privileges"}; !reflect.DeepEqual(kernel.calls, want) {
+		t.Fatalf("calls = %v, want %v", kernel.calls, want)
+	}
+}
+
+func TestApplyServiceRejectsUnknownPolicyWithoutKernelChanges(t *testing.T) {
+	kernel := &fakeServiceKernel{last: 63}
+	err := applyService(kernel, Service("containerd"))
+	if err == nil || !strings.Contains(err.Error(), "unknown service hardening policy") {
+		t.Fatalf("applyService error = %v, want unknown-policy error", err)
+	}
+	if len(kernel.calls) != 0 {
+		t.Fatalf("unknown policy made kernel calls: %v", kernel.calls)
+	}
+}
+
+func TestApplyServiceStopsAtFirstKernelFailure(t *testing.T) {
+	dropErr := errors.New("drop denied")
+	failedCapability := 0
+	kernel := &fakeServiceKernel{
+		last:              unix.CAP_NET_ADMIN,
+		dropFailureAt:     &failedCapability,
+		dropCapabilityErr: dropErr,
+	}
+	err := applyService(kernel, ServiceEgress)
+	if !errors.Is(err, dropErr) {
+		t.Fatalf("applyService error = %v, want %v", err, dropErr)
+	}
+	want := []string{"drop:0"}
+	if !reflect.DeepEqual(kernel.calls, want) {
+		t.Fatalf("calls after failure = %v, want %v", kernel.calls, want)
+	}
+}
+
+func TestApplyServiceDoesNotSetNoNewPrivilegesAfterCapsetFailure(t *testing.T) {
+	capsetErr := errors.New("capset denied")
+	kernel := &fakeServiceKernel{
+		last:          unix.CAP_NET_BIND_SERVICE,
+		capabilityErr: capsetErr,
+	}
+	err := applyService(kernel, ServiceShim)
+	if !errors.Is(err, capsetErr) {
+		t.Fatalf("applyService error = %v, want %v", err, capsetErr)
+	}
+	if got := kernel.calls[len(kernel.calls)-1]; got != "set-capabilities" {
+		t.Fatalf("last call after capset failure = %q, want set-capabilities", got)
+	}
+}
+
+func TestRaisedRlimitOnlyRaisesFloors(t *testing.T) {
+	tests := []struct {
+		name    string
+		current unix.Rlimit
+		floor   unix.Rlimit
+		want    unix.Rlimit
+	}{
+		{
+			name:    "raises soft and hard",
+			current: unix.Rlimit{Cur: 1024, Max: 4096},
+			floor:   unix.Rlimit{Cur: runtimeNOFILEFloor, Max: runtimeNOFILEFloor},
+			want:    unix.Rlimit{Cur: runtimeNOFILEFloor, Max: runtimeNOFILEFloor},
+		},
+		{
+			name:    "preserves higher limits",
+			current: unix.Rlimit{Cur: 1048576, Max: unix.RLIM_INFINITY},
+			floor:   unix.Rlimit{Cur: runtimeNOFILEFloor, Max: runtimeNOFILEFloor},
+			want:    unix.Rlimit{Cur: 1048576, Max: unix.RLIM_INFINITY},
+		},
+		{
+			name:    "raises only soft",
+			current: unix.Rlimit{Cur: 1024, Max: unix.RLIM_INFINITY},
+			floor:   unix.Rlimit{Cur: runtimeNOFILEFloor, Max: runtimeNOFILEFloor},
+			want:    unix.Rlimit{Cur: runtimeNOFILEFloor, Max: unix.RLIM_INFINITY},
+		},
+		{
+			name:    "hard stays at least soft floor",
+			current: unix.Rlimit{Cur: 1, Max: 2},
+			floor:   unix.Rlimit{Cur: 8, Max: 4},
+			want:    unix.Rlimit{Cur: 8, Max: 8},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := raisedRlimit(test.current, test.floor); got != test.want {
+				t.Fatalf("raisedRlimit(%#v, %#v) = %#v, want %#v", test.current, test.floor, got, test.want)
+			}
+		})
+	}
+}
+
+func TestApplyRuntimeLimitsRaisesAndVerifiesFloors(t *testing.T) {
+	kernel := &fakeRlimitKernel{
+		limits: map[int]unix.Rlimit{
+			unix.RLIMIT_NOFILE:  {Cur: 1024, Max: 4096},
+			unix.RLIMIT_MEMLOCK: {Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY},
+		},
+	}
+	if err := applyRuntimeLimits(kernel); err != nil {
+		t.Fatalf("applyRuntimeLimits: %v", err)
+	}
+
+	wantNOFILE := unix.Rlimit{Cur: runtimeNOFILEFloor, Max: runtimeNOFILEFloor}
+	if got := kernel.limits[unix.RLIMIT_NOFILE]; got != wantNOFILE {
+		t.Fatalf("NOFILE = %#v, want %#v", got, wantNOFILE)
+	}
+	wantSets := []rlimitSet{{resource: unix.RLIMIT_NOFILE, limit: wantNOFILE}}
+	if !reflect.DeepEqual(kernel.sets, wantSets) {
+		t.Fatalf("setrlimit calls = %#v, want %#v", kernel.sets, wantSets)
+	}
+	if kernel.getCounts[unix.RLIMIT_NOFILE] != 2 || kernel.getCounts[unix.RLIMIT_MEMLOCK] != 2 {
+		t.Fatalf("getrlimit counts = %v, want two verification reads per resource", kernel.getCounts)
+	}
+}
+
+func TestApplyRuntimeLimitsFailsWhenVerificationStaysBelowFloor(t *testing.T) {
+	kernel := &fakeRlimitKernel{
+		limits: map[int]unix.Rlimit{
+			unix.RLIMIT_NOFILE:  {Cur: 1024, Max: 4096},
+			unix.RLIMIT_MEMLOCK: {Cur: unix.RLIM_INFINITY, Max: unix.RLIM_INFINITY},
+		},
+		ignoreSets: true,
+	}
+	err := applyRuntimeLimits(kernel)
+	if err == nil || !strings.Contains(err.Error(), "stayed below requested floor") {
+		t.Fatalf("applyRuntimeLimits error = %v, want verification error", err)
+	}
+	if kernel.getCounts[unix.RLIMIT_MEMLOCK] != 0 {
+		t.Fatalf("continued to MEMLOCK after NOFILE verification failure: %v", kernel.getCounts)
+	}
+}
+
+type fakeServiceKernel struct {
+	last               int
+	dropFailureAt      *int
+	dropCapabilityErr  error
+	capabilityErr      error
+	noNewPrivilegesErr error
+
+	calls          []string
+	dropped        []int
+	capabilityData [2]unix.CapUserData
+}
+
+func (kernel *fakeServiceKernel) dropBoundingCapability(capability int) error {
+	if capability > kernel.last {
+		return unix.EINVAL
+	}
+	kernel.calls = append(kernel.calls, fmt.Sprintf("drop:%d", capability))
+	kernel.dropped = append(kernel.dropped, capability)
+	if kernel.dropFailureAt != nil && capability == *kernel.dropFailureAt {
+		return kernel.dropCapabilityErr
+	}
+	return nil
+}
+
+func (kernel *fakeServiceKernel) setCapabilities(data [2]unix.CapUserData) error {
+	kernel.calls = append(kernel.calls, "set-capabilities")
+	kernel.capabilityData = data
+	return kernel.capabilityErr
+}
+
+func (kernel *fakeServiceKernel) setNoNewPrivileges() error {
+	kernel.calls = append(kernel.calls, "no-new-privileges")
+	return kernel.noNewPrivilegesErr
+}
+
+type rlimitSet struct {
+	resource int
+	limit    unix.Rlimit
+}
+
+type fakeRlimitKernel struct {
+	limits     map[int]unix.Rlimit
+	getCounts  map[int]int
+	sets       []rlimitSet
+	ignoreSets bool
+}
+
+func (kernel *fakeRlimitKernel) getRlimit(resource int) (unix.Rlimit, error) {
+	if kernel.getCounts == nil {
+		kernel.getCounts = make(map[int]int)
+	}
+	kernel.getCounts[resource]++
+	return kernel.limits[resource], nil
+}
+
+func (kernel *fakeRlimitKernel) setRlimit(resource int, limit unix.Rlimit) error {
+	kernel.sets = append(kernel.sets, rlimitSet{resource: resource, limit: limit})
+	if !kernel.ignoreSets {
+		kernel.limits[resource] = limit
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- add fixed hardening identities for tinfoil-boot, container-status, egress, and shim
- apply exact capability bounding and `no_new_privileges` in the future PID 1 self-exec child
- raise and verify PID 1's NOFILE and MEMLOCK runtime-limit floors without lowering stronger inherited limits

## Fixed policy

Callers select one of four closed service identities; they cannot supply arbitrary capability sets. Container-status receives no capabilities, egress retains only `CAP_NET_ADMIN`, and shim retains only `CAP_NET_BIND_SERVICE`. Boot retains its inherited bounding set because its current responsibilities still include mounts, device-mapper, and nftables operations.

The capability ABI is a fixed two-word Linux structure. The implementation attempts all representable bounding-set drops and treats `EINVAL` as an unsupported capability number, avoiding a `/proc/sys/kernel/cap_last_cap` parser. Exact effective, permitted, and inheritable sets are then applied, so unsupported required capabilities fail closed at `capset`.

No UID/GID transition is added here: the current services have no dedicated measured accounts and still require root-owned sockets, keys, mounts, or network setup. Mount namespaces, seccomp, and account separation remain later service-isolation work rather than implicit policy in this foundation.

## Scope

This is an independently buildable `internal/pid1/hardening` package. It adds no placeholder init binary and changes no current image behavior. The corrected lifecycle PR will own the self-exec wrapper and compose these APIs.

## Review focus

- exact per-service capability policy and nil-versus-empty semantics
- fail-closed bounding-set/capset/no-new-privileges ordering
- two-word high-capability packing
- floor-only NOFILE/MEMLOCK changes and read-back verification

## Validation

- `go build ./...`
- `go test ./...`
- `go test -race ./internal/pid1/hardening`
- `go vet ./...`
- `git diff --check origin/jules/harden-tcb...HEAD`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fixed PID 1 service hardening with exact capability bounds, no_new_privileges, and runtime limit floors. Introduces `tinfoil/internal/pid1/hardening` with `ApplyService` and `ApplyRuntimeLimits`; no current image behavior changes.

- New Features
  - Fixed service identities: boot (inherit bound set), container-status (none), egress (CAP_NET_ADMIN), shim (CAP_NET_BIND_SERVICE).
  - Applies exact effective/permitted/inheritable sets and sets no_new_privileges in the self-exec child.
  - Drops all other bounding-set caps; treats EINVAL as unsupported (no cap_last_cap parsing).
  - Raises PID 1 NOFILE to 524288 and MEMLOCK to infinity; raises floors only and verifies by read-back.

<sup>Written for commit 07a69e598b02778ab43a10ae049878514c6f2eb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

