### PR TITLE
Add bounded NVIDIA PCI and device setup

### DIFF
--- a/tinfoil/internal/nvidia/devices.go
+++ b/tinfoil/internal/nvidia/devices.go
@@ -78,7 +78,8 @@ type charDevice struct {
 	mode  os.FileMode
 }
 
-// HasPCIDevice reports whether sysfs contains a PCI function owned by NVIDIA.
+// HasPCIDevice reports whether sysfs contains a supported NVIDIA GPU or
+// NVSwitch PCI function.
 func HasPCIDevice() (bool, error) {
 	return hasPCIDevice(systemDevicePaths)
 }
@@ -120,16 +121,12 @@ func SetupDeviceNodes() error {
 }
 
 func hasPCIDevice(paths devicePaths) (bool, error) {
-	entries, err := os.ReadDir(paths.pciDevices)
+	devices, err := nvidiaPCIDevices(paths)
 	if err != nil {
-		return false, fmt.Errorf("read PCI devices: %w", err)
+		return false, err
 	}
-	for _, entry := range entries {
-		vendor, err := readHexAttribute(filepath.Join(paths.pciDevices, entry.Name(), "vendor"))
-		if err != nil {
-			return false, fmt.Errorf("read PCI vendor for %s: %w", entry.Name(), err)
-		}
-		if vendor == nvidiaPCIVendor {
+	for _, device := range devices {
+		if isSupportedPCIClass(device.class) {
 			return true, nil
 		}
 	}
@@ -179,6 +176,10 @@ func readHexAttribute(path string) (uint64, error) {
 
 func isGPUClass(class uint64) bool {
 	return class == pciClassVGAController || class == pciClass3DController
+}
+
+func isSupportedPCIClass(class uint64) bool {
+	return isGPUClass(class) || class == pciClassNVSwitch
 }
 
 func holdGPUEnableReferences(paths devicePaths) error {

--- a/tinfoil/internal/nvidia/devices.go
+++ b/tinfoil/internal/nvidia/devices.go
@@ -1,0 +1,793 @@
+package nvidia
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	nvidiaPCIVendor = 0x10de
+
+	pciClassVGAController = 0x030000
+	pciClass3DController  = 0x030200
+	pciClassNVSwitch      = 0x068000
+
+	nvidiaCtlMinor         = 255
+	nvidiaModesetMinor     = 254
+	nvidiaUVMMinor         = 0
+	nvidiaUVMToolsMinor    = 1
+	nvidiaNVLinkMinor      = 0
+	nvidiaNVSwitchCtlMinor = 255
+	maxNVSwitches          = 64
+
+	maxDeviceMajor = (1 << 12) - 1
+	maxDeviceMinor = (1 << 20) - 1
+)
+
+var allowedCapabilityFiles = [...]string{
+	"mig/config",
+	"mig/monitor",
+}
+
+type devicePaths struct {
+	pciDevices   string
+	gpus         string
+	capabilities string
+	nvswitches   string
+	nvswitchMode string
+	nvlinkMode   string
+	procDevices  string
+	dev          string
+}
+
+var systemDevicePaths = devicePaths{
+	pciDevices:   "/sys/bus/pci/devices",
+	gpus:         "/proc/driver/nvidia/gpus",
+	capabilities: "/proc/driver/nvidia/capabilities",
+	nvswitches:   "/proc/driver/nvidia-nvswitch/devices",
+	nvswitchMode: "/proc/driver/nvidia-nvswitch/permissions",
+	nvlinkMode:   "/proc/driver/nvidia-nvlink/permissions",
+	procDevices:  "/proc/devices",
+	dev:          "/dev",
+}
+
+type pciDevice struct {
+	name  string
+	class uint64
+}
+
+type capabilityDevice struct {
+	path  string
+	minor int
+	mode  os.FileMode
+}
+
+type charDevice struct {
+	path  string
+	major int
+	minor int
+	mode  os.FileMode
+}
+
+// HasPCIDevice reports whether sysfs contains a PCI function owned by NVIDIA.
+func HasPCIDevice() (bool, error) {
+	return hasPCIDevice(systemDevicePaths)
+}
+
+// HasNVSwitch reports whether sysfs contains an NVIDIA NVSwitch function.
+func HasNVSwitch() (bool, error) {
+	return hasNVSwitch(systemDevicePaths)
+}
+
+func hasNVSwitch(paths devicePaths) (bool, error) {
+	devices, err := nvidiaPCIDevices(paths)
+	if err != nil {
+		return false, err
+	}
+	for _, device := range devices {
+		if device.class == pciClassNVSwitch {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// HoldGPUEnableReferences increments the PCI enable reference for each NVIDIA
+// VGA or 3D controller. It must run before the NVIDIA driver probes the GPUs.
+func HoldGPUEnableReferences() error {
+	return holdGPUEnableReferences(systemDevicePaths)
+}
+
+// EnableGPURuntimePowerManagement switches NVIDIA VGA and 3D controllers to
+// automatic runtime power management when the kernel exposes that control.
+func EnableGPURuntimePowerManagement() error {
+	return enableGPURuntimePowerManagement(systemDevicePaths)
+}
+
+// SetupDeviceNodes creates and verifies the NVIDIA character devices and their
+// /dev/char links using kernel-assigned majors and NVIDIA-assigned minors.
+func SetupDeviceNodes() error {
+	return setupDeviceNodes(systemDevicePaths)
+}
+
+func hasPCIDevice(paths devicePaths) (bool, error) {
+	entries, err := os.ReadDir(paths.pciDevices)
+	if err != nil {
+		return false, fmt.Errorf("read PCI devices: %w", err)
+	}
+	for _, entry := range entries {
+		vendor, err := readHexAttribute(filepath.Join(paths.pciDevices, entry.Name(), "vendor"))
+		if err != nil {
+			return false, fmt.Errorf("read PCI vendor for %s: %w", entry.Name(), err)
+		}
+		if vendor == nvidiaPCIVendor {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func nvidiaPCIDevices(paths devicePaths) ([]pciDevice, error) {
+	entries, err := os.ReadDir(paths.pciDevices)
+	if err != nil {
+		return nil, fmt.Errorf("read PCI devices: %w", err)
+	}
+
+	var devices []pciDevice
+	for _, entry := range entries {
+		base := filepath.Join(paths.pciDevices, entry.Name())
+		vendor, err := readHexAttribute(filepath.Join(base, "vendor"))
+		if err != nil {
+			return nil, fmt.Errorf("read PCI vendor for %s: %w", entry.Name(), err)
+		}
+		if vendor != nvidiaPCIVendor {
+			continue
+		}
+		class, err := readHexAttribute(filepath.Join(base, "class"))
+		if err != nil {
+			return nil, fmt.Errorf("read NVIDIA PCI class for %s: %w", entry.Name(), err)
+		}
+		devices = append(devices, pciDevice{name: entry.Name(), class: class})
+	}
+	sort.Slice(devices, func(i, j int) bool {
+		return devices[i].name < devices[j].name
+	})
+	return devices, nil
+}
+
+func readHexAttribute(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	value := strings.TrimSpace(string(data))
+	parsed, err := strconv.ParseUint(value, 0, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse %s value %q: %w", path, value, err)
+	}
+	return parsed, nil
+}
+
+func isGPUClass(class uint64) bool {
+	return class == pciClassVGAController || class == pciClass3DController
+}
+
+func holdGPUEnableReferences(paths devicePaths) error {
+	devices, err := nvidiaPCIDevices(paths)
+	if err != nil {
+		return err
+	}
+	for _, device := range devices {
+		if !isGPUClass(device.class) {
+			continue
+		}
+		path := filepath.Join(paths.pciDevices, device.name, "enable")
+		if err := os.WriteFile(path, []byte("1\n"), 0644); err != nil {
+			return fmt.Errorf("hold PCI enable reference for %s: %w", device.name, err)
+		}
+	}
+	return nil
+}
+
+func enableGPURuntimePowerManagement(paths devicePaths) error {
+	devices, err := nvidiaPCIDevices(paths)
+	if err != nil {
+		return err
+	}
+	for _, device := range devices {
+		if !isGPUClass(device.class) {
+			continue
+		}
+		path := filepath.Join(paths.pciDevices, device.name, "power", "control")
+		if err := os.WriteFile(path, []byte("auto\n"), 0644); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return fmt.Errorf("enable runtime power management for %s: %w", device.name, err)
+		}
+	}
+	return nil
+}
+
+func setupDeviceNodes(paths devicePaths) error {
+	majors, err := charDeviceMajors(paths.procDevices)
+	if err != nil {
+		return fmt.Errorf("read character device majors: %w", err)
+	}
+	frontend, ok := firstMajor(majors, "nvidia-frontend", "nvidia")
+	if !ok {
+		return errors.New("missing nvidia-frontend character device major")
+	}
+
+	gpuMinors, err := nvidiaDeviceMinors(paths.gpus)
+	if err != nil {
+		return fmt.Errorf("discover NVIDIA GPU minors: %w", err)
+	}
+	capabilities, err := nvidiaCapabilityDevices(paths.capabilities)
+	if err != nil {
+		return fmt.Errorf("discover NVIDIA capability devices: %w", err)
+	}
+
+	devices := []charDevice{
+		{
+			path:  filepath.Join(paths.dev, "nvidiactl"),
+			major: frontend,
+			minor: nvidiaCtlMinor,
+			mode:  0666,
+		},
+		{
+			path:  filepath.Join(paths.dev, "nvidia-modeset"),
+			major: frontend,
+			minor: nvidiaModesetMinor,
+			mode:  0666,
+		},
+	}
+	for _, minor := range gpuMinors {
+		devices = append(devices, charDevice{
+			path:  filepath.Join(paths.dev, "nvidia"+strconv.Itoa(minor)),
+			major: frontend,
+			minor: minor,
+			mode:  0666,
+		})
+	}
+
+	if uvm, ok := majors["nvidia-uvm"]; ok {
+		devices = append(devices,
+			charDevice{
+				path:  filepath.Join(paths.dev, "nvidia-uvm"),
+				major: uvm,
+				minor: nvidiaUVMMinor,
+				mode:  0666,
+			},
+			charDevice{
+				path:  filepath.Join(paths.dev, "nvidia-uvm-tools"),
+				major: uvm,
+				minor: nvidiaUVMToolsMinor,
+				mode:  0666,
+			},
+		)
+	}
+
+	if len(capabilities) > 0 {
+		caps, ok := majors["nvidia-caps"]
+		if !ok {
+			return errors.New("NVIDIA capability descriptors exist without nvidia-caps character device major")
+		}
+		for _, capability := range capabilities {
+			devices = append(devices, charDevice{
+				path:  filepath.Join(paths.dev, "nvidia-caps", "nvidia-cap"+strconv.Itoa(capability.minor)),
+				major: caps,
+				minor: capability.minor,
+				mode:  capability.mode,
+			})
+		}
+	}
+	interconnects, err := nvidiaInterconnectDevices(paths, majors)
+	if err != nil {
+		return fmt.Errorf("discover NVIDIA interconnect devices: %w", err)
+	}
+	devices = append(devices, interconnects...)
+
+	if err := validateCharDevices(devices); err != nil {
+		return err
+	}
+	for _, device := range devices {
+		if err := ensureCharDevice(paths.dev, device); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nvidiaInterconnectDevices(paths devicePaths, majors map[string]int) ([]charDevice, error) {
+	hasSwitch, err := hasNVSwitch(paths)
+	if err != nil {
+		return nil, err
+	}
+	switchMajor, switchLoaded := majors["nvidia-nvswitch"]
+	nvlinkMajor, nvlinkLoaded := majors["nvidia-nvlink"]
+	if hasSwitch && (!switchLoaded || !nvlinkLoaded) {
+		return nil, errors.New("NVSwitch PCI device requires nvidia-nvswitch and nvidia-nvlink character majors")
+	}
+
+	var devices []charDevice
+	if switchLoaded {
+		mode, err := deviceFileMode(paths.nvswitchMode)
+		if err != nil {
+			return nil, err
+		}
+		minors, err := nvidiaNVSwitchMinors(paths.nvswitches)
+		if err != nil {
+			return nil, err
+		}
+		devices = append(devices, charDevice{
+			path: filepath.Join(paths.dev, "nvidia-nvswitchctl"), major: switchMajor,
+			minor: nvidiaNVSwitchCtlMinor, mode: mode,
+		})
+		for _, minor := range minors {
+			devices = append(devices, charDevice{
+				path:  filepath.Join(paths.dev, "nvidia-nvswitch"+strconv.Itoa(minor)),
+				major: switchMajor, minor: minor, mode: mode,
+			})
+		}
+	}
+	if nvlinkLoaded {
+		mode, err := deviceFileMode(paths.nvlinkMode)
+		if err != nil {
+			return nil, err
+		}
+		devices = append(devices, charDevice{
+			path: filepath.Join(paths.dev, "nvidia-nvlink"), major: nvlinkMajor,
+			minor: nvidiaNVLinkMinor, mode: mode,
+		})
+	}
+	return devices, nil
+}
+
+func nvidiaNVSwitchMinors(root string) ([]int, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	// The driver exposes one directory per bound switch but no minor field.
+	// During static boot probing it allocates the lowest free minors from zero.
+	if len(entries) > maxNVSwitches {
+		return nil, fmt.Errorf("NVSwitch count %d exceeds driver maximum %d", len(entries), maxNVSwitches)
+	}
+	minors := make([]int, len(entries))
+	for index, entry := range entries {
+		if !entry.IsDir() {
+			return nil, fmt.Errorf("unexpected non-directory NVSwitch entry %s", entry.Name())
+		}
+		minors[index] = index
+	}
+	return minors, nil
+}
+
+func deviceFileMode(path string) (os.FileMode, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	var (
+		value string
+		found bool
+	)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, candidate, ok := strings.Cut(scanner.Text(), ":")
+		if !ok || strings.TrimSpace(key) != "DeviceFileMode" {
+			continue
+		}
+		if found {
+			return 0, fmt.Errorf("%s contains duplicate DeviceFileMode fields", path)
+		}
+		value = strings.TrimSpace(candidate)
+		found = true
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	mode, err := strconv.ParseUint(value, 0, 32)
+	if err != nil || mode > 0777 {
+		return 0, fmt.Errorf("invalid DeviceFileMode in %s: %q", path, value)
+	}
+	return os.FileMode(mode), nil
+}
+
+func nvidiaDeviceMinors(root string) ([]int, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	minors := make(map[int]struct{})
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		path := filepath.Join(root, entry.Name(), "information")
+		minor, err := parseGPUDeviceMinor(path)
+		if err != nil {
+			return nil, err
+		}
+		minors[minor] = struct{}{}
+	}
+
+	result := make([]int, 0, len(minors))
+	for minor := range minors {
+		result = append(result, minor)
+	}
+	sort.Ints(result)
+	return result, nil
+}
+
+func parseGPUDeviceMinor(path string) (int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer file.Close()
+
+	var (
+		value string
+		found bool
+	)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, candidate, ok := strings.Cut(scanner.Text(), ":")
+		if !ok || strings.TrimSpace(key) != "Device Minor" {
+			continue
+		}
+		if found {
+			return 0, fmt.Errorf("%s contains duplicate Device Minor fields", path)
+		}
+		value = strings.TrimSpace(candidate)
+		found = true
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	if !found {
+		return 0, fmt.Errorf("%s has no Device Minor field", path)
+	}
+	minor, err := parseDeviceNumber(value, maxDeviceMinor)
+	if err != nil {
+		return 0, fmt.Errorf("invalid Device Minor in %s: %w", path, err)
+	}
+	return minor, nil
+}
+
+func nvidiaCapabilityDevices(root string) ([]capabilityDevice, error) {
+	devices := make([]capabilityDevice, 0, len(allowedCapabilityFiles))
+	minors := make(map[int]string)
+	for _, relative := range allowedCapabilityFiles {
+		path := filepath.Join(root, filepath.FromSlash(relative))
+		info, err := os.Lstat(path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("capability descriptor %s is not a regular file", path)
+		}
+		device, err := parseCapabilityDevice(path)
+		if err != nil {
+			return nil, err
+		}
+		if previous, ok := minors[device.minor]; ok {
+			return nil, fmt.Errorf("capability descriptors %s and %s use minor %d", previous, path, device.minor)
+		}
+		minors[device.minor] = path
+		devices = append(devices, device)
+	}
+	return devices, nil
+}
+
+func parseCapabilityDevice(path string) (capabilityDevice, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return capabilityDevice{}, err
+	}
+	defer file.Close()
+
+	var (
+		minorValue string
+		modeValue  string
+		minorFound bool
+		modeFound  bool
+	)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		key, value, ok := strings.Cut(scanner.Text(), ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "DeviceFileMinor":
+			if minorFound {
+				return capabilityDevice{}, fmt.Errorf("%s contains duplicate DeviceFileMinor fields", path)
+			}
+			minorValue = strings.TrimSpace(value)
+			minorFound = true
+		case "DeviceFileMode":
+			if modeFound {
+				return capabilityDevice{}, fmt.Errorf("%s contains duplicate DeviceFileMode fields", path)
+			}
+			modeValue = strings.TrimSpace(value)
+			modeFound = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return capabilityDevice{}, err
+	}
+	if !minorFound {
+		return capabilityDevice{}, fmt.Errorf("%s has no DeviceFileMinor field", path)
+	}
+	minor, err := parseDeviceNumber(minorValue, maxDeviceMinor)
+	if err != nil {
+		return capabilityDevice{}, fmt.Errorf("invalid DeviceFileMinor in %s: %w", path, err)
+	}
+
+	mode := os.FileMode(0600)
+	if modeFound {
+		value, err := strconv.ParseUint(modeValue, 0, 32)
+		if err != nil || value > 0777 {
+			return capabilityDevice{}, fmt.Errorf("invalid DeviceFileMode in %s: %q", path, modeValue)
+		}
+		mode = os.FileMode(value)
+	}
+	return capabilityDevice{path: path, minor: minor, mode: mode}, nil
+}
+
+func parseDeviceNumber(value string, maximum int) (int, error) {
+	parsed, err := strconv.ParseUint(value, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse %q: %w", value, err)
+	}
+	if parsed > uint64(maximum) {
+		return 0, fmt.Errorf("%d exceeds maximum %d", parsed, maximum)
+	}
+	return int(parsed), nil
+}
+
+func charDeviceMajors(path string) (map[string]int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	majors := make(map[string]int)
+	inCharacterDevices := false
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		switch line {
+		case "Character devices:":
+			inCharacterDevices = true
+			continue
+		case "Block devices:":
+			inCharacterDevices = false
+			continue
+		}
+		if !inCharacterDevices {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) != 2 || !wantedDeviceMajor(fields[1]) {
+			continue
+		}
+		major, err := parseDeviceNumber(fields[0], maxDeviceMajor)
+		if err != nil {
+			return nil, fmt.Errorf("invalid major for %s: %w", fields[1], err)
+		}
+		if previous, ok := majors[fields[1]]; ok && previous != major {
+			return nil, fmt.Errorf("conflicting majors for %s: %d and %d", fields[1], previous, major)
+		}
+		majors[fields[1]] = major
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return majors, nil
+}
+
+func wantedDeviceMajor(name string) bool {
+	switch name {
+	case "nvidia-frontend", "nvidia", "nvidia-uvm", "nvidia-caps",
+		"nvidia-nvswitch", "nvidia-nvlink":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstMajor(majors map[string]int, names ...string) (int, bool) {
+	for _, name := range names {
+		major, ok := majors[name]
+		if ok {
+			return major, true
+		}
+	}
+	return 0, false
+}
+
+func validateCharDevices(devices []charDevice) error {
+	numbers := make(map[string]string)
+	for _, device := range devices {
+		if err := validateDeviceNumber(device.major, device.minor); err != nil {
+			return fmt.Errorf("invalid character device %s: %w", device.path, err)
+		}
+		if device.mode != device.mode.Perm() {
+			return fmt.Errorf("invalid character device mode for %s: %#o", device.path, device.mode)
+		}
+		key := fmt.Sprintf("%d:%d", device.major, device.minor)
+		if previous, ok := numbers[key]; ok && previous != device.path {
+			return fmt.Errorf("character device number %s is assigned to both %s and %s", key, previous, device.path)
+		}
+		numbers[key] = device.path
+	}
+	return nil
+}
+
+func validateDeviceNumber(major, minor int) error {
+	if major < 0 || major > maxDeviceMajor {
+		return fmt.Errorf("major %d is outside 0..%d", major, maxDeviceMajor)
+	}
+	if minor < 0 || minor > maxDeviceMinor {
+		return fmt.Errorf("minor %d is outside 0..%d", minor, maxDeviceMinor)
+	}
+	return nil
+}
+
+func ensureCharDevice(devRoot string, device charDevice) error {
+	if err := ensureCharNode(device); err != nil {
+		return fmt.Errorf("ensure NVIDIA character device %s: %w", device.path, err)
+	}
+	if err := ensureDevCharSymlink(devRoot, device); err != nil {
+		return fmt.Errorf("ensure /dev/char link for %s: %w", device.path, err)
+	}
+	return nil
+}
+
+func ensureCharNode(device charDevice) error {
+	if err := validateDeviceNumber(device.major, device.minor); err != nil {
+		return err
+	}
+	if device.mode != device.mode.Perm() {
+		return fmt.Errorf("invalid mode %#o", device.mode)
+	}
+
+	info, err := os.Lstat(device.path)
+	if err == nil {
+		actualMajor, actualMinor, err := charDeviceNumber(info)
+		if err != nil {
+			return err
+		}
+		if actualMajor == device.major && actualMinor == device.minor {
+			if err := os.Chmod(device.path, device.mode); err != nil {
+				return fmt.Errorf("chmod: %w", err)
+			}
+			return nil
+		}
+		if err := os.Remove(device.path); err != nil {
+			return fmt.Errorf("remove stale character device: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	if err := ensureDirectory(filepath.Dir(device.path)); err != nil {
+		return err
+	}
+	dev := int(unix.Mkdev(uint32(device.major), uint32(device.minor)))
+	if err := unix.Mknod(device.path, uint32(unix.S_IFCHR|device.mode.Perm()), dev); err != nil {
+		return fmt.Errorf("mknod %d:%d: %w", device.major, device.minor, err)
+	}
+	if err := os.Chmod(device.path, device.mode); err != nil {
+		return fmt.Errorf("chmod: %w", err)
+	}
+	info, err = os.Lstat(device.path)
+	if err != nil {
+		return fmt.Errorf("verify created character device: %w", err)
+	}
+	actualMajor, actualMinor, err := charDeviceNumber(info)
+	if err != nil {
+		return fmt.Errorf("verify created character device: %w", err)
+	}
+	if actualMajor != device.major || actualMinor != device.minor {
+		return fmt.Errorf("created character device is %d:%d, want %d:%d", actualMajor, actualMinor, device.major, device.minor)
+	}
+	return nil
+}
+
+func charDeviceNumber(info os.FileInfo) (int, int, error) {
+	if info.Mode()&os.ModeCharDevice == 0 {
+		return 0, 0, errors.New("existing path is not a character device")
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, errors.New("character device has no Linux stat data")
+	}
+	return int(unix.Major(uint64(stat.Rdev))), int(unix.Minor(uint64(stat.Rdev))), nil
+}
+
+func ensureDevCharSymlink(devRoot string, device charDevice) error {
+	relativeDevice, err := filepath.Rel(devRoot, device.path)
+	if err != nil {
+		return err
+	}
+	if relativeDevice == "." || relativeDevice == ".." ||
+		strings.HasPrefix(relativeDevice, ".."+string(filepath.Separator)) ||
+		filepath.IsAbs(relativeDevice) {
+		return fmt.Errorf("device path %s escapes %s", device.path, devRoot)
+	}
+
+	charDir := filepath.Join(devRoot, "char")
+	if err := ensureDirectory(charDir); err != nil {
+		return err
+	}
+	link := filepath.Join(charDir, fmt.Sprintf("%d:%d", device.major, device.minor))
+	target, err := filepath.Rel(charDir, device.path)
+	if err != nil {
+		return err
+	}
+
+	info, err := os.Lstat(link)
+	if err == nil {
+		if info.Mode()&os.ModeSymlink == 0 {
+			return errors.New("existing /dev/char path is not a symlink")
+		}
+		current, err := os.Readlink(link)
+		if err != nil {
+			return err
+		}
+		if current == target {
+			return nil
+		}
+		if err := os.Remove(link); err != nil {
+			return fmt.Errorf("remove stale symlink: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	if err := os.Symlink(target, link); err != nil {
+		return fmt.Errorf("create symlink to %s: %w", target, err)
+	}
+	current, err := os.Readlink(link)
+	if err != nil {
+		return fmt.Errorf("verify symlink: %w", err)
+	}
+	if current != target {
+		return fmt.Errorf("symlink target is %s, want %s", current, target)
+	}
+	return nil
+}
+
+func ensureDirectory(path string) error {
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+	return nil
+}

--- a/tinfoil/internal/nvidia/devices_test.go
+++ b/tinfoil/internal/nvidia/devices_test.go
@@ -1,0 +1,374 @@
+package nvidia
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func testDevicePaths(t *testing.T) devicePaths {
+	t.Helper()
+	root := t.TempDir()
+	paths := devicePaths{
+		pciDevices:   filepath.Join(root, "pci"),
+		gpus:         filepath.Join(root, "gpus"),
+		capabilities: filepath.Join(root, "capabilities"),
+		nvswitches:   filepath.Join(root, "nvswitches"),
+		nvswitchMode: filepath.Join(root, "nvswitch-permissions"),
+		nvlinkMode:   filepath.Join(root, "nvlink-permissions"),
+		procDevices:  filepath.Join(root, "devices"),
+		dev:          filepath.Join(root, "dev"),
+	}
+	for _, path := range []string{paths.pciDevices, paths.gpus, paths.capabilities, paths.nvswitches, paths.dev} {
+		if err := os.MkdirAll(path, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return paths
+}
+
+func writeTestFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func addPCIFixture(t *testing.T, paths devicePaths, name, vendor, class string, powerControl bool) {
+	t.Helper()
+	base := filepath.Join(paths.pciDevices, name)
+	writeTestFile(t, filepath.Join(base, "vendor"), vendor+"\n")
+	writeTestFile(t, filepath.Join(base, "class"), class+"\n")
+	writeTestFile(t, filepath.Join(base, "enable"), "0\n")
+	if powerControl {
+		writeTestFile(t, filepath.Join(base, "power", "control"), "on\n")
+	}
+}
+
+func TestPCIDiscoveryAndGPUSetupUseExactClasses(t *testing.T) {
+	paths := testDevicePaths(t)
+	fixtures := map[string]struct {
+		vendor string
+		class  string
+		gpu    bool
+		power  bool
+	}{
+		"0000:01:00.0": {"0x10de", "0x030000", true, true},
+		"0000:02:00.0": {"0x10de", "0x030200", true, true},
+		"0000:03:00.0": {"0x10de", "0x068000", false, true},
+		"0000:04:00.0": {"0x10de", "0x030201", false, true},
+		"0000:05:00.0": {"0x1af4", "0x068000", false, true},
+	}
+	for name, fixture := range fixtures {
+		addPCIFixture(t, paths, name, fixture.vendor, fixture.class, fixture.power)
+	}
+	addPCIFixture(t, paths, "0000:06:00.0", "0x10de", "0x030200", false)
+
+	present, err := hasPCIDevice(paths)
+	if err != nil || !present {
+		t.Fatalf("hasPCIDevice = %v, %v; want true, nil", present, err)
+	}
+	nvswitch, err := hasNVSwitch(paths)
+	if err != nil || !nvswitch {
+		t.Fatalf("hasNVSwitch = %v, %v; want true, nil", nvswitch, err)
+	}
+	writeTestFile(t, filepath.Join(paths.pciDevices, "0000:03:00.0", "class"), "0x068001\n")
+	nvswitch, err = hasNVSwitch(paths)
+	if err != nil || nvswitch {
+		t.Fatalf("inexact hasNVSwitch = %v, %v; want false, nil", nvswitch, err)
+	}
+	writeTestFile(t, filepath.Join(paths.pciDevices, "0000:03:00.0", "class"), "0x068000\n")
+	if err := holdGPUEnableReferences(paths); err != nil {
+		t.Fatalf("holdGPUEnableReferences: %v", err)
+	}
+	if err := enableGPURuntimePowerManagement(paths); err != nil {
+		t.Fatalf("enableGPURuntimePowerManagement: %v", err)
+	}
+
+	for name, fixture := range fixtures {
+		enable, err := os.ReadFile(filepath.Join(paths.pciDevices, name, "enable"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantEnable := "0\n"
+		if fixture.gpu {
+			wantEnable = "1\n"
+		}
+		if string(enable) != wantEnable {
+			t.Errorf("%s enable = %q, want %q", name, enable, wantEnable)
+		}
+		control, err := os.ReadFile(filepath.Join(paths.pciDevices, name, "power", "control"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantControl := "on\n"
+		if fixture.gpu {
+			wantControl = "auto\n"
+		}
+		if string(control) != wantControl {
+			t.Errorf("%s power/control = %q, want %q", name, control, wantControl)
+		}
+	}
+}
+
+func TestNVIDIAPresenceAndNVSwitchErrorsAreReported(t *testing.T) {
+	paths := testDevicePaths(t)
+	present, err := hasPCIDevice(paths)
+	if err != nil || present {
+		t.Fatalf("empty hasPCIDevice = %v, %v; want false, nil", present, err)
+	}
+	writeTestFile(t, filepath.Join(paths.pciDevices, "0000:01:00.0", "vendor"), "invalid\n")
+	if _, err := hasPCIDevice(paths); err == nil {
+		t.Fatal("hasPCIDevice accepted an invalid vendor")
+	}
+	if _, err := hasNVSwitch(paths); err == nil {
+		t.Fatal("hasNVSwitch accepted an invalid vendor")
+	}
+}
+
+func TestGPUDeviceMinorsUseOnlyProcInformation(t *testing.T) {
+	paths := testDevicePaths(t)
+	fixtures := map[string]string{
+		"0000:01:00.0": "Model: B300\nDevice Minor: 7\n",
+		"0000:02:00.0": "Device Minor: 2\n",
+		"0000:03:00.0": "Device Minor: 7\n",
+	}
+	for name, contents := range fixtures {
+		writeTestFile(t, filepath.Join(paths.gpus, name, "information"), contents)
+	}
+	writeTestFile(t, filepath.Join(paths.gpus, "not-a-directory"), "Device Minor: 9\n")
+
+	got, err := nvidiaDeviceMinors(paths.gpus)
+	if err != nil {
+		t.Fatalf("nvidiaDeviceMinors: %v", err)
+	}
+	if want := []int{2, 7}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("nvidiaDeviceMinors = %v, want %v", got, want)
+	}
+
+	writeTestFile(t, filepath.Join(paths.gpus, "0000:04:00.0", "information"), "Model: B300\n")
+	if _, err := nvidiaDeviceMinors(paths.gpus); err == nil {
+		t.Fatal("nvidiaDeviceMinors accepted missing Device Minor")
+	}
+}
+
+func TestCapabilityDiscoveryIsBoundedAndPreservesModes(t *testing.T) {
+	paths := testDevicePaths(t)
+	config := filepath.Join(paths.capabilities, "mig", "config")
+	monitor := filepath.Join(paths.capabilities, "mig", "monitor")
+	writeTestFile(t, config, "DeviceFileMinor: 1\nDeviceFileMode: 256\n")
+	writeTestFile(t, monitor, "DeviceFileMinor: 2\nDeviceFileMode: 288\n")
+	writeTestFile(t, filepath.Join(paths.capabilities, "fabric-imex-mgmt"),
+		"DeviceFileMinor: 3\nDeviceFileMode: 511\n")
+	writeTestFile(t, filepath.Join(paths.capabilities, "mig", "unexpected"),
+		"DeviceFileMinor: 4\nDeviceFileMode: 511\n")
+
+	got, err := nvidiaCapabilityDevices(paths.capabilities)
+	if err != nil {
+		t.Fatalf("nvidiaCapabilityDevices: %v", err)
+	}
+	want := []capabilityDevice{
+		{path: config, minor: 1, mode: 0400},
+		{path: monitor, minor: 2, mode: 0440},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("capabilities = %#v, want %#v", got, want)
+	}
+
+	if err := os.Remove(config); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(monitor, config); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := nvidiaCapabilityDevices(paths.capabilities); err == nil {
+		t.Fatal("capability discovery followed a descriptor symlink")
+	}
+}
+
+func TestCapabilityParserFailsClosed(t *testing.T) {
+	tests := []string{
+		"DeviceFileMode: 256\n",
+		"DeviceFileMinor: -1\n",
+		"DeviceFileMinor: 1\nDeviceFileMode: 512\n",
+		"DeviceFileMinor: 1\nDeviceFileMinor: 2\n",
+	}
+	for index, contents := range tests {
+		t.Run(strconv.Itoa(index), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config")
+			writeTestFile(t, path, contents)
+			if _, err := parseCapabilityDevice(path); err == nil {
+				t.Fatalf("parseCapabilityDevice accepted %q", contents)
+			}
+		})
+	}
+}
+
+func TestCharacterDeviceMajorsUseOnlyCharacterSection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devices")
+	writeTestFile(t, path, `Character devices:
+  1 mem
+195 nvidia-frontend
+236 nvidia-caps
+237 nvidia-uvm
+238 nvidia-nvlink
+239 nvidia-nvswitch
+
+Block devices:
+  8 nvidia
+`)
+	got, err := charDeviceMajors(path)
+	if err != nil {
+		t.Fatalf("charDeviceMajors: %v", err)
+	}
+	want := map[string]int{"nvidia-frontend": 195, "nvidia-caps": 236, "nvidia-uvm": 237,
+		"nvidia-nvlink": 238, "nvidia-nvswitch": 239}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("majors = %v, want %v", got, want)
+	}
+}
+
+func TestInterconnectDevicesCoverMultipleSwitchesAndNVLink(t *testing.T) {
+	paths := testDevicePaths(t)
+	addPCIFixture(t, paths, "0000:01:00.0", "0x10de", "0x068000", false)
+	if _, err := nvidiaInterconnectDevices(paths, nil); err == nil {
+		t.Fatal("NVSwitch hardware without driver majors was accepted")
+	}
+	for _, name := range []string{"0000:01:00.0", "0000:02:00.0"} {
+		if err := os.Mkdir(filepath.Join(paths.nvswitches, name), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeTestFile(t, paths.nvswitchMode, "DeviceFileMode: 438\n")
+	writeTestFile(t, paths.nvlinkMode, "DeviceFileMode: 432\n")
+	majors := map[string]int{"nvidia-nvswitch": 239, "nvidia-nvlink": 238}
+	got, err := nvidiaInterconnectDevices(paths, majors)
+	if err != nil {
+		t.Fatalf("nvidiaInterconnectDevices: %v", err)
+	}
+	want := []charDevice{
+		{path: filepath.Join(paths.dev, "nvidia-nvswitchctl"), major: 239, minor: 255, mode: 0666},
+		{path: filepath.Join(paths.dev, "nvidia-nvswitch0"), major: 239, minor: 0, mode: 0666},
+		{path: filepath.Join(paths.dev, "nvidia-nvswitch1"), major: 239, minor: 1, mode: 0666},
+		{path: filepath.Join(paths.dev, "nvidia-nvlink"), major: 238, minor: 0, mode: 0660},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("interconnect devices = %#v, want %#v", got, want)
+	}
+	writeTestFile(t, paths.nvswitchMode, "DeviceFileMode: malformed\n")
+	if _, err := nvidiaInterconnectDevices(paths, majors); err == nil {
+		t.Fatal("malformed NVSwitch permissions were accepted")
+	}
+}
+
+func TestDevCharSymlinkIsBoundedAndRepairsStaleLinks(t *testing.T) {
+	paths := testDevicePaths(t)
+	device := charDevice{
+		path:  filepath.Join(paths.dev, "nvidia-caps", "nvidia-cap1"),
+		major: 236,
+		minor: 1,
+		mode:  0400,
+	}
+	if err := ensureDevCharSymlink(paths.dev, device); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+	link := filepath.Join(paths.dev, "char", "236:1")
+	if got, err := os.Readlink(link); err != nil || got != "../nvidia-caps/nvidia-cap1" {
+		t.Fatalf("link = %q, %v", got, err)
+	}
+
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("../stale", link); err != nil {
+		t.Fatal(err)
+	}
+	if err := ensureDevCharSymlink(paths.dev, device); err != nil {
+		t.Fatalf("repair symlink: %v", err)
+	}
+	if got, err := os.Readlink(link); err != nil || got != "../nvidia-caps/nvidia-cap1" {
+		t.Fatalf("repaired link = %q, %v", got, err)
+	}
+
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, link, "do not replace\n")
+	if err := ensureDevCharSymlink(paths.dev, device); err == nil {
+		t.Fatal("ensureDevCharSymlink replaced a non-symlink")
+	}
+	device.path = filepath.Join(paths.dev, "..", "outside")
+	if err := ensureDevCharSymlink(paths.dev, device); err == nil {
+		t.Fatal("ensureDevCharSymlink accepted an escaping device path")
+	}
+}
+
+func TestEnsureCharNodeRecreatesOnlyStaleCharacterDevices(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nvidia-nvswitch0")
+	oldUmask := syscall.Umask(0022)
+	t.Cleanup(func() { syscall.Umask(oldUmask) })
+
+	oldDev := int(unix.Mkdev(1, 3))
+	if err := unix.Mknod(path, unix.S_IFCHR|0600, oldDev); err != nil {
+		if errors.Is(err, unix.EPERM) || errors.Is(err, unix.EACCES) {
+			t.Skipf("mknod not permitted: %v", err)
+		}
+		t.Fatal(err)
+	}
+	device := charDevice{path: path, major: 1, minor: 7, mode: 0660}
+	if err := ensureCharNode(device); err != nil {
+		t.Fatalf("ensureCharNode: %v", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	major, minor, err := charDeviceNumber(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if major != 1 || minor != 7 || info.Mode().Perm() != 0660 {
+		t.Fatalf("node = %d:%d mode %#o, want 1:7 mode 0660", major, minor, info.Mode().Perm())
+	}
+
+	regular := filepath.Join(t.TempDir(), "nvidiactl")
+	writeTestFile(t, regular, "keep\n")
+	device = charDevice{path: regular, major: 1, minor: 3, mode: 0666}
+	if err := ensureCharNode(device); err == nil {
+		t.Fatal("ensureCharNode replaced a regular file")
+	}
+	if contents, err := os.ReadFile(regular); err != nil || string(contents) != "keep\n" {
+		t.Fatalf("regular file changed: %q, %v", contents, err)
+	}
+}
+
+func TestSetupDeviceNodesFailsBeforeReplacingRequiredPaths(t *testing.T) {
+	paths := testDevicePaths(t)
+	writeTestFile(t, paths.procDevices, "Character devices:\n195 nvidia-frontend\n")
+	writeTestFile(t, filepath.Join(paths.dev, "nvidiactl"), "keep\n")
+
+	err := setupDeviceNodes(paths)
+	if err == nil || !strings.Contains(err.Error(), "not a character device") {
+		t.Fatalf("setupDeviceNodes error = %v, want required node error", err)
+	}
+	if contents, err := os.ReadFile(filepath.Join(paths.dev, "nvidiactl")); err != nil || string(contents) != "keep\n" {
+		t.Fatalf("required path changed: %q, %v", contents, err)
+	}
+
+	writeTestFile(t, filepath.Join(paths.capabilities, "mig", "config"),
+		"DeviceFileMinor: 1\nDeviceFileMode: 256\n")
+	err = setupDeviceNodes(paths)
+	if err == nil || !strings.Contains(err.Error(), "without nvidia-caps") {
+		t.Fatalf("setupDeviceNodes capability error = %v", err)
+	}
+}

--- a/tinfoil/internal/nvidia/devices_test.go
+++ b/tinfoil/internal/nvidia/devices_test.go
@@ -121,6 +121,33 @@ func TestPCIDiscoveryAndGPUSetupUseExactClasses(t *testing.T) {
 	}
 }
 
+func TestHasPCIDeviceUsesSupportedGPUAndNVSwitchClasses(t *testing.T) {
+	tests := []struct {
+		name  string
+		class string
+		want  bool
+	}{
+		{name: "VGA controller", class: "0x030000", want: true},
+		{name: "3D controller", class: "0x030200", want: true},
+		{name: "NVSwitch", class: "0x068000", want: true},
+		{name: "HDA controller", class: "0x040300", want: false},
+		{name: "inexact 3D controller", class: "0x030201", want: false},
+		{name: "inexact NVSwitch", class: "0x068001", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			paths := testDevicePaths(t)
+			addPCIFixture(t, paths, "0000:01:00.0", "0x10de", test.class, false)
+
+			present, err := hasPCIDevice(paths)
+			if err != nil || present != test.want {
+				t.Fatalf("hasPCIDevice = %v, %v; want %v, nil", present, err, test.want)
+			}
+		})
+	}
+}
+
 func TestNVIDIAPresenceAndNVSwitchErrorsAreReported(t *testing.T) {
 	paths := testDevicePaths(t)
 	present, err := hasPCIDevice(paths)


### PR DESCRIPTION
## Summary

- add bounded NVIDIA GPU and NVSwitch PCI discovery
- hold GPU PCI enable references and configure runtime power management
- create and verify NVIDIA core, UVM, modeset, capability, NVSwitch, and NVLink character nodes
- repair stale device nodes and `/dev/char` links without replacing ordinary files

## Trust boundary

Discovery is restricted to NVIDIA vendor IDs and exact GPU/NVSwitch PCI classes. Capability input is restricted to `mig/config` and `mig/monitor`; NVSwitch enumeration is capped at 64 devices. Device majors, minors, and driver-requested modes are validated before use, and conflicting metadata fails closed.

Three narrow driver interfaces remain because NVIDIA does not expose equivalent usable sysfs classes: `/proc/devices` for dynamic character majors, per-GPU `Device Minor`, and capability minor/mode fields. The implementation does not parse arbitrary PCI capabilities, scan for executable helpers, or accept caller-provided device paths.

## Scope

This is a source-only library foundation on merged #178. It does not start NVIDIA services, alter bootstrap order, wire PID 1, add debug diagnostics, or change current image behavior. Userspace services and orchestration remain separate PRs; helper removal waits for final activation.

## Review focus

- exact GPU/NVSwitch class and vendor filtering
- enable-reference lifetime and power-control writes
- mandatory versus optional NVIDIA majors/nodes
- MIG capability-mode preservation
- NVSwitch/NVLink bounds and dynamic-major handling
- stale node/symlink verification and non-device-file rejection

## Validation

- `go test ./...`
- `go test -race ./internal/nvidia`
- `go vet ./...`
- `git diff --check origin/jules/harden-tcb...HEAD`

H200/B300/NVSwitch boot validation remains required before the later image switch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded NVIDIA GPU and NVSwitch discovery and creates/verifies NVIDIA character devices with strict validation. This is a library-only foundation that doesn’t change boot order or start services.

- **New Features**
  - Discover NVIDIA PCI by vendor ID and exact GPU/NVSwitch classes; hold GPU enable refs and set runtime PM to auto.
  - Create and verify nvidiactl, nvidia-modeset, per-GPU nvidiaN, nvidia-uvm/nvidia-uvm-tools, nvidia-caps/*, nvidia-nvswitch*, nvidia-nvlink, plus /dev/char links.
  - Parse only mig/config and mig/monitor capability descriptors; preserve modes; validate majors/minors; fail closed on conflicts.
  - Support up to 64 NVSwitch devices; require nvidia-nvswitch and nvidia-nvlink majors when NVSwitch hardware is present; use /proc/devices and driver-provided minors.
  - Repair stale nodes and links without replacing non-device files.

- **Bug Fixes**
  - Restrict NVIDIA PCI presence detection to exact class IDs: VGA 0x030000, 3D 0x030200, and NVSwitch 0x068000 (prevents false positives).

<sup>Written for commit 63e1707e01d83e528a0b96569df58ee42105ccaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

