### PR TITLE
Add race-free PID 1 child supervision

### DIFF
--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -46,6 +46,7 @@ func (e Exit) Err() error {
 type backendProcess interface {
 	pid() int
 	signal(syscall.Signal) error
+	groupAlive() (bool, error)
 	release() error
 }
 
@@ -57,10 +58,9 @@ type processBackend interface {
 // Process is a child whose status is owned by Manager. Wait may be called by
 // multiple observers; all receive the same result.
 type Process struct {
-	manager *Manager
-	child   backendProcess
-	done    chan struct{}
-	exit    Exit
+	child backendProcess
+	done  chan struct{}
+	exit  Exit
 }
 
 func (p *Process) PID() int              { return p.child.pid() }
@@ -81,16 +81,10 @@ func (p *Process) complete(exit Exit) {
 }
 
 func (p *Process) Signal(sig syscall.Signal) error {
-	reply := make(chan error, 1)
-	p.manager.ops <- func(children map[int]*Process) {
-		if current := children[p.PID()]; current != p {
-			reply <- os.ErrProcessDone
-		} else {
-			reply <- p.child.signal(sig)
-		}
-	}
-	return <-reply
+	return p.child.signal(sig)
 }
+
+func (p *Process) groupAlive() (bool, error) { return p.child.groupAlive() }
 
 type startResponse struct {
 	process *Process
@@ -141,7 +135,7 @@ func (m *Manager) Start(command Command) (*Process, error) {
 			reply <- startResponse{err: err}
 			return
 		}
-		process := &Process{manager: m, child: child, done: make(chan struct{})}
+		process := &Process{child: child, done: make(chan struct{})}
 		children[child.pid()] = process
 		reply <- startResponse{process: process}
 	}
@@ -230,6 +224,16 @@ func (p osChild) signal(sig syscall.Signal) error {
 	}
 	return err
 }
+func (p osChild) groupAlive() (bool, error) {
+	err := syscall.Kill(-p.process.Pid, 0)
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	if errors.Is(err, syscall.EPERM) {
+		return true, nil
+	}
+	return err == nil, err
+}
 func (p osChild) release() error { return p.process.Release() }
 
 // State reports whether a managed service is ready. A required service is
@@ -273,6 +277,7 @@ type Config struct {
 type serviceRecord struct {
 	spec    Service
 	process *Process
+	groups  map[*Process]struct{}
 	started time.Time
 	delay   time.Duration
 	done    chan struct{}
@@ -298,8 +303,11 @@ func New(parent context.Context, manager *Manager, config Config) *Supervisor {
 	if config.RestartBase <= 0 {
 		config.RestartBase = 2 * time.Second
 	}
-	if config.RestartMax < config.RestartBase {
+	if config.RestartMax <= 0 {
 		config.RestartMax = 30 * time.Second
+	}
+	if config.RestartMax < config.RestartBase {
+		config.RestartMax = config.RestartBase
 	}
 	if config.StableAfter <= 0 {
 		config.StableAfter = time.Minute
@@ -316,7 +324,10 @@ func New(parent context.Context, manager *Manager, config Config) *Supervisor {
 }
 
 func (s *Supervisor) Start(ctx context.Context, service Service) error {
-	record := &serviceRecord{spec: service, delay: s.base, done: make(chan struct{})}
+	record := &serviceRecord{
+		spec: service, groups: map[*Process]struct{}{},
+		delay: s.base, done: make(chan struct{}),
+	}
 	s.mu.Lock()
 	if s.draining {
 		s.mu.Unlock()
@@ -328,14 +339,19 @@ func (s *Supervisor) Start(ctx context.Context, service Service) error {
 	}
 	s.services[service.Name] = record
 	process, err := s.startLocked(record)
+	if err != nil {
+		s.retireLocked(record)
+	}
 	s.mu.Unlock()
 	if err != nil {
 		s.emit(State{Name: service.Name, Required: service.Required, Err: err})
 		return err
 	}
 	if err := s.ready(ctx, record, process); err != nil {
-		s.emit(State{Name: service.Name, Required: service.Required, Err: err})
-		return fmt.Errorf("%s readiness: %w", service.Name, err)
+		cleanupErr := s.stopInitial(record, process)
+		readinessErr := fmt.Errorf("%s readiness: %w", service.Name, errors.Join(err, cleanupErr))
+		s.emit(State{Name: service.Name, Required: service.Required, Err: readinessErr})
+		return readinessErr
 	}
 	s.emit(State{Name: service.Name, Required: service.Required, Ready: true})
 	go func() {
@@ -353,8 +369,30 @@ func (s *Supervisor) startLocked(record *serviceRecord) (*Process, error) {
 		return nil, err
 	}
 	record.process = process
+	record.groups[process] = struct{}{}
 	record.started = s.clock.Now()
 	return process, nil
+}
+
+func (s *Supervisor) stopInitial(record *serviceRecord, process *Process) error {
+	var errs []error
+	if err := process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		errs = append(errs, err)
+	}
+	if _, err := process.Wait(context.Background()); err != nil {
+		errs = append(errs, err)
+	}
+	s.mu.Lock()
+	s.retireLocked(record)
+	s.mu.Unlock()
+	return errors.Join(errs...)
+}
+
+func (s *Supervisor) retireLocked(record *serviceRecord) {
+	if s.services[record.spec.Name] == record {
+		delete(s.services, record.spec.Name)
+	}
+	close(record.done)
 }
 
 func (s *Supervisor) ready(ctx context.Context, record *serviceRecord, process *Process) error {
@@ -381,6 +419,10 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 		s.mu.Lock()
 		if record.process == process {
 			record.process = nil
+		}
+		alive, aliveErr := process.groupAlive()
+		if aliveErr == nil && !alive {
+			delete(record.groups, process)
 		}
 		draining := s.draining
 		runtime := s.clock.Now().Sub(record.started)
@@ -423,6 +465,9 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 				s.mu.Lock()
 				if record.process == next {
 					record.process = nil
+				}
+				if alive, err := next.groupAlive(); err == nil && !alive {
+					delete(record.groups, next)
 				}
 				if s.clock.Now().Sub(record.started) >= s.stable {
 					record.delay = s.base
@@ -482,9 +527,15 @@ func (s *Supervisor) Drain(groups [][]string, termGrace, killGrace time.Duration
 func (s *Supervisor) drainGroup(names []string, termGrace, killGrace time.Duration) error {
 	s.mu.Lock()
 	processes := make([]*Process, 0, len(names))
+	seen := map[*Process]bool{}
 	for _, name := range names {
-		if record := s.services[name]; record != nil && record.process != nil {
-			processes = append(processes, record.process)
+		if record := s.services[name]; record != nil {
+			for process := range record.groups {
+				if !seen[process] {
+					seen[process] = true
+					processes = append(processes, process)
+				}
+			}
 		}
 	}
 	s.mu.Unlock()
@@ -493,27 +544,37 @@ func (s *Supervisor) drainGroup(names []string, termGrace, killGrace time.Durati
 	}
 
 	var errs []error
+	alive := processes[:0]
 	for _, process := range processes {
-		if err := process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		if err := process.Signal(syscall.SIGTERM); errors.Is(err, os.ErrProcessDone) {
+			continue
+		} else if err != nil {
 			errs = append(errs, err)
 		}
+		alive = append(alive, process)
 	}
-	alive := waitProcesses(processes, s.clock.After(termGrace))
+	alive, waitErrs := waitProcessGroups(alive, s.clock.After(termGrace))
+	errs = append(errs, waitErrs...)
+	killed := alive[:0]
 	for _, process := range alive {
-		if err := process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		if err := process.Signal(syscall.SIGKILL); errors.Is(err, os.ErrProcessDone) {
+			continue
+		} else if err != nil {
 			errs = append(errs, err)
 		}
+		killed = append(killed, process)
 	}
-	alive = waitProcesses(alive, s.clock.After(killGrace))
+	alive, waitErrs = waitProcessGroups(killed, s.clock.After(killGrace))
+	errs = append(errs, waitErrs...)
 	for _, process := range alive {
 		errs = append(errs, fmt.Errorf("pid %d did not exit after SIGKILL", process.PID()))
 	}
 	return errors.Join(errs...)
 }
 
-func waitProcesses(processes []*Process, timeout <-chan time.Time) []*Process {
+func waitProcessGroups(processes []*Process, timeout <-chan time.Time) ([]*Process, []error) {
 	if len(processes) == 0 {
-		return nil
+		return nil, nil
 	}
 	exited := make(chan *Process, len(processes))
 	alive := make(map[*Process]bool, len(processes))
@@ -527,14 +588,35 @@ func waitProcesses(processes []*Process, timeout <-chan time.Time) []*Process {
 	for len(alive) > 0 {
 		select {
 		case process := <-exited:
-			delete(alive, process)
-		case <-timeout:
-			result := make([]*Process, 0, len(alive))
-			for process := range alive {
-				result = append(result, process)
+			groupAlive, err := process.groupAlive()
+			if err != nil {
+				return processSlice(alive), []error{err}
 			}
-			return result
+			if !groupAlive {
+				delete(alive, process)
+			}
+		case <-timeout:
+			var errs []error
+			for process := range alive {
+				groupAlive, err := process.groupAlive()
+				if err != nil {
+					errs = append(errs, err)
+					continue
+				}
+				if !groupAlive {
+					delete(alive, process)
+				}
+			}
+			return processSlice(alive), errs
 		}
 	}
-	return nil
+	return nil, nil
+}
+
+func processSlice(processes map[*Process]bool) []*Process {
+	result := make([]*Process, 0, len(processes))
+	for process := range processes {
+		result = append(result, process)
+	}
+	return result
 }

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -1,0 +1,540 @@
+// Package supervisor owns child creation, wait status collection, service
+// restart, and ordered shutdown for Tinfoil PID 1.
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sort"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Command describes a direct child of PID 1.
+type Command struct {
+	Name string
+	Path string
+	Args []string
+	Env  []string
+	Dir  string
+}
+
+// Exit is the wait status collected for a child.
+type Exit struct {
+	PID    int
+	Status syscall.WaitStatus
+}
+
+func (e Exit) Err() error {
+	switch {
+	case e.Status.Exited() && e.Status.ExitStatus() == 0:
+		return nil
+	case e.Status.Exited():
+		return fmt.Errorf("pid %d exited with status %d", e.PID, e.Status.ExitStatus())
+	case e.Status.Signaled():
+		return fmt.Errorf("pid %d killed by %s", e.PID, e.Status.Signal())
+	default:
+		return fmt.Errorf("pid %d ended with wait status %#x", e.PID, uint32(e.Status))
+	}
+}
+
+type backendProcess interface {
+	pid() int
+	signal(syscall.Signal) error
+	release() error
+}
+
+type processBackend interface {
+	start(Command) (backendProcess, error)
+	waitNoHang() (int, syscall.WaitStatus, error)
+}
+
+// Process is a child whose status is owned by Manager. Wait may be called by
+// multiple observers; all receive the same result.
+type Process struct {
+	manager *Manager
+	child   backendProcess
+	done    chan struct{}
+	exit    Exit
+}
+
+func (p *Process) PID() int              { return p.child.pid() }
+func (p *Process) Done() <-chan struct{} { return p.done }
+
+func (p *Process) Wait(ctx context.Context) (Exit, error) {
+	select {
+	case <-p.done:
+		return p.exit, nil
+	case <-ctx.Done():
+		return Exit{}, ctx.Err()
+	}
+}
+
+func (p *Process) complete(exit Exit) {
+	p.exit = exit
+	close(p.done)
+}
+
+func (p *Process) Signal(sig syscall.Signal) error {
+	reply := make(chan error, 1)
+	p.manager.ops <- func(children map[int]*Process) {
+		if current := children[p.PID()]; current != p {
+			reply <- os.ErrProcessDone
+		} else {
+			reply <- p.child.signal(sig)
+		}
+	}
+	return <-reply
+}
+
+type startResponse struct {
+	process *Process
+	err     error
+}
+
+// Manager is the sole wait4 owner. Every PID 1 child must be started through
+// this manager; mixing it with os/exec Wait would race for child statuses.
+// Child creation is serialized with reaping, so even a child that exits
+// immediately is registered before wait4(-1) can collect it.
+type Manager struct {
+	backend processBackend
+	log     func(string, ...any)
+	ops     chan func(map[int]*Process)
+	sigchld chan os.Signal
+}
+
+// NewManager starts the production Linux child manager.
+func NewManager(log func(string, ...any)) *Manager {
+	sigchld := make(chan os.Signal, 1)
+	signal.Notify(sigchld, syscall.SIGCHLD)
+	manager := newManager(osBackend{}, sigchld, log)
+	return manager
+}
+
+func newManager(backend processBackend, sigchld chan os.Signal, log func(string, ...any)) *Manager {
+	manager := &Manager{
+		backend: backend,
+		log:     log,
+		ops:     make(chan func(map[int]*Process)),
+		sigchld: sigchld,
+	}
+	go manager.loop()
+	return manager
+}
+
+func (m *Manager) Start(command Command) (*Process, error) {
+	if command.Name == "" {
+		return nil, errors.New("child name is required")
+	}
+	if !filepath.IsAbs(command.Path) {
+		return nil, fmt.Errorf("child path must be absolute: %q", command.Path)
+	}
+	reply := make(chan startResponse, 1)
+	m.ops <- func(children map[int]*Process) {
+		child, err := m.backend.start(command)
+		if err != nil {
+			reply <- startResponse{err: err}
+			return
+		}
+		process := &Process{manager: m, child: child, done: make(chan struct{})}
+		children[child.pid()] = process
+		reply <- startResponse{process: process}
+	}
+	response := <-reply
+	return response.process, response.err
+}
+
+func (m *Manager) loop() {
+	children := map[int]*Process{}
+	m.reapChildren(children)
+	for {
+		select {
+		case operation := <-m.ops:
+			operation(children)
+		case <-m.sigchld:
+			m.reapChildren(children)
+		}
+	}
+}
+
+func (m *Manager) reapChildren(children map[int]*Process) {
+	for {
+		pid, status, err := m.backend.waitNoHang()
+		if errors.Is(err, syscall.EINTR) {
+			continue
+		}
+		if errors.Is(err, syscall.ECHILD) || (err == nil && pid == 0) {
+			return
+		}
+		if err != nil {
+			m.logf("reaping children: %v", err)
+			return
+		}
+		exit := Exit{PID: pid, Status: status}
+		process, owned := children[pid]
+		if !owned {
+			m.logf("reaped adopted child pid=%d status=%#x", pid, uint32(status))
+			continue
+		}
+		delete(children, pid)
+		process.complete(exit)
+		if err := process.child.release(); err != nil {
+			m.logf("releasing child pid=%d: %v", pid, err)
+		}
+	}
+}
+
+func (m *Manager) logf(format string, args ...any) {
+	if m.log != nil {
+		m.log(format, args...)
+	}
+}
+
+type osBackend struct{}
+
+func (osBackend) start(command Command) (backendProcess, error) {
+	env := command.Env
+	if env == nil {
+		env = os.Environ()
+	}
+	process, err := os.StartProcess(command.Path, append([]string{command.Path}, command.Args...), &os.ProcAttr{
+		Dir:   command.Dir,
+		Env:   env,
+		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
+		Sys:   &syscall.SysProcAttr{Setpgid: true},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("start %s: %w", command.Name, err)
+	}
+	return osChild{process: process}, nil
+}
+
+func (osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
+	var status syscall.WaitStatus
+	pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
+	return pid, status, err
+}
+
+type osChild struct{ process *os.Process }
+
+func (p osChild) pid() int { return p.process.Pid }
+func (p osChild) signal(sig syscall.Signal) error {
+	err := syscall.Kill(-p.process.Pid, sig)
+	if errors.Is(err, syscall.ESRCH) {
+		return os.ErrProcessDone
+	}
+	return err
+}
+func (p osChild) release() error { return p.process.Release() }
+
+// State reports whether a managed service is ready. A required service is
+// marked unready before restart delay begins, allowing callers to fail closed.
+type State struct {
+	Name     string
+	Required bool
+	Ready    bool
+	Err      error
+}
+
+// Service is a long-lived child. Ready is called after every start and must
+// return only when that instance is usable.
+type Service struct {
+	Name     string
+	Command  Command
+	Required bool
+	Restart  bool
+	Ready    func(context.Context) error
+}
+
+type Clock interface {
+	Now() time.Time
+	After(time.Duration) <-chan time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time                             { return time.Now() }
+func (realClock) After(delay time.Duration) <-chan time.Time { return time.After(delay) }
+
+// Config controls restart and drain timing.
+type Config struct {
+	RestartBase time.Duration
+	RestartMax  time.Duration
+	StableAfter time.Duration
+	Clock       Clock
+	Observe     func(State)
+}
+
+type serviceRecord struct {
+	spec    Service
+	process *Process
+	started time.Time
+	delay   time.Duration
+	done    chan struct{}
+}
+
+// Supervisor restarts services and drains them in dependency order.
+type Supervisor struct {
+	manager *Manager
+	context context.Context
+	cancel  context.CancelFunc
+	clock   Clock
+	base    time.Duration
+	max     time.Duration
+	stable  time.Duration
+	observe func(State)
+
+	mu       sync.Mutex
+	draining bool
+	services map[string]*serviceRecord
+}
+
+func New(parent context.Context, manager *Manager, config Config) *Supervisor {
+	if config.RestartBase <= 0 {
+		config.RestartBase = 2 * time.Second
+	}
+	if config.RestartMax < config.RestartBase {
+		config.RestartMax = 30 * time.Second
+	}
+	if config.StableAfter <= 0 {
+		config.StableAfter = time.Minute
+	}
+	if config.Clock == nil {
+		config.Clock = realClock{}
+	}
+	ctx, cancel := context.WithCancel(parent)
+	return &Supervisor{
+		manager: manager, context: ctx, cancel: cancel, clock: config.Clock,
+		base: config.RestartBase, max: config.RestartMax, stable: config.StableAfter,
+		observe: config.Observe, services: map[string]*serviceRecord{},
+	}
+}
+
+func (s *Supervisor) Start(ctx context.Context, service Service) error {
+	record := &serviceRecord{spec: service, delay: s.base, done: make(chan struct{})}
+	s.mu.Lock()
+	if s.draining {
+		s.mu.Unlock()
+		return context.Canceled
+	}
+	if _, exists := s.services[service.Name]; exists {
+		s.mu.Unlock()
+		return fmt.Errorf("service %s already registered", service.Name)
+	}
+	s.services[service.Name] = record
+	process, err := s.startLocked(record)
+	s.mu.Unlock()
+	if err != nil {
+		s.emit(State{Name: service.Name, Required: service.Required, Err: err})
+		return err
+	}
+	if err := s.ready(ctx, record, process); err != nil {
+		s.emit(State{Name: service.Name, Required: service.Required, Err: err})
+		return fmt.Errorf("%s readiness: %w", service.Name, err)
+	}
+	s.emit(State{Name: service.Name, Required: service.Required, Ready: true})
+	go func() {
+		defer close(record.done)
+		s.monitor(record, process)
+	}()
+	return nil
+}
+func (s *Supervisor) startLocked(record *serviceRecord) (*Process, error) {
+	if s.draining {
+		return nil, context.Canceled
+	}
+	process, err := s.manager.Start(record.spec.Command)
+	if err != nil {
+		return nil, err
+	}
+	record.process = process
+	record.started = s.clock.Now()
+	return process, nil
+}
+
+func (s *Supervisor) ready(ctx context.Context, record *serviceRecord, process *Process) error {
+	if record.spec.Ready != nil {
+		if err := record.spec.Ready(ctx); err != nil {
+			return err
+		}
+	}
+	select {
+	case <-process.Done():
+		exit, _ := process.Wait(context.Background())
+		return exit.Err()
+	default:
+		return nil
+	}
+}
+
+func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
+	for {
+		exit, err := process.Wait(context.Background())
+		if err != nil {
+			return
+		}
+		s.mu.Lock()
+		if record.process == process {
+			record.process = nil
+		}
+		draining := s.draining
+		runtime := s.clock.Now().Sub(record.started)
+		if runtime >= s.stable {
+			record.delay = s.base
+		}
+		s.mu.Unlock()
+		s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: exit.Err()})
+		if draining || !record.spec.Restart {
+			return
+		}
+
+		for {
+			delay := record.delay
+			if s.context.Err() != nil {
+				return
+			}
+			select {
+			case <-s.context.Done():
+				return
+			case <-s.clock.After(delay):
+			}
+
+			s.mu.Lock()
+			if s.draining || s.context.Err() != nil {
+				s.mu.Unlock()
+				return
+			}
+			record.delay = nextDelay(delay, s.max)
+			next, startErr := s.startLocked(record)
+			s.mu.Unlock()
+			if startErr != nil {
+				s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: startErr})
+				continue
+			}
+			if readyErr := s.ready(s.context, record, next); readyErr != nil {
+				s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: readyErr})
+				_ = next.Signal(syscall.SIGKILL)
+				_, _ = next.Wait(context.Background())
+				s.mu.Lock()
+				if record.process == next {
+					record.process = nil
+				}
+				if s.clock.Now().Sub(record.started) >= s.stable {
+					record.delay = s.base
+				}
+				s.mu.Unlock()
+				continue
+			}
+			s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Ready: true})
+			process = next
+			break
+		}
+	}
+}
+
+func nextDelay(current, maximum time.Duration) time.Duration {
+	if current >= maximum || current > maximum/2 {
+		return maximum
+	}
+	return current * 2
+}
+
+func (s *Supervisor) emit(state State) {
+	if s.observe != nil {
+		s.observe(state)
+	}
+}
+
+// Drain prevents new starts, then stops each dependency group with TERM and a
+// bounded wait before escalating remaining members to KILL.
+func (s *Supervisor) Drain(groups [][]string, termGrace, killGrace time.Duration) error {
+	s.mu.Lock()
+	s.draining = true
+	s.cancel()
+	s.mu.Unlock()
+
+	var errs []error
+	seen := map[string]bool{}
+	for _, group := range groups {
+		for _, name := range group {
+			seen[name] = true
+		}
+		errs = append(errs, s.drainGroup(group, termGrace, killGrace))
+	}
+	s.mu.Lock()
+	var remaining []string
+	for name := range s.services {
+		if !seen[name] {
+			remaining = append(remaining, name)
+		}
+	}
+	s.mu.Unlock()
+	sort.Strings(remaining)
+	errs = append(errs, s.drainGroup(remaining, termGrace, killGrace))
+	return errors.Join(errs...)
+}
+
+func (s *Supervisor) drainGroup(names []string, termGrace, killGrace time.Duration) error {
+	s.mu.Lock()
+	processes := make([]*Process, 0, len(names))
+	for _, name := range names {
+		if record := s.services[name]; record != nil && record.process != nil {
+			processes = append(processes, record.process)
+		}
+	}
+	s.mu.Unlock()
+	if len(processes) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for _, process := range processes {
+		if err := process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			errs = append(errs, err)
+		}
+	}
+	alive := waitProcesses(processes, s.clock.After(termGrace))
+	for _, process := range alive {
+		if err := process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			errs = append(errs, err)
+		}
+	}
+	alive = waitProcesses(alive, s.clock.After(killGrace))
+	for _, process := range alive {
+		errs = append(errs, fmt.Errorf("pid %d did not exit after SIGKILL", process.PID()))
+	}
+	return errors.Join(errs...)
+}
+
+func waitProcesses(processes []*Process, timeout <-chan time.Time) []*Process {
+	if len(processes) == 0 {
+		return nil
+	}
+	exited := make(chan *Process, len(processes))
+	alive := make(map[*Process]bool, len(processes))
+	for _, process := range processes {
+		alive[process] = true
+		go func(process *Process) {
+			<-process.Done()
+			exited <- process
+		}(process)
+	}
+	for len(alive) > 0 {
+		select {
+		case process := <-exited:
+			delete(alive, process)
+		case <-timeout:
+			result := make([]*Process, 0, len(alive))
+			for process := range alive {
+				result = append(result, process)
+			}
+			return result
+		}
+	}
+	return nil
+}

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -17,36 +18,48 @@ type fakeWait struct {
 }
 
 type fakeBackend struct {
-	mu         sync.Mutex
-	nextPID    int
-	waits      []fakeWait
-	children   map[int]*fakeProcess
-	sigchld    chan os.Signal
-	started    chan int
-	signaled   chan string
-	exitOnTERM map[string]bool
+	mu            sync.Mutex
+	nextPID       int
+	waits         []fakeWait
+	children      map[int]*fakeProcess
+	sigchld       chan os.Signal
+	started       chan int
+	signaled      chan string
+	startErrs     []error
+	beforeStart   func()
+	exitOnTERM    map[string]bool
+	groupSurvives map[string]bool
 }
 
 type fakeProcess struct {
-	backend *fakeBackend
-	id      int
-	name    string
-	exited  bool
+	backend      *fakeBackend
+	id           int
+	name         string
+	exited       bool
+	groupRunning bool
 }
 
 func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
 	return &fakeBackend{
 		nextPID: 100, children: map[int]*fakeProcess{}, sigchld: sigchld,
 		started: make(chan int, 32), signaled: make(chan string, 32),
-		exitOnTERM: map[string]bool{},
+		exitOnTERM: map[string]bool{}, groupSurvives: map[string]bool{},
 	}
 }
 
 func (b *fakeBackend) start(command Command) (backendProcess, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	if b.beforeStart != nil {
+		b.beforeStart()
+	}
+	if len(b.startErrs) > 0 {
+		err := b.startErrs[0]
+		b.startErrs = b.startErrs[1:]
+		return nil, err
+	}
 	b.nextPID++
-	child := &fakeProcess{backend: b, id: b.nextPID, name: command.Name}
+	child := &fakeProcess{backend: b, id: b.nextPID, name: command.Name, groupRunning: true}
 	b.children[child.id] = child
 	b.started <- child.id
 	return child, nil
@@ -67,6 +80,9 @@ func (b *fakeBackend) exit(pid int, status syscall.WaitStatus) {
 	b.mu.Lock()
 	if child := b.children[pid]; child != nil {
 		child.exited = true
+		if !b.groupSurvives[child.name] {
+			child.groupRunning = false
+		}
 	}
 	b.waits = append(b.waits, fakeWait{pid: pid, status: status})
 	b.mu.Unlock()
@@ -79,15 +95,25 @@ func (p *fakeProcess) signal(signal syscall.Signal) error {
 	p.backend.signaled <- fmt.Sprintf("%s:%s", p.name, signal)
 	p.backend.mu.Lock()
 	exited := p.exited
+	groupAlive := p.groupRunning
 	exitOnTERM := p.backend.exitOnTERM[p.name]
+	if signal == syscall.SIGKILL {
+		p.groupRunning = false
+	}
 	p.backend.mu.Unlock()
-	if exited {
+	if !groupAlive {
 		return os.ErrProcessDone
 	}
-	if signal == syscall.SIGKILL || (signal == syscall.SIGTERM && exitOnTERM) {
+	if !exited && (signal == syscall.SIGKILL || (signal == syscall.SIGTERM && exitOnTERM)) {
 		p.backend.exit(p.id, syscall.WaitStatus(uint32(signal)&0x7f))
 	}
 	return nil
+}
+
+func (p *fakeProcess) groupAlive() (bool, error) {
+	p.backend.mu.Lock()
+	defer p.backend.mu.Unlock()
+	return p.groupRunning, nil
 }
 
 func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
@@ -138,6 +164,113 @@ func TestManagerRejectsUnboundedCommands(t *testing.T) {
 		if _, err := manager.Start(command); err == nil {
 			t.Fatalf("Start accepted command %#v", command)
 		}
+	}
+}
+
+func TestInitialStartFailureRetiresRegistrationAndPermitsRetry(t *testing.T) {
+	sigchld := make(chan os.Signal, 4)
+	backend := newFakeBackend(sigchld)
+	backend.startErrs = []error{errors.New("start failed")}
+	manager := newManager(backend, sigchld, nil)
+	supervisor := New(context.Background(), manager, Config{})
+	var failedRecord *serviceRecord
+	backend.beforeStart = func() {
+		failedRecord = supervisor.services["service"]
+	}
+	service := Service{Name: "service", Command: Command{Name: "service", Path: "/service"}}
+
+	if err := supervisor.Start(context.Background(), service); err == nil {
+		t.Fatal("initial start succeeded")
+	}
+	if failedRecord == nil {
+		t.Fatal("failed registration was not captured")
+	}
+	select {
+	case <-failedRecord.done:
+	default:
+		t.Fatal("failed registration done channel was not closed")
+	}
+	supervisor.mu.Lock()
+	_, registered := supervisor.services[service.Name]
+	supervisor.mu.Unlock()
+	if registered {
+		t.Fatal("failed service remained registered")
+	}
+	backend.beforeStart = nil
+	if err := supervisor.Start(context.Background(), service); err != nil {
+		t.Fatalf("retry start: %v", err)
+	}
+	_ = receive(t, backend.started)
+}
+
+func TestInitialReadinessFailureKillsGroupWaitsAndPermitsRetry(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	backend.groupSurvives["service"] = true
+	manager := newManager(backend, sigchld, nil)
+	supervisor := New(context.Background(), manager, Config{})
+	var failedRecord *serviceRecord
+	readyCalls := 0
+	service := Service{
+		Name: "service", Command: Command{Name: "service", Path: "/service"},
+		Ready: func(context.Context) error {
+			readyCalls++
+			if readyCalls > 1 {
+				return nil
+			}
+			pid := receive(t, backend.started)
+			supervisor.mu.Lock()
+			failedRecord = supervisor.services["service"]
+			supervisor.mu.Unlock()
+			backend.exit(pid, 0)
+			return errors.New("not ready")
+		},
+	}
+
+	if err := supervisor.Start(context.Background(), service); err == nil {
+		t.Fatal("readiness failure was ignored")
+	}
+	if got := receive(t, backend.signaled); got != "service:killed" {
+		t.Fatalf("cleanup signal = %q, want service:killed", got)
+	}
+	if failedRecord == nil {
+		t.Fatal("failed readiness record was not captured")
+	}
+	select {
+	case <-failedRecord.done:
+	default:
+		t.Fatal("failed readiness done channel was not closed")
+	}
+	supervisor.mu.Lock()
+	_, registered := supervisor.services[service.Name]
+	supervisor.mu.Unlock()
+	if registered {
+		t.Fatal("readiness-failed service remained registered")
+	}
+	if err := supervisor.Start(context.Background(), service); err != nil {
+		t.Fatalf("retry start: %v", err)
+	}
+	_ = receive(t, backend.started)
+}
+
+func TestRestartMaximumIsNeverBelowBase(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		base    time.Duration
+		maximum time.Duration
+	}{
+		{name: "default below large base", base: time.Minute, maximum: 0},
+		{name: "explicit below base", base: 5 * time.Second, maximum: time.Second},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			supervisor := New(context.Background(), nil, Config{
+				RestartBase: test.base,
+				RestartMax:  test.maximum,
+			})
+			if supervisor.max != test.base {
+				t.Fatalf("restart max = %s, want %s", supervisor.max, test.base)
+			}
+		})
 	}
 }
 
@@ -199,6 +332,22 @@ func receive[T any](t *testing.T, channel <-chan T) T {
 	}
 }
 
+func waitForServiceProcess(t *testing.T, supervisor *Supervisor, name string, pid int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		supervisor.mu.Lock()
+		record := supervisor.services[name]
+		ready := record != nil && record.process != nil && record.process.PID() == pid
+		supervisor.mu.Unlock()
+		if ready {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("service %q did not publish pid %d", name, pid)
+}
+
 func TestRestartBackoffCapsAndResetsOnlyAfterStableRun(t *testing.T) {
 	sigchld := make(chan os.Signal, 16)
 	backend := newFakeBackend(sigchld)
@@ -216,11 +365,13 @@ func TestRestartBackoffCapsAndResetsOnlyAfterStableRun(t *testing.T) {
 		t.Fatal(err)
 	}
 	pid := receive(t, backend.started)
+	waitForServiceProcess(t, supervisor, "required", pid)
 
 	for _, delay := range []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 4 * time.Second} {
 		backend.exit(pid, syscall.WaitStatus(1<<8))
 		clock.fire(t, delay)
 		pid = receive(t, backend.started)
+		waitForServiceProcess(t, supervisor, "required", pid)
 	}
 
 	clock.elapse(10 * time.Second)
@@ -288,5 +439,40 @@ func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
 	case pid := <-backend.started:
 		t.Fatalf("service resurrected during drain as pid %d", pid)
 	default:
+	}
+}
+
+func TestDrainKillsSurvivingGroupAfterDirectChildExit(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	backend.exitOnTERM["service"] = true
+	backend.groupSurvives["service"] = true
+	manager := newManager(backend, sigchld, nil)
+	clock := newFakeClock()
+	supervisor := New(context.Background(), manager, Config{Clock: clock})
+	if err := supervisor.Start(context.Background(), Service{
+		Name: "service", Command: Command{Name: "service", Path: "/service"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	_ = receive(t, backend.started)
+	supervisor.mu.Lock()
+	process := supervisor.services["service"].process
+	supervisor.mu.Unlock()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- supervisor.Drain([][]string{{"service"}}, time.Second, 2*time.Second)
+	}()
+	if got := receive(t, backend.signaled); got != "service:terminated" {
+		t.Fatalf("TERM signal = %q", got)
+	}
+	receive(t, process.Done())
+	clock.fire(t, time.Second)
+	if got := receive(t, backend.signaled); got != "service:killed" {
+		t.Fatalf("KILL signal = %q", got)
+	}
+	if err := receive(t, result); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -1,0 +1,292 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type fakeWait struct {
+	pid    int
+	status syscall.WaitStatus
+}
+
+type fakeBackend struct {
+	mu         sync.Mutex
+	nextPID    int
+	waits      []fakeWait
+	children   map[int]*fakeProcess
+	sigchld    chan os.Signal
+	started    chan int
+	signaled   chan string
+	exitOnTERM map[string]bool
+}
+
+type fakeProcess struct {
+	backend *fakeBackend
+	id      int
+	name    string
+	exited  bool
+}
+
+func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
+	return &fakeBackend{
+		nextPID: 100, children: map[int]*fakeProcess{}, sigchld: sigchld,
+		started: make(chan int, 32), signaled: make(chan string, 32),
+		exitOnTERM: map[string]bool{},
+	}
+}
+
+func (b *fakeBackend) start(command Command) (backendProcess, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.nextPID++
+	child := &fakeProcess{backend: b, id: b.nextPID, name: command.Name}
+	b.children[child.id] = child
+	b.started <- child.id
+	return child, nil
+}
+
+func (b *fakeBackend) waitNoHang() (int, syscall.WaitStatus, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.waits) == 0 {
+		return 0, 0, nil
+	}
+	wait := b.waits[0]
+	b.waits = b.waits[1:]
+	return wait.pid, wait.status, nil
+}
+
+func (b *fakeBackend) exit(pid int, status syscall.WaitStatus) {
+	b.mu.Lock()
+	if child := b.children[pid]; child != nil {
+		child.exited = true
+	}
+	b.waits = append(b.waits, fakeWait{pid: pid, status: status})
+	b.mu.Unlock()
+	b.sigchld <- syscall.SIGCHLD
+}
+
+func (p *fakeProcess) pid() int       { return p.id }
+func (p *fakeProcess) release() error { return nil }
+func (p *fakeProcess) signal(signal syscall.Signal) error {
+	p.backend.signaled <- fmt.Sprintf("%s:%s", p.name, signal)
+	p.backend.mu.Lock()
+	exited := p.exited
+	exitOnTERM := p.backend.exitOnTERM[p.name]
+	p.backend.mu.Unlock()
+	if exited {
+		return os.ErrProcessDone
+	}
+	if signal == syscall.SIGKILL || (signal == syscall.SIGTERM && exitOnTERM) {
+		p.backend.exit(p.id, syscall.WaitStatus(uint32(signal)&0x7f))
+	}
+	return nil
+}
+
+func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	var logsMu sync.Mutex
+	var logs []string
+	manager := newManager(backend, sigchld, func(format string, args ...any) {
+		logsMu.Lock()
+		logs = append(logs, fmt.Sprintf(format, args...))
+		logsMu.Unlock()
+	})
+
+	managed, err := manager.Start(Command{Name: "managed", Path: "/managed"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	oneShot, err := manager.Start(Command{Name: "one-shot", Path: "/one-shot"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend.exit(999, 0)
+	backend.exit(oneShot.PID(), syscall.WaitStatus(3<<8))
+	backend.exit(managed.PID(), 0)
+
+	managedExit, err := managed.Wait(context.Background())
+	if err != nil || managedExit.Err() != nil {
+		t.Fatalf("managed wait = (%+v, %v)", managedExit, err)
+	}
+	oneShotExit, err := oneShot.Wait(context.Background())
+	if err != nil || oneShotExit.Status.ExitStatus() != 3 {
+		t.Fatalf("one-shot wait = (%+v, %v)", oneShotExit, err)
+	}
+	logsMu.Lock()
+	defer logsMu.Unlock()
+	if got := strings.Join(logs, "\n"); !strings.Contains(got, "reaped adopted child pid=999") {
+		t.Fatalf("orphan was not reported:\n%s", got)
+	}
+}
+
+func TestManagerRejectsUnboundedCommands(t *testing.T) {
+	sigchld := make(chan os.Signal, 1)
+	manager := newManager(newFakeBackend(sigchld), sigchld, nil)
+	for _, command := range []Command{
+		{Path: "/usr/bin/service"},
+		{Name: "service", Path: "service"},
+	} {
+		if _, err := manager.Start(command); err == nil {
+			t.Fatalf("Start accepted command %#v", command)
+		}
+	}
+}
+
+type fakeTimer struct {
+	delay time.Duration
+	fire  chan time.Time
+}
+
+type fakeClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers chan fakeTimer
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Unix(1, 0), timers: make(chan fakeTimer, 32)}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) After(delay time.Duration) <-chan time.Time {
+	timer := fakeTimer{delay: delay, fire: make(chan time.Time, 1)}
+	c.timers <- timer
+	return timer.fire
+}
+
+func (c *fakeClock) fire(t *testing.T, want time.Duration) {
+	t.Helper()
+	timer := receive(t, c.timers)
+	if timer.delay != want {
+		t.Fatalf("timer delay = %s, want %s", timer.delay, want)
+	}
+	c.mu.Lock()
+	c.now = c.now.Add(timer.delay)
+	now := c.now
+	c.mu.Unlock()
+	timer.fire <- now
+}
+
+func (c *fakeClock) elapse(delay time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(delay)
+	c.mu.Unlock()
+}
+
+func receive[T any](t *testing.T, channel <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-channel:
+		return value
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for test event")
+		var zero T
+		return zero
+	}
+}
+
+func TestRestartBackoffCapsAndResetsOnlyAfterStableRun(t *testing.T) {
+	sigchld := make(chan os.Signal, 16)
+	backend := newFakeBackend(sigchld)
+	manager := newManager(backend, sigchld, nil)
+	clock := newFakeClock()
+	parent, cancel := context.WithCancel(context.Background())
+	supervisor := New(parent, manager, Config{
+		RestartBase: time.Second, RestartMax: 4 * time.Second,
+		StableAfter: 10 * time.Second, Clock: clock,
+	})
+	if err := supervisor.Start(context.Background(), Service{
+		Name: "required", Required: true, Restart: true,
+		Command: Command{Name: "required", Path: "/required"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pid := receive(t, backend.started)
+
+	for _, delay := range []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 4 * time.Second} {
+		backend.exit(pid, syscall.WaitStatus(1<<8))
+		clock.fire(t, delay)
+		pid = receive(t, backend.started)
+	}
+
+	clock.elapse(10 * time.Second)
+	backend.exit(pid, syscall.WaitStatus(1<<8))
+	clock.fire(t, time.Second)
+	pid = receive(t, backend.started)
+	supervisor.mu.Lock()
+	done := supervisor.services["required"].done
+	supervisor.mu.Unlock()
+	cancel()
+	backend.exit(pid, syscall.WaitStatus(1<<8))
+	receive(t, done)
+	select {
+	case pid := <-backend.started:
+		t.Fatalf("required service restarted after cancellation as pid %d", pid)
+	default:
+	}
+}
+
+func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
+	sigchld := make(chan os.Signal, 16)
+	backend := newFakeBackend(sigchld)
+	backend.exitOnTERM["shim"] = true
+	backend.exitOnTERM["dockerd"] = true
+	backend.exitOnTERM["containerd"] = true
+	manager := newManager(backend, sigchld, nil)
+	clock := newFakeClock()
+	supervisor := New(context.Background(), manager, Config{Clock: clock})
+	for _, name := range []string{"egress", "shim", "dockerd", "containerd"} {
+		if err := supervisor.Start(context.Background(), Service{
+			Name: name, Restart: true, Command: Command{Name: name, Path: "/" + name},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		_ = receive(t, backend.started)
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		result <- supervisor.Drain(
+			[][]string{{"egress", "shim"}, {"dockerd"}, {"containerd"}},
+			time.Second, 2*time.Second,
+		)
+	}()
+
+	got := []string{
+		receive(t, backend.signaled),
+		receive(t, backend.signaled),
+	}
+	clock.fire(t, time.Second)
+	got = append(got, receive(t, backend.signaled))
+	got = append(got, receive(t, backend.signaled))
+	got = append(got, receive(t, backend.signaled))
+	if err := receive(t, result); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"egress:terminated", "shim:terminated", "egress:killed",
+		"dockerd:terminated", "containerd:terminated",
+	}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("signals = %v, want %v", got, want)
+	}
+	select {
+	case pid := <-backend.started:
+		t.Fatalf("service resurrected during drain as pid %d", pid)
+	default:
+	}
+}


### PR DESCRIPTION
## Summary

- add one central owner for child creation and `wait4(-1)` collection
- reap both managed children and adopted orphan descendants without racing `os/exec.Wait`
- supervise long-lived services with readiness state and capped crash-loop backoff
- drain services in explicit dependency groups with TERM, bounded wait, then KILL

## Child ownership

Every future PID 1 child must be started through this manager. Child start and registration are serialized in the same goroutine that owns all waits, so an immediately exiting child cannot be reaped before registration. Managed and one-shot callers observe the same immutable exit result; unknown adopted children are reaped and logged.

Commands require a fixed name and absolute executable path. Each child gets its own process group so shutdown signals include descendants. This package deliberately does not expose or use a second `os/exec` wait path.

## Supervision policy

- required-service exits publish an unready state before restart delay begins
- exponential delay is capped and resets only after a stable run
- cancellation prevents any further restart
- ordered drain handles edge services before dockerd and containerd when composed by PID 1
- graceful TERM is followed by KILL and a second bounded wait

## Scope

This is an independently buildable internal package. It adds no init binary, service inventory, mounts, NVIDIA behavior, image wiring, debug code, or rootfs changes. The smaller CPU lifecycle PR will compose it after the runtime and hardening foundations merge.

## Review focus

- serialization between start, registration, SIGCHLD, and `wait4`
- process-group signal and release semantics
- immediate-crash/stable-run backoff transitions
- no restart during drain or parent cancellation
- deterministic group ordering and TERM-to-KILL escalation

## Validation

- `go build ./...`
- `go test ./...`
- `go test -race ./internal/pid1/supervisor`
- `go test -count=100 ./internal/pid1/supervisor`
- `go vet ./...`
- `git diff --check origin/jules/harden-tcb...HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces `tinfoil/internal/pid1/supervisor`: a race-free PID 1 child manager and service supervisor that owns child start and `wait4(-1)`, restarts services with readiness and capped backoff, drains them in dependency order, and cleans up failed process groups.

- **New Features**
  - Single `Manager` owns child creation and `wait4(-1)`; reaps adopted orphans; removes `os/exec.Wait` races.
  - Each child runs in its own process group so TERM/KILL reach descendants.
  - `Supervisor` runs required/optional services with readiness checks, capped exponential backoff that resets after a stable run, and no restart after cancellation.
  - Ordered drain: TERM with bounded wait per group, then KILL, then final bounded wait.

- **Bug Fixes**
  - Kill and wait failed service groups on start/readiness errors; drop exited groups from tracking to avoid orphaned descendants.
  - Ensure drain escalates to KILL for groups that survive after the direct child exits.

<sup>Written for commit 219de7fc3a3ef28abf2acff603c213d7e40b75ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

