### PR TITLE
Use a fixed measured resolver contract

### DIFF
--- a/mkosi.extra/etc/resolv.conf
+++ b/mkosi.extra/etc/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 1.1.1.1
+nameserver 1.0.0.1

--- a/tinfoil/cmd/boot/network_ready.go
+++ b/tinfoil/cmd/boot/network_ready.go
@@ -38,6 +38,9 @@ func runCommand(ctx context.Context, name string, args ...string) ([]byte, error
 }
 
 func configureGuestNetwork(ctx context.Context, config *shimconfig.ExternalNetworkConfig) (string, error) {
+	if err := verifyFixedResolver(resolverPath); err != nil {
+		return "", err
+	}
 	ctx, cancel := context.WithTimeout(ctx, networkReadyTimeout)
 	defer cancel()
 
@@ -48,9 +51,6 @@ func configureGuestNetwork(ctx context.Context, config *shimconfig.ExternalNetwo
 		networkPollInterval,
 	)
 	if err != nil {
-		return "", err
-	}
-	if err := verifyFixedResolver(resolverPath); err != nil {
 		return "", err
 	}
 	if err := applyStaticNetwork(ctx, iface, config, runCommand); err != nil {
@@ -132,10 +132,6 @@ func verifyFixedResolver(path string) error {
 		return fmt.Errorf("open fixed resolver %s: %w", path, err)
 	}
 	file := os.NewFile(uintptr(fd), path)
-	if file == nil {
-		unix.Close(fd)
-		return fmt.Errorf("open fixed resolver %s: invalid file descriptor", path)
-	}
 	defer file.Close()
 
 	info, err := file.Stat()

--- a/tinfoil/cmd/boot/network_ready.go
+++ b/tinfoil/cmd/boot/network_ready.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 
+	"golang.org/x/sys/unix"
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 )
@@ -18,9 +22,10 @@ const (
 	networkReadyTimeout = 90 * time.Second
 	networkPollInterval = 100 * time.Millisecond
 	ipBinary            = "/usr/sbin/ip"
-	resolvectlBinary    = "/usr/bin/resolvectl"
+	resolverPath        = "/etc/resolv.conf"
 	primaryNameserver   = "1.1.1.1"
 	secondaryNameserver = "1.0.0.1"
+	fixedResolver       = "nameserver 1.1.1.1\nnameserver 1.0.0.1\n"
 )
 
 var sysBusPCIDevices = "/sys/bus/pci/devices"
@@ -43,6 +48,9 @@ func configureGuestNetwork(ctx context.Context, config *shimconfig.ExternalNetwo
 		networkPollInterval,
 	)
 	if err != nil {
+		return "", err
+	}
+	if err := verifyFixedResolver(resolverPath); err != nil {
 		return "", err
 	}
 	if err := applyStaticNetwork(ctx, iface, config, runCommand); err != nil {
@@ -118,13 +126,41 @@ func compactStrings(values []string) []string {
 	return out
 }
 
+func verifyFixedResolver(path string) error {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+	if err != nil {
+		return fmt.Errorf("open fixed resolver %s: %w", path, err)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	if file == nil {
+		unix.Close(fd)
+		return fmt.Errorf("open fixed resolver %s: invalid file descriptor", path)
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat fixed resolver %s: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("fixed resolver %s is not a regular file", path)
+	}
+	contents, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("read fixed resolver %s: %w", path, err)
+	}
+	if !bytes.Equal(contents, []byte(fixedResolver)) {
+		return fmt.Errorf("fixed resolver %s does not match measured contents", path)
+	}
+	return nil
+}
+
 func applyStaticNetwork(
 	ctx context.Context,
 	iface string,
 	config *shimconfig.ExternalNetworkConfig,
 	run commandRunner,
 ) error {
-	dnsArgs := []string{"dns", iface, primaryNameserver, secondaryNameserver}
 	commands := []struct {
 		name string
 		args []string
@@ -134,9 +170,6 @@ func applyStaticNetwork(
 		{ipBinary, []string{"route", "flush", "dev", iface}},
 		{ipBinary, []string{"addr", "replace", config.Address, "dev", iface}},
 		{ipBinary, []string{"route", "replace", "default", "via", config.Gateway, "dev", iface}},
-		{resolvectlBinary, dnsArgs},
-		{resolvectlBinary, []string{"domain", iface, "~."}},
-		{resolvectlBinary, []string{"default-route", iface, "yes"}},
 	}
 	for _, command := range commands {
 		output, err := run(ctx, command.name, command.args...)

--- a/tinfoil/cmd/boot/network_ready_test.go
+++ b/tinfoil/cmd/boot/network_ready_test.go
@@ -91,12 +91,90 @@ func TestApplyStaticNetworkUsesFixedIPCommands(t *testing.T) {
 		"/usr/sbin/ip route flush dev ens2",
 		"/usr/sbin/ip addr replace 100.64.0.42/20 dev ens2",
 		"/usr/sbin/ip route replace default via 100.64.0.1 dev ens2",
-		"/usr/bin/resolvectl dns ens2 1.1.1.1 1.0.0.1",
-		"/usr/bin/resolvectl domain ens2 ~.",
-		"/usr/bin/resolvectl default-route ens2 yes",
 	}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestVerifyFixedResolverAcceptsExactRegularFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolv.conf")
+	if err := os.WriteFile(path, []byte(fixedResolver), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyFixedResolver(path); err != nil {
+		t.Fatalf("verifyFixedResolver() = %v", err)
+	}
+}
+
+func TestVerifyFixedResolverFailsClosed(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, string)
+	}{
+		{
+			name: "missing",
+			setup: func(_ *testing.T, _ string) {
+			},
+		},
+		{
+			name: "symlink",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				target := filepath.Join(filepath.Dir(path), "target")
+				if err := os.WriteFile(target, []byte(fixedResolver), 0644); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "directory",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.Mkdir(path, 0755); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "mismatch",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				contents := "nameserver 1.1.1.1\nnameserver 8.8.8.8\n"
+				if err := os.WriteFile(path, []byte(contents), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "extra bytes",
+			setup: func(t *testing.T, path string) {
+				t.Helper()
+				if err := os.WriteFile(path, []byte(fixedResolver+"search example.com\n"), 0644); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "resolv.conf")
+			test.setup(t, path)
+			if err := verifyFixedResolver(path); err == nil {
+				t.Fatal("verifyFixedResolver() accepted invalid resolver")
+			}
+		})
+	}
+}
+
+func TestMeasuredResolverAssetMatchesFixedContract(t *testing.T) {
+	path := "../../../mkosi.extra/etc/resolv.conf"
+	if err := verifyFixedResolver(path); err != nil {
+		t.Fatalf("measured resolver asset: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- install the fixed resolver policy as a measured regular `/etc/resolv.conf`
- remove runtime `resolvectl` calls from static guest network setup
- fail closed unless the resolver file is regular and byte-for-byte matches the compiled contract

## Contract
The guest accepts only:

```
nameserver 1.1.1.1
nameserver 1.0.0.1
```

No resolver service, parser, compatibility fallback, or host-provided DNS enters the runtime contract.

## Validation
- `gofmt`
- `go build ./...`
- `go test ./...`
- `go test -race ./cmd/boot`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install a fixed, measured `/etc/resolv.conf` and validate it at boot (now before NIC wait). DNS is static and `resolvectl` is no longer used in guest network setup.

- **New Features**
  - Ship exact `/etc/resolv.conf` with nameservers 1.1.1.1 and 1.0.0.1.
  - Verify the resolver at startup (before NIC wait): require a regular file and an exact byte-for-byte match; fail closed on any mismatch.
  - Remove `resolvectl` DNS commands from static network setup; only IP and route configuration remain. Tests cover valid and invalid resolver cases and ensure the asset matches the contract.

<sup>Written for commit 14062021ee439f246fa0043fdef83c634ae118a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

