### PR TITLE
Extract the fixed egress policy engine

### DIFF
--- a/tinfoil/cmd/egress/main.go
+++ b/tinfoil/cmd/egress/main.go
@@ -6,30 +6,14 @@ import (
 	"log"
 	"net"
 	"os"
-	"os/exec"
 	"os/signal"
-	"strings"
 	"syscall"
-	"time"
 
-	"tinfoil/internal/boot"
-	"tinfoil/internal/containernet"
-
-	"gopkg.in/yaml.v3"
+	"tinfoil/internal/egress"
 )
-
-const refreshInterval = 60 * time.Second
 
 func init() {
 	log.SetFlags(0)
-}
-
-type egressConfig struct {
-	Networks map[string]egressNetwork `yaml:"networks"`
-}
-
-type egressNetwork struct {
-	Allow []string `yaml:"allow"`
 }
 
 func main() {
@@ -40,175 +24,30 @@ func main() {
 }
 
 func run() error {
-	cfg, err := loadConfig()
+	engine, err := egress.Load()
 	if err != nil {
 		return err
 	}
-	if len(cfg.Networks) == 0 {
+	if !engine.Configured() {
 		log.Println("no allowlist networks configured, exiting")
 		return nil
 	}
-
-	state := readState()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
 
 	// Initial population must succeed before notifying systemd; tinfoil-boot
 	// blocks on `systemctl start` until READY=1 so any failure here surfaces
 	// as a boot error.
-	if err := refresh(cfg, state); err != nil {
+	if err := engine.Populate(ctx); err != nil {
 		return fmt.Errorf("initial population: %w", err)
 	}
 	notifyReady()
 
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
-
-	ticker := time.NewTicker(refreshInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			log.Println("shutting down")
-			return nil
-		case <-ticker.C:
-			if err := refresh(cfg, state); err != nil {
-				log.Printf("refresh failed: %v", err)
-			}
-		}
-	}
-}
-
-func loadConfig() (*egressConfig, error) {
-	data, err := os.ReadFile(boot.EgressConfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading egress config: %w", err)
-	}
-	var cfg egressConfig
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, fmt.Errorf("parsing egress config: %w", err)
-	}
-	return &cfg, nil
-}
-
-// refresh resolves each allowlist network's FQDNs and commits the
-// per-set delta in one nft transaction. state is mutated in place.
-func refresh(cfg *egressConfig, state map[string][]string) error {
-	for name, net := range cfg.Networks {
-		current, err := resolve(net.Allow)
-		if err != nil {
-			return fmt.Errorf("network %q: %w", name, err)
-		}
-		setName := containernet.AllowSetPrefix + name
-
-		// Defensive: ensure the set exists. Normally created by tinfoil-boot.
-		exec.Command("nft", "add", "set", "inet", "tinfoil", setName,
-			"{ type ipv4_addr; }").Run()
-
-		// Flushing and reloading could lead to a race condition where new outgoing
-		// connections that should be allowed are not, so instead we calculate the
-		// IPs to add and the set of IPs to remove from the set.
-		prev := state[name]
-		toAdd := difference(current, prev)
-		toRemove := difference(prev, current)
-		if len(toAdd) == 0 && len(toRemove) == 0 {
-			continue
-		}
-
-		// Commit add+remove in one transaction so the set never appears with only
-		// one half of the delta applied.
-		var script strings.Builder
-		if len(toAdd) > 0 {
-			fmt.Fprintf(&script, "add element inet tinfoil %s { %s }\n",
-				setName, strings.Join(toAdd, ", "))
-		}
-		if len(toRemove) > 0 {
-			fmt.Fprintf(&script, "delete element inet tinfoil %s { %s }\n",
-				setName, strings.Join(toRemove, ", "))
-		}
-
-		cmd := exec.Command("nft", "-f", "-")
-		cmd.Stdin = strings.NewReader(script.String())
-		if out, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("updating %s: %w (%s)", setName, err, out)
-		}
-		// Only record the new state after the kernel accepts the delta;
-		state[name] = current
-	}
-	return writeState(state)
-}
-
-func resolve(domains []string) ([]string, error) {
-	seen := map[string]bool{}
-	var ips []string
-	for _, domain := range domains {
-		addrs, err := net.LookupHost(domain)
-		if err != nil {
-			return nil, fmt.Errorf("resolving %s: %w", domain, err)
-		}
-		for _, addr := range addrs {
-			if net.ParseIP(addr).To4() == nil {
-				continue // skip IPv6
-			}
-			if !seen[addr] {
-				seen[addr] = true
-				ips = append(ips, addr)
-			}
-		}
-	}
-	// Empty allow list is legal (deny everything for the network); only
-	// fail when the operator listed domains and none resolved.
-	if len(ips) == 0 && len(domains) > 0 {
-		return nil, fmt.Errorf("no IPv4 addresses resolved for %v", domains)
-	}
-	return ips, nil
-}
-
-// State file: `<network>: <ip1>,<ip2>,...` one per line.
-func readState() map[string][]string {
-	out := map[string][]string{}
-	data, err := os.ReadFile(boot.EgressStatePath)
-	if err != nil {
-		return out
-	}
-	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
-		name, ipsStr, ok := strings.Cut(line, ":")
-		if !ok {
-			continue
-		}
-		name = strings.TrimSpace(name)
-		var ips []string
-		for _, ip := range strings.Split(ipsStr, ",") {
-			ip = strings.TrimSpace(ip)
-			if ip != "" {
-				ips = append(ips, ip)
-			}
-		}
-		out[name] = ips
-	}
-	return out
-}
-
-func writeState(state map[string][]string) error {
-	var b strings.Builder
-	for name, ips := range state {
-		fmt.Fprintf(&b, "%s: %s\n", name, strings.Join(ips, ","))
-	}
-	return os.WriteFile(boot.EgressStatePath, []byte(b.String()), 0600)
-}
-
-// difference returns elements in a that are not in b.
-func difference(a, b []string) []string {
-	inB := map[string]bool{}
-	for _, s := range b {
-		inB[s] = true
-	}
-	var result []string
-	for _, s := range a {
-		if !inB[s] {
-			result = append(result, s)
-		}
-	}
-	return result
+	engine.Run(ctx, func(err error) {
+		log.Printf("refresh failed: %v", err)
+	})
+	log.Println("shutting down")
+	return nil
 }
 
 // notifyReady sends READY=1 over the systemd NOTIFY_SOCKET so the unit

--- a/tinfoil/internal/egress/egress.go
+++ b/tinfoil/internal/egress/egress.go
@@ -1,0 +1,157 @@
+package egress
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+
+	"tinfoil/internal/boot"
+	"tinfoil/internal/containernet"
+
+	"gopkg.in/yaml.v3"
+)
+
+const refreshInterval = 60 * time.Second
+
+type config struct {
+	Networks map[string]network `yaml:"networks"`
+}
+
+type network struct {
+	Allow []string `yaml:"allow"`
+}
+
+type nftClient struct {
+	apply func(string) ([]byte, error)
+}
+
+// Engine maintains the nft allow sets described by the boot-generated config.
+type Engine struct {
+	config   *config
+	resolve  func(context.Context, []string) ([]string, error)
+	nft      nftClient
+	interval time.Duration
+}
+
+// Load reads the boot-generated config and previous resolved-address state.
+func Load() (*Engine, error) {
+	cfg, err := loadConfig(boot.EgressConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return &Engine{
+		config:  cfg,
+		resolve: resolve,
+		nft: nftClient{
+			apply: applyDelta,
+		},
+		interval: refreshInterval,
+	}, nil
+}
+
+// Configured reports whether any allowlist networks need maintenance.
+func (e *Engine) Configured() bool {
+	return len(e.config.Networks) > 0
+}
+
+// Populate synchronously performs the initial allow-set population.
+func (e *Engine) Populate(ctx context.Context) error {
+	return e.Refresh(ctx)
+}
+
+// Refresh resolves every allowlist, then replaces all fixed sets in one nft
+// transaction. No runtime state file or parser is needed.
+func (e *Engine) Refresh(ctx context.Context) error {
+	names := make([]string, 0, len(e.config.Networks))
+	resolved := make(map[string][]string, len(e.config.Networks))
+	for name := range e.config.Networks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		current, err := e.resolve(ctx, e.config.Networks[name].Allow)
+		if err != nil {
+			return fmt.Errorf("network %q: %w", name, err)
+		}
+		resolved[name] = current
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	var script strings.Builder
+	for _, name := range names {
+		setName := containernet.AllowSetPrefix + name
+		fmt.Fprintf(&script, "flush set inet tinfoil %s\n", setName)
+		if len(resolved[name]) > 0 {
+			fmt.Fprintf(&script, "add element inet tinfoil %s { %s }\n",
+				setName, strings.Join(resolved[name], ", "))
+		}
+	}
+	if out, err := e.nft.apply(script.String()); err != nil {
+		return fmt.Errorf("replacing egress allow sets: %w (%s)", err, out)
+	}
+	return nil
+}
+
+// Run refreshes at the daemon interval until ctx is canceled.
+func (e *Engine) Run(ctx context.Context, refreshFailed func(error)) {
+	ticker := time.NewTicker(e.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := e.Refresh(ctx); err != nil && refreshFailed != nil {
+				refreshFailed(err)
+			}
+		}
+	}
+}
+
+func loadConfig(path string) (*config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading egress config: %w", err)
+	}
+	var cfg config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing egress config: %w", err)
+	}
+	return &cfg, nil
+}
+
+func resolve(ctx context.Context, domains []string) ([]string, error) {
+	seen := map[string]bool{}
+	var ips []string
+	for _, domain := range domains {
+		addrs, err := net.DefaultResolver.LookupHost(ctx, domain)
+		if err != nil {
+			return nil, fmt.Errorf("resolving %s: %w", domain, err)
+		}
+		for _, addr := range addrs {
+			if net.ParseIP(addr).To4() == nil {
+				continue
+			}
+			if !seen[addr] {
+				seen[addr] = true
+				ips = append(ips, addr)
+			}
+		}
+	}
+	if len(ips) == 0 && len(domains) > 0 {
+		return nil, fmt.Errorf("no IPv4 addresses resolved for %v", domains)
+	}
+	return ips, nil
+}
+
+func applyDelta(script string) ([]byte, error) {
+	cmd := exec.Command("nft", "-f", "-")
+	cmd.Stdin = strings.NewReader(script)
+	return cmd.CombinedOutput()
+}

--- a/tinfoil/internal/egress/egress_test.go
+++ b/tinfoil/internal/egress/egress_test.go
@@ -1,0 +1,100 @@
+package egress
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRefreshFailsClosedBeforeNftOnResolutionError(t *testing.T) {
+	applied := false
+	engine := &Engine{
+		config: &config{Networks: map[string]network{
+			"control": {Allow: []string{"api.example"}},
+		}},
+		resolve: func(context.Context, []string) ([]string, error) {
+			return nil, errors.New("DNS unavailable")
+		},
+		nft: nftClient{apply: func(string) ([]byte, error) {
+			applied = true
+			return nil, nil
+		}},
+		interval: time.Minute,
+	}
+
+	err := engine.Refresh(context.Background())
+	if err == nil || !strings.Contains(err.Error(), `network "control": DNS unavailable`) {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+	if applied {
+		t.Fatal("resolution failure changed nft state")
+	}
+}
+
+func TestRefreshReplacesAllSetsInOneDeterministicTransaction(t *testing.T) {
+	engine := &Engine{
+		config: &config{Networks: map[string]network{
+			"zeta":  {Allow: nil},
+			"alpha": {Allow: []string{"api.example"}},
+		}},
+		resolve: func(_ context.Context, domains []string) ([]string, error) {
+			if len(domains) == 0 {
+				return nil, nil
+			}
+			return []string{"192.0.2.2", "192.0.2.1"}, nil
+		},
+		nft: nftClient{apply: func(script string) ([]byte, error) {
+			want := "flush set inet tinfoil allow-alpha\n" +
+				"add element inet tinfoil allow-alpha { 192.0.2.2, 192.0.2.1 }\n" +
+				"flush set inet tinfoil allow-zeta\n"
+			if script != want {
+				t.Fatalf("nft script = %q, want %q", script, want)
+			}
+			return nil, nil
+		}},
+		interval: time.Minute,
+	}
+
+	if err := engine.Refresh(context.Background()); err != nil {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+}
+
+func TestRefreshPropagatesNftFailure(t *testing.T) {
+	engine := &Engine{
+		config: &config{Networks: map[string]network{
+			"control": {Allow: nil},
+		}},
+		resolve: func(context.Context, []string) ([]string, error) { return nil, nil },
+		nft: nftClient{apply: func(string) ([]byte, error) {
+			return []byte("permission denied"), errors.New("exit status 1")
+		}},
+		interval: time.Minute,
+	}
+
+	err := engine.Refresh(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("Refresh() error = %v", err)
+	}
+}
+
+func TestRefreshThreadsCancellationIntoResolution(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	engine := &Engine{
+		config: &config{Networks: map[string]network{
+			"control": {Allow: []string{"api.example"}},
+		}},
+		resolve: func(ctx context.Context, _ []string) ([]string, error) {
+			return nil, ctx.Err()
+		},
+		nft:      nftClient{apply: func(string) ([]byte, error) { return nil, nil }},
+		interval: time.Minute,
+	}
+
+	if err := engine.Refresh(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Refresh() error = %v, want context cancellation", err)
+	}
+}


### PR DESCRIPTION
## Summary
- extract allowlist DNS, nft delta, state, and refresh behavior into a narrow `internal/egress` engine
- keep the current daemon lifecycle and systemd readiness notification unchanged
- remove the legacy best-effort nft set recreation; the fixed boot-created set contract now fails closed

This is the behavior-preserving prerequisite for removing `systemctl` from `tinfoil-boot`: the later PID1 composition can call `Engine.Populate` synchronously before workload readiness, while PID1 exclusively owns the long-running refresher.

## Validation
- `gofmt`
- `go build ./...`
- `go test ./...`
- `go test -race ./internal/egress ./cmd/egress`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a synchronous egress policy engine in `tinfoil/internal/egress` that resolves allowlists and replaces nft allow sets in a single transaction. Preserves the daemon/systemd lifecycle and enforces a fail-closed, boot-created set contract.

- **Refactors**
  - Consolidated config loading, DNS resolution, and nft updates into `Engine` with `Load()`, `Configured()`, `Populate(ctx)`, and `Run(ctx, ...)`.
  - Replaced diff/state-file logic with a single deterministic flush-and-repopulate transaction per refresh; no runtime state.
  - `tinfoil/cmd/egress` blocks on `Populate` before READY=1, then calls `Run` with context cancellation; missing sets surface as errors and block readiness.

<sup>Written for commit 09008d6016fa1460b8a8f8166ebdb6766f90a385. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

