### PR TITLE
Restrict PID 1 service socket domains

### DIFF
--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -27,8 +27,9 @@ const (
 )
 
 type servicePolicy struct {
-	noNewPrivileges   bool
-	boundCapabilities []int
+	noNewPrivileges      bool
+	boundCapabilities    []int
+	allowedSocketDomains []uint32
 }
 
 // A nil boundCapabilities list deliberately preserves the inherited bounding
@@ -41,18 +42,21 @@ func policyFor(service Service) (servicePolicy, bool) {
 		return servicePolicy{noNewPrivileges: true}, true
 	case ServiceContainerStatus:
 		return servicePolicy{
-			noNewPrivileges:   true,
-			boundCapabilities: []int{},
+			noNewPrivileges:      true,
+			boundCapabilities:    []int{},
+			allowedSocketDomains: []uint32{unix.AF_UNIX},
 		}, true
 	case ServiceEgress:
 		return servicePolicy{
-			noNewPrivileges:   true,
-			boundCapabilities: []int{unix.CAP_NET_ADMIN},
+			noNewPrivileges:      true,
+			boundCapabilities:    []int{unix.CAP_NET_ADMIN},
+			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6, unix.AF_NETLINK},
 		}, true
 	case ServiceShim:
 		return servicePolicy{
-			noNewPrivileges:   true,
-			boundCapabilities: []int{unix.CAP_NET_BIND_SERVICE},
+			noNewPrivileges:      true,
+			boundCapabilities:    []int{unix.CAP_NET_BIND_SERVICE},
+			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6},
 		}, true
 	default:
 		return servicePolicy{}, false
@@ -70,6 +74,7 @@ type serviceKernel interface {
 	dropBoundingCapability(int) error
 	setCapabilities([2]unix.CapUserData) error
 	setNoNewPrivileges() error
+	restrictSocketDomains([]uint32) error
 }
 
 func applyService(kernel serviceKernel, service Service) error {
@@ -105,6 +110,11 @@ func applyService(kernel serviceKernel, service Service) error {
 	if policy.noNewPrivileges {
 		if err := kernel.setNoNewPrivileges(); err != nil {
 			return fmt.Errorf("set no_new_privileges for %s: %w", service, err)
+		}
+	}
+	if policy.allowedSocketDomains != nil {
+		if err := kernel.restrictSocketDomains(policy.allowedSocketDomains); err != nil {
+			return fmt.Errorf("restrict socket domains for %s: %w", service, err)
 		}
 	}
 	return nil

--- a/tinfoil/internal/pid1/hardening/hardening_test.go
+++ b/tinfoil/internal/pid1/hardening/hardening_test.go
@@ -16,16 +16,19 @@ func TestServicePoliciesAreExact(t *testing.T) {
 			noNewPrivileges: true,
 		},
 		ServiceContainerStatus: {
-			noNewPrivileges:   true,
-			boundCapabilities: []int{},
+			noNewPrivileges:      true,
+			boundCapabilities:    []int{},
+			allowedSocketDomains: []uint32{unix.AF_UNIX},
 		},
 		ServiceEgress: {
-			noNewPrivileges:   true,
-			boundCapabilities: []int{unix.CAP_NET_ADMIN},
+			noNewPrivileges:      true,
+			boundCapabilities:    []int{unix.CAP_NET_ADMIN},
+			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6, unix.AF_NETLINK},
 		},
 		ServiceShim: {
-			noNewPrivileges:   true,
-			boundCapabilities: []int{unix.CAP_NET_BIND_SERVICE},
+			noNewPrivileges:      true,
+			boundCapabilities:    []int{unix.CAP_NET_BIND_SERVICE},
+			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6},
 		},
 	}
 	for service, wantPolicy := range want {
@@ -75,7 +78,7 @@ func TestPackCapabilitiesRejectsOutOfRangeValues(t *testing.T) {
 	}
 }
 
-func TestApplyServiceAppliesExactBoundingSetThenNoNewPrivileges(t *testing.T) {
+func TestApplyServiceAppliesCapabilitiesThenNoNewPrivilegesThenSocketPolicy(t *testing.T) {
 	kernel := &fakeServiceKernel{last: 13}
 	if err := applyService(kernel, ServiceEgress); err != nil {
 		t.Fatalf("applyService: %v", err)
@@ -92,8 +95,11 @@ func TestApplyServiceAppliesExactBoundingSetThenNoNewPrivileges(t *testing.T) {
 	if kernel.capabilityData != wantData {
 		t.Fatalf("capability data = %#v, want %#v", kernel.capabilityData, wantData)
 	}
-	if got := kernel.calls[len(kernel.calls)-1]; got != "no-new-privileges" {
-		t.Fatalf("last call = %q, want no-new-privileges; all calls: %v", got, kernel.calls)
+	if got := kernel.calls[len(kernel.calls)-1]; got != "restrict-sockets" {
+		t.Fatalf("last call = %q, want restrict-sockets; all calls: %v", got, kernel.calls)
+	}
+	if want := []uint32{unix.AF_INET, unix.AF_INET6, unix.AF_NETLINK}; !reflect.DeepEqual(kernel.socketDomains, want) {
+		t.Fatalf("socket domains = %v, want %v", kernel.socketDomains, want)
 	}
 }
 
@@ -133,6 +139,36 @@ func TestApplyServiceStopsAtFirstKernelFailure(t *testing.T) {
 	want := []string{"drop:0"}
 	if !reflect.DeepEqual(kernel.calls, want) {
 		t.Fatalf("calls after failure = %v, want %v", kernel.calls, want)
+	}
+}
+
+func TestApplyServiceStopsAtSocketRestrictionFailure(t *testing.T) {
+	restrictErr := errors.New("seccomp denied")
+	kernel := &fakeServiceKernel{
+		last:               unix.CAP_NET_BIND_SERVICE,
+		restrictSocketsErr: restrictErr,
+	}
+	err := applyService(kernel, ServiceShim)
+	if !errors.Is(err, restrictErr) {
+		t.Fatalf("applyService error = %v, want %v", err, restrictErr)
+	}
+	if got := kernel.calls[len(kernel.calls)-1]; got != "restrict-sockets" {
+		t.Fatalf("last call after socket restriction failure = %q, want restrict-sockets", got)
+	}
+}
+
+func TestApplyServiceDoesNotRestrictSocketsAfterNoNewPrivilegesFailure(t *testing.T) {
+	noNewPrivilegesErr := errors.New("prctl denied")
+	kernel := &fakeServiceKernel{
+		last:               unix.CAP_NET_BIND_SERVICE,
+		noNewPrivilegesErr: noNewPrivilegesErr,
+	}
+	err := applyService(kernel, ServiceShim)
+	if !errors.Is(err, noNewPrivilegesErr) {
+		t.Fatalf("applyService error = %v, want %v", err, noNewPrivilegesErr)
+	}
+	if got := kernel.calls[len(kernel.calls)-1]; got != "no-new-privileges" {
+		t.Fatalf("last call after no_new_privileges failure = %q, want no-new-privileges", got)
 	}
 }
 
@@ -239,10 +275,12 @@ type fakeServiceKernel struct {
 	dropCapabilityErr  error
 	capabilityErr      error
 	noNewPrivilegesErr error
+	restrictSocketsErr error
 
 	calls          []string
 	dropped        []int
 	capabilityData [2]unix.CapUserData
+	socketDomains  []uint32
 }
 
 func (kernel *fakeServiceKernel) dropBoundingCapability(capability int) error {
@@ -266,6 +304,12 @@ func (kernel *fakeServiceKernel) setCapabilities(data [2]unix.CapUserData) error
 func (kernel *fakeServiceKernel) setNoNewPrivileges() error {
 	kernel.calls = append(kernel.calls, "no-new-privileges")
 	return kernel.noNewPrivilegesErr
+}
+
+func (kernel *fakeServiceKernel) restrictSocketDomains(domains []uint32) error {
+	kernel.calls = append(kernel.calls, "restrict-sockets")
+	kernel.socketDomains = append([]uint32(nil), domains...)
+	return kernel.restrictSocketsErr
 }
 
 type rlimitSet struct {

--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64.go
@@ -1,0 +1,53 @@
+package hardening
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	seccompDataNumberOffset = 0
+	seccompDataArchOffset   = 4
+	seccompDataArg0Offset   = 16
+)
+
+func (linuxServiceKernel) restrictSocketDomains(domains []uint32) error {
+	filters := socketDomainFilters(domains)
+	program := unix.SockFprog{
+		Len:    uint16(len(filters)),
+		Filter: &filters[0],
+	}
+	if err := unix.Prctl(
+		unix.PR_SET_SECCOMP,
+		unix.SECCOMP_MODE_FILTER,
+		uintptr(unsafe.Pointer(&program)),
+		0,
+		0,
+	); err != nil {
+		return fmt.Errorf("install seccomp filter: %w", err)
+	}
+	return nil
+}
+
+func socketDomainFilters(domains []uint32) []unix.SockFilter {
+	filters := []unix.SockFilter{
+		{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataArchOffset},
+		{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 1, K: unix.AUDIT_ARCH_X86_64},
+		{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_KILL_PROCESS},
+		{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataNumberOffset},
+		{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: uint8(2*len(domains) + 2), K: unix.SYS_SOCKET},
+		{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataArg0Offset},
+	}
+	for _, domain := range domains {
+		filters = append(filters,
+			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: 1, K: domain},
+			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ALLOW},
+		)
+	}
+	return append(filters,
+		unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.EAFNOSUPPORT)},
+		unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ALLOW},
+	)
+}

--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
@@ -1,0 +1,88 @@
+package hardening
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestServiceSocketDomains(t *testing.T) {
+	if os.Getenv("TINFOIL_SOCKET_DOMAIN_CHILD") == "1" {
+		service := Service(os.Getenv("TINFOIL_SOCKET_SERVICE"))
+		domain, err := strconv.Atoi(os.Getenv("TINFOIL_SOCKET_DOMAIN"))
+		if err != nil {
+			os.Exit(20)
+		}
+		wantAllowed, err := strconv.ParseBool(os.Getenv("TINFOIL_SOCKET_ALLOWED"))
+		if err != nil {
+			os.Exit(21)
+		}
+		policy, ok := policyFor(service)
+		if !ok || policy.allowedSocketDomains == nil {
+			os.Exit(22)
+		}
+		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+			os.Exit(23)
+		}
+		if err := (linuxServiceKernel{}).restrictSocketDomains(policy.allowedSocketDomains); err != nil {
+			os.Exit(24)
+		}
+		socketType := unix.SOCK_STREAM | unix.SOCK_CLOEXEC
+		if domain == unix.AF_NETLINK {
+			socketType = unix.SOCK_RAW | unix.SOCK_CLOEXEC
+		}
+		descriptor, socketErr := unix.Socket(domain, socketType, 0)
+		if descriptor >= 0 {
+			unix.Close(descriptor)
+		}
+		if wantAllowed && socketErr != nil {
+			os.Exit(25)
+		}
+		if !wantAllowed && !errors.Is(socketErr, syscall.EAFNOSUPPORT) {
+			os.Exit(26)
+		}
+		os.Exit(0)
+	}
+
+	tests := []struct {
+		name    string
+		service Service
+		domain  int
+		allowed bool
+	}{
+		{name: "container-status-unix", service: ServiceContainerStatus, domain: unix.AF_UNIX, allowed: true},
+		{name: "container-status-inet", service: ServiceContainerStatus, domain: unix.AF_INET},
+		{name: "container-status-packet", service: ServiceContainerStatus, domain: unix.AF_PACKET},
+		{name: "container-status-vsock", service: ServiceContainerStatus, domain: unix.AF_VSOCK},
+		{name: "shim-inet", service: ServiceShim, domain: unix.AF_INET, allowed: true},
+		{name: "shim-inet6", service: ServiceShim, domain: unix.AF_INET6, allowed: true},
+		{name: "shim-unix", service: ServiceShim, domain: unix.AF_UNIX},
+		{name: "shim-packet", service: ServiceShim, domain: unix.AF_PACKET},
+		{name: "shim-vsock", service: ServiceShim, domain: unix.AF_VSOCK},
+		{name: "egress-inet", service: ServiceEgress, domain: unix.AF_INET, allowed: true},
+		{name: "egress-inet6", service: ServiceEgress, domain: unix.AF_INET6, allowed: true},
+		{name: "egress-netlink", service: ServiceEgress, domain: unix.AF_NETLINK, allowed: true},
+		{name: "egress-unix", service: ServiceEgress, domain: unix.AF_UNIX},
+		{name: "egress-packet", service: ServiceEgress, domain: unix.AF_PACKET},
+		{name: "egress-vsock", service: ServiceEgress, domain: unix.AF_VSOCK},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.Command(os.Args[0], "-test.run=^TestServiceSocketDomains$")
+			command.Env = append(os.Environ(),
+				"TINFOIL_SOCKET_DOMAIN_CHILD=1",
+				"TINFOIL_SOCKET_SERVICE="+string(test.service),
+				"TINFOIL_SOCKET_DOMAIN="+strconv.Itoa(test.domain),
+				"TINFOIL_SOCKET_ALLOWED="+strconv.FormatBool(test.allowed),
+			)
+			if output, err := command.CombinedOutput(); err != nil {
+				t.Fatalf("socket-domain child failed: %v: %s", err, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add fixed per-service socket-domain allowlists to the PID 1 hardening policy
- install a minimal seccomp filter after `no_new_privs`
- keep `tinfoil-boot` unrestricted while limiting container-status to Unix sockets, shim to IPv4/IPv6, and egress to IPv4/IPv6/netlink
- fail disallowed `socket(2)` domains with `EAFNOSUPPORT`

There is no runtime policy parser or generic configuration surface. The policy is compiled into the measured guest and unknown service names already fail closed.

## Validation

- `gofmt` on all changed Go files
- `go build ./...`
- `go test ./...`
- `go test -race -count=25 ./internal/pid1/hardening`
- `go vet ./...`
- real-kernel subprocess coverage for Unix, IPv4, IPv6, netlink, packet, and vsock domains
- clean application and focused build/test/race/vet over the prepared CPU PID 1 composition
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lock down PID 1 services with per-service socket-domain allowlists enforced by a minimal seccomp filter. Disallowed socket domains now fail with EAFNOSUPPORT.

- **New Features**
  - Added `allowedSocketDomains` to the service policy and `restrictSocketDomains` (seccomp-BPF) in `tinfoil/internal/pid1/hardening`.
  - Applied after capability setup and `no_new_privs`; errors propagate on failure.
  - Service policies: `container-status` → Unix only; `shim` → IPv4/IPv6; `egress` → IPv4/IPv6/netlink; `tinfoil-boot` remains unrestricted; unknown services fail closed.
  - Added real-kernel tests covering Unix, IPv4/IPv6, netlink, packet, and vsock.

<sup>Written for commit 0474d9858ed3af80806d16cb57843b592dea40a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

