### PR TITLE
Bound DNS attestation decoding

### DIFF
--- a/tinfoil/internal/dcode/dcode.go
+++ b/tinfoil/internal/dcode/dcode.go
@@ -15,16 +15,32 @@ import (
 	"tinfoil/internal/compress"
 )
 
+const (
+	maxDomainChunks         = 100
+	maxDecompressedAttBytes = 1 << 20
+)
+
 func gzDecompress(data []byte) ([]byte, error) {
 	gzReader, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create gzip reader: %v", err)
 	}
-	return io.ReadAll(gzReader)
+	defer gzReader.Close()
+	decompressed, err := io.ReadAll(io.LimitReader(gzReader, maxDecompressedAttBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(decompressed) > maxDecompressedAttBytes {
+		return nil, fmt.Errorf("decompressed payload exceeds %d-byte limit", maxDecompressedAttBytes)
+	}
+	return decompressed, nil
 }
 
 // Encode encodes a byte slice into a string of domains
 func Encode(content []byte, domain string) ([]string, error) {
+	if len(content) == 0 {
+		return nil, fmt.Errorf("payload must not be empty")
+	}
 	// Encode the entire compressed data using base32
 	encoder := base32.StdEncoding.WithPadding(base32.NoPadding)
 	encoded := encoder.EncodeToString(content)
@@ -41,8 +57,8 @@ func Encode(content []byte, domain string) ([]string, error) {
 		end := min(i+maxLength, len(encoded))
 		chunk := encoded[i:end]
 		index := len(domains)
-		if index > 99 {
-			return nil, fmt.Errorf("payload requires %d+ chunks; 2-digit prefix supports at most 100", index+1)
+		if index >= maxDomainChunks {
+			return nil, fmt.Errorf("payload requires more than %d chunks", maxDomainChunks)
 		}
 		domains = append(domains, fmt.Sprintf("%02d%s%s", index, chunk, domainSuffix))
 	}
@@ -65,10 +81,16 @@ func EncodeAtt(att *attestation.Document, domain string) ([]string, error) {
 
 // Decode decodes a string of domains into an attestation document
 func Decode(domains []string) (*attestation.Document, error) {
+	if len(domains) == 0 || len(domains) > maxDomainChunks {
+		return nil, fmt.Errorf("domain chunk count must be between 1 and %d", maxDomainChunks)
+	}
 	for _, d := range domains {
-		label := strings.Split(d, ".")[0]
-		if len(label) < 3 {
+		label := strings.SplitN(d, ".", 2)[0]
+		if len(label) < 3 || len(label) > 63 {
 			return nil, fmt.Errorf("malformed domain chunk: %q", d)
+		}
+		if label[0] < '0' || label[0] > '9' || label[1] < '0' || label[1] > '9' {
+			return nil, fmt.Errorf("malformed domain chunk index: %q", d)
 		}
 	}
 
@@ -76,11 +98,16 @@ func Decode(domains []string) (*attestation.Document, error) {
 	sort.Slice(domains, func(i, j int) bool {
 		return domains[i][:2] < domains[j][:2]
 	})
+	for index, domain := range domains {
+		if domain[:2] != fmt.Sprintf("%02d", index) {
+			return nil, fmt.Errorf("domain chunks must have unique contiguous indexes starting at 00")
+		}
+	}
 
 	// Extract encoded data from the domains
 	var encodedData string
 	for _, domain := range domains {
-		domain = strings.Split(domain, ".")[0]
+		domain = strings.SplitN(domain, ".", 2)[0]
 		encodedData += domain[2:]
 	}
 

--- a/tinfoil/internal/dcode/dcode_test.go
+++ b/tinfoil/internal/dcode/dcode_test.go
@@ -1,6 +1,8 @@
 package dcode
 
 import (
+	"bytes"
+	"compress/gzip"
 	"encoding/json"
 	"math/rand/v2"
 	"strings"
@@ -57,4 +59,51 @@ func TestEncodeRejectsTooManyChunks(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when chunk count exceeds 100")
 	}
+}
+
+func TestEncodeRejectsEmptyPayload(t *testing.T) {
+	if _, err := Encode(nil, "example.com"); err == nil {
+		t.Fatal("Encode accepted an empty payload")
+	}
+}
+
+func TestDecodeRejectsMalformedChunkSets(t *testing.T) {
+	for name, domains := range map[string][]string{
+		"empty":     nil,
+		"too many":  make([]string, maxDomainChunks+1),
+		"duplicate": {"00aa.example.com", "00bb.example.com"},
+		"gap":       {"00aa.example.com", "02bb.example.com"},
+		"bad index": {"xxaa.example.com"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Decode(domains); err == nil {
+				t.Fatalf("Decode accepted %s", name)
+			}
+		})
+	}
+}
+
+func TestDecodeRejectsDecompressionBomb(t *testing.T) {
+	exact := gzipBytes(t, make([]byte, maxDecompressedAttBytes))
+	if decompressed, err := gzDecompress(exact); err != nil || len(decompressed) != maxDecompressedAttBytes {
+		t.Fatalf("exact decompression limit: len=%d error=%v", len(decompressed), err)
+	}
+
+	compressed := gzipBytes(t, make([]byte, maxDecompressedAttBytes+1))
+	if _, err := gzDecompress(compressed); err == nil || !strings.Contains(err.Error(), "decompressed payload exceeds") {
+		t.Fatalf("decompression bomb error = %v", err)
+	}
+}
+
+func gzipBytes(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return compressed.Bytes()
 }


### PR DESCRIPTION
## Summary

- require a nonempty, contiguous DNS chunk set with at most 100 two-digit indexes
- reject malformed, duplicate, missing, oversized, packet, or reordered-index ambiguity before decoding
- cap decompressed attestation JSON at exactly 1 MiB
- reject empty encoder payloads so encode/decode share one fail-closed contract

This hardens the existing DNS attestation protocol parser; it adds no new runtime format, fallback, or generic input mechanism.

## Validation

- `gofmt` on changed Go files
- `go build ./...`
- `go test ./...`
- `go test -count=100 ./internal/dcode`
- `go test -race -count=50 ./internal/dcode`
- `go vet ./...`
- exact decompression-boundary and decompression-bomb tests
- malformed empty/oversized/duplicate/gapped/non-numeric chunk-set tests
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened DNS attestation parsing by bounding chunk counts and decompression size, and by rejecting malformed or ambiguous domains. No format changes; this prevents decompression bombs and index ambiguity.

- **Bug Fixes**
  - Enforce 1–100 chunks with contiguous 2-digit indexes (00..NN); reject duplicates, gaps, reordering, non-numeric indexes, and invalid label lengths.
  - Limit decompressed attestation to 1 MiB; error on overflow.
  - Reject empty payloads in `Encode` to keep the encode/decode contract fail-closed.

<sup>Written for commit 8bf762b2476261e8876212350d19029df8418fda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

