### PR TITLE
Bound shim configuration inputs

### DIFF
--- a/tinfoil/internal/config/bounds.go
+++ b/tinfoil/internal/config/bounds.go
@@ -97,83 +97,188 @@ func decodeYAMLDocument(data []byte) (*yaml.Node, error) {
 func validateYAMLStructureBudget(data []byte) error {
 	potentialNodes := 2
 	flowDepth := 0
-	lineOnlySpace := true
 	var quote byte
 	escaped := false
-	comment := false
+	blockHeaderIndent := -1
+	blockContentIndent := -1
 
-	for index := 0; index < len(data); index++ {
-		character := data[index]
-		if comment {
-			if character == '\n' {
-				comment = false
-				lineOnlySpace = true
+	for offset := 0; offset < len(data); {
+		line, nextOffset := nextYAMLLine(data, offset)
+		offset = nextOffset
+		indent := yamlLineIndent(line)
+		if blockHeaderIndent >= 0 {
+			if yamlLineBlank(line) {
+				continue
 			}
-			continue
+			if blockContentIndent < 0 && indent > blockHeaderIndent {
+				blockContentIndent = indent
+				continue
+			}
+			if blockContentIndent >= 0 && indent >= blockContentIndent {
+				continue
+			}
+			blockHeaderIndent = -1
+			blockContentIndent = -1
 		}
-		if quote != 0 {
-			if quote == '"' && escaped {
-				escaped = false
-				continue
-			}
-			if quote == '"' && character == '\\' {
-				escaped = true
-				continue
-			}
-			if character == quote {
-				if quote == '\'' && index+1 < len(data) && data[index+1] == '\'' {
-					index++
+
+		lineOnlySpace := true
+		for index := 0; index < len(line); index++ {
+			character := line[index]
+			if quote != 0 {
+				if quote == '"' && escaped {
+					escaped = false
 					continue
 				}
-				quote = 0
+				if quote == '"' && character == '\\' {
+					escaped = true
+					continue
+				}
+				if character == quote {
+					if quote == '\'' && index+1 < len(line) && line[index+1] == '\'' {
+						index++
+						continue
+					}
+					quote = 0
+				}
+				continue
 			}
-			continue
-		}
 
-		if character == '#' && (index == 0 || isYAMLSeparation(data[index-1])) {
-			comment = true
-			continue
-		}
-		switch character {
-		case '\n', '\r':
-			lineOnlySpace = true
-		case ' ', '\t':
-			continue
-		case '\'', '"':
-			quote = character
-			lineOnlySpace = false
-		case '[', '{':
-			potentialNodes++
-			flowDepth++
-			lineOnlySpace = false
-		case ']', '}':
-			if flowDepth > 0 {
-				flowDepth--
+			if character == '#' && (index == 0 || isYAMLSeparation(line[index-1])) {
+				break
 			}
-			lineOnlySpace = false
-		case ',':
-			if flowDepth > 0 {
+			switch character {
+			case ' ', '\t':
+				continue
+			case '\'', '"':
+				quote = character
+				lineOnlySpace = false
+			case '[', '{':
 				potentialNodes++
+				flowDepth++
+				lineOnlySpace = false
+			case ']', '}':
+				if flowDepth > 0 {
+					flowDepth--
+				}
+				lineOnlySpace = false
+			case ',':
+				if flowDepth > 0 {
+					potentialNodes++
+				}
+				lineOnlySpace = false
+			case ':':
+				if flowDepth > 0 || index+1 == len(line) || isYAMLSeparation(line[index+1]) {
+					potentialNodes += 2
+				}
+				lineOnlySpace = false
+			case '-', '?':
+				if lineOnlySpace && (index+1 == len(line) || isYAMLSeparation(line[index+1])) {
+					potentialNodes++
+				}
+				lineOnlySpace = false
+			case '|', '>':
+				explicitIndent, ok := yamlBlockScalarHeader(line[index:])
+				if flowDepth == 0 && ok && yamlBlockScalarPosition(line, index, indent) {
+					blockHeaderIndent = indent
+					blockContentIndent = -1
+					if explicitIndent > 0 {
+						blockContentIndent = indent + explicitIndent
+					}
+					index = len(line)
+				}
+				lineOnlySpace = false
+			default:
+				lineOnlySpace = false
 			}
-			lineOnlySpace = false
-		case ':':
-			if flowDepth > 0 || index+1 == len(data) || isYAMLSeparation(data[index+1]) {
-				potentialNodes += 2
+			if potentialNodes > maxYAMLNodes {
+				return fmt.Errorf("YAML exceeds %d-node structural budget", maxYAMLNodes)
 			}
-			lineOnlySpace = false
-		case '-', '?':
-			if lineOnlySpace && (index+1 == len(data) || isYAMLSeparation(data[index+1])) {
-				potentialNodes++
-			}
-			lineOnlySpace = false
-		default:
-			lineOnlySpace = false
 		}
-		if potentialNodes > maxYAMLNodes {
-			return fmt.Errorf("YAML exceeds %d-node structural budget", maxYAMLNodes)
+		if quote == '"' && escaped {
+			escaped = false
 		}
 	}
 	return nil
+}
+
+func nextYAMLLine(data []byte, offset int) ([]byte, int) {
+	end := offset
+	for end < len(data) && data[end] != '\n' && data[end] != '\r' {
+		end++
+	}
+	next := end
+	if next < len(data) {
+		if data[next] == '\r' && next+1 < len(data) && data[next+1] == '\n' {
+			next += 2
+		} else {
+			next++
+		}
+	}
+	return data[offset:end], next
+}
+
+func yamlLineIndent(line []byte) int {
+	indent := 0
+	for indent < len(line) && line[indent] == ' ' {
+		indent++
+	}
+	return indent
+}
+
+func yamlLineBlank(line []byte) bool {
+	for _, character := range line {
+		if character != ' ' && character != '\t' {
+			return false
+		}
+	}
+	return true
+}
+
+func yamlBlockScalarHeader(header []byte) (int, bool) {
+	if len(header) == 0 || header[0] != '|' && header[0] != '>' {
+		return 0, false
+	}
+	explicitIndent := 0
+	seenChomp := false
+	for index := 1; index < len(header); index++ {
+		character := header[index]
+		switch {
+		case character == '+' || character == '-':
+			if seenChomp {
+				return 0, false
+			}
+			seenChomp = true
+		case character >= '1' && character <= '9':
+			if explicitIndent != 0 {
+				return 0, false
+			}
+			explicitIndent = int(character - '0')
+		case character == ' ' || character == '\t':
+			for index < len(header) && (header[index] == ' ' || header[index] == '\t') {
+				index++
+			}
+			return explicitIndent, index == len(header) || header[index] == '#'
+		default:
+			return 0, false
+		}
+	}
+	return explicitIndent, true
+}
+
+func yamlBlockScalarPosition(line []byte, index, indent int) bool {
+	if index == indent {
+		return true
+	}
+	if index == 0 || !isYAMLSeparation(line[index-1]) {
+		return false
+	}
+	for previous := index - 1; previous >= 0; previous-- {
+		if line[previous] == ' ' || line[previous] == '\t' {
+			continue
+		}
+		return line[previous] == ':' || line[previous] == '-' || line[previous] == '?'
+	}
+	return false
 }
 
 func isYAMLSeparation(character byte) bool {

--- a/tinfoil/internal/config/bounds.go
+++ b/tinfoil/internal/config/bounds.go
@@ -36,14 +36,14 @@ func readConfigFile(path string) ([]byte, error) {
 		return nil, fmt.Errorf("open descriptor")
 	}
 	defer file.Close()
-	info, err := file.Stat()
-	if err != nil {
+	var initialStat unix.Stat_t
+	if err := unix.Fstat(descriptor, &initialStat); err != nil {
 		return nil, err
 	}
-	if !info.Mode().IsRegular() {
+	if initialStat.Mode&unix.S_IFMT != unix.S_IFREG {
 		return nil, fmt.Errorf("not a regular file")
 	}
-	if info.Size() > maxConfigFileBytes {
+	if initialStat.Size > maxConfigFileBytes {
 		return nil, fmt.Errorf("exceeds %d-byte limit", maxConfigFileBytes)
 	}
 	data, err := io.ReadAll(io.LimitReader(file, maxConfigFileBytes+1))
@@ -53,19 +53,28 @@ func readConfigFile(path string) ([]byte, error) {
 	if len(data) > maxConfigFileBytes {
 		return nil, fmt.Errorf("exceeds %d-byte limit", maxConfigFileBytes)
 	}
-	finalInfo, err := file.Stat()
-	if err != nil {
+	var finalStat unix.Stat_t
+	if err := unix.Fstat(descriptor, &finalStat); err != nil {
 		return nil, err
 	}
-	if info.Size() != finalInfo.Size() || !info.ModTime().Equal(finalInfo.ModTime()) {
+	if !sameConfigFileVersion(&initialStat, &finalStat) {
 		return nil, fmt.Errorf("changed while being read")
 	}
 	return data, nil
 }
 
+func sameConfigFileVersion(initial, final *unix.Stat_t) bool {
+	return initial.Size == final.Size &&
+		initial.Mtim.Sec == final.Mtim.Sec && initial.Mtim.Nsec == final.Mtim.Nsec &&
+		initial.Ctim.Sec == final.Ctim.Sec && initial.Ctim.Nsec == final.Ctim.Nsec
+}
+
 func decodeYAMLDocument(data []byte) (*yaml.Node, error) {
 	if len(data) > maxConfigFileBytes {
 		return nil, fmt.Errorf("input exceeds %d-byte limit", maxConfigFileBytes)
+	}
+	if err := validateYAMLStructureBudget(data); err != nil {
+		return nil, err
 	}
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	var node yaml.Node
@@ -83,6 +92,92 @@ func decodeYAMLDocument(data []byte) (*yaml.Node, error) {
 		return nil, err
 	}
 	return &node, nil
+}
+
+func validateYAMLStructureBudget(data []byte) error {
+	potentialNodes := 2
+	flowDepth := 0
+	lineOnlySpace := true
+	var quote byte
+	escaped := false
+	comment := false
+
+	for index := 0; index < len(data); index++ {
+		character := data[index]
+		if comment {
+			if character == '\n' {
+				comment = false
+				lineOnlySpace = true
+			}
+			continue
+		}
+		if quote != 0 {
+			if quote == '"' && escaped {
+				escaped = false
+				continue
+			}
+			if quote == '"' && character == '\\' {
+				escaped = true
+				continue
+			}
+			if character == quote {
+				if quote == '\'' && index+1 < len(data) && data[index+1] == '\'' {
+					index++
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+
+		if character == '#' && (index == 0 || isYAMLSeparation(data[index-1])) {
+			comment = true
+			continue
+		}
+		switch character {
+		case '\n', '\r':
+			lineOnlySpace = true
+		case ' ', '\t':
+			continue
+		case '\'', '"':
+			quote = character
+			lineOnlySpace = false
+		case '[', '{':
+			potentialNodes++
+			flowDepth++
+			lineOnlySpace = false
+		case ']', '}':
+			if flowDepth > 0 {
+				flowDepth--
+			}
+			lineOnlySpace = false
+		case ',':
+			if flowDepth > 0 {
+				potentialNodes++
+			}
+			lineOnlySpace = false
+		case ':':
+			if flowDepth > 0 || index+1 == len(data) || isYAMLSeparation(data[index+1]) {
+				potentialNodes += 2
+			}
+			lineOnlySpace = false
+		case '-', '?':
+			if lineOnlySpace && (index+1 == len(data) || isYAMLSeparation(data[index+1])) {
+				potentialNodes++
+			}
+			lineOnlySpace = false
+		default:
+			lineOnlySpace = false
+		}
+		if potentialNodes > maxYAMLNodes {
+			return fmt.Errorf("YAML exceeds %d-node structural budget", maxYAMLNodes)
+		}
+	}
+	return nil
+}
+
+func isYAMLSeparation(character byte) bool {
+	return character == ' ' || character == '\t' || character == '\r' || character == '\n'
 }
 
 func validateYAMLTree(root *yaml.Node) error {

--- a/tinfoil/internal/config/bounds.go
+++ b/tinfoil/internal/config/bounds.go
@@ -1,0 +1,210 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/sys/unix"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	maxConfigFileBytes    = 1 << 20
+	maxYAMLNodes          = 16384
+	maxYAMLDepth          = 64
+	maxExternalEntries    = 1024
+	maxExternalKeyBytes   = 256
+	maxExternalValueBytes = 64 << 10
+	maxMetadataFieldBytes = 4096
+	maxOperatorKeyBytes   = 256
+)
+
+func readConfigFile(path string) ([]byte, error) {
+	descriptor, err := unix.Openat2(unix.AT_FDCWD, path, &unix.OpenHow{
+		Flags:   unix.O_RDONLY | unix.O_CLOEXEC,
+		Resolve: unix.RESOLVE_NO_SYMLINKS | unix.RESOLVE_NO_MAGICLINKS,
+	})
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(descriptor), path)
+	if file == nil {
+		unix.Close(descriptor)
+		return nil, fmt.Errorf("open descriptor")
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("not a regular file")
+	}
+	if info.Size() > maxConfigFileBytes {
+		return nil, fmt.Errorf("exceeds %d-byte limit", maxConfigFileBytes)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxConfigFileBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxConfigFileBytes {
+		return nil, fmt.Errorf("exceeds %d-byte limit", maxConfigFileBytes)
+	}
+	finalInfo, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() != finalInfo.Size() || !info.ModTime().Equal(finalInfo.ModTime()) {
+		return nil, fmt.Errorf("changed while being read")
+	}
+	return data, nil
+}
+
+func decodeYAMLDocument(data []byte) (*yaml.Node, error) {
+	if len(data) > maxConfigFileBytes {
+		return nil, fmt.Errorf("input exceeds %d-byte limit", maxConfigFileBytes)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	var node yaml.Node
+	if err := decoder.Decode(&node); err != nil {
+		return nil, err
+	}
+	var trailing yaml.Node
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("multiple YAML documents")
+		}
+		return nil, err
+	}
+	if err := validateYAMLTree(&node); err != nil {
+		return nil, err
+	}
+	return &node, nil
+}
+
+func validateYAMLTree(root *yaml.Node) error {
+	if root == nil {
+		return fmt.Errorf("missing YAML document")
+	}
+	type pendingNode struct {
+		node  *yaml.Node
+		depth int
+	}
+	stack := []pendingNode{{node: root}}
+	count := 0
+	valueBytes := 0
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		pending := stack[last]
+		stack = stack[:last]
+		count++
+		if count > maxYAMLNodes {
+			return fmt.Errorf("YAML exceeds %d-node limit", maxYAMLNodes)
+		}
+		if pending.depth > maxYAMLDepth {
+			return fmt.Errorf("YAML exceeds depth limit %d", maxYAMLDepth)
+		}
+		if pending.node.Kind == yaml.AliasNode || pending.node.Alias != nil {
+			return fmt.Errorf("YAML aliases are not supported")
+		}
+		valueBytes += len(pending.node.Value) + len(pending.node.Tag) + len(pending.node.Anchor)
+		if valueBytes > maxConfigFileBytes {
+			return fmt.Errorf("YAML scalar data exceeds %d-byte limit", maxConfigFileBytes)
+		}
+		for index := len(pending.node.Content) - 1; index >= 0; index-- {
+			stack = append(stack, pendingNode{
+				node:  pending.node.Content[index],
+				depth: pending.depth + 1,
+			})
+		}
+	}
+	return nil
+}
+
+func (config *ExternalConfig) validateBounds() error {
+	if err := validateStringMap("env", config.Env); err != nil {
+		return err
+	}
+	if err := validateStringMap("secrets", config.Secrets); err != nil {
+		return err
+	}
+	for field, value := range map[string]string{
+		"metadata.id":     config.Metadata.ID,
+		"metadata.domain": config.Metadata.Domain,
+		"metadata.image":  config.Metadata.Image,
+		"metadata.cpu":    config.Metadata.CPU,
+		"metadata.gpu":    config.Metadata.GPU,
+		"metadata.repo":   config.Metadata.Repo,
+		"metadata.digest": config.Metadata.Digest,
+		"network.address": networkValue(config.Network, true),
+		"network.gateway": networkValue(config.Network, false),
+	} {
+		if len(value) > maxMetadataFieldBytes || strings.IndexByte(value, 0) >= 0 {
+			return fmt.Errorf("%s exceeds safe value limits", field)
+		}
+	}
+	if len(config.VaultToken) > maxExternalValueBytes || strings.IndexByte(config.VaultToken, 0) >= 0 {
+		return fmt.Errorf("vault-token exceeds safe value limits")
+	}
+	if err := validateOperatorMap("metadata", config.Metadata.Extra); err != nil {
+		return err
+	}
+	return validateOperatorMap("external config", config.Extra)
+}
+
+func validateStringMap(section string, values map[string]string) error {
+	if len(values) > maxExternalEntries {
+		return fmt.Errorf("%s exceeds %d-entry limit", section, maxExternalEntries)
+	}
+	for key, value := range values {
+		if !validEnvironmentKey(key) {
+			return fmt.Errorf("%s contains invalid key %q", section, key)
+		}
+		if len(value) > maxExternalValueBytes || strings.IndexByte(value, 0) >= 0 {
+			return fmt.Errorf("%s value for %q exceeds safe limits", section, key)
+		}
+	}
+	return nil
+}
+
+func validEnvironmentKey(key string) bool {
+	if len(key) == 0 || len(key) > maxExternalKeyBytes {
+		return false
+	}
+	for index := 0; index < len(key); index++ {
+		character := key[index]
+		if character == '_' || character >= 'A' && character <= 'Z' || character >= 'a' && character <= 'z' {
+			continue
+		}
+		if index > 0 && character >= '0' && character <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validateOperatorMap(section string, values map[string]yaml.Node) error {
+	if len(values) > maxExternalEntries {
+		return fmt.Errorf("%s exceeds %d-entry limit", section, maxExternalEntries)
+	}
+	for key := range values {
+		if len(key) == 0 || len(key) > maxOperatorKeyBytes || strings.ContainsAny(key, "\x00\t\r\n") {
+			return fmt.Errorf("%s contains invalid key %q", section, key)
+		}
+	}
+	return nil
+}
+
+func networkValue(network *ExternalNetworkConfig, address bool) string {
+	if network == nil {
+		return ""
+	}
+	if address {
+		return network.Address
+	}
+	return network.Gateway
+}

--- a/tinfoil/internal/config/bounds_test.go
+++ b/tinfoil/internal/config/bounds_test.go
@@ -1,0 +1,103 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestDecodeExternalRejectsAliasesAndBounds(t *testing.T) {
+	tests := map[string][]byte{
+		"alias":     []byte("metadata: &metadata\n  cpu: amd\ncopy: *metadata\n"),
+		"oversized": []byte(strings.Repeat("x", maxConfigFileBytes+1)),
+		"deep":      []byte(strings.Repeat("- ", maxYAMLDepth+1) + "value\n"),
+	}
+	for name, data := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := DecodeExternal(data); err == nil {
+				t.Fatalf("DecodeExternal accepted %s input", name)
+			}
+		})
+	}
+}
+
+func TestDecodeRejectsOversizedNodeTree(t *testing.T) {
+	root := yaml.Node{Kind: yaml.DocumentNode}
+	sequence := yaml.Node{Kind: yaml.SequenceNode}
+	root.Content = []*yaml.Node{&sequence}
+	for range maxYAMLNodes {
+		sequence.Content = append(sequence.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: "x"})
+	}
+	if _, err := Decode(&root); err == nil {
+		t.Fatal("Decode accepted oversized YAML node tree")
+	}
+}
+
+func TestDecodeRejectsOversizedScalarData(t *testing.T) {
+	root := yaml.Node{Kind: yaml.DocumentNode, Content: []*yaml.Node{{
+		Kind:  yaml.ScalarNode,
+		Value: strings.Repeat("x", maxConfigFileBytes+1),
+	}}}
+	if _, err := Decode(&root); err == nil {
+		t.Fatal("Decode accepted oversized scalar data")
+	}
+}
+
+func TestDecodeExternalRejectsUnsafeMapsAndValues(t *testing.T) {
+	tooMany := make(map[string]string, maxExternalEntries+1)
+	for index := range maxExternalEntries + 1 {
+		tooMany["KEY_"+string(rune(index+1))] = "value"
+	}
+	for name, config := range map[string]ExternalConfig{
+		"env count":    {Env: tooMany},
+		"env key":      {Env: map[string]string{"BAD-KEY": "value"}},
+		"secret value": {Secrets: map[string]string{"KEY": strings.Repeat("x", maxExternalValueBytes+1)}},
+		"metadata":     {Metadata: Metadata{Domain: strings.Repeat("x", maxMetadataFieldBytes+1)}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := config.validateBounds(); err == nil {
+				t.Fatalf("validateBounds accepted %s", name)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsSymlinkAndOversizedFiles(t *testing.T) {
+	directory := t.TempDir()
+	valid := filepath.Join(directory, "valid.yaml")
+	if err := os.WriteFile(valid, []byte("upstream-port: 8080\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(directory, "symlink.yaml")
+	if err := os.Symlink(valid, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readConfigFile(symlink); err == nil {
+		t.Fatal("readConfigFile accepted symlink")
+	}
+	parent := filepath.Join(directory, "parent")
+	if err := os.Mkdir(parent, 0700); err != nil {
+		t.Fatal(err)
+	}
+	parentFile := filepath.Join(parent, "config.yaml")
+	if err := os.WriteFile(parentFile, []byte("upstream-port: 8080\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	parentLink := filepath.Join(directory, "parent-link")
+	if err := os.Symlink(parent, parentLink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readConfigFile(filepath.Join(parentLink, "config.yaml")); err == nil {
+		t.Fatal("readConfigFile accepted symlinked parent")
+	}
+	oversized := filepath.Join(directory, "oversized.yaml")
+	if err := os.WriteFile(oversized, []byte(strings.Repeat("x", maxConfigFileBytes+1)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readConfigFile(oversized); err == nil {
+		t.Fatal("readConfigFile accepted oversized file")
+	}
+}

--- a/tinfoil/internal/config/bounds_test.go
+++ b/tinfoil/internal/config/bounds_test.go
@@ -54,10 +54,45 @@ func TestYAMLStructureBudgetRejectsNodeBombBeforeDecode(t *testing.T) {
 	}
 }
 
+func TestYAMLStructureBudgetRejectsCRCommentBypass(t *testing.T) {
+	data := []byte("# comment\r" + strings.Repeat("- x\r", maxYAMLNodes))
+	if err := validateYAMLStructureBudget(data); err == nil {
+		t.Fatal("validateYAMLStructureBudget accepted a CR-only oversized sequence")
+	}
+}
+
 func TestYAMLStructureBudgetAllowsLargeQuotedScalar(t *testing.T) {
 	data := []byte("value: \"" + strings.Repeat("-?:,[]{}", 4096) + "\"\n")
 	if err := validateYAMLStructureBudget(data); err != nil {
 		t.Fatalf("validateYAMLStructureBudget rejected a scalar payload: %v", err)
+	}
+}
+
+func TestYAMLStructureBudgetAllowsLargeBlockScalars(t *testing.T) {
+	for _, indicator := range []string{"|", ">", "|2-", ">+2"} {
+		t.Run(indicator, func(t *testing.T) {
+			data := []byte("- " + indicator + "\n" + strings.Repeat("  - ?:,[]{}\n", 4096))
+			if err := validateYAMLStructureBudget(data); err != nil {
+				t.Fatalf("validateYAMLStructureBudget rejected block scalar: %v", err)
+			}
+			if _, err := decodeYAMLDocument(data); err != nil {
+				t.Fatalf("decodeYAMLDocument rejected block scalar: %v", err)
+			}
+		})
+	}
+}
+
+func TestYAMLStructureBudgetResumesAfterBlockScalar(t *testing.T) {
+	data := []byte("- |\n  text\n" + strings.Repeat("- x\n", maxYAMLNodes))
+	if err := validateYAMLStructureBudget(data); err == nil {
+		t.Fatal("validateYAMLStructureBudget ignored structure after a block scalar")
+	}
+}
+
+func TestYAMLStructureBudgetDoesNotTreatPlainPipeAsBlockScalar(t *testing.T) {
+	data := []byte("- plain |\n" + strings.Repeat("- x\n", maxYAMLNodes))
+	if err := validateYAMLStructureBudget(data); err == nil {
+		t.Fatal("validateYAMLStructureBudget treated a plain pipe as a block scalar")
 	}
 }
 

--- a/tinfoil/internal/config/bounds_test.go
+++ b/tinfoil/internal/config/bounds_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 )
 
@@ -43,6 +44,36 @@ func TestDecodeRejectsOversizedScalarData(t *testing.T) {
 	}}}
 	if _, err := Decode(&root); err == nil {
 		t.Fatal("Decode accepted oversized scalar data")
+	}
+}
+
+func TestYAMLStructureBudgetRejectsNodeBombBeforeDecode(t *testing.T) {
+	data := []byte(strings.Repeat("- x\n", maxYAMLNodes))
+	if err := validateYAMLStructureBudget(data); err == nil {
+		t.Fatal("validateYAMLStructureBudget accepted an oversized sequence")
+	}
+}
+
+func TestYAMLStructureBudgetAllowsLargeQuotedScalar(t *testing.T) {
+	data := []byte("value: \"" + strings.Repeat("-?:,[]{}", 4096) + "\"\n")
+	if err := validateYAMLStructureBudget(data); err != nil {
+		t.Fatalf("validateYAMLStructureBudget rejected a scalar payload: %v", err)
+	}
+}
+
+func TestSameConfigFileVersionIncludesChangeTime(t *testing.T) {
+	initial := unix.Stat_t{
+		Size: 4,
+		Mtim: unix.Timespec{Sec: 10, Nsec: 20},
+		Ctim: unix.Timespec{Sec: 30, Nsec: 40},
+	}
+	final := initial
+	if !sameConfigFileVersion(&initial, &final) {
+		t.Fatal("sameConfigFileVersion rejected identical metadata")
+	}
+	final.Ctim.Nsec++
+	if sameConfigFileVersion(&initial, &final) {
+		t.Fatal("sameConfigFileVersion ignored a change-time update")
 	}
 }
 

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"slices"
 
 	"github.com/creasty/defaults"
@@ -99,6 +98,9 @@ func (e *ExternalConfig) GetSecret(key string) string {
 // DecodeExternal strictly decodes typed external-config sections. Unknown
 // operator-owned top-level keys remain opaque through ExternalConfig.Extra.
 func DecodeExternal(data []byte) (*ExternalConfig, error) {
+	if _, err := decodeYAMLDocument(data); err != nil {
+		return nil, fmt.Errorf("failed to decode external config: %v", err)
+	}
 	var config ExternalConfig
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
@@ -115,6 +117,9 @@ func DecodeExternal(data []byte) (*ExternalConfig, error) {
 	if err := defaults.Set(&config); err != nil {
 		return nil, fmt.Errorf("failed to set external config defaults: %v", err)
 	}
+	if err := config.validateBounds(); err != nil {
+		return nil, fmt.Errorf("invalid external config: %v", err)
+	}
 
 	config.MetricsAPIKey = config.GetSecret(SecretMetricsAPIKey)
 	config.ACPIAPIKey = config.GetSecret(SecretACPIAPIKey)
@@ -125,6 +130,9 @@ func DecodeExternal(data []byte) (*ExternalConfig, error) {
 // applies defaults, and validates. Used by boot, which has already parsed
 // the parent config and needs to type the `shim:` subsection.
 func Decode(n *yaml.Node) (*Config, error) {
+	if err := validateYAMLTree(n); err != nil {
+		return nil, fmt.Errorf("failed to decode config: %v", err)
+	}
 	var config Config
 	if err := defaults.Set(&config); err != nil {
 		return nil, fmt.Errorf("failed to set defaults: %v", err)
@@ -159,20 +167,20 @@ func (c *Config) Validate() error {
 
 // Load reads and parses both config files from disk.
 func Load(configFile, externalConfigFile string) (*Config, *ExternalConfig, error) {
-	configBytes, err := os.ReadFile(configFile)
+	configBytes, err := readConfigFile(configFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read config file: %v", err)
 	}
-	var node yaml.Node
-	if err := yaml.Unmarshal(configBytes, &node); err != nil {
+	node, err := decodeYAMLDocument(configBytes)
+	if err != nil {
 		return nil, nil, fmt.Errorf("failed to unmarshal config: %v", err)
 	}
-	config, err := Decode(&node)
+	config, err := Decode(node)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	externalConfigBytes, err := os.ReadFile(externalConfigFile)
+	externalConfigBytes, err := readConfigFile(externalConfigFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read external config file: %v", err)
 	}


### PR DESCRIPTION
## Summary

- read shim and external config files with pinned-kernel `openat2(RESOLVE_NO_SYMLINKS)` and require regular files
- cap each input at 1 MiB and reject files that change while being read
- cap YAML at 16,384 nodes, depth 64, and 1 MiB of scalar data
- reject YAML aliases instead of permitting expansion
- bound external env/secrets/operator maps, keys, values, metadata, network strings, and vault tokens

This preserves the current strict network decoding and opaque operator extension fields. It adds no generic host-input package, runtime format, compatibility fallback, or regex policy.

## Validation

- `gofmt` on changed Go files
- `go build ./...`
- `go test ./...`
- `go test -count=100 ./internal/config`
- `go test -race -count=50 ./internal/config`
- `go vet ./...`
- symlinked file and symlinked parent rejection
- oversized file, node tree, scalar data, map, key, value, and metadata rejection
- alias, excessive-depth, and multiple-document rejection
- existing operator-extension and strict-network behavior retained
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened shim config loading with symlink-safe reads and strict, pre-materialization YAML/input bounds to block oversized, mutated, multi-doc, alias-based, or malformed configs. Structural budget now correctly handles line and block scalars.

- **New Features**
  - Safe file reads: use `openat2(RESOLVE_NO_SYMLINKS)`, require regular files, cap at 1 MiB, reject files that change during read.
  - YAML bounds: enforce structural budget before decode; single document; reject aliases; max 16,384 nodes, depth 64, 1 MiB scalar data; handle quoted, line, and block scalars (`|`, `>` with chomp/indent), CR/CRLF; resume counting after block scalars.
  - External config limits: max 1,024 entries; env keys ≤256 bytes with `[A-Za-z_][A-Za-z0-9_]*`; values ≤64 KiB; operator keys ≤256 bytes; metadata fields ≤4 KiB; vault token ≤64 KiB; reject NUL bytes.
  - Wiring and tests: bound before materialization in `DecodeExternal`, validate trees in `Decode`, use `readConfigFile` in `Load`; tests for structure budget, aliases/multi-doc, CR-only bypass, plain `|` vs block scalar, block scalar handling, symlinked parent, and change-time checks.

<sup>Written for commit 4cd97e969763e2b5a8d7f0ecd0e5d92035dff0d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

