### PR TITLE
Bound boot configuration shape

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -49,8 +49,27 @@ type NetworkSpec struct {
 func (n *NetworkSpec) UnmarshalYAML(node *yaml.Node) error {
 	// `name:` with a null scalar body decodes to a ScalarNode here.
 	if node.Kind == yaml.ScalarNode {
+		if node.Tag != "!!null" {
+			return fmt.Errorf("network entry must be a mapping or null")
+		}
 		n.Egress = "closed"
 		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("network entry must be a mapping")
+	}
+	seen := map[string]bool{}
+	for index := 0; index < len(node.Content); index += 2 {
+		field := node.Content[index].Value
+		if seen[field] {
+			return fmt.Errorf("duplicate network field %q", field)
+		}
+		seen[field] = true
+		switch field {
+		case "egress", "allow":
+		default:
+			return fmt.Errorf("unknown network field %q", field)
+		}
 	}
 	type alias NetworkSpec
 	var raw alias
@@ -220,6 +239,9 @@ func loadAndVerifyConfig() (*Config, error) {
 	if err := yaml.Unmarshal(configData, &config); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
+	if err := validateConfigShape(&config); err != nil {
+		return nil, err
+	}
 
 	if err := validateGPUCount(config.GPUs); err != nil {
 		return nil, err
@@ -300,6 +322,9 @@ func loadConfigFromRamdisk() (*Config, error) {
 	var config Config
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
+	}
+	if err := validateConfigShape(&config); err != nil {
+		return nil, err
 	}
 	if err := validateModelCount(len(config.Models)); err != nil {
 		return nil, err

--- a/tinfoil/cmd/boot/config_shape.go
+++ b/tinfoil/cmd/boot/config_shape.go
@@ -1,0 +1,116 @@
+package main
+
+import "fmt"
+
+const (
+	maxConfigContainers       = 64
+	maxConfigModels           = 64
+	maxConfigNetworks         = 32
+	maxConfigInboundPorts     = 64
+	maxContainerListEntries   = 256
+	maxContainerTmpfsEntries  = 64
+	maxNetworkAllowEntries    = 256
+	maxHealthcheckTestEntries = 64
+	maxEnvironmentNameBytes   = 256
+)
+
+func validateConfigShape(config *Config) error {
+	if len(config.Containers) > maxConfigContainers {
+		return fmt.Errorf("containers exceeds limit %d", maxConfigContainers)
+	}
+	if len(config.Models) > maxConfigModels {
+		return fmt.Errorf("models exceeds limit %d", maxConfigModels)
+	}
+	if len(config.Networks) > maxConfigNetworks {
+		return fmt.Errorf("networks exceeds limit %d", maxConfigNetworks)
+	}
+	if len(config.CVMNetwork.InboundPorts) > maxConfigInboundPorts {
+		return fmt.Errorf("cvm-network.inbound-ports exceeds limit %d", maxConfigInboundPorts)
+	}
+	for name, network := range config.Networks {
+		if network != nil && len(network.Allow) > maxNetworkAllowEntries {
+			return fmt.Errorf("networks.%s.allow exceeds limit %d", name, maxNetworkAllowEntries)
+		}
+	}
+	for index := range config.Containers {
+		if err := validateContainerShape(index, &config.Containers[index]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateContainerShape(index int, container *Container) error {
+	lists := []struct {
+		name  string
+		count int
+	}{
+		{name: "command", count: len(container.Command)},
+		{name: "entrypoint", count: len(container.Entrypoint)},
+		{name: "env", count: len(container.Env)},
+		{name: "secrets", count: len(container.Secrets)},
+		{name: "volumes", count: len(container.Volumes)},
+		{name: "devices", count: len(container.Devices)},
+		{name: "cap_add", count: len(container.CapAdd)},
+		{name: "security_opt", count: len(container.SecurityOpt)},
+		{name: "networks", count: len(container.Networks)},
+	}
+	for _, list := range lists {
+		if list.count > maxContainerListEntries {
+			return fmt.Errorf("containers[%d].%s exceeds limit %d", index, list.name, maxContainerListEntries)
+		}
+	}
+	if len(container.Tmpfs) > maxContainerTmpfsEntries {
+		return fmt.Errorf("containers[%d].tmpfs exceeds limit %d", index, maxContainerTmpfsEntries)
+	}
+	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
+		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
+	}
+	for envIndex, item := range container.Env {
+		switch value := item.(type) {
+		case string:
+			if !validEnvironmentName(value) {
+				return fmt.Errorf("containers[%d].env[%d] has invalid environment name %q", index, envIndex, value)
+			}
+		case map[string]interface{}:
+			if len(value) != 1 {
+				return fmt.Errorf("containers[%d].env[%d] must contain exactly one key", index, envIndex)
+			}
+			for key, scalar := range value {
+				if !validEnvironmentName(key) {
+					return fmt.Errorf("containers[%d].env[%d] has invalid environment name %q", index, envIndex, key)
+				}
+				switch scalar.(type) {
+				case string, bool, int, uint64, float64:
+				default:
+					return fmt.Errorf("containers[%d].env[%d].%s must be a scalar", index, envIndex, key)
+				}
+			}
+		default:
+			return fmt.Errorf("containers[%d].env[%d] must be a name or one-key mapping", index, envIndex)
+		}
+	}
+	for secretIndex, secret := range container.Secrets {
+		if !validEnvironmentName(secret) {
+			return fmt.Errorf("containers[%d].secrets[%d] has invalid environment name %q", index, secretIndex, secret)
+		}
+	}
+	return nil
+}
+
+func validEnvironmentName(name string) bool {
+	if len(name) == 0 || len(name) > maxEnvironmentNameBytes {
+		return false
+	}
+	for index := 0; index < len(name); index++ {
+		character := name[index]
+		if character == '_' || character >= 'A' && character <= 'Z' || character >= 'a' && character <= 'z' {
+			continue
+		}
+		if index > 0 && character >= '0' && character <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/tinfoil/cmd/boot/config_shape_test.go
+++ b/tinfoil/cmd/boot/config_shape_test.go
@@ -13,6 +13,10 @@ func TestValidateConfigShapeEnforcesCollectionLimits(t *testing.T) {
 	for index := 0; index <= maxConfigNetworks; index++ {
 		networks[fmt.Sprintf("network-%d", index)] = &NetworkSpec{}
 	}
+	tmpfs := make(map[string]string, maxContainerTmpfsEntries+1)
+	for index := 0; index <= maxContainerTmpfsEntries; index++ {
+		tmpfs[fmt.Sprintf("/tmp/%d", index)] = "size=1m"
+	}
 	tests := []struct {
 		name   string
 		config Config
@@ -23,6 +27,8 @@ func TestValidateConfigShapeEnforcesCollectionLimits(t *testing.T) {
 		{name: "networks", config: Config{Networks: networks}, want: "networks exceeds"},
 		{name: "ports", config: Config{CVMNetwork: CVMNetworkConfig{InboundPorts: make([]int, maxConfigInboundPorts+1)}}, want: "inbound-ports exceeds"},
 		{name: "command", config: Config{Containers: []Container{{Command: make([]string, maxContainerListEntries+1)}}}, want: "command exceeds"},
+		{name: "tmpfs", config: Config{Containers: []Container{{Tmpfs: tmpfs}}}, want: "tmpfs exceeds"},
+		{name: "healthcheck", config: Config{Containers: []Container{{Healthcheck: &Healthcheck{Test: make([]string, maxHealthcheckTestEntries+1)}}}}, want: "healthcheck.test exceeds"},
 		{name: "allow", config: Config{Networks: map[string]*NetworkSpec{"web": {Allow: make([]string, maxNetworkAllowEntries+1)}}}, want: "allow exceeds"},
 	}
 	for _, test := range tests {

--- a/tinfoil/cmd/boot/config_shape_test.go
+++ b/tinfoil/cmd/boot/config_shape_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestValidateConfigShapeEnforcesCollectionLimits(t *testing.T) {
+	networks := make(map[string]*NetworkSpec, maxConfigNetworks+1)
+	for index := 0; index <= maxConfigNetworks; index++ {
+		networks[fmt.Sprintf("network-%d", index)] = &NetworkSpec{}
+	}
+	tests := []struct {
+		name   string
+		config Config
+		want   string
+	}{
+		{name: "containers", config: Config{Containers: make([]Container, maxConfigContainers+1)}, want: "containers exceeds"},
+		{name: "models", config: Config{Models: make([]ModelSpec, maxConfigModels+1)}, want: "models exceeds"},
+		{name: "networks", config: Config{Networks: networks}, want: "networks exceeds"},
+		{name: "ports", config: Config{CVMNetwork: CVMNetworkConfig{InboundPorts: make([]int, maxConfigInboundPorts+1)}}, want: "inbound-ports exceeds"},
+		{name: "command", config: Config{Containers: []Container{{Command: make([]string, maxContainerListEntries+1)}}}, want: "command exceeds"},
+		{name: "allow", config: Config{Networks: map[string]*NetworkSpec{"web": {Allow: make([]string, maxNetworkAllowEntries+1)}}}, want: "allow exceeds"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateConfigShape(&test.config)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateConfigShape error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateConfigShapeRejectsNestedOrAmbiguousEnv(t *testing.T) {
+	for name, item := range map[string]interface{}{
+		"invalid name":  "BAD-NAME",
+		"long name":     strings.Repeat("A", maxEnvironmentNameBytes+1),
+		"multiple keys": map[string]interface{}{"A": "1", "B": "2"},
+		"nested value":  map[string]interface{}{"A": map[string]interface{}{"B": "2"}},
+		"sequence":      []interface{}{"A"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := Config{Containers: []Container{{Env: []interface{}{item}}}}
+			if err := validateConfigShape(&config); err == nil {
+				t.Fatalf("validateConfigShape accepted %s", name)
+			}
+		})
+	}
+}
+
+func TestNetworkSpecRejectsUnknownOrNonMappingShape(t *testing.T) {
+	for name, data := range map[string]string{
+		"unknown":   "egress: closed\nunexpected: true\n",
+		"sequence":  "- closed\n",
+		"scalar":    "closed\n",
+		"duplicate": "egress: closed\negress: allowlist\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			var network NetworkSpec
+			if err := yaml.Unmarshal([]byte(data), &network); err == nil {
+				t.Fatalf("NetworkSpec accepted %s shape", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- cap top-level containers, models, networks, inbound ports, allowlists, container lists, tmpfs entries, and healthcheck commands
- require container environment and secret names to use one fixed ASCII identifier contract
- accept environment values only as names or one-key scalar mappings
- require each network entry to be null or a mapping containing unique `egress`/`allow` fields
- apply the same shape validation to verified-disk boot and manual ramdisk subcommands

The existing disk reader already caps the measured payload at 1 MiB. This PR adds only domain-specific decoded-shape limits; it does not introduce a generic input package, parser, fallback, or new configuration format.

## Validation

- `gofmt` on changed Go files
- `go build ./...`
- `go test ./...`
- `go test -count=100 ./cmd/boot`
- `go test -race -count=50 ./cmd/boot`
- `go vet ./...`
- excessive collection and nested environment rejection
- invalid, oversized, multi-key, and non-scalar environment rejection
- unknown, duplicate, scalar, and sequence network-shape rejection
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds strict shape validation for boot config to cap collection sizes and enforce predictable YAML structures. Applies to both verified-disk boot and manual ramdisk paths to block oversized or ambiguous inputs.

- **New Features**
  - Caps counts for containers, models, networks, inbound ports, container list fields, tmpfs, network allowlists, and healthcheck args.
  - Enforces env/secret names as ASCII identifiers ([A-Za-z_][A-Za-z0-9_]*) up to 256 bytes; env values must be names or one-key scalar mappings.
  - Requires each network entry to be null or a mapping with unique `egress`/`allow` fields; runs shape checks in both load paths and adds tests covering all collection limits and invalid env/network shapes.

<sup>Written for commit 7737110d9953624e26e9b902b368cdb0b8c44dc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

