### PR TITLE
Add bounded NVIDIA userspace services

### DIFF
--- a/tinfoil/internal/nvidia/devices.go
+++ b/tinfoil/internal/nvidia/devices.go
@@ -192,12 +192,9 @@ func hasSWManagementVPD(paths devicePaths) (bool, error) {
 			return false, fmt.Errorf("PCI VPD for %s is not a regular file", entry.Name())
 		}
 		swManaged, readErr := scanSWManagementVPD(file)
-		closeErr := file.Close()
+		_ = file.Close()
 		if readErr != nil {
 			return false, fmt.Errorf("read PCI VPD for %s: %w", entry.Name(), readErr)
-		}
-		if closeErr != nil {
-			return false, fmt.Errorf("close PCI VPD for %s: %w", entry.Name(), closeErr)
 		}
 		if swManaged {
 			return true, nil

--- a/tinfoil/internal/nvidia/devices.go
+++ b/tinfoil/internal/nvidia/devices.go
@@ -2,8 +2,10 @@ package nvidia
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -28,10 +30,29 @@ const (
 	nvidiaNVLinkMinor      = 0
 	nvidiaNVSwitchCtlMinor = 255
 	maxNVSwitches          = 64
+	maxVPDSize             = 64 << 10
 
 	maxDeviceMajor = (1 << 12) - 1
 	maxDeviceMinor = (1 << 20) - 1
 )
+
+var swManagementVPDMarker = []byte("SW_MNG")
+
+// FabricMode identifies the userspace fabric services required by detected
+// hardware.
+type FabricMode uint8
+
+const (
+	FabricModeNone FabricMode = iota
+	FabricModeFabricManager
+)
+
+// ErrNVL5RequiresNVLSM reports NVL5 hardware when NVLSM is not allowlisted.
+type ErrNVL5RequiresNVLSM struct{}
+
+func (*ErrNVL5RequiresNVLSM) Error() string {
+	return "NVL5 fabric requires allowlisted NVLSM"
+}
 
 var allowedCapabilityFiles = [...]string{
 	"mig/config",
@@ -89,6 +110,18 @@ func HasNVSwitch() (bool, error) {
 	return hasNVSwitch(systemDevicePaths)
 }
 
+// GPUCount returns the number of NVIDIA PCI functions with an exact VGA or 3D
+// controller class. Any unreadable or malformed PCI identity fails closed.
+func GPUCount() (int, error) {
+	return gpuCount(systemDevicePaths)
+}
+
+// DetectFabricMode selects the userspace fabric contract from direct NVIDIA
+// NVSwitch PCI functions and vendor-independent SW_MNG VPD markers.
+func DetectFabricMode() (FabricMode, error) {
+	return detectFabricMode(systemDevicePaths)
+}
+
 func hasNVSwitch(paths devicePaths) (bool, error) {
 	devices, err := nvidiaPCIDevices(paths)
 	if err != nil {
@@ -100,6 +133,88 @@ func hasNVSwitch(paths devicePaths) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func gpuCount(paths devicePaths) (int, error) {
+	devices, err := nvidiaPCIDevices(paths)
+	if err != nil {
+		return 0, err
+	}
+	count := 0
+	for _, device := range devices {
+		if isGPUClass(device.class) {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func detectFabricMode(paths devicePaths) (FabricMode, error) {
+	nvswitch, err := hasNVSwitch(paths)
+	if err != nil {
+		return FabricModeNone, fmt.Errorf("detect NVIDIA NVSwitch: %w", err)
+	}
+	swManaged, err := hasSWManagementVPD(paths)
+	if err != nil {
+		return FabricModeNone, fmt.Errorf("detect SW_MNG VPD: %w", err)
+	}
+	if swManaged {
+		return FabricModeNone, &ErrNVL5RequiresNVLSM{}
+	}
+	if nvswitch {
+		return FabricModeFabricManager, nil
+	}
+	return FabricModeNone, nil
+}
+
+func hasSWManagementVPD(paths devicePaths) (bool, error) {
+	entries, err := os.ReadDir(paths.pciDevices)
+	if err != nil {
+		return false, fmt.Errorf("read PCI devices: %w", err)
+	}
+	for _, entry := range entries {
+		path := filepath.Join(paths.pciDevices, entry.Name(), "vpd")
+		fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK, 0)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return false, fmt.Errorf("open PCI VPD for %s: %w", entry.Name(), err)
+		}
+		file := os.NewFile(uintptr(fd), path)
+		info, statErr := file.Stat()
+		if statErr != nil {
+			_ = file.Close()
+			return false, fmt.Errorf("inspect PCI VPD for %s: %w", entry.Name(), statErr)
+		}
+		if !info.Mode().IsRegular() {
+			_ = file.Close()
+			return false, fmt.Errorf("PCI VPD for %s is not a regular file", entry.Name())
+		}
+		swManaged, readErr := scanSWManagementVPD(file)
+		closeErr := file.Close()
+		if readErr != nil {
+			return false, fmt.Errorf("read PCI VPD for %s: %w", entry.Name(), readErr)
+		}
+		if closeErr != nil {
+			return false, fmt.Errorf("close PCI VPD for %s: %w", entry.Name(), closeErr)
+		}
+		if swManaged {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func scanSWManagementVPD(reader io.Reader) (bool, error) {
+	data, err := io.ReadAll(io.LimitReader(reader, maxVPDSize+1))
+	if err != nil {
+		return false, err
+	}
+	if len(data) > maxVPDSize {
+		return false, fmt.Errorf("PCI VPD exceeds %d bytes", maxVPDSize)
+	}
+	return bytes.Contains(data, swManagementVPDMarker), nil
 }
 
 // HoldGPUEnableReferences increments the PCI enable reference for each NVIDIA
@@ -114,10 +229,20 @@ func EnableGPURuntimePowerManagement() error {
 	return enableGPURuntimePowerManagement(systemDevicePaths)
 }
 
-// SetupDeviceNodes creates and verifies the NVIDIA character devices and their
-// /dev/char links using kernel-assigned majors and NVIDIA-assigned minors.
-func SetupDeviceNodes() error {
-	return setupDeviceNodes(systemDevicePaths)
+// SetupCoreDeviceNodes creates and verifies the core NVIDIA character devices
+// only after the driver reports exactly the detected number of GPUs.
+func SetupCoreDeviceNodes(expectedGPUs int) error {
+	return setupDeviceNodes(systemDevicePaths, deviceNodeRequirements{expectedGPUs: expectedGPUs})
+}
+
+// SetupUVMDeviceNodes creates and verifies the core, UVM, and allowlisted
+// capability character devices after the UVM modules load.
+func SetupUVMDeviceNodes(expectedGPUs int) error {
+	return setupDeviceNodes(systemDevicePaths, deviceNodeRequirements{
+		expectedGPUs:        expectedGPUs,
+		requireUVM:          true,
+		requireCapabilities: true,
+	})
 }
 
 func hasPCIDevice(paths devicePaths) (bool, error) {
@@ -219,23 +344,62 @@ func enableGPURuntimePowerManagement(paths devicePaths) error {
 	return nil
 }
 
-func setupDeviceNodes(paths devicePaths) error {
+type deviceNodeRequirements struct {
+	expectedGPUs        int
+	requireUVM          bool
+	requireCapabilities bool
+}
+
+func setupDeviceNodes(paths devicePaths, requirements deviceNodeRequirements) error {
+	devices, err := discoverDeviceNodes(paths, requirements)
+	if err != nil {
+		return err
+	}
+	if err := validateCharDevices(devices); err != nil {
+		return err
+	}
+	for _, device := range devices {
+		if err := ensureCharDevice(paths.dev, device); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func discoverDeviceNodes(paths devicePaths, requirements deviceNodeRequirements) ([]charDevice, error) {
+	if requirements.expectedGPUs < 1 {
+		return nil, fmt.Errorf("invalid expected NVIDIA GPU count %d", requirements.expectedGPUs)
+	}
 	majors, err := charDeviceMajors(paths.procDevices)
 	if err != nil {
-		return fmt.Errorf("read character device majors: %w", err)
+		return nil, fmt.Errorf("read character device majors: %w", err)
 	}
 	frontend, ok := firstMajor(majors, "nvidia-frontend", "nvidia")
 	if !ok {
-		return errors.New("missing nvidia-frontend character device major")
+		return nil, errors.New("missing nvidia-frontend character device major")
 	}
 
 	gpuMinors, err := nvidiaDeviceMinors(paths.gpus)
 	if err != nil {
-		return fmt.Errorf("discover NVIDIA GPU minors: %w", err)
+		return nil, fmt.Errorf("discover NVIDIA GPU minors: %w", err)
+	}
+	if len(gpuMinors) != requirements.expectedGPUs {
+		return nil, fmt.Errorf("NVIDIA driver reported %d GPU device minors, want %d", len(gpuMinors), requirements.expectedGPUs)
+	}
+	if requirements.requireCapabilities {
+		for _, relative := range allowedCapabilityFiles {
+			path := filepath.Join(paths.capabilities, filepath.FromSlash(relative))
+			if _, err := os.Lstat(path); err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return nil, fmt.Errorf("missing NVIDIA capability descriptor %s", path)
+				}
+				return nil, fmt.Errorf("inspect NVIDIA capability descriptor %s: %w", path, err)
+			}
+		}
 	}
 	capabilities, err := nvidiaCapabilityDevices(paths.capabilities)
 	if err != nil {
-		return fmt.Errorf("discover NVIDIA capability devices: %w", err)
+		return nil, fmt.Errorf("discover NVIDIA capability devices: %w", err)
 	}
 
 	devices := []charDevice{
@@ -261,7 +425,11 @@ func setupDeviceNodes(paths devicePaths) error {
 		})
 	}
 
-	if uvm, ok := majors["nvidia-uvm"]; ok {
+	uvm, uvmLoaded := majors["nvidia-uvm"]
+	if requirements.requireUVM && !uvmLoaded {
+		return nil, errors.New("missing nvidia-uvm character device major")
+	}
+	if uvmLoaded {
 		devices = append(devices,
 			charDevice{
 				path:  filepath.Join(paths.dev, "nvidia-uvm"),
@@ -281,7 +449,7 @@ func setupDeviceNodes(paths devicePaths) error {
 	if len(capabilities) > 0 {
 		caps, ok := majors["nvidia-caps"]
 		if !ok {
-			return errors.New("NVIDIA capability descriptors exist without nvidia-caps character device major")
+			return nil, errors.New("NVIDIA capability descriptors exist without nvidia-caps character device major")
 		}
 		for _, capability := range capabilities {
 			devices = append(devices, charDevice{
@@ -294,19 +462,10 @@ func setupDeviceNodes(paths devicePaths) error {
 	}
 	interconnects, err := nvidiaInterconnectDevices(paths, majors)
 	if err != nil {
-		return fmt.Errorf("discover NVIDIA interconnect devices: %w", err)
+		return nil, fmt.Errorf("discover NVIDIA interconnect devices: %w", err)
 	}
 	devices = append(devices, interconnects...)
-
-	if err := validateCharDevices(devices); err != nil {
-		return err
-	}
-	for _, device := range devices {
-		if err := ensureCharDevice(paths.dev, device); err != nil {
-			return err
-		}
-	}
-	return nil
+	return devices, nil
 }
 
 func nvidiaInterconnectDevices(paths devicePaths, majors map[string]int) ([]charDevice, error) {

--- a/tinfoil/internal/nvidia/devices_test.go
+++ b/tinfoil/internal/nvidia/devices_test.go
@@ -121,6 +121,100 @@ func TestPCIDiscoveryAndGPUSetupUseExactClasses(t *testing.T) {
 	}
 }
 
+func TestGPUCountUsesExactNVIDIAClassesAndFailsClosed(t *testing.T) {
+	paths := testDevicePaths(t)
+	for name, fixture := range map[string][2]string{
+		"0000:01:00.0": {"0x10de", "0x030000"},
+		"0000:02:00.0": {"0x10de", "0x030200"},
+		"0000:03:00.0": {"0x10de", "0x030201"},
+		"0000:04:00.0": {"0x10de", "0x068000"},
+		"0000:05:00.0": {"0x1af4", "0x030200"},
+	} {
+		addPCIFixture(t, paths, name, fixture[0], fixture[1], false)
+	}
+	count, err := gpuCount(paths)
+	if err != nil || count != 2 {
+		t.Fatalf("gpuCount = %d, %v; want 2, nil", count, err)
+	}
+	writeTestFile(t, filepath.Join(paths.pciDevices, "0000:04:00.0", "class"), "invalid\n")
+	if _, err := gpuCount(paths); err == nil {
+		t.Fatal("gpuCount accepted malformed NVIDIA class")
+	}
+}
+
+func TestSWManagementVPDDetectionIsBoundedAndVendorIndependent(t *testing.T) {
+	paths := testDevicePaths(t)
+	addPCIFixture(t, paths, "0000:01:00.0", "0x15b3", "0x020000", false)
+	vpd := filepath.Join(paths.pciDevices, "0000:01:00.0", "vpd")
+	writeTestFile(t, vpd, "MLX:MN=MLNX:SMDL=SW_MNG:MODL=C7010Z")
+	present, err := hasSWManagementVPD(paths)
+	if err != nil || !present {
+		t.Fatalf("hasSWManagementVPD = %v, %v; want true, nil", present, err)
+	}
+
+	writeTestFile(t, vpd, strings.Repeat("x", maxVPDSize+1))
+	if _, err := hasSWManagementVPD(paths); err == nil {
+		t.Fatal("hasSWManagementVPD accepted oversized VPD")
+	}
+	if err := os.Remove(vpd); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, vpd+".target", "SMDL=SW_MNG")
+	if err := os.Symlink(vpd+".target", vpd); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := hasSWManagementVPD(paths); err == nil {
+		t.Fatal("hasSWManagementVPD followed VPD symlink")
+	}
+}
+
+func TestSWManagementVPDDetectionFailsClosedOnReadError(t *testing.T) {
+	wantErr := errors.New("VPD read failed")
+	present, err := scanSWManagementVPD(errorReader{err: wantErr})
+	if present || !errors.Is(err, wantErr) {
+		t.Fatalf("scanSWManagementVPD = %v, %v; want false, %v", present, err, wantErr)
+	}
+}
+
+type errorReader struct {
+	err error
+}
+
+func (reader errorReader) Read([]byte) (int, error) {
+	return 0, reader.err
+}
+
+func TestDetectFabricMode(t *testing.T) {
+	t.Run("none", func(t *testing.T) {
+		mode, err := detectFabricMode(testDevicePaths(t))
+		if err != nil || mode != FabricModeNone {
+			t.Fatalf("detectFabricMode = %v, %v", mode, err)
+		}
+	})
+
+	t.Run("fabric manager", func(t *testing.T) {
+		paths := testDevicePaths(t)
+		addPCIFixture(t, paths, "0000:01:00.0", "0x10de", "0x068000", false)
+		mode, err := detectFabricMode(paths)
+		if err != nil || mode != FabricModeFabricManager {
+			t.Fatalf("detectFabricMode = %v, %v", mode, err)
+		}
+	})
+
+	t.Run("NVL5 denied", func(t *testing.T) {
+		paths := testDevicePaths(t)
+		addPCIFixture(t, paths, "0000:01:00.0", "0x10de", "0x068000", false)
+		addPCIFixture(t, paths, "0000:02:00.0", "0x15b3", "0x020000", false)
+		writeTestFile(t, filepath.Join(paths.pciDevices, "0000:02:00.0", "vpd"), "SMDL=SW_MNG")
+		mode, err := detectFabricMode(paths)
+		var nvlsmErr *ErrNVL5RequiresNVLSM
+		if mode != FabricModeNone || !errors.As(err, &nvlsmErr) {
+			t.Fatalf("detectFabricMode = %v, %v; want typed NVLSM error", mode, err)
+		}
+	})
+
+}
+
 func TestHasPCIDeviceUsesSupportedGPUAndNVSwitchClasses(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -238,6 +332,56 @@ func TestCapabilityParserFailsClosed(t *testing.T) {
 				t.Fatalf("parseCapabilityDevice accepted %q", contents)
 			}
 		})
+	}
+}
+
+func TestDeviceNodeReadinessRequiresExpectedGPUsAndUVMCapabilities(t *testing.T) {
+	paths := testDevicePaths(t)
+	writeTestFile(t, paths.procDevices, `Character devices:
+195 nvidia-frontend
+236 nvidia-caps
+237 nvidia-uvm
+`)
+	writeTestFile(t, filepath.Join(paths.gpus, "0000:01:00.0", "information"), "Device Minor: 0\n")
+
+	core := deviceNodeRequirements{expectedGPUs: 2}
+	if _, err := discoverDeviceNodes(paths, core); err == nil || !strings.Contains(err.Error(), "want 2") {
+		t.Fatalf("core readiness error = %v, want GPU count mismatch", err)
+	}
+
+	uvm := deviceNodeRequirements{expectedGPUs: 1, requireUVM: true, requireCapabilities: true}
+	if _, err := discoverDeviceNodes(paths, uvm); err == nil || !strings.Contains(err.Error(), "missing NVIDIA capability descriptor") {
+		t.Fatalf("UVM readiness error = %v, want missing capability descriptor", err)
+	}
+	writeTestFile(t, filepath.Join(paths.capabilities, "mig", "config"),
+		"DeviceFileMinor: 1\nDeviceFileMode: 256\n")
+	writeTestFile(t, filepath.Join(paths.capabilities, "mig", "monitor"),
+		"DeviceFileMinor: 2\nDeviceFileMode: 288\n")
+
+	devices, err := discoverDeviceNodes(paths, uvm)
+	if err != nil {
+		t.Fatalf("discoverDeviceNodes: %v", err)
+	}
+	wantPaths := []string{
+		filepath.Join(paths.dev, "nvidiactl"),
+		filepath.Join(paths.dev, "nvidia-modeset"),
+		filepath.Join(paths.dev, "nvidia0"),
+		filepath.Join(paths.dev, "nvidia-uvm"),
+		filepath.Join(paths.dev, "nvidia-uvm-tools"),
+		filepath.Join(paths.dev, "nvidia-caps", "nvidia-cap1"),
+		filepath.Join(paths.dev, "nvidia-caps", "nvidia-cap2"),
+	}
+	gotPaths := make([]string, 0, len(devices))
+	for _, device := range devices {
+		gotPaths = append(gotPaths, device.path)
+	}
+	if !reflect.DeepEqual(gotPaths, wantPaths) {
+		t.Fatalf("device paths = %v, want %v", gotPaths, wantPaths)
+	}
+
+	writeTestFile(t, paths.procDevices, "Character devices:\n195 nvidia-frontend\n236 nvidia-caps\n")
+	if _, err := discoverDeviceNodes(paths, uvm); err == nil || !strings.Contains(err.Error(), "missing nvidia-uvm") {
+		t.Fatalf("UVM major error = %v, want missing nvidia-uvm major", err)
 	}
 }
 
@@ -382,9 +526,11 @@ func TestEnsureCharNodeRecreatesOnlyStaleCharacterDevices(t *testing.T) {
 func TestSetupDeviceNodesFailsBeforeReplacingRequiredPaths(t *testing.T) {
 	paths := testDevicePaths(t)
 	writeTestFile(t, paths.procDevices, "Character devices:\n195 nvidia-frontend\n")
+	writeTestFile(t, filepath.Join(paths.gpus, "0000:01:00.0", "information"), "Device Minor: 0\n")
 	writeTestFile(t, filepath.Join(paths.dev, "nvidiactl"), "keep\n")
 
-	err := setupDeviceNodes(paths)
+	requirements := deviceNodeRequirements{expectedGPUs: 1}
+	err := setupDeviceNodes(paths, requirements)
 	if err == nil || !strings.Contains(err.Error(), "not a character device") {
 		t.Fatalf("setupDeviceNodes error = %v, want required node error", err)
 	}
@@ -394,7 +540,7 @@ func TestSetupDeviceNodesFailsBeforeReplacingRequiredPaths(t *testing.T) {
 
 	writeTestFile(t, filepath.Join(paths.capabilities, "mig", "config"),
 		"DeviceFileMinor: 1\nDeviceFileMode: 256\n")
-	err = setupDeviceNodes(paths)
+	err = setupDeviceNodes(paths, requirements)
 	if err == nil || !strings.Contains(err.Error(), "without nvidia-caps") {
 		t.Fatalf("setupDeviceNodes capability error = %v", err)
 	}

--- a/tinfoil/internal/nvidia/services.go
+++ b/tinfoil/internal/nvidia/services.go
@@ -1,0 +1,362 @@
+package nvidia
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	persistencedUID     = 143
+	persistencedGID     = 143
+	serviceReadyWait    = 15 * time.Second
+	servicePollInterval = 500 * time.Millisecond
+	maxPIDFileSize      = 32
+)
+
+type nvmlAPI interface {
+	Init() nvml.Return
+	DeviceGetCount() (int, nvml.Return)
+	Shutdown() nvml.Return
+}
+
+type servicePaths struct {
+	persistencedRun  string
+	persistencedPID  string
+	persistencedSock string
+	fabricRun        string
+	fabricPID        string
+	fabricSock       string
+	cdiSpec          string
+}
+
+var systemServicePaths = servicePaths{
+	persistencedRun:  "/run/nvidia-persistenced",
+	persistencedPID:  "/run/nvidia-persistenced/nvidia-persistenced.pid",
+	persistencedSock: "/run/nvidia-persistenced/socket",
+	fabricRun:        "/run/nvidia-fabricmanager",
+	fabricPID:        "/run/nvidia-fabricmanager/nv-fabricmanager.pid",
+	fabricSock:       "/run/nvidia-fabricmanager/socket",
+	cdiSpec:          "/var/run/cdi/nvidia.yaml",
+}
+
+// Services provides fixed, execution-free NVIDIA userspace readiness and
+// publication contracts. Process paths, arguments, and ordering belong to the
+// bootstrap orchestrator.
+type Services struct {
+	paths        servicePaths
+	nvml         nvmlAPI
+	persistUID   int
+	persistGID   int
+	readyWait    time.Duration
+	pollInterval time.Duration
+}
+
+// NewServices creates the production NVIDIA userspace service helpers.
+func NewServices() *Services {
+	return newServices(nvml.New())
+}
+
+func newServices(api nvmlAPI) *Services {
+	return &Services{
+		paths:        systemServicePaths,
+		nvml:         api,
+		persistUID:   persistencedUID,
+		persistGID:   persistencedGID,
+		readyWait:    serviceReadyWait,
+		pollInterval: servicePollInterval,
+	}
+}
+
+// PreparePersistencedRuntime creates the measured 143:143 runtime directory
+// and removes stale PID and socket files without following unexpected types.
+func (s *Services) PreparePersistencedRuntime() error {
+	if err := os.MkdirAll(s.paths.persistencedRun, 0755); err != nil {
+		return fmt.Errorf("create nvidia-persistenced runtime: %w", err)
+	}
+	info, err := os.Lstat(s.paths.persistencedRun)
+	if err != nil {
+		return fmt.Errorf("inspect nvidia-persistenced runtime: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("nvidia-persistenced runtime %s is not a directory", s.paths.persistencedRun)
+	}
+	if err := os.Chown(s.paths.persistencedRun, s.persistUID, s.persistGID); err != nil {
+		return fmt.Errorf("chown nvidia-persistenced runtime: %w", err)
+	}
+	if err := os.Chmod(s.paths.persistencedRun, 0755); err != nil {
+		return fmt.Errorf("chmod nvidia-persistenced runtime: %w", err)
+	}
+	if err := removeRuntimeState(s.paths.persistencedPID, false); err != nil {
+		return fmt.Errorf("remove stale nvidia-persistenced PID: %w", err)
+	}
+	if err := removeRuntimeState(s.paths.persistencedSock, true); err != nil {
+		return fmt.Errorf("remove stale nvidia-persistenced socket: %w", err)
+	}
+	return nil
+}
+
+// PrepareFabricManagerRuntime creates the fixed Fabric Manager runtime
+// directory and removes stale PID and socket files without executing helpers
+// or following unexpected types.
+func (s *Services) PrepareFabricManagerRuntime() error {
+	if err := os.MkdirAll(s.paths.fabricRun, 0755); err != nil {
+		return fmt.Errorf("create NVIDIA Fabric Manager runtime: %w", err)
+	}
+	info, err := os.Lstat(s.paths.fabricRun)
+	if err != nil {
+		return fmt.Errorf("inspect NVIDIA Fabric Manager runtime: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("NVIDIA Fabric Manager runtime %s is not a directory", s.paths.fabricRun)
+	}
+	if err := os.Chmod(s.paths.fabricRun, 0755); err != nil {
+		return fmt.Errorf("chmod NVIDIA Fabric Manager runtime: %w", err)
+	}
+	if err := removeRuntimeState(s.paths.fabricPID, false); err != nil {
+		return fmt.Errorf("remove stale NVIDIA Fabric Manager PID: %w", err)
+	}
+	if err := removeRuntimeState(s.paths.fabricSock, true); err != nil {
+		return fmt.Errorf("remove stale NVIDIA Fabric Manager socket: %w", err)
+	}
+	return nil
+}
+
+// WaitForPersistenced waits for the fixed nvidia-persistenced Unix socket.
+func (s *Services) WaitForPersistenced(ctx context.Context) error {
+	return s.waitForService(ctx, "nvidia-persistenced", s.paths.persistencedPID, s.paths.persistencedSock)
+}
+
+// WaitForFabricManager waits for a regular, nonempty bounded PID file and the
+// fixed Fabric Manager Unix socket.
+func (s *Services) WaitForFabricManager(ctx context.Context) error {
+	return s.waitForService(ctx, "NVIDIA Fabric Manager", s.paths.fabricPID, s.paths.fabricSock)
+}
+
+func (s *Services) waitForService(ctx context.Context, name, pidPath, socketPath string) error {
+	waitCtx, cancel := context.WithTimeout(ctx, s.readyWait)
+	defer cancel()
+
+	var lastErr error
+	for {
+		if err := validateLivePID(pidPath); err != nil {
+			lastErr = fmt.Errorf("validate %s PID: %w", name, err)
+		} else if err := validateUnixSocket(socketPath); err != nil {
+			lastErr = fmt.Errorf("validate %s socket: %w", name, err)
+		} else {
+			return nil
+		}
+		if err := waitPoll(waitCtx, s.pollInterval); err != nil {
+			return fmt.Errorf("%s readiness failed (%v): %w", name, lastErr, err)
+		}
+	}
+}
+
+// WaitForNVML polls go-nvml directly until it reports exactly expected GPUs.
+// Every successful Init is paired with Shutdown before the next poll or return.
+func (s *Services) WaitForNVML(ctx context.Context, expected int) error {
+	if expected < 1 {
+		return fmt.Errorf("invalid expected GPU count %d", expected)
+	}
+	if s.nvml == nil {
+		return errors.New("NVML is not configured")
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, s.readyWait)
+	defer cancel()
+
+	var lastErr error
+	for {
+		lastErr = probeNVML(s.nvml, expected)
+		if lastErr == nil {
+			return nil
+		}
+		if err := waitPoll(waitCtx, s.pollInterval); err != nil {
+			return fmt.Errorf("NVIDIA NVML readiness failed (%v): %w", lastErr, err)
+		}
+	}
+}
+
+func probeNVML(api nvmlAPI, expected int) error {
+	if result := api.Init(); result != nvml.SUCCESS {
+		return fmt.Errorf("initialize NVML: %s", nvml.ErrorString(result))
+	}
+	count, countResult := api.DeviceGetCount()
+	shutdownResult := api.Shutdown()
+	if countResult != nvml.SUCCESS {
+		return fmt.Errorf("query NVML device count: %s", nvml.ErrorString(countResult))
+	}
+	if shutdownResult != nvml.SUCCESS {
+		return fmt.Errorf("shutdown NVML: %s", nvml.ErrorString(shutdownResult))
+	}
+	if count != expected {
+		return fmt.Errorf("NVML reported %d GPUs, want %d", count, expected)
+	}
+	return nil
+}
+
+// CreateCDITemporary creates an empty same-directory temporary file for the
+// bootstrap orchestrator to populate with the fixed CDI generator contract.
+func (s *Services) CreateCDITemporary() (string, error) {
+	directory := filepath.Dir(s.paths.cdiSpec)
+	if err := ensureDirectory(directory); err != nil {
+		return "", fmt.Errorf("prepare NVIDIA CDI directory: %w", err)
+	}
+	file, err := os.CreateTemp(directory, ".nvidia.yaml.*")
+	if err != nil {
+		return "", fmt.Errorf("create NVIDIA CDI temporary file: %w", err)
+	}
+	path := file.Name()
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("close NVIDIA CDI temporary file: %w", err)
+	}
+	return path, nil
+}
+
+// PublishCDI validates, syncs, and atomically renames a same-directory regular
+// nonempty temporary file over the fixed CDI destination, then syncs its
+// directory. Validation failures leave the existing destination untouched.
+func (s *Services) PublishCDI(temporary string) error {
+	destination := filepath.Clean(s.paths.cdiSpec)
+	temporary = filepath.Clean(temporary)
+	directory := filepath.Dir(destination)
+	if filepath.Dir(temporary) != directory || temporary == destination {
+		return fmt.Errorf("NVIDIA CDI temporary file %s is not a distinct same-directory file", temporary)
+	}
+
+	fd, err := unix.Open(temporary, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return fmt.Errorf("open NVIDIA CDI temporary file: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), temporary)
+	info, err := file.Stat()
+	if err == nil && !info.Mode().IsRegular() {
+		err = fmt.Errorf("%s is not a regular file", temporary)
+	}
+	if err == nil && info.Size() == 0 {
+		err = fmt.Errorf("%s is empty", temporary)
+	}
+	if err == nil {
+		err = file.Sync()
+	}
+	if err == nil {
+		pathInfo, pathErr := os.Lstat(temporary)
+		if pathErr != nil {
+			err = pathErr
+		} else if !pathInfo.Mode().IsRegular() || !os.SameFile(info, pathInfo) {
+			err = fmt.Errorf("%s changed during validation", temporary)
+		}
+	}
+	closeErr := file.Close()
+	if err != nil {
+		return fmt.Errorf("validate NVIDIA CDI temporary file: %w", err)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close NVIDIA CDI temporary file: %w", closeErr)
+	}
+	if err := os.Rename(temporary, destination); err != nil {
+		return fmt.Errorf("publish NVIDIA CDI specification: %w", err)
+	}
+	if err := syncDirectory(directory); err != nil {
+		return fmt.Errorf("sync NVIDIA CDI directory: %w", err)
+	}
+	return nil
+}
+
+func removeRuntimeState(path string, socket bool) error {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	valid := info.Mode().IsRegular()
+	if socket {
+		valid = info.Mode()&os.ModeSocket != 0
+	}
+	if !valid {
+		return fmt.Errorf("%s has unexpected type %s", path, info.Mode().Type())
+	}
+	return os.Remove(path)
+}
+
+func validateLivePID(path string) error {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return err
+	}
+	file := os.NewFile(uintptr(fd), path)
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", path)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxPIDFileSize+1))
+	if err != nil {
+		return err
+	}
+	if len(data) > maxPIDFileSize {
+		return fmt.Errorf("%s exceeds %d bytes", path, maxPIDFileSize)
+	}
+	value := strings.TrimSpace(string(data))
+	if value == "" {
+		return fmt.Errorf("%s contains an empty PID", path)
+	}
+	for _, digit := range value {
+		if digit < '0' || digit > '9' {
+			return fmt.Errorf("%s contains invalid PID %q", path, value)
+		}
+	}
+	pid, err := strconv.ParseInt(value, 10, 32)
+	if err != nil || pid < 1 {
+		return fmt.Errorf("%s contains invalid PID %q", path, value)
+	}
+	if err := unix.Kill(int(pid), 0); err != nil {
+		return fmt.Errorf("PID %d is not live: %w", pid, err)
+	}
+	return nil
+}
+
+func validateUnixSocket(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return fmt.Errorf("%s is not a Unix socket", path)
+	}
+	return nil
+}
+
+func syncDirectory(path string) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return file.Sync()
+}
+
+func waitPoll(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/tinfoil/internal/nvidia/services_test.go
+++ b/tinfoil/internal/nvidia/services_test.go
@@ -1,0 +1,413 @@
+package nvidia
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+type nvmlProbe struct {
+	initResult     nvml.Return
+	count          int
+	countResult    nvml.Return
+	shutdownResult nvml.Return
+}
+
+type fakeNVML struct {
+	mu        sync.Mutex
+	probes    []nvmlProbe
+	current   nvmlProbe
+	attempts  int
+	shutdowns int
+}
+
+func (f *fakeNVML) Init() nvml.Return {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	index := f.attempts
+	if index >= len(f.probes) {
+		index = len(f.probes) - 1
+	}
+	f.current = f.probes[index]
+	f.attempts++
+	return f.current.initResult
+}
+
+func (f *fakeNVML) DeviceGetCount() (int, nvml.Return) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.current.count, f.current.countResult
+}
+
+func (f *fakeNVML) Shutdown() nvml.Return {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.shutdowns++
+	return f.current.shutdownResult
+}
+
+func testServices(t *testing.T, api nvmlAPI) *Services {
+	t.Helper()
+	root := t.TempDir()
+	services := newServices(api)
+	services.paths = servicePaths{
+		persistencedRun:  filepath.Join(root, "run", "nvidia-persistenced"),
+		persistencedPID:  filepath.Join(root, "run", "nvidia-persistenced", "nvidia-persistenced.pid"),
+		persistencedSock: filepath.Join(root, "run", "nvidia-persistenced", "socket"),
+		fabricRun:        filepath.Join(root, "run", "nvidia-fabricmanager"),
+		fabricPID:        filepath.Join(root, "run", "nvidia-fabricmanager", "nv-fabricmanager.pid"),
+		fabricSock:       filepath.Join(root, "run", "nvidia-fabricmanager", "socket"),
+		cdiSpec:          filepath.Join(root, "run", "cdi", "nvidia.yaml"),
+	}
+	services.persistUID = os.Getuid()
+	services.persistGID = os.Getgid()
+	services.readyWait = 100 * time.Millisecond
+	services.pollInterval = time.Millisecond
+	return services
+}
+
+func writeServiceFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func listenUnix(t *testing.T, path string) net.Listener {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return listener
+}
+
+func TestNewServicesUsesMeasuredPersistencedIdentity(t *testing.T) {
+	services := NewServices()
+	if services.persistUID != 143 || services.persistGID != 143 {
+		t.Fatalf("persistenced identity = %d:%d, want 143:143", services.persistUID, services.persistGID)
+	}
+	if services.nvml == nil {
+		t.Fatal("NewServices did not configure NVML")
+	}
+}
+
+func TestPreparePersistencedRuntime(t *testing.T) {
+	services := testServices(t, nil)
+	if err := os.MkdirAll(services.paths.persistencedRun, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeServiceFile(t, services.paths.persistencedPID, "stale\n")
+	listenUnix(t, services.paths.persistencedSock)
+
+	if err := services.PreparePersistencedRuntime(); err != nil {
+		t.Fatalf("PreparePersistencedRuntime: %v", err)
+	}
+	info, err := os.Stat(services.paths.persistencedRun)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Fatalf("runtime mode = %#o, want 0755", info.Mode().Perm())
+	}
+	for _, path := range []string{services.paths.persistencedPID, services.paths.persistencedSock} {
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stale path %s remains: %v", path, err)
+		}
+	}
+}
+
+func TestPreparePersistencedRuntimeRejectsUnexpectedStaleType(t *testing.T) {
+	services := testServices(t, nil)
+	if err := os.MkdirAll(services.paths.persistencedPID, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := services.PreparePersistencedRuntime(); err == nil {
+		t.Fatal("PreparePersistencedRuntime accepted directory PID path")
+	}
+	if info, err := os.Stat(services.paths.persistencedPID); err != nil || !info.IsDir() {
+		t.Fatalf("unexpected PID path changed: %v, %v", info, err)
+	}
+}
+
+func TestPrepareFabricManagerRuntimeCreatesDirectory(t *testing.T) {
+	services := testServices(t, nil)
+
+	if err := services.PrepareFabricManagerRuntime(); err != nil {
+		t.Fatalf("PrepareFabricManagerRuntime: %v", err)
+	}
+	info, err := os.Stat(services.paths.fabricRun)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.IsDir() || info.Mode().Perm() != 0755 {
+		t.Fatalf("runtime mode = %v, want directory 0755", info.Mode())
+	}
+}
+
+func TestPrepareFabricManagerRuntimeRemovesStaleState(t *testing.T) {
+	services := testServices(t, nil)
+	if err := os.MkdirAll(services.paths.fabricRun, 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeServiceFile(t, services.paths.fabricPID, "stale\n")
+	listenUnix(t, services.paths.fabricSock)
+
+	if err := services.PrepareFabricManagerRuntime(); err != nil {
+		t.Fatalf("PrepareFabricManagerRuntime: %v", err)
+	}
+	info, err := os.Stat(services.paths.fabricRun)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Fatalf("runtime mode = %#o, want 0755", info.Mode().Perm())
+	}
+	for _, path := range []string{services.paths.fabricPID, services.paths.fabricSock} {
+		if _, err := os.Lstat(path); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("stale path %s remains: %v", path, err)
+		}
+	}
+}
+
+func TestPrepareFabricManagerRuntimeRejectsUnexpectedTypes(t *testing.T) {
+	t.Run("PID directory", func(t *testing.T) {
+		services := testServices(t, nil)
+		if err := os.MkdirAll(services.paths.fabricPID, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := services.PrepareFabricManagerRuntime(); err == nil {
+			t.Fatal("PrepareFabricManagerRuntime accepted directory PID path")
+		}
+		if info, err := os.Lstat(services.paths.fabricPID); err != nil || !info.IsDir() {
+			t.Fatalf("unexpected PID path changed: %v, %v", info, err)
+		}
+	})
+
+	t.Run("socket symlink", func(t *testing.T) {
+		services := testServices(t, nil)
+		target := filepath.Join(filepath.Dir(services.paths.fabricRun), "socket-target")
+		writeServiceFile(t, target, "preserve\n")
+		if err := os.MkdirAll(services.paths.fabricRun, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, services.paths.fabricSock); err != nil {
+			t.Fatal(err)
+		}
+		if err := services.PrepareFabricManagerRuntime(); err == nil {
+			t.Fatal("PrepareFabricManagerRuntime accepted socket symlink")
+		}
+		contents, err := os.ReadFile(target)
+		if err != nil || string(contents) != "preserve\n" {
+			t.Fatalf("symlink target changed to %q: %v", contents, err)
+		}
+		if info, err := os.Lstat(services.paths.fabricSock); err != nil || info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("socket symlink changed: %v, %v", info, err)
+		}
+	})
+
+	t.Run("runtime symlink", func(t *testing.T) {
+		services := testServices(t, nil)
+		target := filepath.Join(filepath.Dir(services.paths.fabricRun), "fabric-target")
+		if err := os.MkdirAll(target, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, services.paths.fabricRun); err != nil {
+			t.Fatal(err)
+		}
+		if err := services.PrepareFabricManagerRuntime(); err == nil {
+			t.Fatal("PrepareFabricManagerRuntime accepted runtime symlink")
+		}
+		if info, err := os.Lstat(services.paths.fabricRun); err != nil || info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("runtime symlink changed: %v, %v", info, err)
+		}
+	})
+}
+
+func TestWaitForPersistencedRequiresUnixSocket(t *testing.T) {
+	services := testServices(t, nil)
+	writeServiceFile(t, services.paths.persistencedPID, strconv.Itoa(os.Getpid())+"\n")
+	writeServiceFile(t, services.paths.persistencedSock, "not a socket")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	if err := services.WaitForPersistenced(ctx); err == nil {
+		t.Fatal("WaitForPersistenced accepted regular file")
+	}
+	if err := os.Remove(services.paths.persistencedSock); err != nil {
+		t.Fatal(err)
+	}
+	listenUnix(t, services.paths.persistencedSock)
+	if err := services.WaitForPersistenced(context.Background()); err != nil {
+		t.Fatalf("WaitForPersistenced: %v", err)
+	}
+}
+
+func TestWaitForFabricManagerRequiresPIDAndSocket(t *testing.T) {
+	services := testServices(t, nil)
+	writeServiceFile(t, services.paths.fabricPID, "")
+	listenUnix(t, services.paths.fabricSock)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	if err := services.WaitForFabricManager(ctx); err == nil {
+		t.Fatal("WaitForFabricManager accepted empty PID file")
+	}
+
+	writeServiceFile(t, services.paths.fabricPID, strconv.Itoa(os.Getpid())+"\n")
+	if err := services.WaitForFabricManager(context.Background()); err != nil {
+		t.Fatalf("WaitForFabricManager: %v", err)
+	}
+}
+
+func TestWaitForFabricManagerRejectsPIDLinksAndOversize(t *testing.T) {
+	services := testServices(t, nil)
+	writeServiceFile(t, services.paths.fabricPID+".target", strconv.Itoa(os.Getpid())+"\n")
+	if err := os.Symlink(services.paths.fabricPID+".target", services.paths.fabricPID); err != nil {
+		t.Fatal(err)
+	}
+	listenUnix(t, services.paths.fabricSock)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	if err := services.WaitForFabricManager(ctx); err == nil {
+		t.Fatal("WaitForFabricManager followed PID symlink")
+	}
+	if err := os.Remove(services.paths.fabricPID); err != nil {
+		t.Fatal(err)
+	}
+	writeServiceFile(t, services.paths.fabricPID, strings.Repeat("1", maxPIDFileSize+1))
+	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	if err := services.WaitForFabricManager(ctx); err == nil {
+		t.Fatal("WaitForFabricManager accepted oversized PID file")
+	}
+}
+
+func TestWaitForNVMLPollsExactCountAndShutsDown(t *testing.T) {
+	api := &fakeNVML{probes: []nvmlProbe{
+		{initResult: nvml.ERROR_UNINITIALIZED},
+		{initResult: nvml.SUCCESS, count: 7, countResult: nvml.SUCCESS, shutdownResult: nvml.SUCCESS},
+		{initResult: nvml.SUCCESS, count: 8, countResult: nvml.SUCCESS, shutdownResult: nvml.SUCCESS},
+	}}
+	services := testServices(t, api)
+	if err := services.WaitForNVML(context.Background(), 8); err != nil {
+		t.Fatalf("WaitForNVML: %v", err)
+	}
+	if api.attempts != 3 || api.shutdowns != 2 {
+		t.Fatalf("NVML attempts/shutdowns = %d/%d, want 3/2", api.attempts, api.shutdowns)
+	}
+}
+
+func TestWaitForNVMLShutsDownAfterCountFailure(t *testing.T) {
+	api := &fakeNVML{probes: []nvmlProbe{
+		{initResult: nvml.SUCCESS, countResult: nvml.ERROR_UNKNOWN, shutdownResult: nvml.SUCCESS},
+		{initResult: nvml.SUCCESS, count: 1, countResult: nvml.SUCCESS, shutdownResult: nvml.SUCCESS},
+	}}
+	services := testServices(t, api)
+	if err := services.WaitForNVML(context.Background(), 1); err != nil {
+		t.Fatalf("WaitForNVML: %v", err)
+	}
+	if api.shutdowns != 2 {
+		t.Fatalf("Shutdown calls = %d, want 2", api.shutdowns)
+	}
+}
+
+func TestWaitForNVMLRejectsInvalidExpectedCount(t *testing.T) {
+	services := testServices(t, nil)
+	for _, count := range []int{-1, 0} {
+		if err := services.WaitForNVML(context.Background(), count); err == nil {
+			t.Fatalf("WaitForNVML accepted invalid expected count %d", count)
+		}
+	}
+}
+
+func TestCreateAndPublishCDIAtomically(t *testing.T) {
+	services := testServices(t, nil)
+	writeServiceFile(t, services.paths.cdiSpec, "old\n")
+	temporary, err := services.CreateCDITemporary()
+	if err != nil {
+		t.Fatalf("CreateCDITemporary: %v", err)
+	}
+	if filepath.Dir(temporary) != filepath.Dir(services.paths.cdiSpec) {
+		t.Fatalf("temporary directory = %s", filepath.Dir(temporary))
+	}
+	if err := os.WriteFile(temporary, []byte("new\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := services.PublishCDI(temporary); err != nil {
+		t.Fatalf("PublishCDI: %v", err)
+	}
+	contents, err := os.ReadFile(services.paths.cdiSpec)
+	if err != nil || string(contents) != "new\n" {
+		t.Fatalf("published CDI = %q, %v", contents, err)
+	}
+	if _, err := os.Lstat(temporary); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary still exists: %v", err)
+	}
+}
+
+func TestPublishCDIPreservesOldFileOnValidationFailure(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(*testing.T, *Services) string
+	}{
+		{
+			name: "empty",
+			setup: func(t *testing.T, services *Services) string {
+				path, err := services.CreateCDITemporary()
+				if err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+		},
+		{
+			name: "different directory",
+			setup: func(t *testing.T, _ *Services) string {
+				path := filepath.Join(t.TempDir(), "nvidia.yaml")
+				writeServiceFile(t, path, "new\n")
+				return path
+			},
+		},
+		{
+			name: "symlink",
+			setup: func(t *testing.T, services *Services) string {
+				target := filepath.Join(filepath.Dir(services.paths.cdiSpec), "target")
+				writeServiceFile(t, target, "new\n")
+				path := filepath.Join(filepath.Dir(services.paths.cdiSpec), ".nvidia.yaml.link")
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			services := testServices(t, nil)
+			writeServiceFile(t, services.paths.cdiSpec, "old\n")
+			temporary := test.setup(t, services)
+			if err := services.PublishCDI(temporary); err == nil {
+				t.Fatal("PublishCDI accepted invalid temporary file")
+			}
+			contents, err := os.ReadFile(services.paths.cdiSpec)
+			if err != nil || string(contents) != "old\n" {
+				t.Fatalf("old CDI changed to %q: %v", contents, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add execution-free NVIDIA persistenced, Fabric Manager, NVML, and CDI readiness/publication helpers
- require exact PCI GPU/device readiness, UVM/capability nodes, and fail closed on VPD read errors
- pin the measured `nvidia-persistenced` identity to `143:143` with fixed runtime paths

## Security properties
- no command runner, child wait path, passwd parser, generic module loader, or `nvidia-smi` text parser
- direct Fabric Manager PID/socket contract and bounded NVML polling
- same-directory atomic CDI publication
- fixed NVIDIA device and capability contracts only

## Validation
- `gofmt` on all changed Go files
- 100 focused `internal/nvidia` test runs
- `go test -race -count=50 ./internal/nvidia`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

Hardware validation on H200, B300, and NVSwitch systems remains required after the complete bootstrap stack lands, but does not block this source-only helper slice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bounded NVIDIA userspace helpers to prepare and validate `nvidia-persistenced` and Fabric Manager, poll `github.com/NVIDIA/go-nvml/pkg/nvml` for exact GPU counts, and publish CDI atomically. Tightens device setup with exact GPU minors and UVM/capability nodes, and adds fail-closed VPD-based fabric detection.

- **New Features**
  - New `Services` helpers: prepare fixed runtime dirs, remove type-safe stale state, wait for PID/socket, poll `nvml` for an exact GPU count, and same-dir atomic CDI publish.
  - Persistenced identity pinned to UID:GID 143:143 with fixed `/run/nvidia-persistenced` paths; rejects symlinks and oversized PID files.
  - Fabric Manager runtime mirrors persistenced; `WaitForFabricManager` validates a live PID and Unix socket.
  - Fabric detection: `DetectFabricMode` uses NVSwitch presence and vendor-independent SW_MNG VPD; returns `FabricModeFabricManager` when needed and typed `ErrNVL5RequiresNVLSM` for NVL5 without NVLSM.
  - Device nodes split: `SetupCoreDeviceNodes(expectedGPUs)` and `SetupUVMDeviceNodes(expectedGPUs)` require the driver to report the exact GPU count and, when requested, UVM + allowlisted capability descriptors.
  - `GPUCount()` returns only exact NVIDIA VGA/3D classes; unreadable or malformed PCI identities fail closed.
  - Focused tests cover services, device readiness, VPD handling, and fabric-mode selection.

- **Refactors**
  - Simplified read-only VPD scanning and cleanup with bounded `scanSWManagementVPD`; never follows symlinks and fails closed on read errors.

<sup>Written for commit f7a732f178b4cb01a94899af696d98c73ce6c3ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

