### PR TITLE
Compose the CPU PID 1 lifecycle

### DIFF
--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -30,7 +30,7 @@ const (
 	defaultPidsLimit   int64 = 65536
 )
 
-func setupContainerNetwork(cli *client.Client, cfg *Config) error {
+func setupContainerNetwork(ctx context.Context, cli *client.Client, cfg *Config) error {
 	for name := range cfg.Networks {
 		if err := ensureNetwork(cli, name); err != nil {
 			return err
@@ -41,7 +41,7 @@ func setupContainerNetwork(cli *client.Client, cfg *Config) error {
 			return err
 		}
 	}
-	return setupContainerNetworkFirewall(cfg)
+	return setupContainerNetworkFirewall(ctx, cfg)
 }
 
 func ensureNetwork(cli *client.Client, name string) error {
@@ -108,7 +108,7 @@ func networkCreateOptions(name string) dockernetwork.CreateOptions {
 }
 
 // launchContainers starts all containers from the config
-func launchContainers(config *Config, extConfig *shimconfig.ExternalConfig) error {
+func launchContainers(ctx context.Context, config *Config, extConfig *shimconfig.ExternalConfig) error {
 	if len(config.Containers) == 0 {
 		log.Println("No containers to launch")
 		return nil
@@ -120,7 +120,7 @@ func launchContainers(config *Config, extConfig *shimconfig.ExternalConfig) erro
 	}
 	defer cli.Close()
 
-	if err := setupContainerNetwork(cli, config); err != nil {
+	if err := setupContainerNetwork(ctx, cli, config); err != nil {
 		return fmt.Errorf("creating container network: %w", err)
 	}
 
@@ -148,7 +148,7 @@ func launchContainers(config *Config, extConfig *shimconfig.ExternalConfig) erro
 // launchContainersAndWaitHealthy launches all containers in parallel with
 // health checking. Each container is tracked as a substage of "containers"
 // with per-phase sub-substages (pull, start, healthy).
-func launchContainersAndWaitHealthy(tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig) error {
+func launchContainersAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig) error {
 	if len(config.Containers) == 0 {
 		log.Println("No containers to launch")
 		tracker.Record(boot.StageContainers, boot.StatusSkipped, 0, "no containers")
@@ -161,7 +161,7 @@ func launchContainersAndWaitHealthy(tracker *boot.Tracker, config *Config, extCo
 	}
 	defer cli.Close()
 
-	if err := setupContainerNetwork(cli, config); err != nil {
+	if err := setupContainerNetwork(ctx, cli, config); err != nil {
 		return fmt.Errorf("creating container network: %w", err)
 	}
 

--- a/tinfoil/cmd/boot/firewall.go
+++ b/tinfoil/cmd/boot/firewall.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -9,6 +10,7 @@ import (
 	"strings"
 
 	"tinfoil/internal/containernet"
+	"tinfoil/internal/egress"
 )
 
 // Non-public destination ranges blocked even on `egress: open` and
@@ -28,12 +30,26 @@ const (
 	nonPublicIPv6Ranges = "{ fc00::/7, fe80::/10, ff00::/8, ::ffff:0:0/96, 64:ff9b::/96, 100::/64, 2001:db8::/32, ::1/128 }"
 )
 
+type egressPopulator interface {
+	Populate(context.Context) error
+}
+
 // setupContainerNetworkFirewall installs one bridge's worth of nftables
 // rules per declared network plus the implicit shim-net, in a single
-// transaction, then starts tinfoil-egress if any network needs it.
+// transaction, then synchronously populates any allowlist sets.
 // Must be called after the bridge interfaces exist so iif/oif resolve
 // by index.
 func setupContainerNetworkFirewall(cfg *Config) error {
+	return setupContainerNetworkFirewallWith(cfg, runNft, func() (egressPopulator, error) {
+		return egress.Load()
+	})
+}
+
+func setupContainerNetworkFirewallWith(
+	cfg *Config,
+	applyNft func(string) error,
+	loadEgress func() (egressPopulator, error),
+) error {
 	names := make([]string, 0, len(cfg.Networks))
 	for k := range cfg.Networks {
 		names = append(names, k)
@@ -47,7 +63,7 @@ func setupContainerNetworkFirewall(cfg *Config) error {
 	if shimUpstreamSet(cfg) {
 		writeBridgeRules(&script, containernet.ShimNetName, &NetworkSpec{Egress: "closed"})
 	}
-	if err := runNft(script.String()); err != nil {
+	if err := applyNft(script.String()); err != nil {
 		return fmt.Errorf("installing container-network firewall rules: %w", err)
 	}
 
@@ -62,12 +78,13 @@ func setupContainerNetworkFirewall(cfg *Config) error {
 		if spec.Egress != "allowlist" {
 			continue
 		}
-		// Type=notify; `systemctl start` blocks until the daemon resolves
-		// the first set of IPs and signals READY=1, so failures here
-		// surface as a boot error.
-		log.Println("Firewall: starting tinfoil-egress for initial IP population")
-		if out, err := exec.Command("systemctl", "start", "tinfoil-egress.service").CombinedOutput(); err != nil {
-			return fmt.Errorf("tinfoil-egress.service failed on initial run: %w (%s)", err, out)
+		engine, err := loadEgress()
+		if err != nil {
+			return fmt.Errorf("loading egress policy: %w", err)
+		}
+		log.Println("Firewall: populating egress allowlists")
+		if err := engine.Populate(context.Background()); err != nil {
+			return fmt.Errorf("populating egress allowlists: %w", err)
 		}
 		break
 	}

--- a/tinfoil/cmd/boot/firewall.go
+++ b/tinfoil/cmd/boot/firewall.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 
 	"tinfoil/internal/containernet"
 	"tinfoil/internal/egress"
@@ -26,8 +27,9 @@ import (
 //   - RFC 6890 / IANA IPv4 Special-Purpose Address Registry: loopback,
 //     "this network", benchmarking, multicast, reserved, and broadcast space.
 const (
-	nonPublicIPv4Ranges = "{ 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.2.0/24, 192.168.0.0/16, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 240.0.0.0/4, 255.255.255.255/32 }"
-	nonPublicIPv6Ranges = "{ fc00::/7, fe80::/10, ff00::/8, ::ffff:0:0/96, 64:ff9b::/96, 100::/64, 2001:db8::/32, ::1/128 }"
+	nonPublicIPv4Ranges            = "{ 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.2.0/24, 192.168.0.0/16, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 240.0.0.0/4, 255.255.255.255/32 }"
+	nonPublicIPv6Ranges            = "{ fc00::/7, fe80::/10, ff00::/8, ::ffff:0:0/96, 64:ff9b::/96, 100::/64, 2001:db8::/32, ::1/128 }"
+	egressInitialPopulationTimeout = 30 * time.Second
 )
 
 type egressPopulator interface {
@@ -39,13 +41,14 @@ type egressPopulator interface {
 // transaction, then synchronously populates any allowlist sets.
 // Must be called after the bridge interfaces exist so iif/oif resolve
 // by index.
-func setupContainerNetworkFirewall(cfg *Config) error {
-	return setupContainerNetworkFirewallWith(cfg, runNft, func() (egressPopulator, error) {
+func setupContainerNetworkFirewall(ctx context.Context, cfg *Config) error {
+	return setupContainerNetworkFirewallWith(ctx, cfg, runNft, func() (egressPopulator, error) {
 		return egress.Load()
 	})
 }
 
 func setupContainerNetworkFirewallWith(
+	ctx context.Context,
 	cfg *Config,
 	applyNft func(string) error,
 	loadEgress func() (egressPopulator, error),
@@ -83,7 +86,10 @@ func setupContainerNetworkFirewallWith(
 			return fmt.Errorf("loading egress policy: %w", err)
 		}
 		log.Println("Firewall: populating egress allowlists")
-		if err := engine.Populate(context.Background()); err != nil {
+		populationCtx, cancel := context.WithTimeout(ctx, egressInitialPopulationTimeout)
+		err = engine.Populate(populationCtx)
+		cancel()
+		if err != nil {
 			return fmt.Errorf("populating egress allowlists: %w", err)
 		}
 		break

--- a/tinfoil/cmd/boot/firewall_test.go
+++ b/tinfoil/cmd/boot/firewall_test.go
@@ -6,16 +6,17 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	shimconfig "tinfoil/internal/config"
 )
 
 type fakeEgressPopulator struct {
-	populate func() error
+	populate func(context.Context) error
 }
 
-func (f fakeEgressPopulator) Populate(context.Context) error {
-	return f.populate()
+func (f fakeEgressPopulator) Populate(ctx context.Context) error {
+	return f.populate(ctx)
 }
 
 func TestFirewall_AllowlistPopulationFollowsNftOnce(t *testing.T) {
@@ -25,6 +26,7 @@ func TestFirewall_AllowlistPopulationFollowsNftOnce(t *testing.T) {
 	}}
 	var events []string
 	err := setupContainerNetworkFirewallWith(
+		context.Background(),
 		cfg,
 		func(string) error {
 			events = append(events, "nft")
@@ -32,7 +34,7 @@ func TestFirewall_AllowlistPopulationFollowsNftOnce(t *testing.T) {
 		},
 		func() (egressPopulator, error) {
 			events = append(events, "load")
-			return fakeEgressPopulator{populate: func() error {
+			return fakeEgressPopulator{populate: func(context.Context) error {
 				events = append(events, "populate")
 				return nil
 			}}, nil
@@ -53,6 +55,7 @@ func TestFirewall_NoAllowlistSkipsPopulation(t *testing.T) {
 	}}
 	loaded := false
 	err := setupContainerNetworkFirewallWith(
+		context.Background(),
 		cfg,
 		func(string) error { return nil },
 		func() (egressPopulator, error) {
@@ -75,10 +78,11 @@ func TestFirewall_PopulationFailureAbortsSetup(t *testing.T) {
 	}}
 	populateCalls := 0
 	err := setupContainerNetworkFirewallWith(
+		context.Background(),
 		cfg,
 		func(string) error { return nil },
 		func() (egressPopulator, error) {
-			return fakeEgressPopulator{populate: func() error {
+			return fakeEgressPopulator{populate: func(context.Context) error {
 				populateCalls++
 				return wantErr
 			}}, nil
@@ -89,6 +93,77 @@ func TestFirewall_PopulationFailureAbortsSetup(t *testing.T) {
 	}
 	if populateCalls != 1 {
 		t.Fatalf("Populate calls = %d, want 1", populateCalls)
+	}
+}
+
+func TestFirewall_PopulationHasFixedBootDeadline(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
+	}}
+	err := setupContainerNetworkFirewallWith(
+		context.Background(),
+		cfg,
+		func(string) error { return nil },
+		func() (egressPopulator, error) {
+			return fakeEgressPopulator{populate: func(ctx context.Context) error {
+				deadline, ok := ctx.Deadline()
+				if !ok {
+					t.Fatal("population context has no deadline")
+				}
+				remaining := time.Until(deadline)
+				if remaining > egressInitialPopulationTimeout || remaining < egressInitialPopulationTimeout-time.Second {
+					t.Fatalf("population deadline = %s, want %s", remaining, egressInitialPopulationTimeout)
+				}
+				return nil
+			}}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFirewall_PopulationInheritsBootCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
+	}}
+	err := setupContainerNetworkFirewallWith(
+		ctx,
+		cfg,
+		func(string) error { return nil },
+		func() (egressPopulator, error) {
+			return fakeEgressPopulator{populate: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			}}, nil
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("setup error = %v, want boot cancellation", err)
+	}
+}
+
+func TestFirewall_PopulationHonorsEarlierBootDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
+	}}
+	err := setupContainerNetworkFirewallWith(
+		ctx,
+		cfg,
+		func(string) error { return nil },
+		func() (egressPopulator, error) {
+			return fakeEgressPopulator{populate: func(ctx context.Context) error {
+				<-ctx.Done()
+				return ctx.Err()
+			}}, nil
+		},
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("setup error = %v, want boot deadline", err)
 	}
 }
 

--- a/tinfoil/cmd/boot/firewall_test.go
+++ b/tinfoil/cmd/boot/firewall_test.go
@@ -1,11 +1,96 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	shimconfig "tinfoil/internal/config"
 )
+
+type fakeEgressPopulator struct {
+	populate func() error
+}
+
+func (f fakeEgressPopulator) Populate(context.Context) error {
+	return f.populate()
+}
+
+func TestFirewall_AllowlistPopulationFollowsNftOnce(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
+		"metrics": {Egress: "allowlist", Allow: []string{"metrics.tinfoil.sh"}},
+	}}
+	var events []string
+	err := setupContainerNetworkFirewallWith(
+		cfg,
+		func(string) error {
+			events = append(events, "nft")
+			return nil
+		},
+		func() (egressPopulator, error) {
+			events = append(events, "load")
+			return fakeEgressPopulator{populate: func() error {
+				events = append(events, "populate")
+				return nil
+			}}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{"nft", "load", "populate"}; !reflect.DeepEqual(events, want) {
+		t.Fatalf("effects = %v, want %v", events, want)
+	}
+}
+
+func TestFirewall_NoAllowlistSkipsPopulation(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"ipc": {Egress: "closed"},
+		"web": {Egress: "open"},
+	}}
+	loaded := false
+	err := setupContainerNetworkFirewallWith(
+		cfg,
+		func(string) error { return nil },
+		func() (egressPopulator, error) {
+			loaded = true
+			return nil, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded {
+		t.Fatal("loaded egress engine without an allowlist network")
+	}
+}
+
+func TestFirewall_PopulationFailureAbortsSetup(t *testing.T) {
+	wantErr := errors.New("resolution failed")
+	cfg := &Config{Networks: map[string]*NetworkSpec{
+		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
+	}}
+	populateCalls := 0
+	err := setupContainerNetworkFirewallWith(
+		cfg,
+		func(string) error { return nil },
+		func() (egressPopulator, error) {
+			return fakeEgressPopulator{populate: func() error {
+				populateCalls++
+				return wantErr
+			}}, nil
+		},
+	)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("setup error = %v, want %v", err, wantErr)
+	}
+	if populateCalls != 1 {
+		t.Fatalf("Populate calls = %d, want 1", populateCalls)
+	}
+}
 
 // renderFirewallScript returns the nft script setupContainerNetworkFirewall
 // would commit, minus the runNft call.

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -12,12 +12,18 @@ import (
 	"tinfoil/internal/boot"
 )
 
+type notifyContextFunc func(context.Context, ...os.Signal) (context.Context, context.CancelFunc)
+
 func init() {
 	log.SetFlags(0)
 }
 
 func main() {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	command := ""
+	if len(os.Args) > 1 {
+		command = os.Args[1]
+	}
+	ctx, stop := commandContext(command, signal.NotifyContext)
 	defer stop()
 
 	if len(os.Args) > 1 {
@@ -36,6 +42,13 @@ func main() {
 	}
 
 	log.Println("Tinfoil boot complete")
+}
+
+func commandContext(command string, notify notifyContextFunc) (context.Context, context.CancelFunc) {
+	if command == "models" {
+		return context.Background(), func() {}
+	}
+	return notify(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 }
 
 func runSubcommand(ctx context.Context, cmd string) error {

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"tinfoil/internal/boot"
@@ -15,8 +17,11 @@ func init() {
 }
 
 func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
 	if len(os.Args) > 1 {
-		if err := runSubcommand(os.Args[1]); err != nil {
+		if err := runSubcommand(ctx, os.Args[1]); err != nil {
 			log.Printf("Failed: %v", err)
 			os.Exit(1)
 		}
@@ -25,7 +30,7 @@ func main() {
 
 	log.Println("Tinfoil boot starting")
 
-	if err := run(); err != nil {
+	if err := run(ctx); err != nil {
 		log.Printf("Boot failed: %v", err)
 		os.Exit(1)
 	}
@@ -33,7 +38,7 @@ func main() {
 	log.Println("Tinfoil boot complete")
 }
 
-func runSubcommand(cmd string) error {
+func runSubcommand(ctx context.Context, cmd string) error {
 	switch cmd {
 	case "containers", "models":
 	default:
@@ -63,7 +68,7 @@ func runSubcommand(cmd string) error {
 			return fmt.Errorf("registry auth setup failed: %w", err)
 		}
 		log.Println("Launching containers")
-		return launchContainers(config, externalConfig)
+		return launchContainers(ctx, config, externalConfig)
 	case "models":
 		externalConfig, err := getExternalConfig()
 		if err != nil {
@@ -75,7 +80,7 @@ func runSubcommand(cmd string) error {
 	return nil
 }
 
-func run() error {
+func run(ctx context.Context) error {
 	tracker := boot.NewTracker(boot.InitialStages)
 
 	// 1. Config
@@ -96,7 +101,7 @@ func run() error {
 	// 2. Network
 	start = time.Now()
 	log.Println("Configuring guest network")
-	networkDetail, err := configureGuestNetwork(context.Background(), externalConfig.Network)
+	networkDetail, err := configureGuestNetwork(ctx, externalConfig.Network)
 	if err != nil {
 		tracker.Record(boot.StageNetwork, boot.StatusFailed, time.Since(start), err.Error())
 		return fmt.Errorf("network configuration failed: %w", err)
@@ -208,7 +213,7 @@ func run() error {
 
 	// 11. Containers + health checks
 	log.Println("Launching containers")
-	if err := launchContainersAndWaitHealthy(tracker, config, externalConfig); err != nil {
+	if err := launchContainersAndWaitHealthy(ctx, tracker, config, externalConfig); err != nil {
 		return err
 	}
 

--- a/tinfoil/cmd/boot/main_test.go
+++ b/tinfoil/cmd/boot/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"os"
+	"reflect"
+	"syscall"
+	"testing"
+)
+
+func TestCommandContextLeavesModelsSignalsAtDefaults(t *testing.T) {
+	notifyCalled := false
+	ctx, stop := commandContext("models", func(context.Context, ...os.Signal) (context.Context, context.CancelFunc) {
+		notifyCalled = true
+		return context.WithCancel(context.Background())
+	})
+	defer stop()
+	if notifyCalled {
+		t.Fatal("models command captured process signals")
+	}
+	if ctx.Done() != nil {
+		t.Fatal("models command received a cancellable context")
+	}
+}
+
+func TestCommandContextCapturesSignalsForCancellableBootPaths(t *testing.T) {
+	for _, command := range []string{"", "containers"} {
+		t.Run(command, func(t *testing.T) {
+			var gotSignals []os.Signal
+			ctx, stop := commandContext(command, func(parent context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {
+				gotSignals = append(gotSignals, signals...)
+				return context.WithCancel(parent)
+			})
+			if !reflect.DeepEqual(gotSignals, []os.Signal{syscall.SIGTERM, syscall.SIGINT}) {
+				t.Fatalf("captured signals = %v", gotSignals)
+			}
+			stop()
+			select {
+			case <-ctx.Done():
+			default:
+				t.Fatal("signal stop did not cancel command context")
+			}
+		})
+	}
+}

--- a/tinfoil/cmd/egress/main.go
+++ b/tinfoil/cmd/egress/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -10,6 +9,11 @@ import (
 
 	"tinfoil/internal/egress"
 )
+
+type egressRunner interface {
+	Configured() bool
+	Run(context.Context, func(error))
+}
 
 func init() {
 	log.SetFlags(0)
@@ -23,7 +27,15 @@ func main() {
 }
 
 func run() error {
-	engine, err := egress.Load()
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+	return runWith(ctx, func() (egressRunner, error) {
+		return egress.Load()
+	})
+}
+
+func runWith(ctx context.Context, load func() (egressRunner, error)) error {
+	engine, err := load()
 	if err != nil {
 		return err
 	}
@@ -31,13 +43,8 @@ func run() error {
 		log.Println("no allowlist networks configured, exiting")
 		return nil
 	}
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
-
-	if err := engine.Populate(ctx); err != nil {
-		return fmt.Errorf("initial population: %w", err)
-	}
-
+	// Boot owns the readiness-gating initial population. This service only
+	// refreshes the already-populated sets at the fixed engine interval.
 	engine.Run(ctx, func(err error) {
 		log.Printf("refresh failed: %v", err)
 	})

--- a/tinfoil/cmd/egress/main.go
+++ b/tinfoil/cmd/egress/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -35,36 +34,13 @@ func run() error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	// Initial population must succeed before notifying systemd; tinfoil-boot
-	// blocks on `systemctl start` until READY=1 so any failure here surfaces
-	// as a boot error.
 	if err := engine.Populate(ctx); err != nil {
 		return fmt.Errorf("initial population: %w", err)
 	}
-	notifyReady()
 
 	engine.Run(ctx, func(err error) {
 		log.Printf("refresh failed: %v", err)
 	})
 	log.Println("shutting down")
 	return nil
-}
-
-// notifyReady sends READY=1 over the systemd NOTIFY_SOCKET so the unit
-// transitions to active only after the first successful resolution. No-op
-// when not running under systemd Type=notify (NOTIFY_SOCKET unset).
-func notifyReady() {
-	addr := os.Getenv("NOTIFY_SOCKET")
-	if addr == "" {
-		return
-	}
-	conn, err := net.DialUnix("unixgram", nil, &net.UnixAddr{Name: addr, Net: "unixgram"})
-	if err != nil {
-		log.Printf("sd_notify dial: %v", err)
-		return
-	}
-	defer conn.Close()
-	if _, err := conn.Write([]byte("READY=1")); err != nil {
-		log.Printf("sd_notify write: %v", err)
-	}
 }

--- a/tinfoil/cmd/egress/main_test.go
+++ b/tinfoil/cmd/egress/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeRunner struct {
+	configured bool
+	runCalls   int
+}
+
+func (f *fakeRunner) Configured() bool {
+	return f.configured
+}
+
+func (f *fakeRunner) Run(ctx context.Context, _ func(error)) {
+	f.runCalls++
+	<-ctx.Done()
+}
+
+func TestRunWithStartsRefreshLoopWithoutInitialPopulation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	runner := &fakeRunner{configured: true}
+	if err := runWith(ctx, func() (egressRunner, error) { return runner, nil }); err != nil {
+		t.Fatal(err)
+	}
+	if runner.runCalls != 1 {
+		t.Fatalf("Run calls = %d, want 1", runner.runCalls)
+	}
+}
+
+func TestRunWithPropagatesLoadFailure(t *testing.T) {
+	wantErr := errors.New("load failed")
+	err := runWith(context.Background(), func() (egressRunner, error) {
+		return nil, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runWith error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRunWithSkipsUnconfiguredEngine(t *testing.T) {
+	runner := &fakeRunner{}
+	if err := runWith(context.Background(), func() (egressRunner, error) { return runner, nil }); err != nil {
+		t.Fatal(err)
+	}
+	if runner.runCalls != 0 {
+		t.Fatalf("Run calls = %d, want 0", runner.runCalls)
+	}
+}

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -1,0 +1,485 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"tinfoil/internal/boot"
+	"tinfoil/internal/pid1/hardening"
+	pidruntime "tinfoil/internal/pid1/runtime"
+	"tinfoil/internal/pid1/supervisor"
+)
+
+const (
+	bootTimeout          = 5 * time.Minute
+	containerdReadyLimit = 30 * time.Second
+	dockerReadyLimit     = 60 * time.Second
+	shimReadyLimit       = 30 * time.Second
+	oneShotStopGrace     = 2 * time.Second
+	serviceTermGrace     = 10 * time.Second
+	serviceKillGrace     = 5 * time.Second
+
+	containerdName   = "containerd"
+	dockerName       = "dockerd"
+	statusName       = "tinfoil-container-status"
+	shimName         = "tinfoil-shim"
+	egressName       = "tinfoil-egress"
+	containerdSocket = "/run/containerd/containerd.sock"
+	dockerSocket     = "/run/docker.sock"
+	readyPath        = "/run/tinfoil-init.ready"
+	selfExecPath     = "/proc/self/exe"
+	pid1Env          = "TINFOIL_PID1"
+	pid1EnvValue     = "tinfoil-init"
+	kmsgInfoPrefix   = "<6>"
+)
+
+var consoleMu sync.Mutex
+
+func main() {
+	log.SetFlags(0)
+	if len(os.Args) > 1 && os.Args[1] == "--exec-service" {
+		if err := execService(os.Args[2:], hardening.ApplyService, syscall.Exec); err != nil {
+			fmt.Fprintf(os.Stderr, "tinfoil-init: exec-service: %v\n", err)
+			os.Exit(127)
+		}
+		panic("syscall.Exec returned without an error")
+	}
+	runPID1()
+}
+
+func runPID1() {
+	_ = os.Setenv("PATH", "/usr/sbin:/usr/bin:/sbin:/bin")
+	_ = os.Setenv(pid1Env, pid1EnvValue)
+	if os.Getpid() != 1 {
+		initLogf("warning: running with pid %d, expected pid 1", os.Getpid())
+	}
+
+	// This is the lifetime context. The boot deadline is deliberately created
+	// inside run and can never end post-boot supervision.
+	parent, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	err := run(parent)
+	if err == nil {
+		initLogf("shutdown complete; powering off")
+		if powerErr := unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF); powerErr != nil {
+			initLogf("power off failed: %v; parking", powerErr)
+		}
+	} else {
+		initLogf("fatal after cleanup: %v; parking", err)
+	}
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+type serviceControl interface {
+	Start(context.Context, supervisor.Service) error
+	Drain([][]string, time.Duration, time.Duration) error
+}
+
+type lifecycleDeps struct {
+	services serviceControl
+	oneShot  func(context.Context, supervisor.Command) error
+	setupFS  func(pidruntime.LogFunc) error
+	sysctls  func(pidruntime.LogFunc) error
+	ramdisk  func(pidruntime.LogFunc) error
+	limits   func() error
+	syslog   func(context.Context)
+	exists   func(string) (bool, error)
+	timeout  time.Duration
+	term     time.Duration
+	kill     time.Duration
+}
+
+func run(parent context.Context) error {
+	readiness := newReadiness(requiredServiceNames(), setReady)
+	manager := supervisor.NewManager(initLogf)
+	services := supervisor.New(parent, manager, supervisor.Config{Observe: readiness.Update})
+	deps := lifecycleDeps{
+		services: services,
+		oneShot: func(ctx context.Context, command supervisor.Command) error {
+			return runOneShot(ctx, manager, command, oneShotStopGrace)
+		},
+		setupFS: pidruntime.SetupFilesystems,
+		sysctls: pidruntime.ApplySysctls,
+		ramdisk: pidruntime.SetupRamdisk,
+		limits:  hardening.ApplyRuntimeLimits,
+		syslog:  startOptionalSyslogSink,
+		exists:  pathExists,
+		timeout: bootTimeout,
+		term:    serviceTermGrace,
+		kill:    serviceKillGrace,
+	}
+	return runLifecycle(parent, deps, readiness)
+}
+
+func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readinessState) (result error) {
+	bootCtx, cancelBoot := context.WithTimeout(parent, deps.timeout)
+	defer cancelBoot()
+	runtimeCtx, cancelRuntime := context.WithCancel(parent)
+	defer func() {
+		readiness.FailClosed()
+		cancelRuntime()
+		drainErr := deps.services.Drain(shutdownGroups(), deps.term, deps.kill)
+		if parent.Err() != nil {
+			result = drainErr
+		} else {
+			result = errors.Join(result, drainErr)
+		}
+	}()
+
+	initLogf("starting CPU lifecycle")
+	if err := deps.setupFS(initLogf); err != nil {
+		return fmt.Errorf("runtime filesystems: %w", err)
+	}
+	if err := deps.sysctls(initLogf); err != nil {
+		return fmt.Errorf("runtime sysctls: %w", err)
+	}
+	if err := deps.ramdisk(initLogf); err != nil {
+		return fmt.Errorf("runtime ramdisk: %w", err)
+	}
+	if err := deps.limits(); err != nil {
+		return fmt.Errorf("runtime limits: %w", err)
+	}
+	if err := deps.oneShot(bootCtx, command("loopback", "/usr/sbin/ip", "link", "set", "dev", "lo", "up")); err != nil {
+		return err
+	}
+	if err := deps.oneShot(bootCtx, command("nftables", "/usr/sbin/nft", "-f", "/etc/nftables.conf")); err != nil {
+		return err
+	}
+	deps.syslog(runtimeCtx)
+
+	if err := deps.services.Start(bootCtx, supervisor.Service{
+		Name: containerdName, Required: true, Restart: true,
+		Command: command(containerdName, "/usr/bin/containerd"),
+		Ready:   endpointReady("unix", containerdSocket, containerdReadyLimit),
+	}); err != nil {
+		return err
+	}
+	if err := deps.services.Start(bootCtx, supervisor.Service{
+		Name: dockerName, Required: true, Restart: true,
+		Command: command(dockerName, "/usr/bin/dockerd",
+			"-H", "unix://"+dockerSocket, "--containerd="+containerdSocket),
+		Ready: endpointReady("unix", dockerSocket, dockerReadyLimit),
+	}); err != nil {
+		return err
+	}
+	if err := deps.oneShot(bootCtx, hardenedCommand(
+		hardening.ServiceBoot, boot.BootBinary,
+	)); err != nil {
+		return err
+	}
+
+	if exists, err := deps.exists(boot.ContainerStatusBinary); err != nil {
+		return err
+	} else if exists {
+		if err := deps.services.Start(bootCtx, supervisor.Service{
+			Name: statusName, Restart: true,
+			Command: hardenedCommand(hardening.ServiceContainerStatus, boot.ContainerStatusBinary),
+		}); err != nil {
+			return err
+		}
+	}
+	if err := deps.services.Start(bootCtx, supervisor.Service{
+		Name: shimName, Required: true, Restart: true,
+		Command: hardenedCommand(hardening.ServiceShim, boot.ShimBinary),
+		Ready:   endpointReady("tcp", "127.0.0.1:443", shimReadyLimit),
+	}); err != nil {
+		return err
+	}
+	if exists, err := deps.exists(boot.EgressConfigPath); err != nil {
+		return err
+	} else if exists {
+		if err := deps.services.Start(bootCtx, supervisor.Service{
+			Name: egressName, Restart: true,
+			Command: hardenedCommand(hardening.ServiceEgress, boot.EgressBinary),
+		}); err != nil {
+			return err
+		}
+	}
+
+	if err := readiness.Publish(); err != nil {
+		return fmt.Errorf("publishing readiness: %w", err)
+	}
+	initLogf("boot complete")
+	cancelBoot()
+	<-parent.Done()
+	initLogf("shutdown requested")
+	return nil
+}
+
+func requiredServiceNames() []string {
+	return []string{containerdName, dockerName, shimName}
+}
+
+func shutdownGroups() [][]string {
+	return [][]string{
+		{egressName, shimName, statusName},
+		{dockerName},
+		{containerdName},
+	}
+}
+
+func command(name, path string, args ...string) supervisor.Command {
+	return supervisor.Command{Name: name, Path: path, Args: args, Env: childEnv(), Dir: "/"}
+}
+
+func hardenedCommand(policy hardening.Service, path string, args ...string) supervisor.Command {
+	wrapperArgs := []string{"--exec-service", string(policy), "--", path}
+	wrapperArgs = append(wrapperArgs, args...)
+	return command(string(policy), selfExecPath, wrapperArgs...)
+}
+
+func execService(
+	args []string,
+	apply func(hardening.Service) error,
+	execFn func(string, []string, []string) error,
+) error {
+	if len(args) < 3 || args[1] != "--" {
+		return errors.New("usage: --exec-service <policy> -- <path> [args...]")
+	}
+	policy := hardening.Service(args[0])
+	if err := apply(policy); err != nil {
+		return fmt.Errorf("apply %s policy: %w", policy, err)
+	}
+	target := args[2]
+	if err := execFn(target, args[2:], childEnv()); err != nil {
+		return fmt.Errorf("exec %s: %w", target, err)
+	}
+	return nil
+}
+
+func runOneShot(ctx context.Context, manager *supervisor.Manager, cmd supervisor.Command, grace time.Duration) error {
+	process, err := manager.Start(cmd)
+	if err != nil {
+		return err
+	}
+	exit, waitErr := process.Wait(ctx)
+	if waitErr == nil {
+		return exit.Err()
+	}
+	_ = process.Signal(syscall.SIGTERM)
+	timer := time.NewTimer(grace)
+	defer timer.Stop()
+	select {
+	case <-process.Done():
+	case <-timer.C:
+		_ = process.Signal(syscall.SIGKILL)
+		_, _ = process.Wait(context.Background())
+	}
+	return fmt.Errorf("%s interrupted: %w", cmd.Name, waitErr)
+}
+
+func endpointReady(network, address string, limit time.Duration) func(context.Context) error {
+	return func(parent context.Context) error {
+		return waitForEndpoint(parent, limit, func(ctx context.Context) error {
+			connection, err := (&net.Dialer{}).DialContext(ctx, network, address)
+			if err == nil {
+				_ = connection.Close()
+			}
+			return err
+		})
+	}
+}
+
+func waitForEndpoint(parent context.Context, limit time.Duration, probe func(context.Context) error) error {
+	ctx, cancel := context.WithTimeout(parent, limit)
+	defer cancel()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	var lastErr error
+	for {
+		probeCtx, probeCancel := context.WithTimeout(ctx, time.Second)
+		lastErr = probe(probeCtx)
+		probeCancel()
+		if lastErr == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%w (last probe: %v)", ctx.Err(), lastErr)
+		case <-ticker.C:
+		}
+	}
+}
+
+func pathExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.Is(err, os.ErrNotExist):
+		return false, nil
+	default:
+		return false, fmt.Errorf("stat %s: %w", path, err)
+	}
+}
+
+func childEnv() []string {
+	env := make([]string, 0, len(os.Environ())+3)
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		if key != "PATH" && key != pid1Env && key != "DOCKER_HOST" {
+			env = append(env, entry)
+		}
+	}
+	return append(env,
+		"PATH=/usr/sbin:/usr/bin:/sbin:/bin",
+		pid1Env+"="+pid1EnvValue,
+		"DOCKER_HOST=unix://"+dockerSocket,
+	)
+}
+
+type readinessState struct {
+	mu        sync.Mutex
+	required  map[string]bool
+	published bool
+	failed    bool
+	set       func(bool) error
+}
+
+func newReadiness(required []string, set func(bool) error) *readinessState {
+	state := &readinessState{required: map[string]bool{}, set: set}
+	for _, name := range required {
+		state.required[name] = false
+	}
+	return state
+}
+
+func (r *readinessState) Update(state supervisor.State) {
+	if !state.Required {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, expected := r.required[state.Name]; !expected || r.failed {
+		return
+	}
+	r.required[state.Name] = state.Ready
+	if r.published {
+		if err := r.set(r.allReadyLocked()); err != nil {
+			initLogf("setting readiness: %v", err)
+		}
+	}
+}
+
+func (r *readinessState) Publish() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.published = true
+	if r.failed || !r.allReadyLocked() {
+		return errors.New("required services are not ready")
+	}
+	if err := r.set(true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *readinessState) FailClosed() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failed = true
+	if err := r.set(false); err != nil {
+		initLogf("clearing readiness: %v", err)
+	}
+}
+
+func (r *readinessState) allReadyLocked() bool {
+	for _, ready := range r.required {
+		if !ready {
+			return false
+		}
+	}
+	return true
+}
+
+func setReady(ready bool) error {
+	if !ready {
+		if err := os.Remove(readyPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+	return os.WriteFile(readyPath, []byte("ready\n"), 0644)
+}
+
+func startOptionalSyslogSink(ctx context.Context) {
+	const path = "/dev/log"
+	if _, err := os.Lstat(path); err == nil {
+		return
+	} else if !errors.Is(err, os.ErrNotExist) {
+		initLogf("warning: checking %s: %v", path, err)
+		return
+	}
+	connection, err := net.ListenUnixgram("unixgram", &net.UnixAddr{Name: path, Net: "unixgram"})
+	if err != nil {
+		initLogf("warning: starting syslog sink: %v", err)
+		return
+	}
+	if err := os.Chmod(path, 0666); err != nil {
+		_ = connection.Close()
+		initLogf("warning: chmod syslog sink: %v", err)
+		return
+	}
+	go func() {
+		<-ctx.Done()
+		_ = connection.Close()
+	}()
+	go func() {
+		defer os.Remove(path)
+		buffer := make([]byte, 8192)
+		for {
+			count, _, err := connection.ReadFromUnix(buffer)
+			if err != nil {
+				if ctx.Err() == nil {
+					initLogf("syslog sink: %v", err)
+				}
+				return
+			}
+			if message := sanitizeSyslogMessage(string(buffer[:count])); message != "" {
+				initLogf("syslog: %s", message)
+			}
+		}
+	}()
+}
+
+func sanitizeSyslogMessage(message string) string {
+	message = strings.Trim(message, "\x00\r\n\t ")
+	message = strings.ReplaceAll(message, "\n", `\n`)
+	message = strings.ReplaceAll(message, "\r", `\r`)
+	if len(message) > 512 {
+		message = message[:512] + "...<truncated>"
+	}
+	return message
+}
+
+func initLogf(format string, args ...any) {
+	message := fmt.Sprintf(format, args...)
+	consoleMu.Lock()
+	defer consoleMu.Unlock()
+	log.Print("tinfoil-init: " + message)
+	for _, path := range []string{"/dev/kmsg", "/dev/ttyS0", "/dev/console"} {
+		file, err := os.OpenFile(path, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+		if err != nil {
+			continue
+		}
+		if path == "/dev/kmsg" {
+			_, _ = fmt.Fprintf(file, kmsgInfoPrefix+"tinfoil-init: %s\n", message)
+		} else {
+			_, _ = fmt.Fprintf(file, "tinfoil-init: %s\n", message)
+		}
+		_ = file.Close()
+	}
+}

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"tinfoil/internal/boot"
+	"tinfoil/internal/pid1/hardening"
+	pidruntime "tinfoil/internal/pid1/runtime"
+	"tinfoil/internal/pid1/supervisor"
+)
+
+type fakeServices struct {
+	mu        sync.Mutex
+	started   []supervisor.Service
+	startedCh chan string
+	drained   chan [][]string
+	fail      map[string]error
+	observe   func(supervisor.State)
+}
+
+func newFakeServices() *fakeServices {
+	return &fakeServices{
+		startedCh: make(chan string, 16),
+		drained:   make(chan [][]string, 1),
+		fail:      map[string]error{},
+	}
+}
+
+func (f *fakeServices) Start(_ context.Context, service supervisor.Service) error {
+	f.mu.Lock()
+	f.started = append(f.started, service)
+	err := f.fail[service.Name]
+	f.mu.Unlock()
+	f.startedCh <- service.Name
+	if err != nil {
+		f.observe(supervisor.State{Name: service.Name, Required: service.Required, Err: err})
+		return err
+	}
+	f.observe(supervisor.State{Name: service.Name, Required: service.Required, Ready: true})
+	return nil
+}
+
+func (f *fakeServices) Drain(groups [][]string, _, _ time.Duration) error {
+	f.drained <- groups
+	return nil
+}
+
+func (f *fakeServices) state(name string, ready bool) {
+	f.observe(supervisor.State{Name: name, Required: true, Ready: ready})
+}
+
+type lifecycleHarness struct {
+	services  *fakeServices
+	deps      lifecycleDeps
+	readiness *readinessState
+	ready     chan bool
+	existing  map[string]bool
+}
+
+func newLifecycleHarness() *lifecycleHarness {
+	harness := &lifecycleHarness{
+		services: newFakeServices(),
+		ready:    make(chan bool, 16),
+		existing: map[string]bool{boot.ContainerStatusBinary: true},
+	}
+	harness.readiness = newReadiness(requiredServiceNames(), func(ready bool) error {
+		harness.ready <- ready
+		return nil
+	})
+	harness.services.observe = harness.readiness.Update
+	noSetup := func(pidruntime.LogFunc) error { return nil }
+	harness.deps = lifecycleDeps{
+		services: harness.services,
+		oneShot:  func(context.Context, supervisor.Command) error { return nil },
+		setupFS:  noSetup,
+		sysctls:  noSetup,
+		ramdisk:  noSetup,
+		limits:   func() error { return nil },
+		syslog:   func(context.Context) {},
+		exists: func(path string) (bool, error) {
+			return harness.existing[path], nil
+		},
+		timeout: time.Hour,
+	}
+	return harness
+}
+
+func receiveTest[T any](t *testing.T, channel <-chan T) T {
+	t.Helper()
+	select {
+	case value := <-channel:
+		return value
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lifecycle event")
+		var zero T
+		return zero
+	}
+}
+
+func TestStartupFailureDrainsStartedServices(t *testing.T) {
+	harness := newLifecycleHarness()
+	harness.services.fail[dockerName] = errors.New("dockerd start failed")
+	result := make(chan error, 1)
+	go func() {
+		result <- runLifecycle(context.Background(), harness.deps, harness.readiness)
+	}()
+
+	if got := receiveTest(t, harness.services.startedCh); got != containerdName {
+		t.Fatalf("first service = %s", got)
+	}
+	if got := receiveTest(t, harness.services.startedCh); got != dockerName {
+		t.Fatalf("second service = %s", got)
+	}
+	groups := receiveTest(t, harness.services.drained)
+	if fmt.Sprint(groups) != fmt.Sprint(shutdownGroups()) {
+		t.Fatalf("drain groups = %v, want %v", groups, shutdownGroups())
+	}
+	if err := receiveTest(t, result); err == nil || !errors.Is(err, harness.services.fail[dockerName]) {
+		t.Fatalf("runLifecycle error = %v", err)
+	}
+}
+
+func TestBootDeadlineDoesNotEndSupervisionAndRequiredDeathFailsClosed(t *testing.T) {
+	harness := newLifecycleHarness()
+	parent, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- runLifecycle(parent, harness.deps, harness.readiness)
+	}()
+
+	if ready := receiveTest(t, harness.ready); !ready {
+		t.Fatal("lifecycle did not become ready")
+	}
+	// runLifecycle cancels its boot context immediately after publishing
+	// readiness. The signal-only parent must remain the sole lifetime gate.
+	select {
+	case err := <-result:
+		t.Fatalf("boot context ended supervision: %v", err)
+	default:
+	}
+	harness.services.state(dockerName, false)
+	if ready := receiveTest(t, harness.ready); ready {
+		t.Fatal("required service death did not fail closed")
+	}
+	harness.services.state(dockerName, true)
+	if ready := receiveTest(t, harness.ready); !ready {
+		t.Fatal("readiness was not restored after required service recovered")
+	}
+	cancel()
+	if err := receiveTest(t, result); err != nil {
+		t.Fatalf("clean cancellation returned %v", err)
+	}
+	if ready := receiveTest(t, harness.ready); ready {
+		t.Fatal("shutdown did not clear readiness")
+	}
+}
+
+func TestHardeningWrapperAppliesPolicyBeforeExec(t *testing.T) {
+	var calls []string
+	err := execService(
+		[]string{string(hardening.ServiceShim), "--", "/usr/bin/tinfoil-shim", "-c", "/config"},
+		func(service hardening.Service) error {
+			calls = append(calls, "apply:"+string(service))
+			return nil
+		},
+		func(path string, args, env []string) error {
+			calls = append(calls, "exec:"+path)
+			if got := fmt.Sprint(args); got != "[/usr/bin/tinfoil-shim -c /config]" {
+				t.Fatalf("exec args = %s", got)
+			}
+			if len(env) == 0 {
+				t.Fatal("exec environment is empty")
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"apply:tinfoil-shim", "exec:/usr/bin/tinfoil-shim"}
+	if fmt.Sprint(calls) != fmt.Sprint(want) {
+		t.Fatalf("dispatch calls = %v, want %v", calls, want)
+	}
+}

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -37,7 +37,11 @@ const (
 	HTTPChallengePort = 80
 
 	// InitBinary is PID 1 after the measured root replaces the initrd.
-	InitBinary = "/usr/bin/tinfoil-init"
+	InitBinary            = "/usr/bin/tinfoil-init"
+	BootBinary            = "/usr/bin/tinfoil-boot"
+	ContainerStatusBinary = "/usr/bin/tinfoil-container-status"
+	EgressBinary          = "/usr/bin/tinfoil-egress"
+	ShimBinary            = "/usr/bin/tinfoil-shim"
 
 	// ExternalNICPCIAddress is the measured virtio-net topology ABI. It MUST
 	// match tinfoild/admin/guest_topology.go.


### PR DESCRIPTION
## Summary
- compose the fixed CPU guest PID1 lifecycle over the merged runtime, hardening, supervisor, resolver, and egress owners
- populate the initial egress allowlist synchronously before readiness and workload creation
- start and supervise the long-lived services without systemd or sd-notify ownership

## Security properties
- no `resolvectl`, fake `systemctl`, or runtime resolver parser
- all PID1 children use the central supervisor; no competing `os/exec.Wait` path
- readiness is withheld until loopback, runtime setup, hardening, resolver validation, synchronous egress population, containerd, and boot complete
- shutdown and failed-start cleanup retain process-group ownership

## Validation
- `gofmt` on all changed Go files
- 100 focused init/boot/egress test runs
- `go test -race -count=25 ./cmd/init ./cmd/boot ./internal/egress ./internal/pid1/supervisor`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce `tinfoil-init` as PID 1 to own the CPU guest lifecycle and supervise core services, replacing systemd. Boot readiness now waits on loopback, nftables, runtime setup, `containerd`/`dockerd` sockets, `tinfoil-shim`, and synchronous egress allowlist population (30s); SIGTERM/SIGINT cancel boot paths while the `models` subcommand preserves default signal handling.

- **New Features**
  - Added `tinfoil-init` (PID 1) that starts and supervises `containerd`, `dockerd`, optional `tinfoil-container-status`, `tinfoil-shim`, and optional `tinfoil-egress`, plus an optional `/dev/log` syslog sink.
  - Egress allowlist population now runs during firewall setup with a fixed 30s timeout and inherits boot cancellation; workloads wait for completion. Tests cover ordering, failures, deadlines, and cancellation.

- **Refactors**
  - Removed systemd coupling: no `systemctl` or `sd_notify`; `tinfoil-egress` no longer performs initial population and only refreshes sets at runtime under the central supervisor.
  - Boot and container flows are context-driven and cancel on SIGINT/SIGTERM; the `models` subcommand leaves signals at defaults to preserve model mount behavior. Context is threaded through network setup and container launch/health checks.
  - Firewall composition applies nft rules once, then loads and populates allowlists via `tinfoil/internal/egress`. Added path constants for `tinfoil-boot`, `tinfoil-container-status`, `tinfoil-egress`, and `tinfoil-shim` in `internal/boot/paths.go`.

<sup>Written for commit ccb91be20f7aa55761775d5cec2f76015dd783f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

