### PR TITLE
Use direct measured roothash artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     
           sudo apt-get update
           sudo apt-get install -y pipx ubuntu-keyring debian-archive-keyring make jq binutils
-          sudo pipx install git+https://github.com/systemd/mkosi.git@54c625c380ef5500f17460981a3c67b109b6a847 #v25.3
+          sudo pipx install git+https://github.com/systemd/mkosi.git@84af20892b61c8e177e391f997ded8b4cb5514f2 #v26
           sudo pipx ensurepath
           mkdir -p packages mkosi.extra/usr/bin
 
@@ -84,6 +84,8 @@ jobs:
           mkdir -p /tmp/out
           sudo chmod 644 tinfoilcvm.*
           sudo chown $USER:$USER tinfoilcvm.*
+          test "$(wc -c < tinfoilcvm.roothash)" -eq 64
+          grep -Eq '^[a-f0-9]{64}$' tinfoilcvm.roothash
 
       - name: Generate manifest
         id: manifest
@@ -94,7 +96,7 @@ jobs:
           cat > "/tmp/out/tinfoil-inference-${REF_NAME}-manifest.json" << EOF
           {
             "version": "${REF_NAME}",
-            "root": "$(objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | cut -d "=" -f 2)",
+            "root": "$(tr -d '\n' < tinfoilcvm.roothash)",
             "initrd": "$(sha256sum tinfoilcvm.initrd | awk '{print $1}')",
             "kernel": "$(sha256sum tinfoilcvm.vmlinuz | awk '{print $1}')",
             "raw": "$(sha256sum tinfoilcvm.raw | awk '{print $1}')",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Test
         run: cd tinfoil && go test ./...
+
+      - name: Test direct roothash contract
+        run: ./scripts/test-roothash-artifacts.sh

--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,33 @@ NVATTEST_BUILDER = ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0
 
 .PHONY: all build rebuild clean deepclean hash nvattest go-binaries \
 	builder-initrd additive-initrd verify-additive-initrd \
-	test-additive-initrd reproducible-additive-initrd
+	test-additive-initrd reproducible-additive-initrd test-roothash-artifacts
 
-# tinfoilcvm.hash is written as an artifact of `build`; read it from there if
-# present, otherwise extract the dm-verity roothash from the UKI's .cmdline
-# section. grep -aoE finds the roothash= token regardless of position so the
-# command stays correct even if mkosi adds other kv pairs to the cmdline.
+# tinfoilcvm.hash is the compatibility copy written by `rebuild`; mkosi's
+# direct roothash split artifact is the source contract.
 hash:
-	@if [ -f tinfoilcvm.hash ]; then \
-	    cat tinfoilcvm.hash; \
-	else \
-	    objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | grep -aoE 'roothash=[a-f0-9]+' | cut -d= -f2; \
-	fi
+	@if [ ! -f tinfoilcvm.roothash ]; then \
+	    echo "missing authoritative tinfoilcvm.roothash" >&2; \
+	    exit 1; \
+	fi; \
+	if [ "$$(wc -c < tinfoilcvm.roothash)" -ne 64 ] || ! grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm.roothash; then \
+	    echo "invalid roothash artifact tinfoilcvm.roothash" >&2; \
+	    exit 1; \
+	fi; \
+	if [ -f tinfoilcvm.hash ]; then \
+	    if [ "$$(wc -c < tinfoilcvm.hash)" -ne 64 ] || ! grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm.hash; then \
+	        echo "invalid compatibility artifact tinfoilcvm.hash" >&2; \
+	        exit 1; \
+	    fi; \
+	    if ! cmp -s tinfoilcvm.roothash tinfoilcvm.hash; then \
+	        echo "tinfoilcvm.hash differs from authoritative tinfoilcvm.roothash" >&2; \
+	        exit 1; \
+	    fi; \
+	fi; \
+	cat tinfoilcvm.roothash
+
+test-roothash-artifacts:
+	./scripts/test-roothash-artifacts.sh
 
 clean:
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm.*
@@ -81,7 +96,9 @@ rebuild: go-binaries
 	mkdir -p mkosi.cache packages
 	$(MKOSI) --force
 	rm -f tinfoilcvm
-	objcopy -O binary --only-section .cmdline tinfoilcvm.efi /dev/stdout | grep -aoE 'roothash=[a-f0-9]+' | cut -d= -f2 > tinfoilcvm.hash
+	test "$$(wc -c < tinfoilcvm.roothash)" -eq 64
+	grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm.roothash
+	cp tinfoilcvm.roothash tinfoilcvm.hash
 	@echo "image hash: $$(cat tinfoilcvm.hash)"
 
 build: nvattest rebuild

--- a/docs/additive-initrd.md
+++ b/docs/additive-initrd.md
@@ -44,9 +44,9 @@ artifact is `initrd.cpio.zst`.
 The additive artifact remains opt-in until the image switch activates the
 minimized built-in kernel. The current distro initrd stays wired to the current
 stock-kernel image, so this milestone does not create a temporarily unbootable
-default build. The release workflow also retains its existing mkosi v25.3 pin;
-the v26 requirement applies only to the opt-in additive targets. No subtractive
-initrd finalizer is introduced.
+default build. The direct-roothash follow-up upgrades the release builder to
+mkosi v26 only to consume its fixed split roothash artifact; it does not select
+this opt-in initrd. No subtractive initrd finalizer is introduced.
 
 The assembler requires Zstandard CLI 1.5.7 and fails closed on another version.
 Compression uses one thread, level 19, no progress output, and a fixed input

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -9,6 +9,7 @@ Repositories=main restricted universe multiverse
 [Output]
 Format=disk
 Output=tinfoilcvm
+SplitArtifacts=kernel,initrd,roothash
 # systemd-repart derives the dm-verity salt as
 # HMAC-SHA256(Seed, "verity-salt"). Keep this synchronized with
 # tinfoil/cmd/initrd so no verity superblock fields enter the runtime TCB.

--- a/scripts/test-roothash-artifacts.sh
+++ b/scripts/test-roothash-artifacts.sh
@@ -41,6 +41,9 @@ else
     exit 1
 fi
 
+printf 'invalid' > "$workdir/tinfoilcvm.hash"
+expect_failure "malformed compatibility hash"
+
 printf '%s' "$hash_b" > "$workdir/tinfoilcvm.hash"
 expect_failure "stale compatibility hash"
 

--- a/scripts/test-roothash-artifacts.sh
+++ b/scripts/test-roothash-artifacts.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+workdir=$(mktemp -d)
+trap 'rm -rf "$workdir"' EXIT
+
+hash_a=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+hash_b=fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210
+
+run_hash() {
+    make --no-print-directory -s -C "$workdir" -f "$repo_root/Makefile" hash
+}
+
+expect_failure() {
+    if run_hash >/dev/null 2>&1; then
+        echo "$1 unexpectedly succeeded" >&2
+        exit 1
+    fi
+}
+
+expect_failure "missing roothash"
+
+printf '%s' "$hash_a" > "$workdir/tinfoilcvm.roothash"
+if output=$(run_hash) && [ "$output" = "$hash_a" ]; then
+    :
+else
+    echo "authoritative roothash was not returned" >&2
+    exit 1
+fi
+
+printf 'invalid' > "$workdir/tinfoilcvm.roothash"
+expect_failure "malformed roothash"
+
+printf '%s' "$hash_a" > "$workdir/tinfoilcvm.roothash"
+printf '%s' "$hash_a" > "$workdir/tinfoilcvm.hash"
+if output=$(run_hash) && [ "$output" = "$hash_a" ]; then
+    :
+else
+    echo "matching compatibility artifact was rejected" >&2
+    exit 1
+fi
+
+printf '%s' "$hash_b" > "$workdir/tinfoilcvm.hash"
+expect_failure "stale compatibility hash"
+
+rm "$workdir/tinfoilcvm.roothash"
+expect_failure "compatibility-only hash"


### PR DESCRIPTION
## Summary
- request mkosi's fixed `kernel,initrd,roothash` split artifacts directly
- consume `tinfoilcvm.roothash` as the sole authoritative root hash
- retain `tinfoilcvm.hash` only as an exact compatibility copy
- remove UKI command-line scraping from local and release paths

## Fail-closed contract
- authoritative roothash must exist and contain exactly 64 lowercase hexadecimal bytes
- an existing compatibility hash must also be canonical and byte-identical
- compatibility-only, malformed, missing, or stale artifacts are rejected
- PR CI runs committed positive and negative artifact tests

## Validation
- 100 focused roothash contract runs
- `make test-roothash-artifacts`
- `go build ./...`
- `go test ./...`
- `go test -race -count=25 ./cmd/initrd`
- `go vet ./...`
- shell syntax and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch build and release to use `mkosi` v26’s split roothash artifact. `tinfoilcvm.roothash` is now the single source of truth; UKI cmdline scraping is removed and CI enforces a strict fail-closed contract.

- **Refactors**
  - Consume `tinfoilcvm.roothash` via `SplitArtifacts=kernel,initrd,roothash`; stop reading the UKI `.cmdline`.
  - Fail-closed hash contract (64 lowercase hex); reject missing, malformed, or mismatched `tinfoilcvm.hash` compatibility copies.
  - Release workflow validates `tinfoilcvm.roothash` and manifest reads `root` from it.
  - Add `scripts/test-roothash-artifacts.sh` and `make test-roothash-artifacts`; CI runs positive and negative cases, including malformed compatibility hashes.

- **Dependencies**
  - Upgrade `mkosi` to v26 in the release workflow. Docs note v26 is only used to consume the roothash artifact; additive initrd remains opt-in.

<sup>Written for commit ef6dc085c75ec8f553cd804ff66452a0c55a8506. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

