### PR TITLE
Add fail-closed NVIDIA bootstrap orchestration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,6 @@ jobs:
 
       - name: Test fixed rootfs policy
         run: make test-rootfs-policy
+
+      - name: Test Fabric Manager config contract
+        run: ./scripts/test-fabric-manager-config.sh

--- a/mkosi.postinst.chroot
+++ b/mkosi.postinst.chroot
@@ -1,6 +1,23 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+pin_fabric_manager_config() {
+    local config="$1"
+    local assignment='^[[:space:]]*FM_CMD_UNIX_SOCKET_PATH[[:space:]]*='
+
+    if [[ $(grep -Ec "$assignment" "$config") -ne 1 ]] ||
+        [[ $(grep -Fxc 'FM_CMD_UNIX_SOCKET_PATH=' "$config") -ne 1 ]]; then
+        echo "ERROR: pinned Fabric Manager config no longer has the expected command socket default" >&2
+        return 1
+    fi
+    sed -i 's|^FM_CMD_UNIX_SOCKET_PATH=$|FM_CMD_UNIX_SOCKET_PATH=/run/nvidia-fabricmanager/socket|' "$config"
+    if [[ $(grep -Ec "$assignment" "$config") -ne 1 ]] ||
+        [[ $(grep -Fxc 'FM_CMD_UNIX_SOCKET_PATH=/run/nvidia-fabricmanager/socket' "$config") -ne 1 ]]; then
+        echo "ERROR: failed to pin the Fabric Manager command socket" >&2
+        return 1
+    fi
+}
+
 # Disable login management.
 systemctl mask systemd-logind.service
 systemctl mask systemd-logind.socket
@@ -23,6 +40,13 @@ systemctl mask rescue.target
 systemctl mask nvidia-powerd.service
 
 systemctl mask systemd-networkd-persistent-storage.service
+
+FABRIC_MANAGER_CONFIG=/usr/share/nvidia/nvswitch/fabricmanager.cfg
+if [[ $(grep -Fxc 'DAEMONIZE=1' "$FABRIC_MANAGER_CONFIG") -ne 1 ]]; then
+    echo "ERROR: pinned Fabric Manager config no longer has the expected daemon contract" >&2
+    exit 1
+fi
+pin_fabric_manager_config "$FABRIC_MANAGER_CONFIG"
 
 echo "export DOCKER_CONFIG=/mnt/ramdisk/private/docker-config" >> /root/.bashrc
 

--- a/scripts/test-fabric-manager-config.sh
+++ b/scripts/test-fabric-manager-config.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+
+function_source=$(sed -n '/^pin_fabric_manager_config() {$/,/^}$/p' "$repo_root/mkosi.postinst.chroot")
+if [[ -z "$function_source" ]]; then
+    echo "Fabric Manager config function not found" >&2
+    exit 1
+fi
+eval "$function_source"
+
+config="$scratch/fabricmanager.cfg"
+cat >"$config" <<'EOF'
+DAEMONIZE=1
+FM_CMD_UNIX_SOCKET_PATH=
+EOF
+pin_fabric_manager_config "$config"
+[[ $(grep -Ec '^[[:space:]]*FM_CMD_UNIX_SOCKET_PATH[[:space:]]*=' "$config") -eq 1 ]]
+[[ $(grep -Fxc 'FM_CMD_UNIX_SOCKET_PATH=/run/nvidia-fabricmanager/socket' "$config") -eq 1 ]]
+
+for conflicting in 'FM_CMD_UNIX_SOCKET_PATH=/tmp/attacker' ' FM_CMD_UNIX_SOCKET_PATH = /tmp/attacker'; do
+    cat >"$config" <<EOF
+DAEMONIZE=1
+FM_CMD_UNIX_SOCKET_PATH=
+$conflicting
+EOF
+    if pin_fabric_manager_config "$config" >/dev/null 2>&1; then
+        echo "duplicate Fabric Manager socket assignment accepted" >&2
+        exit 1
+    fi
+done
+
+mkdir "$scratch/bin"
+cat >"$scratch/bin/sed" <<'EOF'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+/usr/bin/sed "$@"
+config=${!#}
+printf '%s\n' 'FM_CMD_UNIX_SOCKET_PATH=/tmp/attacker' >>"$config"
+EOF
+chmod +x "$scratch/bin/sed"
+cat >"$config" <<'EOF'
+DAEMONIZE=1
+FM_CMD_UNIX_SOCKET_PATH=
+EOF
+if PATH="$scratch/bin:$PATH" pin_fabric_manager_config "$config" >/dev/null 2>&1; then
+    echo "post-rewrite duplicate Fabric Manager socket assignment accepted" >&2
+    exit 1
+fi

--- a/tinfoil/cmd/boot/gpuattest.go
+++ b/tinfoil/cmd/boot/gpuattest.go
@@ -50,16 +50,6 @@ func forEachNVIDIAGPU(fn func(entryName string) bool) error {
 	return nil
 }
 
-// detectGPUCount returns the number of NVIDIA 3D-controller PCI devices
-// in the guest. The caller validates against the config-declared count.
-func detectGPUCount() (int, error) {
-	count := 0
-	if err := forEachNVIDIAGPU(func(string) bool { count++; return true }); err != nil {
-		return 0, err
-	}
-	return count, nil
-}
-
 // detectGPUArch returns "h100", "h200", "b200", "b300", or "" from the first GPU.
 func detectGPUArch() (string, error) {
 	const pciPath = "/sys/bus/pci/devices"

--- a/tinfoil/cmd/boot/gpuattest_bootstrap_test.go
+++ b/tinfoil/cmd/boot/gpuattest_bootstrap_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/nvidia"
+)
+
+func TestGPUAttestationBootstrapFailsClosedInRealAndDummyModes(t *testing.T) {
+	for _, dummy := range []bool{false, true} {
+		t.Run(map[bool]string{false: "real", true: "dummy"}[dummy], func(t *testing.T) {
+			directory := t.TempDir()
+			path := filepath.Join(directory, "status")
+			config := &Config{GPUs: 8, ShimCfg: &shimconfig.Config{DummyAttestation: dummy}}
+
+			if err := nvidia.WriteBootstrapStatus(path, nvidia.ReadyBootstrapStatus(8)); err != nil {
+				t.Fatal(err)
+			}
+			if err := validateGPUAttestationBootstrap(path, config); err != nil {
+				t.Fatalf("matching ready status failed: %v", err)
+			}
+
+			invalid := []struct {
+				name  string
+				setup func() string
+			}{
+				{name: "missing", setup: func() string { return filepath.Join(directory, "missing") }},
+				{name: "malformed", setup: func() string {
+					candidate := filepath.Join(directory, "malformed")
+					if err := os.WriteFile(candidate, []byte("tinfoil-nvidia-bootstrap-v1:ready:08\n"), 0600); err != nil {
+						t.Fatal(err)
+					}
+					return candidate
+				}},
+				{name: "oversized", setup: func() string {
+					candidate := filepath.Join(directory, "oversized")
+					if err := os.WriteFile(candidate, []byte(strings.Repeat("x", 41)), 0600); err != nil {
+						t.Fatal(err)
+					}
+					return candidate
+				}},
+				{name: "symlink", setup: func() string {
+					candidate := filepath.Join(directory, "symlink")
+					if err := os.Symlink(path, candidate); err != nil {
+						t.Fatal(err)
+					}
+					return candidate
+				}},
+				{name: "failed", setup: func() string {
+					candidate := filepath.Join(directory, "failed")
+					if err := nvidia.WriteBootstrapStatus(candidate, nvidia.FailedBootstrapStatus()); err != nil {
+						t.Fatal(err)
+					}
+					return candidate
+				}},
+				{name: "count-mismatch", setup: func() string {
+					candidate := filepath.Join(directory, "mismatch")
+					if err := nvidia.WriteBootstrapStatus(candidate, nvidia.ReadyBootstrapStatus(1)); err != nil {
+						t.Fatal(err)
+					}
+					return candidate
+				}},
+				{name: "no-gpu-mismatch", setup: func() string {
+					candidate := filepath.Join(directory, "no-gpu")
+					if err := nvidia.WriteBootstrapStatus(candidate, nvidia.NoGPUBootstrapStatus()); err != nil {
+						t.Fatal(err)
+					}
+					return candidate
+				}},
+			}
+			for _, test := range invalid {
+				t.Run(test.name, func(t *testing.T) {
+					if err := validateGPUAttestationBootstrap(test.setup(), config); err == nil {
+						t.Fatal("invalid bootstrap status passed GPU attestation")
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestGPUAttestationBootstrapRequiresExplicitNoGPUStatus(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "status")
+	config := &Config{GPUs: 0, ShimCfg: &shimconfig.Config{DummyAttestation: true}}
+	if err := nvidia.WriteBootstrapStatus(path, nvidia.NoGPUBootstrapStatus()); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateGPUAttestationBootstrap(path, config); err != nil {
+		t.Fatalf("explicit no-GPU status failed: %v", err)
+	}
+	if err := nvidia.WriteBootstrapStatus(path, nvidia.ReadyBootstrapStatus(1)); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateGPUAttestationBootstrap(path, config); err == nil {
+		t.Fatal("ready status passed gpus=0 config")
+	}
+}

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"tinfoil/internal/boot"
+	"tinfoil/internal/nvidia"
 )
 
 type notifyContextFunc func(context.Context, ...os.Signal) (context.Context, context.CancelFunc)
@@ -144,17 +145,10 @@ func run(ctx context.Context) error {
 	// 5. GPU attestation
 	start = time.Now()
 	gpuCount := config.GPUs
-	if gpuCount == 0 {
-		detected, err := detectGPUCount()
-		if err != nil {
-			tracker.Record("gpu-attestation", boot.StatusFailed, time.Since(start), err.Error())
-			return err
-		}
-		if detected > 0 {
-			tracker.Record("gpu-attestation", boot.StatusFailed, time.Since(start),
-				fmt.Sprintf("detected %d GPU(s) but config declares gpus: 0 — set the correct gpu count in the config", detected))
-			return fmt.Errorf("gpu count mismatch: detected %d, config says 0", detected)
-		}
+	if err := validateGPUAttestationBootstrap(boot.NVIDIABootstrapStatusPath, config); err != nil {
+		wrapped := fmt.Errorf("NVIDIA bootstrap status: %w", err)
+		tracker.Record("gpu-attestation", boot.StatusFailed, time.Since(start), wrapped.Error())
+		return wrapped
 	}
 	if gpuCount > 0 && config.ShimCfg.DummyAttestation {
 		log.Printf("Skipping GPU attestation for %d GPUs (dummy-attestation mode)", gpuCount)
@@ -231,4 +225,11 @@ func run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func validateGPUAttestationBootstrap(path string, config *Config) error {
+	if config == nil || config.ShimCfg == nil {
+		return fmt.Errorf("GPU attestation config is incomplete")
+	}
+	return nvidia.ValidateBootstrapStatus(path, config.GPUs)
 }

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"tinfoil/internal/boot"
+	"tinfoil/internal/nvidia"
 	"tinfoil/internal/pid1/hardening"
 	pidruntime "tinfoil/internal/pid1/runtime"
 	"tinfoil/internal/pid1/supervisor"
@@ -29,6 +30,9 @@ const (
 	oneShotStopGrace     = 2 * time.Second
 	serviceTermGrace     = 10 * time.Second
 	serviceKillGrace     = 5 * time.Second
+	nvidiaChildLimit     = 4 * time.Minute
+	nvidiaDeviceWait     = 15 * time.Second
+	nvidiaDevicePoll     = 500 * time.Millisecond
 
 	containerdName   = "containerd"
 	dockerName       = "dockerd"
@@ -42,6 +46,7 @@ const (
 	pid1Env          = "TINFOIL_PID1"
 	pid1EnvValue     = "tinfoil-init"
 	kmsgInfoPrefix   = "<6>"
+	fabricConfigPath = "/usr/share/nvidia/nvswitch/fabricmanager.cfg"
 )
 
 var consoleMu sync.Mutex
@@ -91,6 +96,7 @@ type serviceControl interface {
 type lifecycleDeps struct {
 	services serviceControl
 	oneShot  func(context.Context, supervisor.Command) error
+	nvidia   func(context.Context) error
 	setupFS  func(pidruntime.LogFunc) error
 	sysctls  func(pidruntime.LogFunc) error
 	ramdisk  func(pidruntime.LogFunc) error
@@ -110,6 +116,18 @@ func run(parent context.Context) error {
 		services: services,
 		oneShot: func(ctx context.Context, command supervisor.Command) error {
 			return runOneShot(ctx, manager, command, oneShotStopGrace)
+		},
+		nvidia: func(ctx context.Context) error {
+			return runNVIDIABootstrap(
+				ctx,
+				newSystemNVIDIA(),
+				func(childCtx context.Context, command supervisor.Command) error {
+					return runOneShot(childCtx, manager, command, oneShotStopGrace)
+				},
+				func(status nvidia.BootstrapStatus) error {
+					return nvidia.WriteBootstrapStatus(boot.NVIDIABootstrapStatusPath, status)
+				},
+			)
 		},
 		setupFS: pidruntime.SetupFilesystems,
 		sysctls: pidruntime.ApplySysctls,
@@ -153,6 +171,9 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 		return fmt.Errorf("runtime limits: %w", err)
 	}
 	if err := deps.oneShot(bootCtx, command("loopback", "/usr/sbin/ip", "link", "set", "dev", "lo", "up")); err != nil {
+		return err
+	}
+	if err := deps.nvidia(bootCtx); err != nil {
 		return err
 	}
 	if err := deps.oneShot(bootCtx, command("nftables", "/usr/sbin/nft", "-f", "/etc/nftables.conf")); err != nil {
@@ -217,6 +238,249 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	<-parent.Done()
 	initLogf("shutdown requested")
 	return nil
+}
+
+type nvidiaBootstrapControl interface {
+	GPUCount() (int, error)
+	HasNVSwitch() (bool, error)
+	HoldGPUEnableReferences() error
+	EnableGPURuntimePowerManagement() error
+	LoadCoreKernelModules() error
+	WaitForCoreDeviceNodes(context.Context, int) error
+	PreparePersistencedRuntime() error
+	WaitForPersistenced(context.Context) error
+	LoadUVMKernelModules() error
+	WaitForUVMDeviceNodes(context.Context, int) error
+	LoadModesetKernelModules() error
+	DetectFabricMode() (nvidia.FabricMode, error)
+	PrepareFabricManagerRuntime() error
+	WaitForFabricManager(context.Context) error
+	WaitForNVML(context.Context, int) error
+	CreateCDITemporary() (string, error)
+	PublishCDI(string) error
+}
+
+type systemNVIDIA struct {
+	services *nvidia.Services
+}
+
+func newSystemNVIDIA() *systemNVIDIA {
+	return &systemNVIDIA{services: nvidia.NewServices()}
+}
+
+func (*systemNVIDIA) GPUCount() (int, error)     { return nvidia.GPUCount() }
+func (*systemNVIDIA) HasNVSwitch() (bool, error) { return nvidia.HasNVSwitch() }
+func (*systemNVIDIA) HoldGPUEnableReferences() error {
+	return nvidia.HoldGPUEnableReferences()
+}
+func (*systemNVIDIA) EnableGPURuntimePowerManagement() error {
+	return nvidia.EnableGPURuntimePowerManagement()
+}
+func (*systemNVIDIA) LoadCoreKernelModules() error { return nvidia.LoadCoreKernelModules() }
+func (*systemNVIDIA) WaitForCoreDeviceNodes(ctx context.Context, expectedGPUs int) error {
+	return waitForNVIDIADeviceNodes(ctx, func() error {
+		return nvidia.SetupCoreDeviceNodes(expectedGPUs)
+	}, nvidiaDeviceWait, nvidiaDevicePoll)
+}
+func (s *systemNVIDIA) PreparePersistencedRuntime() error {
+	return s.services.PreparePersistencedRuntime()
+}
+func (s *systemNVIDIA) WaitForPersistenced(ctx context.Context) error {
+	return s.services.WaitForPersistenced(ctx)
+}
+func (*systemNVIDIA) LoadUVMKernelModules() error { return nvidia.LoadUVMKernelModules() }
+func (*systemNVIDIA) WaitForUVMDeviceNodes(ctx context.Context, expectedGPUs int) error {
+	return waitForNVIDIADeviceNodes(ctx, func() error {
+		return nvidia.SetupUVMDeviceNodes(expectedGPUs)
+	}, nvidiaDeviceWait, nvidiaDevicePoll)
+}
+func (*systemNVIDIA) LoadModesetKernelModules() error {
+	return nvidia.LoadModesetKernelModules()
+}
+func (*systemNVIDIA) DetectFabricMode() (nvidia.FabricMode, error) {
+	return nvidia.DetectFabricMode()
+}
+func (s *systemNVIDIA) PrepareFabricManagerRuntime() error {
+	return s.services.PrepareFabricManagerRuntime()
+}
+func (s *systemNVIDIA) WaitForFabricManager(ctx context.Context) error {
+	return s.services.WaitForFabricManager(ctx)
+}
+func (s *systemNVIDIA) WaitForNVML(ctx context.Context, count int) error {
+	return s.services.WaitForNVML(ctx, count)
+}
+func (s *systemNVIDIA) CreateCDITemporary() (string, error) {
+	return s.services.CreateCDITemporary()
+}
+func (s *systemNVIDIA) PublishCDI(path string) error { return s.services.PublishCDI(path) }
+
+func runNVIDIABootstrap(
+	ctx context.Context,
+	control nvidiaBootstrapControl,
+	oneShot func(context.Context, supervisor.Command) error,
+	writeStatus func(nvidia.BootstrapStatus) error,
+) error {
+	gpuCount, err := control.GPUCount()
+	if err == nil && gpuCount == 0 {
+		var hasSwitch bool
+		hasSwitch, err = control.HasNVSwitch()
+		if err == nil && !hasSwitch {
+			return writeStatus(nvidia.NoGPUBootstrapStatus())
+		}
+		if err == nil {
+			err = errors.New("NVIDIA NVSwitch topology has no detected GPUs")
+		}
+	}
+	if err == nil {
+		err = runNVIDIABootstrapSteps(ctx, control, oneShot, gpuCount)
+	}
+	if err != nil {
+		initLogf("NVIDIA bootstrap failed: %v", err)
+		if statusErr := writeStatus(nvidia.FailedBootstrapStatus()); statusErr != nil {
+			return fmt.Errorf("persist failed NVIDIA bootstrap status after %v: %w", err, statusErr)
+		}
+		return nil
+	}
+	if err := writeStatus(nvidia.ReadyBootstrapStatus(gpuCount)); err != nil {
+		return fmt.Errorf("persist ready NVIDIA bootstrap status: %w", err)
+	}
+	return nil
+}
+
+func runNVIDIABootstrapSteps(
+	ctx context.Context,
+	control nvidiaBootstrapControl,
+	oneShot func(context.Context, supervisor.Command) error,
+	gpuCount int,
+) error {
+	if gpuCount < 1 {
+		return fmt.Errorf("invalid detected NVIDIA GPU count %d", gpuCount)
+	}
+	if err := control.HoldGPUEnableReferences(); err != nil {
+		return fmt.Errorf("hold NVIDIA PCI enable references: %w", err)
+	}
+	if err := control.EnableGPURuntimePowerManagement(); err != nil {
+		return fmt.Errorf("enable NVIDIA runtime power management: %w", err)
+	}
+	if err := control.LoadCoreKernelModules(); err != nil {
+		return fmt.Errorf("load NVIDIA core kernel modules: %w", err)
+	}
+	if err := control.WaitForCoreDeviceNodes(ctx, gpuCount); err != nil {
+		return fmt.Errorf("set up NVIDIA core device nodes: %w", err)
+	}
+	if err := control.PreparePersistencedRuntime(); err != nil {
+		return fmt.Errorf("prepare nvidia-persistenced runtime: %w", err)
+	}
+	persistencedCtx, cancelPersistenced := context.WithTimeout(ctx, nvidiaChildLimit)
+	err := oneShot(persistencedCtx, command(
+		"nvidia-persistenced",
+		"/usr/bin/nvidia-persistenced",
+		"--user", "nvidia-persistenced", "--uvm-persistence-mode", "--verbose",
+	))
+	cancelPersistenced()
+	if err != nil {
+		return fmt.Errorf("start nvidia-persistenced: %w", err)
+	}
+	if err := control.WaitForPersistenced(ctx); err != nil {
+		return fmt.Errorf("wait for nvidia-persistenced: %w", err)
+	}
+	if err := control.LoadUVMKernelModules(); err != nil {
+		return fmt.Errorf("load NVIDIA UVM kernel modules: %w", err)
+	}
+	if err := control.WaitForUVMDeviceNodes(ctx, gpuCount); err != nil {
+		return fmt.Errorf("set up NVIDIA UVM device nodes: %w", err)
+	}
+	if err := control.LoadModesetKernelModules(); err != nil {
+		return fmt.Errorf("load NVIDIA modeset kernel modules: %w", err)
+	}
+	if err := control.WaitForUVMDeviceNodes(ctx, gpuCount); err != nil {
+		return fmt.Errorf("set up NVIDIA modeset device nodes: %w", err)
+	}
+	fabricMode, err := control.DetectFabricMode()
+	if err != nil {
+		var nvl5 *nvidia.ErrNVL5RequiresNVLSM
+		if errors.As(err, &nvl5) {
+			return nvl5
+		}
+		return fmt.Errorf("detect NVIDIA fabric mode: %w", err)
+	}
+	switch fabricMode {
+	case nvidia.FabricModeNone:
+	case nvidia.FabricModeFabricManager:
+		if err := control.PrepareFabricManagerRuntime(); err != nil {
+			return fmt.Errorf("prepare NVIDIA Fabric Manager runtime: %w", err)
+		}
+		if err := oneShot(ctx, fabricManagerCommand()); err != nil {
+			return fmt.Errorf("start NVIDIA Fabric Manager: %w", err)
+		}
+		if err := control.WaitForFabricManager(ctx); err != nil {
+			return fmt.Errorf("wait for NVIDIA Fabric Manager: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported NVIDIA fabric mode %d", fabricMode)
+	}
+	if err := control.WaitForNVML(ctx, gpuCount); err != nil {
+		return fmt.Errorf("wait for NVIDIA NVML: %w", err)
+	}
+	temporary, err := control.CreateCDITemporary()
+	if err != nil {
+		return fmt.Errorf("create NVIDIA CDI temporary file: %w", err)
+	}
+	defer os.Remove(temporary)
+	if err := oneShot(ctx, command(
+		"nvidia-ctk-cdi",
+		"/usr/bin/nvidia-ctk",
+		"cdi", "generate", "--output="+temporary,
+	)); err != nil {
+		return fmt.Errorf("generate NVIDIA CDI specification: %w", err)
+	}
+	if err := control.PublishCDI(temporary); err != nil {
+		return fmt.Errorf("publish NVIDIA CDI specification: %w", err)
+	}
+	return nil
+}
+
+func waitForNVIDIADeviceNodes(
+	ctx context.Context,
+	setup func() error,
+	limit time.Duration,
+	poll time.Duration,
+) error {
+	waitCtx, cancel := context.WithTimeout(ctx, limit)
+	defer cancel()
+
+	var lastErr error
+	for {
+		if err := setup(); err == nil {
+			return nil
+		} else {
+			lastErr = err
+		}
+		timer := time.NewTimer(poll)
+		select {
+		case <-waitCtx.Done():
+			timer.Stop()
+			return fmt.Errorf("NVIDIA device readiness failed (%v): %w", lastErr, waitCtx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func fabricManagerCommand() supervisor.Command {
+	cmd := command(
+		"nvidia-fabricmanager",
+		"/usr/bin/nv-fabricmanager",
+		"-c", fabricConfigPath,
+	)
+	env := make([]string, 0, len(cmd.Env))
+	for _, entry := range cmd.Env {
+		key, _, _ := strings.Cut(entry, "=")
+		if key != "FM_CONFIG_FILE" && key != "FM_PID_FILE" {
+			env = append(env, entry)
+		}
+	}
+	cmd.Env = env
+	return cmd
 }
 
 func requiredServiceNames() []string {

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"tinfoil/internal/boot"
+	"tinfoil/internal/nvidia"
 	"tinfoil/internal/pid1/hardening"
 	pidruntime "tinfoil/internal/pid1/runtime"
 	"tinfoil/internal/pid1/supervisor"
@@ -21,6 +25,7 @@ type fakeServices struct {
 	drained   chan [][]string
 	fail      map[string]error
 	observe   func(supervisor.State)
+	onStart   func(string)
 }
 
 func newFakeServices() *fakeServices {
@@ -37,6 +42,9 @@ func (f *fakeServices) Start(_ context.Context, service supervisor.Service) erro
 	err := f.fail[service.Name]
 	f.mu.Unlock()
 	f.startedCh <- service.Name
+	if f.onStart != nil {
+		f.onStart(service.Name)
+	}
 	if err != nil {
 		f.observe(supervisor.State{Name: service.Name, Required: service.Required, Err: err})
 		return err
@@ -77,6 +85,7 @@ func newLifecycleHarness() *lifecycleHarness {
 	harness.deps = lifecycleDeps{
 		services: harness.services,
 		oneShot:  func(context.Context, supervisor.Command) error { return nil },
+		nvidia:   func(context.Context) error { return nil },
 		setupFS:  noSetup,
 		sysctls:  noSetup,
 		ramdisk:  noSetup,
@@ -88,6 +97,360 @@ func newLifecycleHarness() *lifecycleHarness {
 		timeout: time.Hour,
 	}
 	return harness
+}
+
+type fakeNVIDIA struct {
+	mu         sync.Mutex
+	calls      []string
+	fail       map[string]error
+	gpuCount   int
+	hasSwitch  bool
+	fabricMode nvidia.FabricMode
+	fabricErr  error
+	temporary  string
+}
+
+func newFakeNVIDIA(t *testing.T, gpuCount int) *fakeNVIDIA {
+	t.Helper()
+	return &fakeNVIDIA{
+		fail:      map[string]error{},
+		gpuCount:  gpuCount,
+		temporary: filepath.Join(t.TempDir(), "nvidia.yaml.tmp"),
+	}
+}
+
+func (f *fakeNVIDIA) call(name string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, name)
+	return f.fail[name]
+}
+
+func (f *fakeNVIDIA) GPUCount() (int, error) {
+	return f.gpuCount, f.call("gpu-count")
+}
+func (f *fakeNVIDIA) HasNVSwitch() (bool, error) {
+	return f.hasSwitch, f.call("has-nvswitch")
+}
+func (f *fakeNVIDIA) HoldGPUEnableReferences() error {
+	return f.call("hold-pci")
+}
+func (f *fakeNVIDIA) EnableGPURuntimePowerManagement() error {
+	return f.call("runtime-pm")
+}
+func (f *fakeNVIDIA) LoadCoreKernelModules() error { return f.call("load-core") }
+func (f *fakeNVIDIA) WaitForCoreDeviceNodes(_ context.Context, expectedGPUs int) error {
+	return f.call(fmt.Sprintf("setup-core-devices-%d", expectedGPUs))
+}
+func (f *fakeNVIDIA) PreparePersistencedRuntime() error { return f.call("prepare-persistenced") }
+func (f *fakeNVIDIA) WaitForPersistenced(context.Context) error {
+	return f.call("wait-persistenced")
+}
+func (f *fakeNVIDIA) LoadUVMKernelModules() error { return f.call("load-uvm") }
+func (f *fakeNVIDIA) WaitForUVMDeviceNodes(_ context.Context, expectedGPUs int) error {
+	return f.call(fmt.Sprintf("setup-uvm-devices-%d", expectedGPUs))
+}
+func (f *fakeNVIDIA) LoadModesetKernelModules() error {
+	return f.call("load-modeset")
+}
+func (f *fakeNVIDIA) DetectFabricMode() (nvidia.FabricMode, error) {
+	if err := f.call("detect-fabric"); err != nil {
+		return nvidia.FabricModeNone, err
+	}
+	return f.fabricMode, f.fabricErr
+}
+func (f *fakeNVIDIA) PrepareFabricManagerRuntime() error {
+	return f.call("prepare-fabric")
+}
+func (f *fakeNVIDIA) WaitForFabricManager(context.Context) error {
+	return f.call("wait-fabric")
+}
+func (f *fakeNVIDIA) WaitForNVML(_ context.Context, count int) error {
+	return f.call(fmt.Sprintf("wait-nvml-%d", count))
+}
+func (f *fakeNVIDIA) CreateCDITemporary() (string, error) {
+	return f.temporary, f.call("create-cdi")
+}
+func (f *fakeNVIDIA) PublishCDI(path string) error {
+	if path != f.temporary {
+		return fmt.Errorf("publish path = %s, want %s", path, f.temporary)
+	}
+	return f.call("publish-cdi")
+}
+
+func TestNVIDIABootstrapExactOrderAndCommandContracts(t *testing.T) {
+	t.Setenv("FM_CONFIG_FILE", "poisoned")
+	t.Setenv("FM_PID_FILE", "poisoned")
+	control := newFakeNVIDIA(t, 8)
+	control.fabricMode = nvidia.FabricModeFabricManager
+	var commands []supervisor.Command
+	var persistencedLimit time.Duration
+	oneShot := func(ctx context.Context, command supervisor.Command) error {
+		control.calls = append(control.calls, "exec:"+command.Name)
+		commands = append(commands, command)
+		if command.Name == "nvidia-persistenced" {
+			deadline, ok := ctx.Deadline()
+			if !ok {
+				t.Fatal("nvidia-persistenced context has no deadline")
+			}
+			persistencedLimit = time.Until(deadline)
+		}
+		return nil
+	}
+	var statuses []nvidia.BootstrapStatus
+	err := runNVIDIABootstrap(context.Background(), control, oneShot, func(status nvidia.BootstrapStatus) error {
+		control.calls = append(control.calls, fmt.Sprintf("status:%d:%d", status.State, status.GPUCount))
+		statuses = append(statuses, status)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantOrder := []string{
+		"gpu-count", "hold-pci", "runtime-pm", "load-core", "setup-core-devices-8",
+		"prepare-persistenced", "exec:nvidia-persistenced", "wait-persistenced",
+		"load-uvm", "setup-uvm-devices-8", "load-modeset", "setup-uvm-devices-8",
+		"detect-fabric", "prepare-fabric", "exec:nvidia-fabricmanager", "wait-fabric", "wait-nvml-8",
+		"create-cdi", "exec:nvidia-ctk-cdi", "publish-cdi",
+		fmt.Sprintf("status:%d:8", nvidia.BootstrapStateReady),
+	}
+	if !slices.Equal(control.calls, wantOrder) {
+		t.Fatalf("calls = %v, want %v", control.calls, wantOrder)
+	}
+	if persistencedLimit > nvidiaChildLimit || persistencedLimit < nvidiaChildLimit-time.Second {
+		t.Fatalf("persistenced child limit = %s, want %s", persistencedLimit, nvidiaChildLimit)
+	}
+	if len(statuses) != 1 || statuses[0] != nvidia.ReadyBootstrapStatus(8) {
+		t.Fatalf("statuses = %#v", statuses)
+	}
+	if len(commands) != 3 {
+		t.Fatalf("commands = %d, want 3", len(commands))
+	}
+	assertCommand(t, commands[0], "nvidia-persistenced", "/usr/bin/nvidia-persistenced",
+		[]string{"--user", "nvidia-persistenced", "--uvm-persistence-mode", "--verbose"})
+	assertCommand(t, commands[1], "nvidia-fabricmanager", "/usr/bin/nv-fabricmanager",
+		[]string{"-c", fabricConfigPath})
+	assertCommand(t, commands[2], "nvidia-ctk-cdi", "/usr/bin/nvidia-ctk",
+		[]string{"cdi", "generate", "--output=" + control.temporary})
+	env := environmentMap(commands[1].Env)
+	if _, ok := env["FM_CONFIG_FILE"]; ok {
+		t.Fatalf("Fabric Manager inherited FM_CONFIG_FILE: %#v", env)
+	}
+	if _, ok := env["FM_PID_FILE"]; ok {
+		t.Fatalf("Fabric Manager inherited FM_PID_FILE: %#v", env)
+	}
+}
+
+func TestNVIDIABootstrapWritesExplicitNoGPUStatus(t *testing.T) {
+	control := newFakeNVIDIA(t, 0)
+	var got nvidia.BootstrapStatus
+	err := runNVIDIABootstrap(context.Background(), control, func(context.Context, supervisor.Command) error {
+		t.Fatal("no-GPU bootstrap ran a child")
+		return nil
+	}, func(status nvidia.BootstrapStatus) error {
+		got = status
+		control.calls = append(control.calls, "status")
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nvidia.NoGPUBootstrapStatus() {
+		t.Fatalf("status = %#v", got)
+	}
+	if !slices.Equal(control.calls, []string{"gpu-count", "has-nvswitch", "status"}) {
+		t.Fatalf("calls = %v", control.calls)
+	}
+}
+
+func TestNVIDIABootstrapRejectsNVSwitchOnlyTopology(t *testing.T) {
+	control := newFakeNVIDIA(t, 0)
+	control.hasSwitch = true
+	var got nvidia.BootstrapStatus
+	err := runNVIDIABootstrap(context.Background(), control, func(context.Context, supervisor.Command) error {
+		t.Fatal("NVSwitch-only bootstrap ran a child")
+		return nil
+	}, func(status nvidia.BootstrapStatus) error {
+		got = status
+		control.calls = append(control.calls, "status")
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nvidia.FailedBootstrapStatus() {
+		t.Fatalf("status = %#v", got)
+	}
+	if !slices.Equal(control.calls, []string{"gpu-count", "has-nvswitch", "status"}) {
+		t.Fatalf("calls = %v", control.calls)
+	}
+}
+
+func TestWaitForNVIDIADeviceNodesRetriesUntilReadyAndHonorsDeadline(t *testing.T) {
+	attempts := 0
+	err := waitForNVIDIADeviceNodes(context.Background(), func() error {
+		attempts++
+		if attempts < 3 {
+			return errors.New("not ready")
+		}
+		return nil
+	}, time.Second, time.Millisecond)
+	if err != nil || attempts != 3 {
+		t.Fatalf("wait error = %v, attempts = %d", err, attempts)
+	}
+
+	err = waitForNVIDIADeviceNodes(context.Background(), func() error {
+		return errors.New("still unavailable")
+	}, 5*time.Millisecond, time.Millisecond)
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("deadline error = %v", err)
+	}
+}
+
+func TestNVIDIABootstrapFailuresPersistAndContinue(t *testing.T) {
+	failure := errors.New("boom")
+	for _, failedCall := range []string{
+		"gpu-count", "hold-pci", "runtime-pm", "load-core", "setup-core-devices-8",
+		"prepare-persistenced", "wait-persistenced", "load-uvm", "setup-uvm-devices-8",
+		"load-modeset", "detect-fabric", "prepare-fabric", "wait-fabric", "wait-nvml-8",
+		"create-cdi", "publish-cdi",
+	} {
+		t.Run(failedCall, func(t *testing.T) {
+			control := newFakeNVIDIA(t, 8)
+			if failedCall == "prepare-fabric" || failedCall == "wait-fabric" {
+				control.fabricMode = nvidia.FabricModeFabricManager
+			}
+			control.fail[failedCall] = failure
+			var got nvidia.BootstrapStatus
+			err := runNVIDIABootstrap(context.Background(), control,
+				func(context.Context, supervisor.Command) error { return nil },
+				func(status nvidia.BootstrapStatus) error { got = status; return nil },
+			)
+			if err != nil {
+				t.Fatalf("bootstrap did not hand failure to boot: %v", err)
+			}
+			if got != nvidia.FailedBootstrapStatus() {
+				t.Fatalf("status = %#v", got)
+			}
+		})
+	}
+}
+
+func TestNVIDIABootstrapChildFailuresPersistAndStatusWriteFailureIsFatal(t *testing.T) {
+	childFailure := errors.New("child failed")
+	for _, child := range []string{"nvidia-persistenced", "nvidia-fabricmanager", "nvidia-ctk-cdi"} {
+		t.Run(child, func(t *testing.T) {
+			control := newFakeNVIDIA(t, 8)
+			control.fabricMode = nvidia.FabricModeFabricManager
+			var got nvidia.BootstrapStatus
+			err := runNVIDIABootstrap(context.Background(), control,
+				func(_ context.Context, command supervisor.Command) error {
+					if command.Name == child {
+						return childFailure
+					}
+					return nil
+				},
+				func(status nvidia.BootstrapStatus) error { got = status; return nil },
+			)
+			if err != nil || got != nvidia.FailedBootstrapStatus() {
+				t.Fatalf("error = %v, status = %#v", err, got)
+			}
+		})
+	}
+	control := newFakeNVIDIA(t, 8)
+	control.fail["hold-pci"] = childFailure
+	writeFailure := errors.New("disk failed")
+	err := runNVIDIABootstrap(context.Background(), control,
+		func(context.Context, supervisor.Command) error { return nil },
+		func(nvidia.BootstrapStatus) error { return writeFailure },
+	)
+	if err == nil || !errors.Is(err, writeFailure) {
+		t.Fatalf("status persistence error = %v", err)
+	}
+	for _, gpuCount := range []int{0, 8} {
+		control := newFakeNVIDIA(t, gpuCount)
+		err := runNVIDIABootstrap(context.Background(), control,
+			func(context.Context, supervisor.Command) error { return nil },
+			func(nvidia.BootstrapStatus) error { return writeFailure },
+		)
+		if err == nil || !errors.Is(err, writeFailure) {
+			t.Fatalf("GPU count %d status persistence error = %v", gpuCount, err)
+		}
+	}
+}
+
+func TestNVIDIABootstrapRejectsNVL5WithTypedError(t *testing.T) {
+	control := newFakeNVIDIA(t, 8)
+	control.fabricErr = &nvidia.ErrNVL5RequiresNVLSM{}
+	err := runNVIDIABootstrapSteps(context.Background(), control,
+		func(context.Context, supervisor.Command) error { return nil }, 8)
+	var typed *nvidia.ErrNVL5RequiresNVLSM
+	if !errors.As(err, &typed) {
+		t.Fatalf("error = %v, want ErrNVL5RequiresNVLSM", err)
+	}
+}
+
+func TestNVIDIABootstrapRejectsUnknownFabricMode(t *testing.T) {
+	control := newFakeNVIDIA(t, 8)
+	control.fabricMode = nvidia.FabricMode(255)
+	if err := runNVIDIABootstrapSteps(context.Background(), control,
+		func(context.Context, supervisor.Command) error { return nil }, 8); err == nil {
+		t.Fatal("unknown fabric mode succeeded")
+	}
+}
+
+func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
+	harness := newLifecycleHarness()
+	var mu sync.Mutex
+	var events []string
+	record := func(event string) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, event)
+	}
+	harness.deps.oneShot = func(_ context.Context, command supervisor.Command) error {
+		record(command.Name)
+		return nil
+	}
+	harness.deps.nvidia = func(context.Context) error {
+		record("nvidia-bootstrap")
+		return nil
+	}
+	harness.services.onStart = record
+	parent, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- runLifecycle(parent, harness.deps, harness.readiness) }()
+	if ready := receiveTest(t, harness.ready); !ready {
+		t.Fatal("lifecycle did not become ready")
+	}
+	cancel()
+	if err := receiveTest(t, result); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	loopback := slices.Index(events, "loopback")
+	bootstrap := slices.Index(events, "nvidia-bootstrap")
+	containerd := slices.Index(events, containerdName)
+	if loopback < 0 || bootstrap != loopback+1 || containerd <= bootstrap {
+		t.Fatalf("startup events = %v", events)
+	}
+}
+
+func assertCommand(t *testing.T, got supervisor.Command, name, path string, args []string) {
+	t.Helper()
+	if got.Name != name || got.Path != path || !slices.Equal(got.Args, args) || got.Dir != "/" {
+		t.Fatalf("command = %#v, want name=%q path=%q args=%v dir=/", got, name, path, args)
+	}
+}
+
+func environmentMap(entries []string) map[string]string {
+	env := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, value, _ := strings.Cut(entry, "=")
+		env[key] = value
+	}
+	return env
 }
 
 func receiveTest[T any](t *testing.T, channel <-chan T) T {

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -29,6 +29,10 @@ const (
 	StatePath          = PrivateDir + "/boot-state.json"
 	EgressStatePath    = PrivateDir + "/egress-prev"
 
+	// NVIDIABootstrapStatusPath is the fixed PID 1 to tinfoil-boot handoff
+	// for NVIDIA bring-up readiness.
+	NVIDIABootstrapStatusPath = "/run/tinfoil/nvidia-bootstrap-status"
+
 	// ShimListenPort is the public TLS port served by tinfoil-shim.
 	ShimListenPort = 443
 

--- a/tinfoil/internal/nvidia/bootstrap_status.go
+++ b/tinfoil/internal/nvidia/bootstrap_status.go
@@ -1,0 +1,206 @@
+package nvidia
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+const maxBootstrapStatusSize = 40
+
+var (
+	bootstrapNoGPU  = []byte("tinfoil-nvidia-bootstrap-v1:no-gpu\n")
+	bootstrapFailed = []byte("tinfoil-nvidia-bootstrap-v1:failed\n")
+	bootstrapReady  = [...][]byte{
+		nil,
+		[]byte("tinfoil-nvidia-bootstrap-v1:ready:1\n"),
+		[]byte("tinfoil-nvidia-bootstrap-v1:ready:2\n"),
+		[]byte("tinfoil-nvidia-bootstrap-v1:ready:3\n"),
+		[]byte("tinfoil-nvidia-bootstrap-v1:ready:4\n"),
+		[]byte("tinfoil-nvidia-bootstrap-v1:ready:5\n"),
+		[]byte("tinfoil-nvidia-bootstrap-v1:ready:6\n"),
+		[]byte("tinfoil-nvidia-bootstrap-v1:ready:7\n"),
+		[]byte("tinfoil-nvidia-bootstrap-v1:ready:8\n"),
+	}
+)
+
+type BootstrapState uint8
+
+const (
+	BootstrapStateNoGPU BootstrapState = iota + 1
+	BootstrapStateReady
+	BootstrapStateFailed
+)
+
+type BootstrapStatus struct {
+	State    BootstrapState
+	GPUCount int
+}
+
+func NoGPUBootstrapStatus() BootstrapStatus {
+	return BootstrapStatus{State: BootstrapStateNoGPU}
+}
+
+func ReadyBootstrapStatus(gpuCount int) BootstrapStatus {
+	return BootstrapStatus{State: BootstrapStateReady, GPUCount: gpuCount}
+}
+
+func FailedBootstrapStatus() BootstrapStatus {
+	return BootstrapStatus{State: BootstrapStateFailed}
+}
+
+func WriteBootstrapStatus(path string, status BootstrapStatus) error {
+	encoded, err := encodeBootstrapStatus(status)
+	if err != nil {
+		return err
+	}
+	directory := filepath.Dir(path)
+	if err := os.MkdirAll(directory, 0755); err != nil {
+		return fmt.Errorf("create NVIDIA bootstrap status directory: %w", err)
+	}
+	info, err := os.Lstat(directory)
+	if err != nil {
+		return fmt.Errorf("inspect NVIDIA bootstrap status directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("NVIDIA bootstrap status directory %s is not a directory", directory)
+	}
+
+	temporary, err := os.CreateTemp(directory, ".nvidia-bootstrap-status.*")
+	if err != nil {
+		return fmt.Errorf("create NVIDIA bootstrap status temporary file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(0644); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("chmod NVIDIA bootstrap status temporary file: %w", err)
+	}
+	if _, err := temporary.Write(encoded); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write NVIDIA bootstrap status: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("sync NVIDIA bootstrap status: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close NVIDIA bootstrap status: %w", err)
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return fmt.Errorf("publish NVIDIA bootstrap status: %w", err)
+	}
+	removeTemporary = false
+	if err := syncBootstrapStatusDirectory(directory); err != nil {
+		return fmt.Errorf("sync NVIDIA bootstrap status directory: %w", err)
+	}
+	return nil
+}
+
+func ReadBootstrapStatus(path string) (BootstrapStatus, error) {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return BootstrapStatus{}, fmt.Errorf("open NVIDIA bootstrap status: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), path)
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return BootstrapStatus{}, fmt.Errorf("inspect NVIDIA bootstrap status: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return BootstrapStatus{}, fmt.Errorf("NVIDIA bootstrap status is not a regular file")
+	}
+	if info.Size() > maxBootstrapStatusSize {
+		return BootstrapStatus{}, fmt.Errorf("NVIDIA bootstrap status exceeds %d bytes", maxBootstrapStatusSize)
+	}
+	encoded, err := io.ReadAll(io.LimitReader(file, maxBootstrapStatusSize+1))
+	if err != nil {
+		return BootstrapStatus{}, fmt.Errorf("read NVIDIA bootstrap status: %w", err)
+	}
+	if len(encoded) > maxBootstrapStatusSize {
+		return BootstrapStatus{}, fmt.Errorf("NVIDIA bootstrap status exceeds %d bytes", maxBootstrapStatusSize)
+	}
+	return decodeBootstrapStatus(encoded)
+}
+
+func ValidateBootstrapStatus(path string, configuredGPUs int) error {
+	status, err := ReadBootstrapStatus(path)
+	if err != nil {
+		return err
+	}
+	switch status.State {
+	case BootstrapStateFailed:
+		return errors.New("NVIDIA bootstrap reported failure")
+	case BootstrapStateNoGPU:
+		if configuredGPUs != 0 {
+			return fmt.Errorf("NVIDIA bootstrap reported no GPUs, config requires %d", configuredGPUs)
+		}
+	case BootstrapStateReady:
+		if configuredGPUs <= 0 {
+			return fmt.Errorf("NVIDIA bootstrap reported %d ready GPUs, config requires none", status.GPUCount)
+		}
+		if status.GPUCount != configuredGPUs {
+			return fmt.Errorf("NVIDIA bootstrap reported %d ready GPUs, config requires %d", status.GPUCount, configuredGPUs)
+		}
+	default:
+		return errors.New("invalid NVIDIA bootstrap state")
+	}
+	return nil
+}
+
+func encodeBootstrapStatus(status BootstrapStatus) ([]byte, error) {
+	switch status.State {
+	case BootstrapStateNoGPU:
+		if status.GPUCount != 0 {
+			return nil, errors.New("no-GPU NVIDIA bootstrap status has a GPU count")
+		}
+		return bootstrapNoGPU, nil
+	case BootstrapStateReady:
+		if status.GPUCount < 1 || status.GPUCount >= len(bootstrapReady) {
+			return nil, fmt.Errorf("unsupported NVIDIA bootstrap GPU count %d", status.GPUCount)
+		}
+		return bootstrapReady[status.GPUCount], nil
+	case BootstrapStateFailed:
+		if status.GPUCount != 0 {
+			return nil, errors.New("failed NVIDIA bootstrap status has a GPU count")
+		}
+		return bootstrapFailed, nil
+	default:
+		return nil, errors.New("invalid NVIDIA bootstrap status")
+	}
+}
+
+func decodeBootstrapStatus(encoded []byte) (BootstrapStatus, error) {
+	switch {
+	case bytes.Equal(encoded, bootstrapNoGPU):
+		return NoGPUBootstrapStatus(), nil
+	case bytes.Equal(encoded, bootstrapFailed):
+		return FailedBootstrapStatus(), nil
+	}
+	for gpuCount := 1; gpuCount < len(bootstrapReady); gpuCount++ {
+		if bytes.Equal(encoded, bootstrapReady[gpuCount]) {
+			return ReadyBootstrapStatus(gpuCount), nil
+		}
+	}
+	return BootstrapStatus{}, errors.New("malformed NVIDIA bootstrap status")
+}
+
+func syncBootstrapStatusDirectory(path string) error {
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_DIRECTORY|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return err
+	}
+	defer unix.Close(fd)
+	return unix.Fsync(fd)
+}

--- a/tinfoil/internal/nvidia/bootstrap_status_test.go
+++ b/tinfoil/internal/nvidia/bootstrap_status_test.go
@@ -1,0 +1,154 @@
+package nvidia
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBootstrapStatusExactEncodingsRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  BootstrapStatus
+		encoded string
+	}{
+		{name: "no-gpu", status: NoGPUBootstrapStatus(), encoded: "tinfoil-nvidia-bootstrap-v1:no-gpu\n"},
+		{name: "failed", status: FailedBootstrapStatus(), encoded: "tinfoil-nvidia-bootstrap-v1:failed\n"},
+		{name: "ready-one", status: ReadyBootstrapStatus(1), encoded: "tinfoil-nvidia-bootstrap-v1:ready:1\n"},
+		{name: "ready-eight", status: ReadyBootstrapStatus(8), encoded: "tinfoil-nvidia-bootstrap-v1:ready:8\n"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "run", "status")
+			if err := WriteBootstrapStatus(path, test.status); err != nil {
+				t.Fatal(err)
+			}
+			encoded, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(encoded) != test.encoded {
+				t.Fatalf("encoding = %q, want %q", encoded, test.encoded)
+			}
+			got, err := ReadBootstrapStatus(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != test.status {
+				t.Fatalf("status = %#v, want %#v", got, test.status)
+			}
+		})
+	}
+}
+
+func TestWriteBootstrapStatusAtomicallyReplacesSymlink(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "status")
+	victim := filepath.Join(directory, "victim")
+	if err := os.WriteFile(victim, []byte("unchanged"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(victim, path); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteBootstrapStatus(path, NoGPUBootstrapStatus()); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Mode().IsRegular() {
+		t.Fatalf("published status mode = %s", info.Mode())
+	}
+	contents, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(contents) != "unchanged" {
+		t.Fatalf("symlink target changed to %q", contents)
+	}
+}
+
+func TestReadBootstrapStatusFailsClosed(t *testing.T) {
+	directory := t.TempDir()
+	regular := filepath.Join(directory, "regular")
+	if err := os.WriteFile(regular, bootstrapNoGPU, 0600); err != nil {
+		t.Fatal(err)
+	}
+	symlink := filepath.Join(directory, "symlink")
+	if err := os.Symlink(regular, symlink); err != nil {
+		t.Fatal(err)
+	}
+	malformed := filepath.Join(directory, "malformed")
+	if err := os.WriteFile(malformed, []byte("tinfoil-nvidia-bootstrap-v1:ready:01\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	oversized := filepath.Join(directory, "oversized")
+	if err := os.WriteFile(oversized, []byte(strings.Repeat("x", maxBootstrapStatusSize+1)), 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{
+		filepath.Join(directory, "missing"),
+		malformed,
+		symlink,
+		oversized,
+		directory,
+	} {
+		if _, err := ReadBootstrapStatus(path); err == nil {
+			t.Fatalf("ReadBootstrapStatus(%q) succeeded", path)
+		}
+	}
+}
+
+func TestValidateBootstrapStatusRequiresExactConfigMatch(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "status")
+	tests := []struct {
+		name       string
+		status     BootstrapStatus
+		configured int
+		wantErr    bool
+	}{
+		{name: "no-gpu", status: NoGPUBootstrapStatus(), configured: 0},
+		{name: "ready", status: ReadyBootstrapStatus(8), configured: 8},
+		{name: "failed", status: FailedBootstrapStatus(), configured: 8, wantErr: true},
+		{name: "no-gpu-configured", status: NoGPUBootstrapStatus(), configured: 1, wantErr: true},
+		{name: "ready-config-zero", status: ReadyBootstrapStatus(1), configured: 0, wantErr: true},
+		{name: "ready-count-mismatch", status: ReadyBootstrapStatus(8), configured: 1, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if err := WriteBootstrapStatus(path, test.status); err != nil {
+				t.Fatal(err)
+			}
+			err := ValidateBootstrapStatus(path, test.configured)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ValidateBootstrapStatus() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatal(err)
+	}
+	if err := ValidateBootstrapStatus(path, 0); err == nil {
+		t.Fatal("missing status succeeded")
+	}
+}
+
+func TestWriteBootstrapStatusRejectsInvalidStates(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "status")
+	for _, status := range []BootstrapStatus{
+		{},
+		ReadyBootstrapStatus(0),
+		ReadyBootstrapStatus(9),
+		{State: BootstrapStateNoGPU, GPUCount: 1},
+		{State: BootstrapStateFailed, GPUCount: 1},
+	} {
+		if err := WriteBootstrapStatus(path, status); err == nil {
+			t.Fatalf("WriteBootstrapStatus(%#v) succeeded", status)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- compose the fixed NVIDIA startup sequence in PID 1: loopback, core modules/devices, persistenced, UVM/capabilities, modeset, Fabric Manager/NVML, then atomic CDI generation
- publish an exact versioned bootstrap status for ready, failed, and explicit no-GPU states
- require GPU attestation to consume that status and fail closed on missing, malformed, failed, or count-mismatched state
- pin the direct Fabric Manager Unix socket contract in the measured guest image

## Security properties

- keeps NVIDIA bootstrap ownership in PID 1 without a competing child wait path
- uses fixed command, device, socket, and status contracts rather than runtime discovery or compatibility parsing
- preserves bounded readiness checks and persists failure before continuing supervision
- represents no-GPU explicitly; absence never means success

## Validation

- `gofmt` on all changed Go files
- `go build ./...`
- `go test ./...`
- `go test -race ./cmd/init ./cmd/boot ./internal/nvidia`
- `go vet ./...`
- `bash -n mkosi.postinst.chroot` plus fixed Fabric Manager contract checks
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-closed NVIDIA GPU bootstrap in PID 1 with a fixed startup sequence and a versioned status handoff at `/run/tinfoil/nvidia-bootstrap-status`. GPU attestation now consumes this status and fails closed on missing, malformed, failed, or GPU count mismatches.

- New Features
  - Deterministic startup order: loopback → core modules/devices → persistenced → UVM/capabilities → modeset → Fabric Manager/NVML → atomic CDI generation.
  - Writes exact, versioned status: ready:<N>, failed, or no-gpu; atomic file publish and directory fsync, size-bounded, no symlink reads; path constant `NVIDIABootstrapStatusPath`.
  - `tinfoil-boot` uses `tinfoil/internal/nvidia.ValidateBootstrapStatus` to enforce configured GPU count and reject invalid states (real and dummy attestation modes).
  - Explicit no-gpu state; NVSwitch-only topologies are treated as failure.
  - Pins Fabric Manager Unix socket (`/run/nvidia-fabricmanager/socket`), strips `FM_CONFIG_FILE`/`FM_PID_FILE` env, and validates `DAEMONIZE=1`; adds CI check `scripts/test-fabric-manager-config.sh`.
  - Bounded readiness waits and child limits; generates CDI via `nvidia-ctk cdi generate` and publishes atomically.
  - Comprehensive tests for order, command/env contracts, failure persistence, deadlines, and status validation.

<sup>Written for commit 762c195f3878f39bd4e9c81976331e7805fb9bd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

