### PR TITLE
Add exact rootfs manifest verification

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Test Fabric Manager config contract
         run: ./scripts/test-fabric-manager-config.sh
+
+      - name: Test rootfs manifest security
+        run: sudo make test-rootfs-manifest

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ NVATTEST_BUILDER = ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0
 
 .PHONY: all build rebuild clean deepclean hash nvattest go-binaries \
 	builder-initrd additive-initrd verify-additive-initrd \
-	test-additive-initrd reproducible-additive-initrd test-roothash-artifacts test-rootfs-policy
+	test-additive-initrd reproducible-additive-initrd test-roothash-artifacts \
+	test-rootfs-policy test-rootfs-manifest
 
 # tinfoilcvm.hash is the compatibility copy written by `rebuild`; mkosi's
 # direct roothash split artifact is the source contract.
@@ -93,6 +94,9 @@ reproducible-additive-initrd:
 
 test-rootfs-policy:
 	./scripts/test-rootfs-policy-adversarial.sh
+
+test-rootfs-manifest:
+	./scripts/test-rootfs-manifest.sh
 
 # First build populates mkosi.cache; later builds reuse it for fast iteration.
 rebuild: go-binaries

--- a/docs/rootfs-manifest-format.md
+++ b/docs/rootfs-manifest-format.md
@@ -1,0 +1,60 @@
+# Rootfs Manifest Format
+
+The rootfs inventory and candidate verifier share one canonical tab-separated
+manifest format. This format is intended to bind later additive construction
+and final-disk verification to one exact measured contract.
+
+## Record format
+
+Comment lines begin with `#`. Blank lines are rejected. Each non-comment line
+has exactly eight tab-separated fields:
+
+```text
+path type mode uid gid content xattrs hardlink
+```
+
+- `path` is an absolute, normalized path. NULs, tabs, newlines, `.` components,
+  `..` components, duplicate paths, and paths outside the selected root are
+  rejected.
+- `type` is one of `file`, `dir`, `symlink`, `char`, `block`, `fifo`, or
+  `socket`.
+- `mode` is exactly four octal digits and includes permission and special bits.
+- `uid` and `gid` are non-negative decimal integers.
+- `content` is `sha256:<hex>` for regular files, `target64:<base64>` for
+  symlinks, `dev:<major>:<minor>` for device nodes, and `-` otherwise.
+- `xattrs` is `-` or a compact JSON object whose sorted keys are xattr names and
+  whose values are base64-encoded byte strings.
+- `hardlink` is `-` unless a regular file has multiple links. Hardlinked files
+  use `path64:<base64>` containing the lexicographically first path in the link
+  group. Raw inode numbers are never serialized.
+
+Filesystem inspection cannot establish package or artifact provenance, so this
+format deliberately records no caller-asserted provenance field. The later
+package/artifact closure owner must bind per-path sources to pinned locks and
+exact reports rather than injecting an unverifiable label into this manifest.
+
+Records are emitted in bytewise path order with a final newline. Numeric fields,
+JSON encoding, and base64 encoding are canonical. Tools run with a fixed locale
+and must produce byte-identical output for the same input tree.
+
+## Comparison rules
+
+Comparison is bidirectional. An undeclared path, missing path, changed type,
+mode, owner, group, content, symlink target, xattr, capability, device number, or
+hardlink group is a failure. The comparison interface has no exception or
+ignored-field mechanism.
+
+The verifier rejects setuid, setgid, file capabilities, device nodes, FIFOs, and
+sockets unless the source manifest explicitly permits the exact path and value.
+The initial additive rootfs policy is expected to permit none of them.
+
+## Safety boundary
+
+Inventory must not follow symlinks and must operate on an explicitly selected
+root directory or read-only mounted artifact. It uses descriptor-relative,
+no-follow traversal for every root component, snapshots directory membership,
+opens regular-file candidates non-blocking, immediately verifies the opened
+descriptor type, and fails if an entry, metadata, xattrs, or special-device
+identity changes while it is inspected. Manifest output uses exclusive
+no-follow temporary creation and atomic replacement within an already verified
+parent descriptor.

--- a/scripts/rootfs_manifest.py
+++ b/scripts/rootfs_manifest.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+
+import argparse
+import base64
+import binascii
+import errno
+import hashlib
+import json
+import os
+import posixpath
+import re
+import secrets
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+FIELD_NAMES = ("type", "mode", "uid", "gid", "content", "xattrs", "hardlink")
+ENTRY_TYPES = {"file", "dir", "symlink", "char", "block", "fifo", "socket"}
+ABSENT = "<absent>"
+SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+MODE_RE = re.compile(r"[0-7]{4}\Z")
+DECIMAL_RE = re.compile(r"(?:0|[1-9][0-9]*)\Z")
+DEVICE_RE = re.compile(r"dev:(0|[1-9][0-9]*):(0|[1-9][0-9]*)\Z")
+
+
+class ManifestError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Entry:
+    path: str
+    kind: str
+    mode: str
+    uid: str
+    gid: str
+    content: str
+    xattrs: str
+    hardlink: str
+
+    def fields(self) -> tuple[str, ...]:
+        return (
+            self.path,
+            self.kind,
+            self.mode,
+            self.uid,
+            self.gid,
+            self.content,
+            self.xattrs,
+            self.hardlink,
+        )
+
+    def field(self, name: str) -> str:
+        if name == "type":
+            return self.kind
+        return getattr(self, name)
+
+
+@dataclass(frozen=True)
+class RawEntry:
+    path: str
+    kind: str
+    mode: int
+    uid: int
+    gid: int
+    content: str
+    xattrs: str
+    device: int
+    inode: int
+    links: int
+
+
+def fail(message: str) -> None:
+    raise ManifestError(message)
+
+
+def path_bytes(path: str) -> bytes:
+    try:
+        return path.encode("utf-8")
+    except UnicodeEncodeError as error:
+        fail(f"path is not valid UTF-8: {path!r}: {error}")
+
+
+def decode_name(name: str, parent: str) -> tuple[str, bytes]:
+    raw = os.fsencode(name)
+    try:
+        decoded = raw.decode("utf-8")
+    except UnicodeDecodeError as error:
+        fail(f"{parent}: filename is not valid UTF-8: {raw!r}: {error}")
+    if "\t" in decoded or "\n" in decoded or "\r" in decoded:
+        fail(f"{parent}: filename contains a forbidden control character: {decoded!r}")
+    return decoded, raw
+
+
+def canonical_base64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def validate_base64(value: str, context: str) -> bytes:
+    try:
+        decoded = base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as error:
+        fail(f"{context}: invalid base64: {error}")
+    if canonical_base64(decoded) != value:
+        fail(f"{context}: non-canonical base64")
+    return decoded
+
+
+def validate_path(path: str, context: str) -> None:
+    if not path.startswith("/"):
+        fail(f"{context}: path must be absolute: {path}")
+    if "\t" in path or "\n" in path or "\r" in path or "\0" in path:
+        fail(f"{context}: path contains a forbidden control character: {path!r}")
+    if path != "/" and path.endswith("/"):
+        fail(f"{context}: path has a trailing slash: {path}")
+    if posixpath.normpath(path) != path or path.startswith("//"):
+        fail(f"{context}: path is not normalized: {path}")
+    path_bytes(path)
+
+
+def canonical_xattrs_for_fd(file_descriptor: int, context: str) -> str:
+    try:
+        names = os.listxattr(file_descriptor)
+    except OSError as error:
+        fail(f"{context}: cannot list xattrs: {error}")
+    attributes = {}
+    for name in names:
+        raw_name = os.fsencode(name)
+        try:
+            decoded_name = raw_name.decode("utf-8")
+        except UnicodeDecodeError as error:
+            fail(f"{context}: xattr name is not valid UTF-8: {raw_name!r}: {error}")
+        try:
+            value = os.getxattr(file_descriptor, name)
+        except OSError as error:
+            fail(f"{context}: cannot read xattr {decoded_name!r}: {error}")
+        attributes[decoded_name] = canonical_base64(value)
+    return canonical_xattrs(attributes)
+
+
+def canonical_xattrs_for_path(path: str, context: str) -> str:
+    try:
+        names = os.listxattr(path, follow_symlinks=False)
+    except OSError as error:
+        fail(f"{context}: cannot list xattrs: {error}")
+    attributes = {}
+    for name in names:
+        raw_name = os.fsencode(name)
+        try:
+            decoded_name = raw_name.decode("utf-8")
+        except UnicodeDecodeError as error:
+            fail(f"{context}: xattr name is not valid UTF-8: {raw_name!r}: {error}")
+        try:
+            value = os.getxattr(path, name, follow_symlinks=False)
+        except OSError as error:
+            fail(f"{context}: cannot read xattr {decoded_name!r}: {error}")
+        attributes[decoded_name] = canonical_base64(value)
+    return canonical_xattrs(attributes)
+
+
+def canonical_xattrs(attributes: dict[str, str]) -> str:
+    if not attributes:
+        return "-"
+    return json.dumps(attributes, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def validate_xattrs(value: str, context: str) -> None:
+    if value == "-":
+        return
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as error:
+        fail(f"{context}: invalid xattr JSON: {error}")
+    if not isinstance(parsed, dict) or not parsed:
+        fail(f"{context}: xattrs must be '-' or a non-empty JSON object")
+    for name, encoded in parsed.items():
+        if not isinstance(name, str) or not name:
+            fail(f"{context}: xattr names must be non-empty strings")
+        if "\t" in name or "\n" in name or "\r" in name:
+            fail(f"{context}: xattr name contains a forbidden control character")
+        if not isinstance(encoded, str):
+            fail(f"{context}: xattr values must be base64 strings")
+        validate_base64(encoded, f"{context}: xattr {name!r}")
+    if canonical_xattrs(parsed) != value:
+        fail(f"{context}: xattr JSON is not canonical")
+
+
+def hash_fd(file_descriptor: int, context: str) -> str:
+    digest = hashlib.sha256()
+    try:
+        os.lseek(file_descriptor, 0, os.SEEK_SET)
+        while True:
+            chunk = os.read(file_descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    except OSError as error:
+        fail(f"{context}: cannot hash file: {error}")
+    return digest.hexdigest()
+
+
+def same_object(first: os.stat_result, second: os.stat_result) -> bool:
+    return (
+        first.st_dev == second.st_dev
+        and first.st_ino == second.st_ino
+        and stat.S_IFMT(first.st_mode) == stat.S_IFMT(second.st_mode)
+    )
+
+
+def stable_metadata(metadata: os.stat_result) -> tuple[int, ...]:
+    return (
+        stat.S_IFMT(metadata.st_mode),
+        stat.S_IMODE(metadata.st_mode),
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_nlink,
+        metadata.st_rdev,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def require_stable_metadata(
+    before: os.stat_result, after: os.stat_result, context: str
+) -> None:
+    if not same_object(before, after) or stable_metadata(before) != stable_metadata(after):
+        fail(f"{context}: entry changed while being inventoried")
+
+
+def open_verified_directory(path: Path, context: str) -> int:
+    raw_path = os.fspath(path)
+    if not raw_path:
+        fail(f"{context}: empty path")
+    absolute = os.path.isabs(raw_path)
+    components = raw_path.split(os.sep)
+    if any(component == os.pardir for component in components):
+        fail(f"{context}: parent traversal is not allowed: {raw_path}")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+    try:
+        current_fd = os.open(os.sep if absolute else os.curdir, flags)
+    except OSError as error:
+        fail(f"{context}: cannot open traversal root: {error}")
+    try:
+        for component in components:
+            if component in {"", os.curdir}:
+                continue
+            try:
+                next_fd = os.open(component, flags, dir_fd=current_fd)
+            except OSError as error:
+                fail(f"{context}: cannot safely open directory component {component!r}: {error}")
+            os.close(current_fd)
+            current_fd = next_fd
+        return current_fd
+    except BaseException:
+        os.close(current_fd)
+        raise
+
+
+def classify(metadata: os.stat_result, context: str) -> str:
+    mode = metadata.st_mode
+    if stat.S_ISREG(mode):
+        return "file"
+    if stat.S_ISDIR(mode):
+        return "dir"
+    if stat.S_ISLNK(mode):
+        return "symlink"
+    if stat.S_ISCHR(mode):
+        return "char"
+    if stat.S_ISBLK(mode):
+        return "block"
+    if stat.S_ISFIFO(mode):
+        return "fifo"
+    if stat.S_ISSOCK(mode):
+        return "socket"
+    fail(f"{context}: unsupported filesystem object mode {mode:#o}")
+
+
+class Inventory:
+    def __init__(self, root: Path):
+        self.root = root
+        self.entries: list[RawEntry] = []
+
+    def collect(self) -> list[Entry]:
+        root_fd = open_verified_directory(self.root, f"cannot open root directory {self.root}")
+        try:
+            root_metadata = os.fstat(root_fd)
+            root_xattrs = canonical_xattrs_for_fd(root_fd, "/")
+            self.entries.append(
+                RawEntry(
+                    "/",
+                    "dir",
+                    stat.S_IMODE(root_metadata.st_mode),
+                    root_metadata.st_uid,
+                    root_metadata.st_gid,
+                    "-",
+                    root_xattrs,
+                    root_metadata.st_dev,
+                    root_metadata.st_ino,
+                    root_metadata.st_nlink,
+                )
+            )
+            self._walk(root_fd, "/")
+            final_root_metadata = os.fstat(root_fd)
+            require_stable_metadata(root_metadata, final_root_metadata, "/")
+            if canonical_xattrs_for_fd(root_fd, "/") != root_xattrs:
+                fail("/: xattrs changed while being inventoried")
+        finally:
+            os.close(root_fd)
+        return self._finalize()
+
+    def _walk(self, directory_fd: int, parent_path: str) -> None:
+        names = self._directory_names(directory_fd, parent_path)
+        for name, raw_name in names:
+            self._collect_name(directory_fd, parent_path, name, raw_name)
+        if self._directory_names(directory_fd, parent_path) != names:
+            fail(f"{parent_path}: directory entries changed while being inventoried")
+
+    def _directory_names(self, directory_fd: int, parent_path: str) -> list[tuple[str, bytes]]:
+        try:
+            raw_names = os.listdir(directory_fd)
+        except OSError as error:
+            fail(f"{parent_path}: cannot list directory: {error}")
+        return sorted((decode_name(name, parent_path) for name in raw_names), key=lambda item: item[1])
+
+    def _collect_name(
+        self, directory_fd: int, parent_path: str, name: str, raw_name: bytes
+    ) -> None:
+        del raw_name
+        path = f"/{name}" if parent_path == "/" else f"{parent_path}/{name}"
+        validate_path(path, path)
+        try:
+            metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        except OSError as error:
+            fail(f"{path}: cannot stat entry: {error}")
+        kind = classify(metadata, path)
+        if kind == "dir":
+            self._collect_directory(directory_fd, name, path, metadata)
+        elif kind == "file":
+            self._collect_file(directory_fd, name, path, metadata)
+        else:
+            self._collect_special(directory_fd, name, path, metadata, kind)
+
+    def _collect_directory(
+        self, directory_fd: int, name: str, path: str, metadata: os.stat_result
+    ) -> None:
+        flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+        try:
+            child_fd = os.open(name, flags, dir_fd=directory_fd)
+        except OSError as error:
+            fail(f"{path}: cannot safely open directory: {error}")
+        try:
+            opened_metadata = os.fstat(child_fd)
+            require_stable_metadata(metadata, opened_metadata, path)
+            xattrs = canonical_xattrs_for_fd(child_fd, path)
+            self.entries.append(
+                RawEntry(
+                    path,
+                    "dir",
+                    stat.S_IMODE(opened_metadata.st_mode),
+                    opened_metadata.st_uid,
+                    opened_metadata.st_gid,
+                    "-",
+                    xattrs,
+                    opened_metadata.st_dev,
+                    opened_metadata.st_ino,
+                    opened_metadata.st_nlink,
+                )
+            )
+            self._walk(child_fd, path)
+            final_metadata = os.fstat(child_fd)
+            require_stable_metadata(opened_metadata, final_metadata, path)
+            if canonical_xattrs_for_fd(child_fd, path) != xattrs:
+                fail(f"{path}: xattrs changed while being inventoried")
+        finally:
+            os.close(child_fd)
+
+    def _collect_file(
+        self, directory_fd: int, name: str, path: str, metadata: os.stat_result
+    ) -> None:
+        flags = os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_NOFOLLOW
+        try:
+            file_fd = os.open(name, flags, dir_fd=directory_fd)
+        except OSError as error:
+            fail(f"{path}: cannot safely open file: {error}")
+        try:
+            opened_metadata = os.fstat(file_fd)
+            if not stat.S_ISREG(opened_metadata.st_mode):
+                fail(f"{path}: opened entry is not a regular file")
+            require_stable_metadata(metadata, opened_metadata, path)
+            digest = hash_fd(file_fd, path)
+            xattrs = canonical_xattrs_for_fd(file_fd, path)
+            final_metadata = os.fstat(file_fd)
+            require_stable_metadata(opened_metadata, final_metadata, path)
+            if canonical_xattrs_for_fd(file_fd, path) != xattrs:
+                fail(f"{path}: xattrs changed while being inventoried")
+            self.entries.append(
+                RawEntry(
+                    path,
+                    "file",
+                    stat.S_IMODE(final_metadata.st_mode),
+                    final_metadata.st_uid,
+                    final_metadata.st_gid,
+                    f"sha256:{digest}",
+                    xattrs,
+                    final_metadata.st_dev,
+                    final_metadata.st_ino,
+                    final_metadata.st_nlink,
+                )
+            )
+        finally:
+            os.close(file_fd)
+
+    def _collect_special(
+        self,
+        directory_fd: int,
+        name: str,
+        path: str,
+        metadata: os.stat_result,
+        kind: str,
+    ) -> None:
+        proc_path = f"/proc/self/fd/{directory_fd}/{name}"
+        if kind == "symlink":
+            try:
+                target = os.readlink(name, dir_fd=directory_fd)
+            except OSError as error:
+                fail(f"{path}: cannot read symlink: {error}")
+            content = f"target64:{canonical_base64(os.fsencode(target))}"
+        elif kind in {"char", "block"}:
+            content = f"dev:{os.major(metadata.st_rdev)}:{os.minor(metadata.st_rdev)}"
+        else:
+            content = "-"
+        xattrs = canonical_xattrs_for_path(proc_path, path)
+        try:
+            final_metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        except OSError as error:
+            fail(f"{path}: entry disappeared while being inventoried: {error}")
+        require_stable_metadata(metadata, final_metadata, path)
+        if kind == "symlink":
+            try:
+                final_target = os.readlink(name, dir_fd=directory_fd)
+            except OSError as error:
+                fail(f"{path}: cannot re-read symlink: {error}")
+            if os.fsencode(final_target) != os.fsencode(target):
+                fail(f"{path}: symlink target changed while being inventoried")
+        if canonical_xattrs_for_path(proc_path, path) != xattrs:
+            fail(f"{path}: xattrs changed while being inventoried")
+        self.entries.append(
+            RawEntry(
+                path,
+                kind,
+                stat.S_IMODE(final_metadata.st_mode),
+                final_metadata.st_uid,
+                final_metadata.st_gid,
+                content,
+                xattrs,
+                final_metadata.st_dev,
+                final_metadata.st_ino,
+                final_metadata.st_nlink,
+            )
+        )
+
+    def _finalize(self) -> list[Entry]:
+        hardlink_paths: dict[tuple[int, int], list[str]] = {}
+        for entry in self.entries:
+            if entry.kind == "file" and entry.links > 1:
+                hardlink_paths.setdefault((entry.device, entry.inode), []).append(entry.path)
+        hardlink_roots = {
+            identity: min(paths, key=path_bytes) for identity, paths in hardlink_paths.items()
+        }
+        for identity in hardlink_paths:
+            members = [
+                entry
+                for entry in self.entries
+                if entry.kind == "file" and (entry.device, entry.inode) == identity
+            ]
+            shared = {
+                (entry.mode, entry.uid, entry.gid, entry.content, entry.xattrs, entry.links)
+                for entry in members
+            }
+            if len(shared) != 1:
+                fail(f"hardlink group {hardlink_roots[identity]} changed while being inventoried")
+        result = []
+        for entry in sorted(self.entries, key=lambda item: path_bytes(item.path)):
+            hardlink = "-"
+            identity = (entry.device, entry.inode)
+            if entry.kind == "file" and entry.links > 1:
+                hardlink = f"path64:{canonical_base64(path_bytes(hardlink_roots[identity]))}"
+            result.append(
+                Entry(
+                    entry.path,
+                    entry.kind,
+                    f"{entry.mode:04o}",
+                    str(entry.uid),
+                    str(entry.gid),
+                    entry.content,
+                    entry.xattrs,
+                    hardlink,
+                )
+            )
+        return result
+
+
+def serialize(entries: list[Entry]) -> bytes:
+    return ("\n".join("\t".join(entry.fields()) for entry in entries) + "\n").encode("utf-8")
+
+
+def write_output(path: str, data: bytes) -> None:
+    if path == "-":
+        sys.stdout.buffer.write(data)
+        return
+    destination = Path(path)
+    destination_name = destination.name
+    if destination_name in {"", os.curdir, os.pardir}:
+        fail(f"cannot write manifest {destination}: invalid destination name")
+    parent_fd = open_verified_directory(destination.parent, f"manifest parent {destination.parent}")
+    temporary_name = ""
+    temporary_fd = -1
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW
+        for _ in range(128):
+            temporary_name = f".{destination_name}.tmp.{secrets.token_hex(16)}"
+            try:
+                temporary_fd = os.open(temporary_name, flags, 0o666, dir_fd=parent_fd)
+                break
+            except FileExistsError:
+                continue
+        else:
+            fail(f"cannot create an exclusive temporary manifest in {destination.parent}")
+        view = memoryview(data)
+        while view:
+            written = os.write(temporary_fd, view)
+            if written == 0:
+                fail(f"cannot write manifest {destination}: short write")
+            view = view[written:]
+        os.fsync(temporary_fd)
+        os.close(temporary_fd)
+        temporary_fd = -1
+        os.replace(
+            temporary_name,
+            destination_name,
+            src_dir_fd=parent_fd,
+            dst_dir_fd=parent_fd,
+        )
+        temporary_name = ""
+        os.fsync(parent_fd)
+    except OSError as error:
+        fail(f"cannot write manifest {destination}: {error}")
+    finally:
+        if temporary_fd >= 0:
+            os.close(temporary_fd)
+        if temporary_name:
+            try:
+                os.unlink(temporary_name, dir_fd=parent_fd)
+            except FileNotFoundError:
+                pass
+        os.close(parent_fd)
+
+
+def parse_manifest(path: Path) -> dict[str, Entry]:
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        fail(f"cannot read manifest {path}: {error}")
+    if not data:
+        fail(f"{path}: manifest is empty")
+    if not data.endswith(b"\n"):
+        fail(f"{path}: manifest must end with a newline")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        fail(f"{path}: manifest is not valid UTF-8: {error}")
+    entries: dict[str, Entry] = {}
+    previous_path: str | None = None
+    for number, line in enumerate(text[:-1].split("\n"), 1):
+        if not line:
+            fail(f"{path}:{number}: blank lines are not allowed")
+        if line.startswith("#"):
+            continue
+        fields = line.split("\t")
+        if len(fields) != 8:
+            fail(f"{path}:{number}: expected exactly eight tab-separated fields")
+        entry = Entry(*fields)
+        context = f"{path}:{number}"
+        validate_entry(entry, context)
+        if entry.path in entries:
+            fail(f"{context}: duplicate path: {entry.path}")
+        if previous_path is not None and path_bytes(entry.path) <= path_bytes(previous_path):
+            fail(f"{context}: records are not in strict bytewise path order")
+        entries[entry.path] = entry
+        previous_path = entry.path
+    if not entries:
+        fail(f"{path}: manifest has no records")
+    validate_hardlinks(entries, str(path))
+    return entries
+
+
+def validate_entry(entry: Entry, context: str) -> None:
+    validate_path(entry.path, context)
+    if entry.kind not in ENTRY_TYPES:
+        fail(f"{context}: unsupported type: {entry.kind}")
+    if not MODE_RE.fullmatch(entry.mode):
+        fail(f"{context}: mode must be exactly four octal digits")
+    if not DECIMAL_RE.fullmatch(entry.uid) or not DECIMAL_RE.fullmatch(entry.gid):
+        fail(f"{context}: uid and gid must be canonical non-negative decimals")
+    validate_xattrs(entry.xattrs, context)
+    if entry.kind == "file":
+        if not SHA256_RE.fullmatch(entry.content):
+            fail(f"{context}: regular file content must be a lowercase SHA-256")
+    elif entry.kind == "symlink":
+        if not entry.content.startswith("target64:"):
+            fail(f"{context}: symlink content must use target64")
+        validate_base64(entry.content.removeprefix("target64:"), f"{context}: symlink target")
+    elif entry.kind in {"char", "block"}:
+        if not DEVICE_RE.fullmatch(entry.content):
+            fail(f"{context}: device content must use canonical dev:<major>:<minor>")
+    elif entry.content != "-":
+        fail(f"{context}: {entry.kind} content must be '-'")
+    if entry.hardlink != "-":
+        if entry.kind != "file" or not entry.hardlink.startswith("path64:"):
+            fail(f"{context}: only regular files may have path64 hardlink groups")
+        decoded = validate_base64(
+            entry.hardlink.removeprefix("path64:"), f"{context}: hardlink path"
+        )
+        try:
+            target = decoded.decode("utf-8")
+        except UnicodeDecodeError as error:
+            fail(f"{context}: hardlink path is not valid UTF-8: {error}")
+        validate_path(target, f"{context}: hardlink path")
+
+
+def validate_hardlinks(entries: dict[str, Entry], context: str) -> None:
+    groups: dict[str, list[str]] = {}
+    for entry in entries.values():
+        if entry.hardlink != "-":
+            groups.setdefault(entry.hardlink, []).append(entry.path)
+    for encoded, paths in groups.items():
+        target = base64.b64decode(encoded.removeprefix("path64:")).decode("utf-8")
+        if target not in entries or entries[target].kind != "file":
+            fail(f"{context}: hardlink group target is not a regular manifest path: {target}")
+        first = min(paths, key=path_bytes)
+        if target != first:
+            fail(f"{context}: hardlink group target {target} is not its first bytewise path {first}")
+        shared_fields = ("type", "mode", "uid", "gid", "content", "xattrs")
+        for path in paths:
+            for field in shared_fields:
+                if entries[path].field(field) != entries[target].field(field):
+                    fail(f"{context}: hardlink group {target} has differing {field}")
+
+
+def compare_manifests(
+    expected: dict[str, Entry],
+    actual: dict[str, Entry],
+) -> list[str]:
+    failures = []
+
+    def report(path: str, field: str, expected_value: str, actual_value: str) -> None:
+        failures.append("difference\t" + "\t".join((path, field, expected_value, actual_value)))
+
+    for path in sorted(set(expected) | set(actual), key=path_bytes):
+        if path not in actual:
+            report(path, "path", path, ABSENT)
+            continue
+        if path not in expected:
+            report(path, "path", ABSENT, path)
+            continue
+        for field in FIELD_NAMES:
+            expected_value = expected[path].field(field)
+            actual_value = actual[path].field(field)
+            if expected_value != actual_value:
+                report(path, field, expected_value, actual_value)
+    return failures
+
+
+def command_inventory(arguments: argparse.Namespace) -> int:
+    entries = Inventory(Path(arguments.root)).collect()
+    write_output(arguments.output, serialize(entries))
+    return 0
+
+
+def command_validate(arguments: argparse.Namespace) -> int:
+    parse_manifest(Path(arguments.manifest))
+    return 0
+
+
+def command_compare(arguments: argparse.Namespace) -> int:
+    expected = parse_manifest(Path(arguments.expected))
+    actual = parse_manifest(Path(arguments.actual))
+    failures = compare_manifests(expected, actual)
+    for line in failures:
+        print(line, file=sys.stderr)
+    return 1 if failures else 0
+
+
+def parser() -> argparse.ArgumentParser:
+    command_parser = argparse.ArgumentParser(
+        description="Inventory and compare canonical additive-rootfs manifests."
+    )
+    subparsers = command_parser.add_subparsers(dest="command", required=True)
+
+    inventory_parser = subparsers.add_parser("inventory", help="inventory an explicit root")
+    inventory_parser.add_argument("--root", required=True, help="root directory to inventory")
+    inventory_parser.add_argument("--output", required=True, help="manifest path or '-' for stdout")
+    inventory_parser.set_defaults(function=command_inventory)
+
+    validate_parser = subparsers.add_parser("validate", help="validate canonical manifest syntax")
+    validate_parser.add_argument("manifest")
+    validate_parser.set_defaults(function=command_validate)
+
+    compare_parser = subparsers.add_parser("compare", help="compare manifests bidirectionally")
+    compare_parser.add_argument("--expected", required=True)
+    compare_parser.add_argument("--actual", required=True)
+    compare_parser.set_defaults(function=command_compare)
+    return command_parser
+
+
+def main() -> int:
+    os.environ["LC_ALL"] = "C"
+    try:
+        arguments = parser().parse_args()
+        return arguments.function(arguments)
+    except ManifestError as error:
+        print(f"rootfs_manifest.py: {error}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-rootfs-manifest.sh
+++ b/scripts/test-rootfs-manifest.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tool="$repo_dir/scripts/rootfs_manifest.py"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/rootfs-manifest-test.XXXXXX")"
+trap 'rm -rf "$scratch"' EXIT
+
+fail() {
+    echo "test-rootfs-manifest.sh: $*" >&2
+    exit 1
+}
+
+expect_failure() {
+    local expected_rc="$1"
+    shift
+    set +e
+    "$@" >"$scratch/stdout" 2>"$scratch/stderr"
+    local actual_rc="$?"
+    set -e
+    [[ "$actual_rc" -eq "$expected_rc" ]] || {
+        cat "$scratch/stdout" >&2
+        cat "$scratch/stderr" >&2
+        fail "expected exit $expected_rc, got $actual_rc: $*"
+    }
+}
+
+field() {
+    local manifest="$1"
+    local path="$2"
+    local number="$3"
+    awk -F '\t' -v path="$path" -v number="$number" '$1 == path { print $number; found = 1 } END { exit !found }' "$manifest"
+}
+
+root="$scratch/root"
+outside="$scratch/outside"
+mkdir -p "$root/a-dir" "$root/z-dir" "$outside"
+chmod 0750 "$root/a-dir"
+printf 'plain payload\n' >"$root/plain"
+printf 'hardlinked payload\n' >"$root/hard-a"
+ln "$root/hard-a" "$root/hard-b"
+printf 'outside payload\n' >"$outside/not-in-root"
+ln -s "$outside" "$root/external-link"
+ln -s '../plain' "$root/a-dir/relative-link"
+mkfifo "$root/named-pipe"
+python3 - "$root/unix-socket" <<'PY'
+import socket
+import sys
+
+server = socket.socket(socket.AF_UNIX)
+server.bind(sys.argv[1])
+server.close()
+PY
+
+xattr_supported=0
+if python3 - "$root/plain" <<'PY'
+import os
+import sys
+
+try:
+    os.setxattr(sys.argv[1], "user.z-last", b"last")
+    os.setxattr(sys.argv[1], "user.a-first", b"\x00first")
+except OSError:
+    raise SystemExit(1)
+PY
+then
+    xattr_supported=1
+fi
+
+manifest_a="$scratch/manifest-a.tsv"
+manifest_b="$scratch/manifest-b.tsv"
+"$tool" inventory --root "$root" --output "$manifest_a"
+"$tool" inventory --root "$root" --output "$manifest_b"
+cmp "$manifest_a" "$manifest_b"
+"$tool" validate "$manifest_a"
+"$tool" compare --expected "$manifest_a" --actual "$manifest_b"
+
+[[ "$(field "$manifest_a" / 2)" == "dir" ]] || fail "root directory record missing"
+[[ "$(field "$manifest_a" /plain 2)" == "file" ]] || fail "regular file type missing"
+[[ "$(field "$manifest_a" /external-link 2)" == "symlink" ]] || fail "symlink type missing"
+[[ "$(field "$manifest_a" /named-pipe 2)" == "fifo" ]] || fail "FIFO type missing"
+[[ "$(field "$manifest_a" /unix-socket 2)" == "socket" ]] || fail "socket type missing"
+[[ "$(field "$manifest_a" /a-dir 3)" == "0750" ]] || fail "mode was not captured"
+[[ "$(field "$manifest_a" /external-link 6)" == target64:* ]] || fail "symlink target is not encoded"
+[[ "$(field "$manifest_a" /hard-a 8)" == "path64:L2hhcmQtYQ==" ]] || fail "hardlink root is wrong"
+[[ "$(field "$manifest_a" /hard-b 8)" == "path64:L2hhcmQtYQ==" ]] || fail "hardlink group is wrong"
+[[ "$(field "$manifest_a" /plain 6)" == sha256:* ]] || fail "file digest is missing"
+if [[ "$xattr_supported" -eq 1 ]]; then
+    [[ "$(field "$manifest_a" /plain 7)" == '{"user.a-first":"AGZpcnN0","user.z-last":"bGFzdA=="}' ]] \
+        || fail "xattrs are missing or non-canonical"
+fi
+if grep -Fq '/not-in-root' "$manifest_a"; then
+    fail "inventory followed a symlink outside the selected root"
+fi
+
+python3 - "$manifest_a" <<'PY'
+import sys
+
+paths = [line.split(b"\t", 1)[0] for line in open(sys.argv[1], "rb") if line and not line.startswith(b"#")]
+if paths != sorted(paths):
+    raise SystemExit("manifest paths are not in bytewise order")
+if not open(sys.argv[1], "rb").read().endswith(b"\n"):
+    raise SystemExit("manifest has no final newline")
+PY
+
+added_root="$scratch/added-root"
+cp -a "$root" "$added_root"
+printf 'new\n' >"$added_root/added"
+added_manifest="$scratch/added.tsv"
+"$tool" inventory --root "$added_root" --output "$added_manifest"
+expect_failure 1 "$tool" compare --expected "$manifest_a" --actual "$added_manifest"
+grep -Fq $'difference\t/added\tpath\t<absent>\t/added' "$scratch/stderr" \
+    || fail "forward comparison did not report the added path"
+expect_failure 1 "$tool" compare --expected "$added_manifest" --actual "$manifest_a"
+grep -Fq $'difference\t/added\tpath\t/added\t<absent>' "$scratch/stderr" \
+    || fail "reverse comparison did not report the missing path"
+
+directory_root="$scratch/directory-root"
+cp -a "$root" "$directory_root"
+mkdir "$directory_root/added-directory"
+directory_manifest="$scratch/directory.tsv"
+"$tool" inventory --root "$directory_root" --output "$directory_manifest"
+expect_failure 1 "$tool" compare --expected "$manifest_a" --actual "$directory_manifest"
+grep -Fq $'difference\t/added-directory\tpath\t<absent>\t/added-directory' "$scratch/stderr" \
+    || fail "added directory was not reported"
+
+content_root="$scratch/content-root"
+cp -a "$root" "$content_root"
+printf 'changed payload\n' >"$content_root/plain"
+content_manifest="$scratch/content.tsv"
+"$tool" inventory --root "$content_root" --output "$content_manifest"
+expect_failure 1 "$tool" compare --expected "$manifest_a" --actual "$content_manifest"
+grep -Fq $'difference\t/plain\tcontent\t' "$scratch/stderr" \
+    || fail "content difference was not reported"
+
+chmod_root="$scratch/chmod-root"
+cp -a "$root" "$chmod_root"
+chmod 0700 "$chmod_root/a-dir"
+chmod_manifest="$scratch/chmod.tsv"
+"$tool" inventory --root "$chmod_root" --output "$chmod_manifest"
+expect_failure 1 "$tool" compare --expected "$manifest_a" --actual "$chmod_manifest"
+grep -Fq $'difference\t/a-dir\tmode\t0750\t0700' "$scratch/stderr" \
+    || fail "metadata difference was not reported"
+
+cp "$manifest_a" "$scratch/no-newline.tsv"
+truncate -s -1 "$scratch/no-newline.tsv"
+expect_failure 2 "$tool" validate "$scratch/no-newline.tsv"
+
+{
+    sed -n '1p' "$manifest_a"
+    printf '\n'
+    sed -n '2,$p' "$manifest_a"
+} >"$scratch/blank-line.tsv"
+expect_failure 2 "$tool" validate "$scratch/blank-line.tsv"
+expect_failure 2 "$tool" compare --expected "$scratch/blank-line.tsv" --actual "$manifest_a"
+
+{
+    printf '# exact rootfs manifest\n'
+    cat "$manifest_a"
+} >"$scratch/comment.tsv"
+"$tool" validate "$scratch/comment.tsv"
+"$tool" compare --expected "$scratch/comment.tsv" --actual "$manifest_a"
+
+python3 - "$scratch/nul-path.tsv" <<'PY'
+import pathlib
+import sys
+
+pathlib.Path(sys.argv[1]).write_bytes(
+    b"/bad\0path\tfile\t0644\t0\t0\tsha256:" + b"0" * 64 + b"\t-\t-\n"
+)
+PY
+expect_failure 2 "$tool" validate "$scratch/nul-path.tsv"
+
+printf '/bad\tfile\t0644\t0\t0\t-\t-\n' >"$scratch/seven-fields.tsv"
+expect_failure 2 "$tool" validate "$scratch/seven-fields.tsv"
+
+{
+    sed -n '2p' "$manifest_a"
+    sed -n '1p' "$manifest_a"
+} >"$scratch/unsorted.tsv"
+expect_failure 2 "$tool" validate "$scratch/unsorted.tsv"
+
+printf '/bad\tfile\t0644\t0\t0\tsha256:%064d\t{"user.z":"YQ==","user.a":"Yg=="}\t-\n' 0 \
+    >"$scratch/noncanonical-xattrs.tsv"
+expect_failure 2 "$tool" validate "$scratch/noncanonical-xattrs.tsv"
+
+awk -F '\t' 'BEGIN { OFS = "\t" } $1 == "/hard-b" { $3 = "0600" } { print }' \
+    "$manifest_a" >"$scratch/hardlink-mode.tsv"
+expect_failure 2 "$tool" validate "$scratch/hardlink-mode.tsv"
+
+symlink_ancestor="$scratch/symlink-ancestor"
+mkdir "$symlink_ancestor"
+ln -s "$root" "$symlink_ancestor/root-link"
+expect_failure 2 "$tool" inventory --root "$symlink_ancestor/root-link" --output "$scratch/symlink-root.tsv"
+
+output_parent="$scratch/output-parent"
+mkdir "$output_parent"
+ln -s "$output_parent" "$scratch/output-parent-link"
+expect_failure 2 "$tool" inventory --root "$root" --output "$scratch/output-parent-link/manifest.tsv"
+
+concurrent_output="$scratch/concurrent.tsv"
+pids=()
+for _ in {1..8}; do
+    "$tool" inventory --root "$root" --output "$concurrent_output" &
+    pids+=("$!")
+done
+for pid in "${pids[@]}"; do
+    wait "$pid"
+done
+"$tool" validate "$concurrent_output"
+if find "$scratch" -maxdepth 1 -name '.concurrent.tsv.tmp.*' -print -quit | grep -q .; then
+    fail "concurrent output left a temporary file"
+fi
+
+timeout --signal=KILL 5s python3 - "$tool" "$scratch" <<'PY'
+import importlib.util
+import os
+import pathlib
+import sys
+
+tool, scratch = sys.argv[1:]
+spec = importlib.util.spec_from_file_location("rootfs_manifest_type_race", tool)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+root = pathlib.Path(scratch, "race-file-to-fifo")
+root.mkdir()
+(root / "candidate").write_text("payload")
+original_open = os.open
+mutated = False
+
+
+def replace_with_fifo(path, flags, mode=0o777, *, dir_fd=None):
+    global mutated
+    if path == "candidate" and dir_fd is not None and not mutated:
+        mutated = True
+        os.unlink(path, dir_fd=dir_fd)
+        os.mkfifo(path, dir_fd=dir_fd)
+    return original_open(path, flags, mode, dir_fd=dir_fd)
+
+
+module.os.open = replace_with_fifo
+try:
+    module.Inventory(root).collect()
+except module.ManifestError:
+    pass
+else:
+    raise SystemExit("regular-file-to-FIFO race was accepted")
+if not mutated:
+    raise SystemExit("regular-file-to-FIFO race was not exercised")
+PY
+
+python3 - "$tool" "$scratch" <<'PY'
+import importlib.util
+import os
+import pathlib
+import sys
+
+tool, scratch = sys.argv[1:]
+spec = importlib.util.spec_from_file_location("rootfs_manifest", tool)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+
+class MutatingInventory(module.Inventory):
+    def __init__(self, root, mutation):
+        super().__init__(root)
+        self.mutation = mutation
+        self.root_reads = 0
+
+    def _directory_names(self, directory_fd, parent_path):
+        if parent_path == "/":
+            self.root_reads += 1
+            if self.root_reads == 2:
+                self.mutation(directory_fd)
+        return super()._directory_names(directory_fd, parent_path)
+
+
+def expect_rejected(name, setup, mutation):
+    root = pathlib.Path(scratch, name)
+    root.mkdir()
+    setup(root)
+    try:
+        MutatingInventory(root, mutation).collect()
+    except module.ManifestError:
+        return
+    raise SystemExit(f"concurrent {name} mutation was accepted")
+
+
+expect_rejected(
+    "race-add",
+    lambda root: None,
+    lambda directory_fd: os.mkdir("added", dir_fd=directory_fd),
+)
+expect_rejected(
+    "race-remove",
+    lambda root: pathlib.Path(root, "removed").write_text("payload"),
+    lambda directory_fd: os.unlink("removed", dir_fd=directory_fd),
+)
+
+
+class MetadataMutatingInventory(module.Inventory):
+    def _walk(self, directory_fd, parent_path):
+        super()._walk(directory_fd, parent_path)
+        if parent_path == "/":
+            os.fchmod(directory_fd, 0o700)
+
+
+metadata_root = pathlib.Path(scratch, "race-metadata")
+metadata_root.mkdir()
+try:
+    MetadataMutatingInventory(metadata_root).collect()
+except module.ManifestError:
+    pass
+else:
+    raise SystemExit("concurrent root metadata mutation was accepted")
+
+if hasattr(os, "setxattr"):
+    class XattrMutatingInventory(module.Inventory):
+        def _walk(self, directory_fd, parent_path):
+            super()._walk(directory_fd, parent_path)
+            if parent_path == "/":
+                try:
+                    os.setxattr(directory_fd, "user.race-test", b"changed")
+                except OSError:
+                    raise module.ManifestError("xattrs unavailable")
+
+    xattr_root = pathlib.Path(scratch, "race-xattr")
+    xattr_root.mkdir()
+    try:
+        XattrMutatingInventory(xattr_root).collect()
+    except module.ManifestError:
+        pass
+    else:
+        raise SystemExit("concurrent root xattr mutation was accepted")
+PY
+
+bad_name_root="$scratch/bad-name-root"
+mkdir "$bad_name_root"
+python3 - "$bad_name_root" <<'PY'
+import os
+import sys
+
+root = os.fsencode(sys.argv[1])
+open(root + b"/line\nbreak", "wb").close()
+PY
+expect_failure 2 "$tool" inventory --root "$bad_name_root" --output "$scratch/bad-name.tsv"
+
+bad_utf8_root="$scratch/bad-utf8-root"
+mkdir "$bad_utf8_root"
+python3 - "$bad_utf8_root" <<'PY'
+import os
+import sys
+
+root = os.fsencode(sys.argv[1])
+descriptor = os.open(root + b"/bad-\xff", os.O_CREAT | os.O_WRONLY, 0o600)
+os.close(descriptor)
+PY
+expect_failure 2 "$tool" inventory --root "$bad_utf8_root" --output "$scratch/bad-utf8.tsv"
+
+if [[ "$(id -u)" -eq 0 ]]; then
+    privileged_root="$scratch/privileged-root"
+    mkdir "$privileged_root"
+    printf '#!/bin/sh\nexit 0\n' >"$privileged_root/setuid-file"
+    chown 123:456 "$privileged_root/setuid-file"
+    chmod 4755 "$privileged_root/setuid-file"
+    printf '#!/bin/sh\nexit 0\n' >"$privileged_root/cap-file"
+    chmod 0755 "$privileged_root/cap-file"
+    mknod "$privileged_root/char-device" c 1 3
+    mknod "$privileged_root/block-device" b 7 0
+    capability_expected=0
+    if command -v setcap >/dev/null && setcap cap_net_bind_service=ep "$privileged_root/cap-file"; then
+        capability_expected=1
+    fi
+    privileged_manifest="$scratch/privileged.tsv"
+    "$tool" inventory --root "$privileged_root" --output "$privileged_manifest"
+    [[ "$(field "$privileged_manifest" /setuid-file 3)" == "4755" ]] || fail "setuid mode missing"
+    [[ "$(field "$privileged_manifest" /setuid-file 4)" == "123" ]] || fail "uid missing"
+    [[ "$(field "$privileged_manifest" /setuid-file 5)" == "456" ]] || fail "gid missing"
+    [[ "$(field "$privileged_manifest" /char-device 2)" == "char" ]] || fail "char device missing"
+    [[ "$(field "$privileged_manifest" /char-device 6)" == "dev:1:3" ]] || fail "char numbers missing"
+    [[ "$(field "$privileged_manifest" /block-device 2)" == "block" ]] || fail "block device missing"
+    [[ "$(field "$privileged_manifest" /block-device 6)" == "dev:7:0" ]] || fail "block numbers missing"
+    if [[ "$capability_expected" -eq 1 ]]; then
+        [[ "$(field "$privileged_manifest" /cap-file 7)" == *'security.capability'* ]] \
+            || fail "file capability xattr missing"
+    fi
+
+    python3 - "$tool" "$privileged_root" <<'PY'
+import importlib.util
+import os
+import pathlib
+import stat
+import sys
+
+tool, root = sys.argv[1:]
+spec = importlib.util.spec_from_file_location("rootfs_manifest_privileged", tool)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+device_candidate = pathlib.Path(root, "device-candidate")
+device_candidate.write_text("payload")
+original_open = os.open
+device_mutated = False
+
+
+def replace_regular_with_device(path, flags, mode=0o777, *, dir_fd=None):
+    global device_mutated
+    if path == "device-candidate" and dir_fd is not None and not device_mutated:
+        device_mutated = True
+        os.unlink(path, dir_fd=dir_fd)
+        os.mknod(path, stat.S_IFCHR | 0o600, os.makedev(1, 3), dir_fd=dir_fd)
+    return original_open(path, flags, mode, dir_fd=dir_fd)
+
+
+module.os.open = replace_regular_with_device
+try:
+    module.Inventory(pathlib.Path(root)).collect()
+except module.ManifestError:
+    pass
+else:
+    raise SystemExit("regular-file-to-device race was accepted")
+finally:
+    module.os.open = original_open
+if not device_mutated:
+    raise SystemExit("regular-file-to-device race was not exercised")
+
+original = module.canonical_xattrs_for_path
+mutated = False
+
+
+def replace_device(path, context):
+    global mutated
+    if context == "/char-device" and not mutated:
+        mutated = True
+        device = pathlib.Path(root, "char-device")
+        device.unlink()
+        os.mknod(device, stat.S_IFCHR | 0o600, os.makedev(1, 5))
+    return original(path, context)
+
+
+module.canonical_xattrs_for_path = replace_device
+try:
+    module.Inventory(pathlib.Path(root)).collect()
+except module.ManifestError:
+    pass
+else:
+    raise SystemExit("concurrent special-device replacement was accepted")
+PY
+fi
+
+echo "rootfs manifest tests passed"


### PR DESCRIPTION
## Summary
- add an exact canonical manifest format for the measured rootfs
- traverse descriptor-relative with `O_NOFOLLOW` and fail closed on metadata/content races
- reject malformed, non-canonical, missing, extra, or mutated entries without adding provenance parsing
- add focused privileged and adversarial security coverage plus CI integration

## Review scope
This is exactly one manifest-verifier commit on the merged fixed-rootfs-policy base. The runtime verifier and format documentation are isolated from later Bazel/rootfs assembly work.

## Validation
- `./scripts/test-rootfs-policy-adversarial.sh`
- `sudo env PATH=/usr/bin:/bin make test-rootfs-manifest`
- `bash -n scripts/test-rootfs-manifest.sh scripts/test-rootfs-policy-adversarial.sh`
- `python3 -m py_compile scripts/rootfs_manifest.py`
- workflow YAML parse
- `go build ./...`
- `go test ./...`
- `go test -race ./cmd/boot ./cmd/init ./internal/boot/...`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a canonical rootfs manifest and a verifier that inventories and compares filesystem facts without following symlinks. Enforces an exact, reproducible contract for the measured rootfs and blocks malformed or mutated entries.

- **New Features**
  - Documented exact 8-field manifest format with canonical encoding and strict bidirectional comparison (`docs/rootfs-manifest-format.md`).
  - Added `scripts/rootfs_manifest.py` with inventory, validate, and compare commands; descriptor-relative `O_NOFOLLOW` traversal; canonical xattrs; hardlink normalization; device/symlink encodings; fail-closed race checks; and atomic, no-follow manifest writes.
  - Added adversarial and privileged tests (`scripts/test-rootfs-manifest.sh`) and Makefile target `test-rootfs-manifest`; wired into CI with `sudo` in `.github/workflows/test.yml`.

<sup>Written for commit 878f31fad027142642b18342d36271c3e4a3fdf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

