### PR TITLE
Add fixed rootfs manifest policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ NVATTEST_BUILDER = ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0
 .PHONY: all build rebuild clean deepclean hash nvattest go-binaries \
 	builder-initrd additive-initrd verify-additive-initrd \
 	test-additive-initrd reproducible-additive-initrd test-roothash-artifacts \
-	test-rootfs-policy test-rootfs-manifest
+	test-rootfs-policy test-rootfs-manifest test-rootfs-manifest-policy
 
 # tinfoilcvm.hash is the compatibility copy written by `rebuild`; mkosi's
 # direct roothash split artifact is the source contract.
@@ -95,8 +95,11 @@ reproducible-additive-initrd:
 test-rootfs-policy:
 	./scripts/test-rootfs-policy-adversarial.sh
 
-test-rootfs-manifest:
+test-rootfs-manifest: test-rootfs-manifest-policy
 	./scripts/test-rootfs-manifest.sh
+
+test-rootfs-manifest-policy:
+	./scripts/test-rootfs-manifest-policy.py
 
 # First build populates mkosi.cache; later builds reuse it for fast iteration.
 rebuild: go-binaries

--- a/docs/rootfs-manifest-format.md
+++ b/docs/rootfs-manifest-format.md
@@ -48,6 +48,30 @@ The verifier rejects setuid, setgid, file capabilities, device nodes, FIFOs, and
 sockets unless the source manifest explicitly permits the exact path and value.
 The initial additive rootfs policy is expected to permit none of them.
 
+## Fixed policy gate
+
+Apply the immutable-rootfs metadata and path contract to an already canonical
+manifest with:
+
+```bash
+scripts/rootfs_manifest.py policy manifest.tsv
+```
+
+The command uses the same eight-field parser as validation and comparison. It
+has no exception file, wildcard, archive reader, or second parsing path. A
+malformed manifest exits `2`; a canonical manifest that violates policy exits
+`1` and reports deterministic `policy` records on standard error.
+
+The fixed gate rejects world-writable objects, special permission bits,
+capability representations, special objects, forbidden package/boot/systemd
+and runtime-state paths, stock or misplaced kernel modules, and shipped PID1
+runtime state. `/dev`, `/proc`, `/run`, and `/sys` must be empty root-owned
+`0755` mountpoint directories. `/tmp` and `/var/tmp` have the same immutable
+metadata before PID1 mounts mode-`1777` tmpfs instances over them. The only
+permitted modules are three unlinked, xattr-free, root-owned `0644` regular
+files named `nvidia.ko`, `nvidia-uvm.ko`, and `nvidia-modeset.ko` directly in
+`/usr/lib/tinfoil/kernel-modules`; all three are required.
+
 ## Safety boundary
 
 Inventory must not follow symlinks and must operate on an explicitly selected

--- a/scripts/rootfs_manifest.py
+++ b/scripts/rootfs_manifest.py
@@ -23,6 +23,124 @@ SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
 MODE_RE = re.compile(r"[0-7]{4}\Z")
 DECIMAL_RE = re.compile(r"(?:0|[1-9][0-9]*)\Z")
 DEVICE_RE = re.compile(r"dev:(0|[1-9][0-9]*):(0|[1-9][0-9]*)\Z")
+MODULE_DIRECTORY = "/usr/lib/tinfoil/kernel-modules"
+REQUIRED_MODULES = {
+    f"{MODULE_DIRECTORY}/nvidia-modeset.ko",
+    f"{MODULE_DIRECTORY}/nvidia-uvm.ko",
+    f"{MODULE_DIRECTORY}/nvidia.ko",
+}
+FORBIDDEN_TREES = (
+    "/EFI",
+    "/boot",
+    "/efi",
+    "/etc/apt",
+    "/etc/dpkg",
+    "/etc/ld.so.conf.d",
+    "/etc/systemd",
+    "/etc/sysctl.d",
+    "/etc/tinfoil/templates",
+    "/etc/tmpfiles.d",
+    "/home",
+    "/lib/systemd",
+    "/root",
+    "/snap",
+    "/usr/lib/apt",
+    "/usr/lib/debconf",
+    "/usr/lib/dpkg",
+    "/usr/lib/modules",
+    "/usr/lib/snapd",
+    "/usr/lib/systemd",
+    "/usr/lib/sysctl.d",
+    "/usr/lib/tmpfiles.d",
+    "/usr/share/tinfoil/templates",
+    "/var/cache/apt",
+    "/var/cache/debconf",
+    "/var/lib/apt",
+    "/var/lib/debconf",
+    "/var/lib/dpkg",
+    "/var/lib/snapd",
+    "/var/log",
+)
+REQUIRED_EMPTY_MOUNTPOINTS = ("/dev", "/proc", "/run", "/sys")
+OPTIONAL_EMPTY_RUNTIME_DIRECTORIES = (
+    "/mnt/ramdisk",
+    "/var/lib/containerd",
+    "/var/lib/docker",
+)
+FORBIDDEN_PATHS = {
+    "/etc/ld.so.cache",
+    "/etc/ld.so.conf",
+    "/etc/shells",
+    "/etc/sysctl.conf",
+    "/sbin/ldconfig",
+    "/sbin/sysctl",
+    "/usr/bin/apt",
+    "/usr/bin/apt-cache",
+    "/usr/bin/apt-cdrom",
+    "/usr/bin/apt-config",
+    "/usr/bin/apt-get",
+    "/usr/bin/apt-mark",
+    "/usr/bin/debconf",
+    "/usr/bin/debconf-apt-progress",
+    "/usr/bin/debconf-communicate",
+    "/usr/bin/debconf-copydb",
+    "/usr/bin/debconf-escape",
+    "/usr/bin/debconf-set-selections",
+    "/usr/bin/debconf-show",
+    "/usr/bin/dpkg",
+    "/usr/bin/dpkg-deb",
+    "/usr/bin/dpkg-divert",
+    "/usr/bin/dpkg-maintscript-helper",
+    "/usr/bin/dpkg-query",
+    "/usr/bin/dpkg-realpath",
+    "/usr/bin/dpkg-split",
+    "/usr/bin/dpkg-statoverride",
+    "/usr/bin/dpkg-trigger",
+    "/usr/bin/docker-init",
+    "/usr/bin/nvidia-smi",
+    "/usr/lib/docker/docker-init",
+    "/usr/libexec/docker/docker-init",
+    "/usr/sbin/ldconfig",
+    "/usr/sbin/sysctl",
+    "/usr/sbin/update-alternatives",
+}
+MODULE_SUFFIXES = (".ko", ".ko.gz", ".ko.xz", ".ko.zst")
+SHELL_NAMES = ("ash", "bash", "busybox", "csh", "dash", "fish", "ksh", "rbash", "sh", "tcsh", "zsh")
+SYSTEMD_TOOLS = (
+    "busctl",
+    "coredumpctl",
+    "hostnamectl",
+    "journalctl",
+    "localectl",
+    "loginctl",
+    "machinectl",
+    "networkctl",
+    "resolvectl",
+    "systemctl",
+    "systemd",
+    "systemd-analyze",
+    "systemd-ask-password",
+    "systemd-cat",
+    "systemd-creds",
+    "systemd-detect-virt",
+    "systemd-escape",
+    "systemd-firstboot",
+    "systemd-id128",
+    "systemd-machine-id-setup",
+    "systemd-mount",
+    "systemd-notify",
+    "systemd-path",
+    "systemd-repart",
+    "systemd-run",
+    "systemd-socket-activate",
+    "systemd-sysusers",
+    "systemd-tmpfiles",
+    "systemd-tty-ask-password-agent",
+    "systemd-umount",
+    "timedatectl",
+)
+FORBIDDEN_PATHS.update(f"{directory}/{name}" for directory in ("/bin", "/usr/bin") for name in SHELL_NAMES)
+FORBIDDEN_PATHS.update(f"/usr/bin/{name}" for name in SYSTEMD_TOOLS)
 
 
 class ManifestError(ValueError):
@@ -674,6 +792,77 @@ def compare_manifests(
     return failures
 
 
+def path_in_tree(path: str, root: str) -> bool:
+    return path == root or path.startswith(root + "/")
+
+
+def capability_xattrs(entry: Entry) -> list[str]:
+    if entry.xattrs == "-":
+        return []
+    attributes = json.loads(entry.xattrs)
+    return sorted(name for name in attributes if "capability" in name.lower())
+
+
+def policy_violations(entries: dict[str, Entry]) -> list[tuple[str, str]]:
+    violations: list[tuple[str, str]] = []
+    for path, entry in entries.items():
+        mode = int(entry.mode, 8)
+        if entry.kind != "symlink" and mode & 0o002:
+            violations.append((path, "world-writable non-symlink object"))
+        if mode & 0o7000:
+            violations.append((path, "setuid, setgid, and sticky bits are forbidden"))
+        for name in capability_xattrs(entry):
+            violations.append((path, f"capability xattr is forbidden: {name}"))
+        if entry.kind in {"char", "block", "fifo", "socket"}:
+            violations.append((path, f"special object is forbidden: {entry.kind}"))
+        if path in FORBIDDEN_PATHS or any(
+            path_in_tree(path, root) for root in FORBIDDEN_TREES
+        ):
+            violations.append((path, "forbidden immutable rootfs path"))
+        if path.endswith(MODULE_SUFFIXES) and path not in REQUIRED_MODULES:
+            violations.append((path, "kernel module is outside the fixed NVIDIA module set"))
+        if (
+            path_in_tree(path, MODULE_DIRECTORY)
+            and path not in REQUIRED_MODULES
+            and path != MODULE_DIRECTORY
+        ):
+            violations.append((path, "extra entry in the fixed NVIDIA module directory"))
+        runtime_directories = (
+            REQUIRED_EMPTY_MOUNTPOINTS
+            + OPTIONAL_EMPTY_RUNTIME_DIRECTORIES
+            + ("/tmp", "/var/tmp")
+        )
+        for directory in runtime_directories:
+            if path == directory and entry.kind != "dir":
+                violations.append((path, "runtime mountpoint must be a directory"))
+            elif path.startswith(directory + "/"):
+                violations.append((path, "runtime state must be created by PID1"))
+
+    for path in REQUIRED_EMPTY_MOUNTPOINTS + ("/tmp", "/var/tmp"):
+        entry = entries.get(path)
+        if entry is None:
+            violations.append((path, "required root-owned 0755 mountpoint is missing"))
+        elif (entry.kind, entry.mode, entry.uid, entry.gid) != ("dir", "0755", "0", "0"):
+            violations.append((path, "mountpoint must be a root-owned 0755 directory"))
+
+    for path in sorted(REQUIRED_MODULES, key=path_bytes):
+        entry = entries.get(path)
+        if entry is None:
+            violations.append((path, "required NVIDIA module is missing"))
+        elif (entry.kind, entry.mode, entry.uid, entry.gid, entry.xattrs, entry.hardlink) != (
+            "file",
+            "0644",
+            "0",
+            "0",
+            "-",
+            "-",
+        ):
+            violations.append(
+                (path, "NVIDIA module must be an unlinked xattr-free root-owned 0644 regular file")
+            )
+    return sorted(violations, key=lambda item: (path_bytes(item[0]), item[1]))
+
+
 def command_inventory(arguments: argparse.Namespace) -> int:
     entries = Inventory(Path(arguments.root)).collect()
     write_output(arguments.output, serialize(entries))
@@ -692,6 +881,14 @@ def command_compare(arguments: argparse.Namespace) -> int:
     for line in failures:
         print(line, file=sys.stderr)
     return 1 if failures else 0
+
+
+def command_policy(arguments: argparse.Namespace) -> int:
+    entries = parse_manifest(Path(arguments.manifest))
+    violations = policy_violations(entries)
+    for path, reason in violations:
+        print(f"policy\t{path}\t{reason}", file=sys.stderr)
+    return 1 if violations else 0
 
 
 def parser() -> argparse.ArgumentParser:
@@ -713,6 +910,10 @@ def parser() -> argparse.ArgumentParser:
     compare_parser.add_argument("--expected", required=True)
     compare_parser.add_argument("--actual", required=True)
     compare_parser.set_defaults(function=command_compare)
+
+    policy_parser = subparsers.add_parser("policy", help="enforce the fixed immutable rootfs policy")
+    policy_parser.add_argument("manifest")
+    policy_parser.set_defaults(function=command_policy)
     return command_parser
 
 

--- a/scripts/test-rootfs-manifest-policy.py
+++ b/scripts/test-rootfs-manifest-policy.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parent.parent
+TOOL = REPO / "scripts/rootfs_manifest.py"
+SPEC = importlib.util.spec_from_file_location("rootfs_manifest", TOOL)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+DIGEST = "sha256:" + "0" * 64
+MODULE_PATHS = (
+    "/usr/lib/tinfoil/kernel-modules/nvidia-modeset.ko",
+    "/usr/lib/tinfoil/kernel-modules/nvidia-uvm.ko",
+    "/usr/lib/tinfoil/kernel-modules/nvidia.ko",
+)
+
+
+def entry(path, kind="file", mode=None, uid="0", gid="0", xattrs="-"):
+    if mode is None:
+        mode = "0755" if kind == "dir" else "0777" if kind == "symlink" else "0644"
+    content = DIGEST if kind == "file" else "target64:dGFyZ2V0" if kind == "symlink" else "-"
+    if kind in {"char", "block"}:
+        content = "dev:1:3"
+    return MODULE.Entry(path, kind, mode, uid, gid, content, xattrs, "-")
+
+
+def minimal_entries():
+    entries = {
+        "/": entry("/", "dir"),
+        "/dev": entry("/dev", "dir"),
+        "/proc": entry("/proc", "dir"),
+        "/run": entry("/run", "dir"),
+        "/sys": entry("/sys", "dir"),
+        "/tmp": entry("/tmp", "dir"),
+        "/var/tmp": entry("/var/tmp", "dir"),
+    }
+    entries.update({path: entry(path) for path in MODULE_PATHS})
+    return entries
+
+
+def full_entries():
+    entries = minimal_entries()
+    for path in (
+        "/etc",
+        "/mnt",
+        "/mnt/ramdisk",
+        "/usr",
+        "/usr/lib",
+        "/usr/lib/tinfoil",
+        "/usr/lib/tinfoil/kernel-modules",
+        "/var",
+        "/var/lib",
+        "/var/lib/containerd",
+        "/var/lib/docker",
+    ):
+        entries[path] = entry(path, "dir")
+    entries["/etc/hosts"] = entry(
+        "/etc/hosts", xattrs=json.dumps({"user.note": "b2s="}, separators=(",", ":"))
+    )
+    return entries
+
+
+def write_manifest(directory, entries, name="manifest.tsv"):
+    path = Path(directory, name)
+    ordered = sorted(entries.values(), key=lambda item: item.path.encode("utf-8"))
+    path.write_bytes(MODULE.serialize(ordered))
+    return path
+
+
+class PolicyTests(unittest.TestCase):
+    def assert_rejected(self, entries, expected_path):
+        violations = MODULE.policy_violations(entries)
+        self.assertTrue(violations)
+        self.assertIn(expected_path, {path for path, _ in violations})
+
+    def test_valid_minimal_and_full_manifests(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            for name, entries in (("minimal", minimal_entries()), ("full", full_entries())):
+                with self.subTest(name=name):
+                    path = write_manifest(scratch, entries, name + ".tsv")
+                    parsed = MODULE.parse_manifest(path)
+                    self.assertEqual([], MODULE.policy_violations(parsed))
+                    result = subprocess.run([TOOL, "policy", path], capture_output=True, text=True)
+                    self.assertEqual(0, result.returncode, result.stderr)
+
+    def test_world_writable_non_symlink_is_rejected(self):
+        entries = minimal_entries()
+        entries["/opt/data"] = entry("/opt/data", mode="0666")
+        self.assert_rejected(entries, "/opt/data")
+        entries["/opt/data"] = entry("/opt/data", "symlink", mode="0777")
+        self.assertEqual([], MODULE.policy_violations(entries))
+
+    def test_all_special_permission_bits_are_rejected(self):
+        for mode in ("4644", "2644", "1755"):
+            with self.subTest(mode=mode):
+                entries = minimal_entries()
+                entries["/opt/privileged"] = entry("/opt/privileged", mode=mode)
+                self.assert_rejected(entries, "/opt/privileged")
+
+    def test_capability_representations_are_rejected(self):
+        for name in ("security.capability", "trusted.file-capability"):
+            with self.subTest(name=name):
+                entries = minimal_entries()
+                xattrs = json.dumps({name: "AA=="}, separators=(",", ":"))
+                entries["/opt/tool"] = entry("/opt/tool", xattrs=xattrs)
+                self.assert_rejected(entries, "/opt/tool")
+
+    def test_every_special_object_type_is_rejected(self):
+        for kind in ("char", "block", "fifo", "socket"):
+            with self.subTest(kind=kind):
+                entries = minimal_entries()
+                entries["/opt/special"] = entry("/opt/special", kind)
+                self.assert_rejected(entries, "/opt/special")
+
+    def test_kernel_module_boundaries_are_rejected(self):
+        cases = (
+            "/usr/lib/modules",
+            "/usr/lib/modules/6.0/kernel/stock.ko",
+            "/opt/nvidia.ko",
+            "/opt/nvidia.ko.zst",
+            "/usr/lib/tinfoil/kernel-modules/nvidia-drm.ko",
+            "/usr/lib/tinfoil/kernel-modules/nvidia.ko.zst",
+        )
+        for path in cases:
+            with self.subTest(path=path):
+                entries = minimal_entries()
+                entries[path] = entry(path, "dir" if path == "/usr/lib/modules" else "file")
+                self.assert_rejected(entries, path)
+
+    def test_exact_module_contract_is_required(self):
+        entries = minimal_entries()
+        del entries[MODULE_PATHS[0]]
+        self.assert_rejected(entries, MODULE_PATHS[0])
+        for changes in (
+            {"kind": "dir", "content": "-"},
+            {"mode": "0600"},
+            {"uid": "1"},
+            {"gid": "1"},
+            {"xattrs": '{"user.note":"b2s="}'},
+            {
+                "hardlink": (
+                    "path64:L3Vzci9saWIvdGluZm9pbC9rZXJuZWwtbW9kdWxlcy8"
+                    "udmlkaWEtbW9kZXNldC5rbw=="
+                )
+            },
+        ):
+            with self.subTest(changes=changes):
+                entries = minimal_entries()
+                entries[MODULE_PATHS[0]] = replace(entries[MODULE_PATHS[0]], **changes)
+                self.assert_rejected(entries, MODULE_PATHS[0])
+
+    def test_forbidden_fixed_contract_categories(self):
+        cases = {
+            "shell-sh": "/bin/sh",
+            "shell-bash": "/usr/bin/bash",
+            "systemd-policy": "/etc/systemd/system/example.service",
+            "systemd-tool": "/usr/bin/systemctl",
+            "sysctl-policy": "/etc/sysctl.d/99-example.conf",
+            "tmpfiles-policy": "/usr/lib/tmpfiles.d/example.conf",
+            "ld-cache": "/etc/ld.so.cache",
+            "ld-config": "/etc/ld.so.conf.d/example.conf",
+            "ld-tool": "/usr/sbin/ldconfig",
+            "nvidia-smi": "/usr/bin/nvidia-smi",
+            "docker-init": "/usr/libexec/docker/docker-init",
+            "chat-template": "/etc/tinfoil/templates/tool_chat_template.jinja",
+            "var-log": "/var/log/messages",
+            "root-home": "/root/secret",
+            "user-home": "/home/user/data",
+            "boot": "/boot/vmlinuz",
+            "efi": "/EFI/BOOT/BOOTX64.EFI",
+            "apt-metadata": "/var/lib/apt/lists/index",
+            "dpkg-metadata": "/var/lib/dpkg/status",
+            "package-tool": "/usr/bin/apt-get",
+        }
+        for name, path in cases.items():
+            with self.subTest(name=name):
+                entries = minimal_entries()
+                entries[path] = entry(path)
+                self.assert_rejected(entries, path)
+
+    def test_runtime_state_must_not_be_shipped(self):
+        for path in (
+            "/dev/precreated",
+            "/proc/precreated",
+            "/run/service.pid",
+            "/sys/precreated",
+            "/tmp/precreated",
+            "/var/tmp/precreated",
+            "/mnt/ramdisk/private/key",
+            "/var/lib/containerd/state",
+            "/var/lib/docker/containers",
+        ):
+            with self.subTest(path=path):
+                entries = full_entries()
+                entries[path] = entry(path)
+                self.assert_rejected(entries, path)
+        entries = minimal_entries()
+        entries["/run"] = entry("/run")
+        self.assert_rejected(entries, "/run")
+
+    def test_kernel_mountpoints_are_required_empty_root_owned_0755_directories(self):
+        for path in ("/dev", "/proc", "/run", "/sys"):
+            with self.subTest(path=path, case="missing"):
+                entries = minimal_entries()
+                del entries[path]
+                self.assert_rejected(entries, path)
+            changesets = (
+                {"mode": "0700"},
+                {"uid": "1"},
+                {"gid": "1"},
+                {"kind": "file", "content": DIGEST},
+            )
+            for changes in changesets:
+                with self.subTest(path=path, changes=changes):
+                    entries = minimal_entries()
+                    entries[path] = replace(entries[path], **changes)
+                    self.assert_rejected(entries, path)
+
+    def test_tmp_mountpoints_are_mandatory_root_owned_0755_directories(self):
+        for path in ("/tmp", "/var/tmp"):
+            entries = minimal_entries()
+            del entries[path]
+            self.assert_rejected(entries, path)
+            for changes in ({"mode": "0700"}, {"uid": "1"}, {"gid": "1"}, {"mode": "1755"}):
+                with self.subTest(path=path, changes=changes):
+                    entries = minimal_entries()
+                    entries[path] = replace(entries[path], **changes)
+                    self.assert_rejected(entries, path)
+
+    def test_path_checks_use_exact_component_semantics(self):
+        entries = minimal_entries()
+        entries["/homeward"] = entry("/homeward", "dir")
+        entries["/usr/lib/modules-extra"] = entry("/usr/lib/modules-extra", "dir")
+        entries["/usr/bin/bashful"] = entry("/usr/bin/bashful")
+        entries["/var/logger"] = entry("/var/logger", "dir")
+        self.assertEqual([], MODULE.policy_violations(entries))
+
+    def test_malformed_manifest_fails_before_policy_evaluation(self):
+        with tempfile.TemporaryDirectory() as scratch:
+            path = Path(scratch, "malformed.tsv")
+            path.write_text("/\tdir\t0755\t0\t0\t-\t-\n")
+            result = subprocess.run([TOOL, "policy", path], capture_output=True, text=True)
+            self.assertEqual(2, result.returncode)
+            self.assertIn("expected exactly eight tab-separated fields", result.stderr)
+            self.assertNotIn("policy\t", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enforce the exact positive measured-rootfs inventory
- reject missing, unexpected, or mismatched entries fail closed
- keep NVIDIA modules at fixed measured paths
- avoid wildcard/exception parsers and compatibility mechanisms

## Dependency and merge order

This is a stacked PR based on #197 (`jules/tcb-rootfs-manifest`).

1. Merge #197 first.
2. Then retarget or rebase this PR onto `jules/harden-tcb`.
3. Merge this PR only after the resulting diff remains the single manifest-policy commit.

## Validation

- rootfs policy and adversarial tests
- rootfs manifest and manifest-policy tests
- Python, shell, workflow YAML, and Make target syntax checks
- `go build ./...`
- `go test ./...`
- focused `go test -race` for PID1 and boot packages
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds canonical rootfs manifest inventory/validation/comparison and a fixed policy gate to enforce an immutable-rootfs contract. Implements strict checks for forbidden paths/tools, the fixed NVIDIA module set, and required empty mountpoints; adds docs, tests, and CI wiring.

- **New Features**
  - `scripts/rootfs_manifest.py inventory --root <dir> --output <path>`: descriptor-relative no-follow traversal; emits canonical eight-field records with canonical xattrs; hardlinks via `path64:`; strict bytewise order with a final newline.
  - `scripts/rootfs_manifest.py validate <manifest.tsv>` and `compare --expected <path> --actual <path>`: validates syntax/canonicalization and performs bidirectional diffs; exits 0 (match), 1 (differences), 2 (malformed); prints `difference<TAB>path<TAB>field<TAB>expected<TAB>actual` to stderr.
  - `scripts/rootfs_manifest.py policy <manifest.tsv>`: enforces the immutable-rootfs policy; rejects world-writable objects, suid/sgid/sticky bits, capability xattrs, special files, package/boot/systemd trees, shells and systemd tools in `/bin`/`/usr/bin`, ldconfig/sysctl tooling and configs, Docker init, `nvidia-smi`, and any kernel modules outside three fixed NVIDIA `.ko` paths; `/dev`, `/proc`, `/run`, `/sys`, `/tmp`, `/var/tmp` must be empty root-owned `0755` dirs; optional runtime dirs like `/mnt/ramdisk`, `/var/lib/containerd`, `/var/lib/docker` may exist but must be empty and populated only by PID1; exits 0/1/2 and prints `policy<TAB>path<TAB>reason`.
  - Docs: `docs/rootfs-manifest-format.md` adds a “Fixed policy gate” section and clarifies the format, comparison rules, and safety boundary.
  - Tests/CI: `scripts/test-rootfs-manifest-policy.py`; `make test-rootfs-manifest-policy` wired and run by `test-rootfs-manifest`; added to CI (`Test rootfs manifest security`).

<sup>Written for commit 51e68c055747f7fa8732f97499332861f967a5e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

