### PR TITLE
Add final raw rootfs verification gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Test rootfs manifest security
         run: sudo make test-rootfs-manifest
+
+      - name: Test final rootfs verifier
+        run: make test-final-rootfs-verifier

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ NVATTEST_BUILDER = ubuntu@sha256:5e275723f82c67e387ba9e3c24baa0abdcb268917f276a0
 .PHONY: all build rebuild clean deepclean hash nvattest go-binaries \
 	builder-initrd additive-initrd verify-additive-initrd \
 	test-additive-initrd reproducible-additive-initrd test-roothash-artifacts \
-	test-rootfs-policy test-rootfs-manifest test-rootfs-manifest-policy
+	test-rootfs-policy test-rootfs-manifest test-rootfs-manifest-policy \
+	verify-final-rootfs test-final-rootfs-verifier
 
 # tinfoilcvm.hash is the compatibility copy written by `rebuild`; mkosi's
 # direct roothash split artifact is the source contract.
@@ -100,6 +101,16 @@ test-rootfs-manifest: test-rootfs-manifest-policy
 
 test-rootfs-manifest-policy:
 	./scripts/test-rootfs-manifest-policy.py
+
+verify-final-rootfs:
+	@test -n "$(FINAL_ROOTFS_IMAGE)" -a -n "$(FINAL_ROOTFS_MANIFEST)" || { \
+		echo "set absolute FINAL_ROOTFS_IMAGE and FINAL_ROOTFS_MANIFEST paths" >&2; exit 2; }
+	sudo env -i PATH="$(TRUSTED_PATH)" LC_ALL=C LANG=C \
+		/usr/bin/python3 -I ./scripts/verify-final-rootfs.py \
+		--image "$(FINAL_ROOTFS_IMAGE)" --manifest "$(FINAL_ROOTFS_MANIFEST)"
+
+test-final-rootfs-verifier:
+	./scripts/test-final-rootfs-verifier.sh
 
 # First build populates mkosi.cache; later builds reuse it for fast iteration.
 rebuild: go-binaries

--- a/docs/final-raw-rootfs-verification.md
+++ b/docs/final-raw-rootfs-verification.md
@@ -1,0 +1,48 @@
+# Final Raw Rootfs Verification
+
+`scripts/verify-final-rootfs.py` verifies the produced raw disk artifact itself.
+It does not accept build logs or intermediate extraction reports as evidence.
+
+The verifier requires absolute, non-symlinked regular-file paths for the raw
+image and canonical rootfs manifest. It validates the protective MBR and both
+GPT copies directly, including CRCs, fixed 512-byte/128-entry geometry, aligned
+first usable LBA 2048, and exactly one x86-64 root partition with GPT type
+`4f68bce3-e8cd-4db1-96e7-fbcaf984b709`, label `root`, and only GPT attribute
+bit 60 set to require read-only use.
+
+After GPT validation it creates a private mount namespace, configures a
+read-only/autoclear/partition-scanning loop device through the kernel ioctl,
+checks the kernel partition geometry against the GPT entry, and mounts ext4
+with `ro,nosuid,nodev,noexec,noload`. The mounted tree is inventoried by the
+descriptor-relative `scripts/rootfs_manifest.py` implementation and compared
+bidirectionally with the copied canonical manifest. All xattrs are retained;
+there is no exception for `user.validatefs.*`.
+
+The executable and both privileged Python boundaries use fixed
+`/usr/bin/python3 -I` execution. The Make entry point and child manifest
+processes additionally use an empty, minimal environment containing only the
+trusted path and C locale settings.
+
+Temporary manifests and the mountpoint live in a process-marker-owned directory
+under `/run`. Signal and error cleanup unmounts the private mount and closes the
+autoclear loop device before removing only that owned directory. There is no
+caller-selected output path; verification succeeds or fails without publishing
+an intermediate manifest as evidence.
+
+Run the unprivileged adversarial suite with:
+
+```sh
+make test-final-rootfs-verifier
+```
+
+Verify a produced artifact with absolute paths:
+
+```sh
+make verify-final-rootfs \
+  FINAL_ROOTFS_IMAGE=/absolute/path/to/image.raw \
+  FINAL_ROOTFS_MANIFEST=/absolute/path/to/rootfs.tsv
+```
+
+The test suite only runs an end-to-end privileged check when
+`FINAL_ROOTFS_PRIVILEGED_TEST=1`, `FINAL_ROOTFS_TEST_IMAGE`, and
+`FINAL_ROOTFS_TEST_MANIFEST` are supplied explicitly.

--- a/scripts/test-final-rootfs-verifier.sh
+++ b/scripts/test-final-rootfs-verifier.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+verifier="$repo_dir/scripts/verify-final-rootfs.py"
+manifest_tool="$repo_dir/scripts/rootfs_manifest.py"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/final-rootfs-test.XXXXXX")"
+trap 'rm -rf "$scratch"' EXIT
+
+fail() { echo "test-final-rootfs-verifier: $*" >&2; exit 1; }
+
+python3 - "$verifier" "$scratch" <<'PY'
+import binascii
+import importlib.util
+import os
+import pathlib
+import stat
+import struct
+import sys
+import types
+import uuid
+
+verifier, scratch = sys.argv[1:]
+spec = importlib.util.spec_from_file_location("verify_final_rootfs", verifier)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+sectors = 8192
+entry_sectors = module.GPT_ENTRY_COUNT * module.GPT_ENTRY_SIZE // module.SECTOR_SIZE
+
+
+def image(path, partitions, first_usable=module.FIRST_USABLE_LBA):
+    data = bytearray(sectors * module.SECTOR_SIZE)
+    data[510:512] = b"\x55\xaa"
+    size = sectors - 1
+    data[446:462] = struct.pack("<B3sB3sII", 0, b"\0" * 3, 0xEE, b"\0" * 3, 1, size)
+    entries = bytearray(module.GPT_ENTRY_COUNT * module.GPT_ENTRY_SIZE)
+    for number, type_uuid, label, first, last, attributes in partitions:
+        raw_label = label.encode("utf-16le").ljust(72, b"\0")
+        module.ENTRY.pack_into(entries, (number - 1) * module.GPT_ENTRY_SIZE,
+                               type_uuid.bytes_le, uuid.uuid4().bytes_le,
+                               first, last, attributes, raw_label)
+    entries_crc = binascii.crc32(entries) & 0xffffffff
+    disk_uuid = uuid.uuid4().bytes_le
+    last_usable = sectors - entry_sectors - 2
+
+    def header(current, backup, entries_lba):
+        block = bytearray(module.SECTOR_SIZE)
+        module.HEADER.pack_into(block, 0, b"EFI PART", 0x10000, module.HEADER.size,
+                                0, 0, current, backup, first_usable, last_usable,
+                                disk_uuid, entries_lba, module.GPT_ENTRY_COUNT,
+                                module.GPT_ENTRY_SIZE, entries_crc)
+        struct.pack_into("<I", block, 16,
+                         binascii.crc32(block[:module.HEADER.size]) & 0xffffffff)
+        return block
+
+    data[module.SECTOR_SIZE:2 * module.SECTOR_SIZE] = header(1, sectors - 1, 2)
+    data[2 * module.SECTOR_SIZE:(2 + entry_sectors) * module.SECTOR_SIZE] = entries
+    backup_lba = sectors - 1 - entry_sectors
+    data[backup_lba * module.SECTOR_SIZE:(sectors - 1) * module.SECTOR_SIZE] = entries
+    data[(sectors - 1) * module.SECTOR_SIZE:] = header(sectors - 1, 1, backup_lba)
+    pathlib.Path(path).write_bytes(data)
+
+
+def accepted(name, partitions, **geometry):
+    path = pathlib.Path(scratch, name)
+    image(path, partitions, **geometry)
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        return module.inspect_gpt(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+root = module.ROOT_TYPE
+linux = uuid.UUID("0fc63daf-8483-4772-8e79-3d69d8477de4")
+readonly = module.ROOT_ATTRIBUTES
+partition = accepted("valid-aligned.raw", [(1, root, "root", 2048, 4095, readonly)])
+assert partition.number == 1 and partition.label == "root" and partition.attributes == readonly
+
+bad = {
+    "wrong-type.raw": [(1, linux, "root", 2048, 4095, readonly)],
+    "wrong-label.raw": [(1, root, "ROOT", 2048, 4095, readonly)],
+    "wrong-attributes.raw": [(1, root, "root", 2048, 4095, 0)],
+    "multiple.raw": [(1, root, "root", 2048, 4095, readonly),
+                     (2, root, "other", 4096, 6143, readonly)],
+    "ambiguous.raw": [(1, root, "root", 2048, 4095, readonly),
+                      (2, linux, "root", 4096, 6143, 0)],
+}
+for name, partitions in bad.items():
+    try:
+        accepted(name, partitions)
+    except module.VerificationError:
+        pass
+    else:
+        raise SystemExit(f"accepted malformed GPT: {name}")
+
+for name, first_usable in (("legacy-lba34.raw", 34), ("drifted-lba2049.raw", 2049)):
+    try:
+        accepted(name, [(1, root, "root", 2048, 4095, readonly)],
+                 first_usable=first_usable)
+    except module.VerificationError:
+        pass
+    else:
+        raise SystemExit(f"accepted non-contract first usable LBA: {first_usable}")
+
+corrupt = pathlib.Path(scratch, "corrupt-backup.raw")
+image(corrupt, [(1, root, "root", 2048, 4095, readonly)])
+with corrupt.open("r+b") as output:
+    output.seek((sectors - 2) * module.SECTOR_SIZE)
+    byte = output.read(1)
+    output.seek(-1, os.SEEK_CUR)
+    output.write(bytes([byte[0] ^ 1]))
+descriptor = os.open(corrupt, os.O_RDONLY)
+try:
+    module.inspect_gpt(descriptor)
+except module.VerificationError:
+    pass
+else:
+    raise SystemExit("accepted corrupt backup GPT")
+finally:
+    os.close(descriptor)
+
+expected_device = os.makedev(7, 201)
+device_state = types.SimpleNamespace(
+    st_mode=stat.S_IFBLK | 0o600,
+    st_rdev=expected_device,
+    st_dev=1,
+    st_ino=2,
+)
+opened = []
+mounted = []
+original_open = module.os.open
+original_fstat = module.os.fstat
+original_libc = module.libc
+
+
+class FakeLibc:
+    @staticmethod
+    def mount(source, target, filesystem, flags, options):
+        mounted.append((source, target, filesystem, flags, options))
+        return 0
+
+
+try:
+    module.os.open = lambda path, flags: opened.append((path, flags)) or 73
+    module.os.fstat = lambda descriptor: device_state
+    descriptor, state = module.open_partition_device(
+        "/dev/loop0p1", os.major(expected_device), os.minor(expected_device)
+    )
+    replacement_device = os.makedev(7, 202)
+    assert replacement_device != state[1]
+    module.libc = FakeLibc()
+    module.mount_root(descriptor, state, "/run/pinned-root")
+finally:
+    module.os.open = original_open
+    module.os.fstat = original_fstat
+    module.libc = original_libc
+
+assert opened and opened[0][0] == "/dev/loop0p1"
+assert mounted and mounted[0][0] == b"/proc/self/fd/73"
+PY
+
+mkdir "$scratch/paths"
+printf x >"$scratch/paths/image.raw"
+printf x >"$scratch/paths/manifest.tsv"
+ln -s image.raw "$scratch/paths/image-link.raw"
+ln -s manifest.tsv "$scratch/paths/manifest-link.tsv"
+ln -s paths "$scratch/paths-link"
+if "$verifier" --image "$scratch/paths/image-link.raw" --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+    fail "accepted symlinked image"
+fi
+if "$verifier" --image "$scratch/paths/image.raw" --manifest "$scratch/paths/manifest-link.tsv" 2>/dev/null; then
+    fail "accepted symlinked manifest"
+fi
+if "$verifier" --image "$scratch/paths-link/image.raw" --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+    fail "accepted symlinked path ancestor"
+fi
+if "$verifier" --image paths/image.raw --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+    fail "accepted relative image path"
+fi
+if "$verifier" --image "$scratch/paths/../paths/image.raw" --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+    fail "accepted non-normalized image path"
+fi
+if "$verifier" --image "$scratch/paths//image.raw" --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+    fail "accepted duplicate path separator"
+fi
+
+mkdir "$scratch/hostile-path"
+cat >"$scratch/hostile-path/python3" <<EOF
+#!/usr/bin/env bash
+touch "$scratch/path-python-ran"
+exit 99
+EOF
+chmod +x "$scratch/hostile-path/python3"
+set +e
+PATH="$scratch/hostile-path:$PATH" "$verifier" \
+    --image "$scratch/paths/image.raw" --manifest "$scratch/paths/manifest.tsv" \
+    >/dev/null 2>&1
+status=$?
+set -e
+[[ "$status" != 99 && ! -e "$scratch/path-python-ran" ]] \
+    || fail "direct invocation used a PATH-selected Python interpreter"
+
+mkdir "$scratch/xattr-root"
+printf payload >"$scratch/xattr-root/file"
+if python3 - "$scratch/xattr-root/file" <<'PY'
+import os, sys
+try:
+    os.setxattr(sys.argv[1], "user.validatefs.probe", b"bound")
+except OSError:
+    raise SystemExit(77)
+PY
+then
+    "$manifest_tool" inventory --root "$scratch/xattr-root" --output "$scratch/with-xattr.tsv"
+    python3 - "$scratch/xattr-root/file" <<'PY'
+import os, sys
+os.removexattr(sys.argv[1], "user.validatefs.probe")
+PY
+    "$manifest_tool" inventory --root "$scratch/xattr-root" --output "$scratch/without-xattr.tsv"
+    if "$manifest_tool" compare --expected "$scratch/with-xattr.tsv" --actual "$scratch/without-xattr.tsv" >/dev/null 2>&1; then
+        fail "user.validatefs xattr mismatch was filtered"
+    fi
+else
+    echo "SKIP: filesystem does not support user xattrs" >&2
+fi
+
+if [[ "${FINAL_ROOTFS_PRIVILEGED_TEST:-0}" == 1 ]]; then
+    [[ "$(id -u)" == 0 ]] || fail "privileged test requested without root"
+    [[ -n "${FINAL_ROOTFS_TEST_IMAGE:-}" && -n "${FINAL_ROOTFS_TEST_MANIFEST:-}" ]] \
+        || fail "set FINAL_ROOTFS_TEST_IMAGE and FINAL_ROOTFS_TEST_MANIFEST"
+    env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+        LC_ALL=C LANG=C /usr/bin/python3 -I "$verifier" \
+        --image "$FINAL_ROOTFS_TEST_IMAGE" --manifest "$FINAL_ROOTFS_TEST_MANIFEST"
+else
+    echo "SKIP: set FINAL_ROOTFS_PRIVILEGED_TEST=1 with produced image inputs" >&2
+fi
+
+echo "final rootfs verifier tests passed"

--- a/scripts/verify-final-rootfs.py
+++ b/scripts/verify-final-rootfs.py
@@ -1,0 +1,414 @@
+#!/usr/bin/python3 -I
+
+import argparse
+import binascii
+import ctypes
+import errno
+import fcntl
+import os
+import shutil
+import signal
+import stat
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SECTOR_SIZE = 512
+GPT_ENTRY_COUNT = 128
+GPT_ENTRY_SIZE = 128
+FIRST_USABLE_LBA = 2048
+ROOT_TYPE = uuid.UUID("4f68bce3-e8cd-4db1-96e7-fbcaf984b709")
+ROOT_LABEL = "root"
+ROOT_ATTRIBUTES = 1 << 60
+PYTHON = "/usr/bin/python3"
+TRUSTED_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+LOOP_CTL_GET_FREE = 0x4C82
+LOOP_CONFIGURE = 0x4C0A
+LO_FLAGS_READ_ONLY = 1
+LO_FLAGS_AUTOCLEAR = 4
+LO_FLAGS_PARTSCAN = 8
+CLONE_NEWNS = 0x00020000
+MS_RDONLY = 1
+MS_NOSUID = 2
+MS_NODEV = 4
+MS_NOEXEC = 8
+MS_REC = 16384
+MS_PRIVATE = 1 << 18
+MNT_DETACH = 2
+HEADER = struct.Struct("<8sIIIIQQQQ16sQIII")
+ENTRY = struct.Struct("<16s16sQQQ72s")
+LOOP_CONFIG = struct.Struct("<IIQQQQQIIII64s64s32sQQ8Q")
+libc = ctypes.CDLL(None, use_errno=True)
+
+
+class VerificationError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class Partition:
+    number: int
+    type_uuid: uuid.UUID
+    unique_uuid: uuid.UUID
+    first_lba: int
+    last_lba: int
+    attributes: int
+    label: str
+
+
+def fail(message):
+    raise VerificationError(message)
+
+
+def syscall(result, operation):
+    if result != 0:
+        error = ctypes.get_errno()
+        fail(f"{operation}: {os.strerror(error)}")
+
+
+def secure_open(path_text):
+    if path_text != os.path.normpath(path_text) or path_text.startswith("//"):
+        fail(f"path is not normalized: {path_text}")
+    path = Path(path_text)
+    if not path.is_absolute() or path == Path("/"):
+        fail(f"path must be an absolute file path: {path_text}")
+    parts = path.parts[1:]
+    directory = os.open("/", os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        for part in parts[:-1]:
+            if part in ("", ".", ".."):
+                fail(f"ambiguous path component in {path_text}")
+            next_directory = os.open(
+                part,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=directory,
+            )
+            os.close(directory)
+            directory = next_directory
+        descriptor = os.open(
+            parts[-1], os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=directory
+        )
+    except OSError as error:
+        fail(f"cannot securely open {path_text}: {error}")
+    finally:
+        os.close(directory)
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISREG(metadata.st_mode):
+        os.close(descriptor)
+        fail(f"input is not a regular file: {path_text}")
+    return descriptor
+
+
+def file_state(descriptor):
+    metadata = os.fstat(descriptor)
+    return (
+        metadata.st_dev, metadata.st_ino, metadata.st_mode, metadata.st_nlink,
+        metadata.st_size, metadata.st_mtime_ns, metadata.st_ctime_ns,
+    )
+
+
+def require_stable(descriptor, original, context):
+    if file_state(descriptor) != original:
+        fail(f"{context} changed during verification")
+
+
+def pread_exact(descriptor, size, offset, context):
+    data = os.pread(descriptor, size, offset)
+    if len(data) != size:
+        fail(f"{context}: truncated input")
+    return data
+
+
+def crc32(data):
+    return binascii.crc32(data) & 0xFFFFFFFF
+
+
+def protective_mbr(descriptor, sectors):
+    mbr = pread_exact(descriptor, SECTOR_SIZE, 0, "protective MBR")
+    if mbr[510:512] != b"\x55\xaa":
+        fail("protective MBR: missing signature")
+    records = [mbr[446 + index * 16:462 + index * 16] for index in range(4)]
+    used = [record for record in records if record[4] != 0]
+    expected_size = min(sectors - 1, 0xFFFFFFFF)
+    if len(used) != 1 or used[0][4] != 0xEE:
+        fail("protective MBR: hybrid or missing GPT partition")
+    if struct.unpack_from("<I", used[0], 8)[0] != 1:
+        fail("protective MBR: GPT partition does not start at LBA 1")
+    if struct.unpack_from("<I", used[0], 12)[0] != expected_size:
+        fail("protective MBR: GPT partition has wrong size")
+    if any(record[4] == 0 and record != b"\0" * 16 for record in records):
+        fail("protective MBR: malformed unused partition entry")
+
+
+def read_header(descriptor, lba, sectors, context):
+    block = pread_exact(descriptor, SECTOR_SIZE, lba * SECTOR_SIZE, context)
+    values = HEADER.unpack_from(block)
+    signature, revision, header_size, stored_crc, reserved = values[:5]
+    if signature != b"EFI PART" or revision != 0x00010000:
+        fail(f"{context}: invalid GPT signature or revision")
+    if header_size != HEADER.size or reserved != 0:
+        fail(f"{context}: non-canonical GPT header")
+    if block[header_size:] != b"\0" * (SECTOR_SIZE - header_size):
+        fail(f"{context}: nonzero reserved header bytes")
+    checked = bytearray(block[:header_size])
+    checked[16:20] = b"\0" * 4
+    if crc32(checked) != stored_crc:
+        fail(f"{context}: header CRC mismatch")
+    current, backup, first, last = values[5:9]
+    entries_lba, count, entry_size, entries_crc = values[10:14]
+    if current != lba or backup >= sectors or first > last:
+        fail(f"{context}: invalid GPT bounds")
+    if count != GPT_ENTRY_COUNT or entry_size != GPT_ENTRY_SIZE:
+        fail(f"{context}: unexpected partition entry geometry")
+    entries_size = count * entry_size
+    entries = pread_exact(
+        descriptor, entries_size, entries_lba * SECTOR_SIZE, f"{context} entries"
+    )
+    if crc32(entries) != entries_crc:
+        fail(f"{context}: partition entry CRC mismatch")
+    return values, entries
+
+
+def decode_label(raw, context):
+    try:
+        text = raw.decode("utf-16le")
+    except UnicodeDecodeError as error:
+        fail(f"{context}: invalid UTF-16 partition label: {error}")
+    label, separator, padding = text.partition("\0")
+    if separator and padding.strip("\0"):
+        fail(f"{context}: nonzero data after partition label")
+    return label
+
+
+def inspect_gpt(descriptor):
+    original = file_state(descriptor)
+    size = os.fstat(descriptor).st_size
+    if size < 68 * SECTOR_SIZE or size % SECTOR_SIZE:
+        fail("raw image has invalid 512-byte sector geometry")
+    sectors = size // SECTOR_SIZE
+    protective_mbr(descriptor, sectors)
+    primary, entries = read_header(descriptor, 1, sectors, "primary GPT")
+    backup, backup_entries = read_header(descriptor, sectors - 1, sectors, "backup GPT")
+    entry_sectors = GPT_ENTRY_COUNT * GPT_ENTRY_SIZE // SECTOR_SIZE
+    if primary[6] != sectors - 1 or backup[6] != 1:
+        fail("GPT headers do not point to each other")
+    if primary[7:10] != backup[7:10] or primary[9] != backup[9]:
+        fail("GPT headers disagree")
+    if uuid.UUID(bytes_le=primary[9]).int == 0:
+        fail("GPT disk UUID is zero")
+    if primary[10] != 2 or backup[10] != sectors - 1 - entry_sectors:
+        fail("GPT entry arrays are not in fixed locations")
+    if primary[7] != FIRST_USABLE_LBA or primary[8] != sectors - entry_sectors - 2:
+        fail("GPT usable range is not canonical")
+    if entries != backup_entries:
+        fail("primary and backup GPT entries disagree")
+    partitions = []
+    unique_ids = set()
+    for index in range(GPT_ENTRY_COUNT):
+        fields = ENTRY.unpack_from(entries, index * GPT_ENTRY_SIZE)
+        if fields[0] == b"\0" * 16:
+            if fields[1] != b"\0" * 16 or any(fields[2:5]) or fields[5] != b"\0" * 72:
+                fail(f"GPT entry {index + 1}: malformed unused entry")
+            continue
+        type_uuid = uuid.UUID(bytes_le=fields[0])
+        unique_uuid = uuid.UUID(bytes_le=fields[1])
+        first, last, attributes = fields[2:5]
+        if unique_uuid.int == 0 or unique_uuid in unique_ids:
+            fail(f"GPT entry {index + 1}: invalid unique UUID")
+        if first < primary[7] or last > primary[8] or first > last:
+            fail(f"GPT entry {index + 1}: invalid partition bounds")
+        unique_ids.add(unique_uuid)
+        partitions.append(
+            Partition(index + 1, type_uuid, unique_uuid, first, last, attributes,
+                      decode_label(fields[5], f"GPT entry {index + 1}"))
+        )
+    ordered = sorted(partitions, key=lambda item: item.first_lba)
+    if any(left.last_lba >= right.first_lba for left, right in zip(ordered, ordered[1:])):
+        fail("GPT partitions overlap")
+    typed = [partition for partition in partitions if partition.type_uuid == ROOT_TYPE]
+    labelled = [partition for partition in partitions if partition.label == ROOT_LABEL]
+    if len(typed) != 1 or len(labelled) != 1 or typed[0] != labelled[0]:
+        fail("GPT must contain exactly one root partition with the fixed type and label")
+    if typed[0].attributes != ROOT_ATTRIBUTES:
+        fail("root partition does not have the fixed read-only GPT attribute")
+    require_stable(descriptor, original, "raw image")
+    return typed[0]
+
+
+def private_mount_namespace():
+    if os.geteuid() != 0:
+        fail("verification requires root for loop and mount isolation")
+    syscall(libc.unshare(CLONE_NEWNS), "unshare mount namespace")
+    syscall(libc.mount(None, b"/", None, MS_REC | MS_PRIVATE, None), "make mounts private")
+
+
+def configure_loop(image_descriptor):
+    control = os.open("/dev/loop-control", os.O_RDWR | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        for _ in range(64):
+            number = fcntl.ioctl(control, LOOP_CTL_GET_FREE)
+            path = f"/dev/loop{number}"
+            loop = os.open(path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW)
+            config = LOOP_CONFIG.pack(
+                image_descriptor, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                LO_FLAGS_READ_ONLY | LO_FLAGS_AUTOCLEAR | LO_FLAGS_PARTSCAN,
+                b"", b"", b"", 0, 0, *([0] * 8),
+            )
+            try:
+                fcntl.ioctl(loop, LOOP_CONFIGURE, config)
+                return number, loop
+            except OSError as error:
+                os.close(loop)
+                if error.errno != errno.EBUSY:
+                    raise
+        fail("no loop device could be configured")
+    finally:
+        os.close(control)
+
+
+def block_device_state(descriptor):
+    metadata = os.fstat(descriptor)
+    return metadata.st_mode, metadata.st_rdev, metadata.st_dev, metadata.st_ino
+
+
+def open_partition_device(path, major, minor):
+    descriptor = os.open(
+        path, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
+    )
+    state = block_device_state(descriptor)
+    if not stat.S_ISBLK(state[0]) or os.major(state[1]) != major \
+            or os.minor(state[1]) != minor:
+        os.close(descriptor)
+        fail("partition device node disagrees with sysfs")
+    return descriptor, state
+
+
+def wait_for_partition(loop_number, partition):
+    name = f"loop{loop_number}p{partition.number}"
+    sysfs = Path("/sys/class/block") / name
+    device = Path("/dev") / name
+    for _ in range(100):
+        try:
+            start = int((sysfs / "start").read_text().strip())
+            size = int((sysfs / "size").read_text().strip())
+            major, minor = (int(value) for value in (sysfs / "dev").read_text().split(":"))
+            descriptor, state = open_partition_device(device, major, minor)
+            if start != partition.first_lba or size != partition.last_lba - start + 1:
+                os.close(descriptor)
+                fail("kernel partition geometry disagrees with GPT")
+            return descriptor, state
+        except OSError as error:
+            if error.errno not in (errno.ENOENT, errno.ENXIO, errno.ENODEV):
+                raise
+        time.sleep(0.02)
+    fail("kernel did not expose the fixed root partition")
+
+
+def copy_manifest(descriptor, destination):
+    original = file_state(descriptor)
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    with os.fdopen(os.dup(descriptor), "rb") as source, open(destination, "xb") as output:
+        shutil.copyfileobj(source, output)
+    require_stable(descriptor, original, "canonical manifest")
+
+
+def mount_root(source_descriptor, source_state, target):
+    if block_device_state(source_descriptor) != source_state:
+        fail("partition block device changed before mount")
+    flags = MS_RDONLY | MS_NOSUID | MS_NODEV | MS_NOEXEC
+    source = f"/proc/self/fd/{source_descriptor}"
+    syscall(
+        libc.mount(os.fsencode(source), os.fsencode(target), b"ext4", flags, b"noload"),
+        "mount root partition read-only",
+    )
+
+
+def verify(image_descriptor, manifest_descriptor):
+    image_state = file_state(image_descriptor)
+    root_partition = inspect_gpt(image_descriptor)
+    private_mount_namespace()
+    scratch = Path(tempfile.mkdtemp(prefix="final-rootfs-verify.", dir="/run"))
+    marker = scratch / ".owned-by-final-rootfs-verifier"
+    marker.write_text(f"{os.getpid()}\n")
+    mountpoint = scratch / "root"
+    mountpoint.mkdir(mode=0o700)
+    mounted = False
+    loop_descriptor = None
+    partition_descriptor = None
+    try:
+        expected = scratch / "expected.tsv"
+        actual = scratch / "actual.tsv"
+        copy_manifest(manifest_descriptor, expected)
+        loop_number, loop_descriptor = configure_loop(image_descriptor)
+        partition_descriptor, partition_state = wait_for_partition(
+            loop_number, root_partition
+        )
+        mount_root(partition_descriptor, partition_state, mountpoint)
+        mounted = True
+        if block_device_state(partition_descriptor) != partition_state:
+            fail("partition block device changed during mount")
+        tool = Path(__file__).resolve().with_name("rootfs_manifest.py")
+        environment = {"PATH": TRUSTED_PATH, "LC_ALL": "C", "LANG": "C"}
+        subprocess.run(
+            [PYTHON, "-I", tool, "inventory", "--root", mountpoint, "--output", actual],
+            check=True,
+            env=environment,
+        )
+        subprocess.run(
+            [PYTHON, "-I", tool, "compare", "--expected", expected, "--actual", actual],
+            check=True,
+            env=environment,
+        )
+        require_stable(image_descriptor, image_state, "raw image")
+    finally:
+        if mounted:
+            if libc.umount2(os.fsencode(mountpoint), 0) != 0:
+                libc.umount2(os.fsencode(mountpoint), MNT_DETACH)
+        if partition_descriptor is not None:
+            os.close(partition_descriptor)
+        if loop_descriptor is not None:
+            os.close(loop_descriptor)
+        if marker.is_file() and marker.read_text() == f"{os.getpid()}\n":
+            shutil.rmtree(scratch)
+
+
+def main():
+    command = argparse.ArgumentParser(description="Verify a produced raw image rootfs")
+    command.add_argument("--image", required=True)
+    command.add_argument("--manifest", required=True)
+    arguments = command.parse_args()
+    image_descriptor = manifest_descriptor = None
+    try:
+        image_descriptor = secure_open(arguments.image)
+        manifest_descriptor = secure_open(arguments.manifest)
+        verify(image_descriptor, manifest_descriptor)
+        print("final raw image rootfs matches the canonical manifest")
+        return 0
+    except (VerificationError, OSError, subprocess.CalledProcessError) as error:
+        print(f"verify-final-rootfs: {error}", file=sys.stderr)
+        return 2
+    finally:
+        for descriptor in (manifest_descriptor, image_descriptor):
+            if descriptor is not None:
+                os.close(descriptor)
+
+
+if __name__ == "__main__":
+    def interrupted(_signal, _frame):
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGINT, interrupted)
+    signal.signal(signal.SIGTERM, interrupted)
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print("verify-final-rootfs: interrupted", file=sys.stderr)
+        sys.exit(130)


### PR DESCRIPTION
## Summary

- verify the final raw image through descriptor-relative, fail-closed GPT and rootfs inventory checks
- compare the mounted root filesystem bidirectionally with the exact canonical manifest
- reject symlinked, relative, non-normalized, unstable, malformed, or metadata-divergent inputs

## Stack dependency and merge order

This is a stacked PR based on #197 (`jules/tcb-rootfs-manifest`).

1. Review and merge #197 first.
2. After #197 merges, retarget/rebase this PR onto `jules/harden-tcb`.
3. Merge this PR only after that retarget/rebase is complete and the resulting checks pass.

Do not merge this PR before #197.

## Validation

- final rootfs verifier adversarial tests
- exact rootfs manifest tests
- fixed rootfs policy adversarial tests
- privileged verification against a preserved produced raw image
- `go build ./...`
- `go test ./...`
- focused `go test -race`
- `go vet ./...`
- shell and Python syntax checks
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a final raw rootfs verification gate that validates the produced raw disk end-to-end against the canonical manifest and fails closed on any mismatch. It enforces strict MBR/GPT rules, isolates loop/mount handling, and compares an exact, xattr-preserving inventory.

- **New Features**
  - New `scripts/verify-final-rootfs.py`: protective MBR and dual GPT CRC/geometry checks (512-byte sectors, 128 entries, `FIRST_USABLE_LBA=2048`, fixed entry arrays at LBA 2 and end-of-disk); requires exactly one root partition (type `4f68bce3-e8cd-4db1-96e7-fbcaf984b709`, label `root`, GPT attr bit 60), rejects overlaps and hybrid MBRs, and validates kernel partition geometry via sysfs.
  - Secure execution: absolute, non-symlinked, normalized inputs; stable-file checks; `/usr/bin/python3 -I` with a minimal env; read-only/autoclear/partscan loop; ext4 mounted `ro,nosuid,nodev,noexec,noload` in a private mount namespace; safe cleanup under `/run`.
  - Uses `scripts/rootfs_manifest.py` to inventory and compare bidirectionally; preserves all xattrs, including `user.validatefs.*`.
  - Makefile: `verify-final-rootfs` and `test-final-rootfs-verifier` targets; docs at `docs/final-raw-rootfs-verification.md`; CI runs `make test-final-rootfs-verifier`.

- **Migration**
  - Verify: make verify-final-rootfs FINAL_ROOTFS_IMAGE=/abs/path/image.raw FINAL_ROOTFS_MANIFEST=/abs/path/rootfs.tsv
  - Tests: make test-final-rootfs-verifier; enable privileged E2E with FINAL_ROOTFS_PRIVILEGED_TEST=1 plus FINAL_ROOTFS_TEST_IMAGE and FINAL_ROOTFS_TEST_MANIFEST.
  - Requires root to run the verifier.

<sup>Written for commit 54a64374583ea1eededd8b39f8469f0f281ca1c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

