### PR TITLE
Verify exact final raw rootfs geometry and verity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,13 @@ test-rootfs-manifest-policy:
 	./scripts/test-rootfs-manifest-policy.py
 
 verify-final-rootfs:
-	@test -n "$(FINAL_ROOTFS_IMAGE)" -a -n "$(FINAL_ROOTFS_MANIFEST)" || { \
-		echo "set absolute FINAL_ROOTFS_IMAGE and FINAL_ROOTFS_MANIFEST paths" >&2; exit 2; }
+	@test -n "$(FINAL_ROOTFS_IMAGE)" -a -n "$(FINAL_ROOTFS_MANIFEST)" \
+		-a -n "$(FINAL_ROOTFS_ROOTHASH)" || { \
+		echo "set absolute FINAL_ROOTFS_IMAGE, FINAL_ROOTFS_MANIFEST, and FINAL_ROOTFS_ROOTHASH paths" >&2; exit 2; }
 	sudo env -i PATH="$(TRUSTED_PATH)" LC_ALL=C LANG=C \
 		/usr/bin/python3 -I ./scripts/verify-final-rootfs.py \
-		--image "$(FINAL_ROOTFS_IMAGE)" --manifest "$(FINAL_ROOTFS_MANIFEST)"
+		--image "$(FINAL_ROOTFS_IMAGE)" --manifest "$(FINAL_ROOTFS_MANIFEST)" \
+		--roothash "$(FINAL_ROOTFS_ROOTHASH)"
 
 test-final-rootfs-verifier:
 	./scripts/test-final-rootfs-verifier.sh

--- a/docs/final-raw-rootfs-verification.md
+++ b/docs/final-raw-rootfs-verification.md
@@ -40,10 +40,11 @@ arguments with only those descriptors passed to the child. The invocation
 disables superblock parsing and pins format 1, SHA-256, 4096-byte data and hash
 blocks, a 4096-byte hash offset, the GPT-derived data-block count, and the
 measured build salt.
-The verifier independently calculates every SHA-256 format-1 hash-tree level
-at 128 digests per 4096-byte block. It requires the complete 4096-byte prefix
-before the tree and every byte after the exact final tree block through the end
-of the fixed verity partition to be zero.
+The verifier independently calculates the exact extent occupied by every
+SHA-256 format-1 hash-tree level at 128 digests per 4096-byte block;
+`veritysetup verify` authenticates the tree contents. The verifier requires the
+complete 4096-byte prefix before the tree and every byte after the exact final
+tree block through the end of the fixed verity partition to be zero.
 
 After GPT validation it creates a private mount namespace, configures a
 read-only/autoclear/partition-scanning loop device through the kernel ioctl,

--- a/docs/final-raw-rootfs-verification.md
+++ b/docs/final-raw-rootfs-verification.md
@@ -4,28 +4,66 @@
 It does not accept build logs or intermediate extraction reports as evidence.
 
 The verifier requires absolute, non-symlinked regular-file paths for the raw
-image and canonical rootfs manifest. It validates the protective MBR and both
+image and canonical rootfs manifest. The raw image must be exactly
+3,490,729,984 bytes. It validates the protective MBR and both
 GPT copies directly, including CRCs, fixed 512-byte/128-entry geometry, aligned
-first usable LBA 2048, and exactly one x86-64 root partition with GPT type
-`4f68bce3-e8cd-4db1-96e7-fbcaf984b709`, label `root`, and only GPT attribute
-bit 60 set to require read-only use.
+first usable LBA 2048, and exactly two partitions with no extras. Entry 1 is
+the x86-64 root partition with GPT type
+`4f68bce3-e8cd-4db1-96e7-fbcaf984b709` and label `root`. Entry 2 is its
+x86-64 verity hash partition with type
+`2c7357ed-ebd2-46d9-aec1-23d437ec2bf5` and label
+`root-x86-64-verity`. Both have only GPT attribute bit 60 set, use 4096-byte
+aligned geometry, and are contiguous from LBA 2048. Their byte counts must
+exactly match the fixed 3 GiB root and 256 MiB verity contracts compiled into
+the verifier; there is no runtime configuration parser. The verity partition
+ends at the largest 4096-byte boundary
+allowed by the GPT last-usable LBA, leaving only the sub-block alignment tail
+before the backup entry array.
+
+All bytes outside the fixed GPT structures and partitions are authenticated as
+zero: protective-MBR boot/reserved bytes, the space from the primary entry
+array through LBA 2047, and the final alignment tail after the verity
+partition. This rejects hidden payloads in otherwise unused raw-image space.
+The protective entry's boot, CHS, and type prefix is exactly
+`00 00 02 00 ee ff ff ff`. The GPT disk UUID is the deterministic
+seed-derived `bd21aac6-0338-4a33-85d9-d14ccf6c5ea1`; arbitrary nonzero UUIDs
+are rejected.
+
+The required direct roothash is a separate, descriptor-opened regular file
+containing exactly 64 lowercase hexadecimal bytes. Its two 128-bit halves must
+equal the root and verity PARTUUIDs. Before the root filesystem is mounted, the
+verifier opens both kernel partition nodes with no-follow descriptors,
+validates their block major/minor numbers against sysfs, and retains those exact
+objects. `/usr/sbin/veritysetup verify` authenticates every root data block
+against the hash partition and supplied roothash through `/proc/self/fd/N`
+arguments with only those descriptors passed to the child. The invocation
+disables superblock parsing and pins format 1, SHA-256, 4096-byte data and hash
+blocks, a 4096-byte hash offset, the GPT-derived data-block count, and the
+measured build salt.
+The verifier independently calculates every SHA-256 format-1 hash-tree level
+at 128 digests per 4096-byte block. It requires the complete 4096-byte prefix
+before the tree and every byte after the exact final tree block through the end
+of the fixed verity partition to be zero.
 
 After GPT validation it creates a private mount namespace, configures a
 read-only/autoclear/partition-scanning loop device through the kernel ioctl,
-checks the kernel partition geometry against the GPT entry, and mounts ext4
-with `ro,nosuid,nodev,noexec,noload`. The mounted tree is inventoried by the
-descriptor-relative `scripts/rootfs_manifest.py` implementation and compared
+checks the kernel partition geometry against the GPT entries, and mounts ext4
+through the pinned root descriptor with `ro,nosuid,nodev,noexec,noload`. Both
+partition objects are rechecked before and after privileged consumption, so
+replacing either `/dev` node cannot redirect verity verification or mount. The
+mounted tree is inventoried by the descriptor-relative
+`scripts/rootfs_manifest.py` implementation and compared
 bidirectionally with the copied canonical manifest. All xattrs are retained;
 there is no exception for `user.validatefs.*`.
 
-The executable and both privileged Python boundaries use fixed
-`/usr/bin/python3 -I` execution. The Make entry point and child manifest
-processes additionally use an empty, minimal environment containing only the
-trusted path and C locale settings.
+Both privileged Python boundaries use fixed `/usr/bin/python3 -I` execution
+with an empty, minimal environment containing only the trusted path and C
+locale settings.
 
 Temporary manifests and the mountpoint live in a process-marker-owned directory
 under `/run`. Signal and error cleanup unmounts the private mount and closes the
-autoclear loop device before removing only that owned directory. There is no
+retained partition descriptors and autoclear loop device before removing only
+that owned directory. There is no
 caller-selected output path; verification succeeds or fails without publishing
 an intermediate manifest as evidence.
 
@@ -40,9 +78,11 @@ Verify a produced artifact with absolute paths:
 ```sh
 make verify-final-rootfs \
   FINAL_ROOTFS_IMAGE=/absolute/path/to/image.raw \
-  FINAL_ROOTFS_MANIFEST=/absolute/path/to/rootfs.tsv
+  FINAL_ROOTFS_MANIFEST=/absolute/path/to/rootfs.tsv \
+  FINAL_ROOTFS_ROOTHASH=/absolute/path/to/image.roothash
 ```
 
 The test suite only runs an end-to-end privileged check when
 `FINAL_ROOTFS_PRIVILEGED_TEST=1`, `FINAL_ROOTFS_TEST_IMAGE`, and
-`FINAL_ROOTFS_TEST_MANIFEST` are supplied explicitly.
+`FINAL_ROOTFS_TEST_MANIFEST`, and `FINAL_ROOTFS_TEST_ROOTHASH` are supplied
+explicitly.

--- a/scripts/test-final-rootfs-verifier.sh
+++ b/scripts/test-final-rootfs-verifier.sh
@@ -16,6 +16,7 @@ import os
 import pathlib
 import stat
 import struct
+import subprocess
 import sys
 import types
 import uuid
@@ -26,30 +27,54 @@ module = importlib.util.module_from_spec(spec)
 sys.modules[spec.name] = module
 spec.loader.exec_module(module)
 
+assert module.ROOT_PARTITION_SIZE == 3 * 1024**3
+assert module.ROOT_VERITY_PARTITION_SIZE == 256 * 1024**2
+assert module.RAW_IMAGE_SIZE == 3490729984
+
 sectors = 8192
+module.RAW_IMAGE_SIZE = sectors * module.SECTOR_SIZE
+for delta in (-module.SECTOR_SIZE, module.SECTOR_SIZE):
+    path = pathlib.Path(scratch, f"wrong-raw-size-{delta}.raw")
+    with path.open("wb") as output:
+        output.truncate(module.RAW_IMAGE_SIZE + delta)
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        try:
+            module.inspect_gpt(descriptor)
+        except module.VerificationError as error:
+            if "raw image size" not in str(error):
+                raise
+        else:
+            raise SystemExit(f"accepted raw image size delta {delta}")
+    finally:
+        os.close(descriptor)
 entry_sectors = module.GPT_ENTRY_COUNT * module.GPT_ENTRY_SIZE // module.SECTOR_SIZE
+roothash = "0123456789abcdef0123456789abcdeffedcba9876543210fedcba9876543210"
+root_uuid = uuid.UUID(hex=roothash[:32])
+verity_uuid = uuid.UUID(hex=roothash[32:])
 
 
-def image(path, partitions, first_usable=module.FIRST_USABLE_LBA):
+def image(path, partitions, first_usable=module.FIRST_USABLE_LBA,
+          disk_uuid=module.DISK_UUID):
     data = bytearray(sectors * module.SECTOR_SIZE)
     data[510:512] = b"\x55\xaa"
     size = sectors - 1
-    data[446:462] = struct.pack("<B3sB3sII", 0, b"\0" * 3, 0xEE, b"\0" * 3, 1, size)
+    data[446:462] = module.PROTECTIVE_MBR_PREFIX + struct.pack("<II", 1, size)
     entries = bytearray(module.GPT_ENTRY_COUNT * module.GPT_ENTRY_SIZE)
-    for number, type_uuid, label, first, last, attributes in partitions:
+    for number, type_uuid, unique_uuid, label, first, last, attributes in partitions:
         raw_label = label.encode("utf-16le").ljust(72, b"\0")
         module.ENTRY.pack_into(entries, (number - 1) * module.GPT_ENTRY_SIZE,
-                               type_uuid.bytes_le, uuid.uuid4().bytes_le,
+                               type_uuid.bytes_le, unique_uuid.bytes_le,
                                first, last, attributes, raw_label)
     entries_crc = binascii.crc32(entries) & 0xffffffff
-    disk_uuid = uuid.uuid4().bytes_le
+    disk_uuid_bytes = disk_uuid.bytes_le
     last_usable = sectors - entry_sectors - 2
 
     def header(current, backup, entries_lba):
         block = bytearray(module.SECTOR_SIZE)
         module.HEADER.pack_into(block, 0, b"EFI PART", 0x10000, module.HEADER.size,
                                 0, 0, current, backup, first_usable, last_usable,
-                                disk_uuid, entries_lba, module.GPT_ENTRY_COUNT,
+                                disk_uuid_bytes, entries_lba, module.GPT_ENTRY_COUNT,
                                 module.GPT_ENTRY_SIZE, entries_crc)
         struct.pack_into("<I", block, 16,
                          binascii.crc32(block[:module.HEADER.size]) & 0xffffffff)
@@ -63,30 +88,115 @@ def image(path, partitions, first_usable=module.FIRST_USABLE_LBA):
     pathlib.Path(path).write_bytes(data)
 
 
-def accepted(name, partitions, **geometry):
+def accepted(name, partitions, supplied_roothash=roothash, **geometry):
     path = pathlib.Path(scratch, name)
     image(path, partitions, **geometry)
     descriptor = os.open(path, os.O_RDONLY)
     try:
-        return module.inspect_gpt(descriptor)
+        layout = module.inspect_gpt(descriptor)
+        module.require_roothash_partition_ids(layout, supplied_roothash)
+        return layout
     finally:
         os.close(descriptor)
 
 
-root = module.ROOT_TYPE
 linux = uuid.UUID("0fc63daf-8483-4772-8e79-3d69d8477de4")
-readonly = module.ROOT_ATTRIBUTES
-partition = accepted("valid-aligned.raw", [(1, root, "root", 2048, 4095, readonly)])
-assert partition.number == 1 and partition.label == "root" and partition.attributes == readonly
+fixed = [
+    (1, module.ROOT_TYPE, root_uuid, module.ROOT_LABEL, 2048, 4095,
+     module.ROOT_ATTRIBUTES),
+    (2, module.ROOT_VERITY_TYPE, verity_uuid, module.ROOT_VERITY_LABEL, 4096, 8151,
+     module.ROOT_VERITY_ATTRIBUTES),
+]
+synthetic_sizes = (
+    (fixed[0][5] - fixed[0][4] + 1) * module.SECTOR_SIZE,
+    (fixed[1][5] - fixed[1][4] + 1) * module.SECTOR_SIZE,
+)
+module.ROOT_PARTITION_SIZE, module.ROOT_VERITY_PARTITION_SIZE = synthetic_sizes
+layout = accepted("valid-aligned.raw", fixed)
+assert layout.root.number == 1 and layout.verity.number == 2
+assert module.VERITY_BLOCK_SIZE == 4096
+assert module.VERITY_HASH_OFFSET == 4096
+assert module.VERITY_SALT == \
+    "d8f43870af05f2fb613c2bb571f911da45cfa46a77e6efeabbdd5ed760ebabde"
+assert str(module.DISK_UUID) == "bd21aac6-0338-4a33-85d9-d14ccf6c5ea1"
+assert module.PROTECTIVE_MBR_PREFIX == bytes.fromhex("00 00 02 00 ee ff ff ff")
+
+for name, value in (
+    ("uppercase", roothash.upper().encode()),
+    ("newline", (roothash + "\n").encode()),
+    ("short", roothash[:-1].encode()),
+    ("non-hex", ("g" + roothash[1:]).encode()),
+):
+    path = pathlib.Path(scratch, f"{name}.roothash")
+    path.write_bytes(value)
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        module.read_roothash(descriptor)
+    except module.VerificationError:
+        pass
+    else:
+        raise SystemExit(f"accepted malformed direct roothash: {name}")
+    finally:
+        os.close(descriptor)
 
 bad = {
-    "wrong-type.raw": [(1, linux, "root", 2048, 4095, readonly)],
-    "wrong-label.raw": [(1, root, "ROOT", 2048, 4095, readonly)],
-    "wrong-attributes.raw": [(1, root, "root", 2048, 4095, 0)],
-    "multiple.raw": [(1, root, "root", 2048, 4095, readonly),
-                     (2, root, "other", 4096, 6143, readonly)],
-    "ambiguous.raw": [(1, root, "root", 2048, 4095, readonly),
-                      (2, linux, "root", 4096, 6143, 0)],
+    "missing-verity.raw": fixed[:1],
+    "extra.raw": fixed + [(3, linux, uuid.uuid4(), "extra", 6144, 7167, 0)],
+    "wrong-root-type.raw": [
+        (1, linux, root_uuid, module.ROOT_LABEL, 2048, 4095, module.ROOT_ATTRIBUTES),
+        fixed[1],
+    ],
+    "wrong-root-label.raw": [
+        (1, module.ROOT_TYPE, root_uuid, "ROOT", 2048, 4095,
+         module.ROOT_ATTRIBUTES),
+        fixed[1],
+    ],
+    "wrong-root-attributes.raw": [
+        (1, module.ROOT_TYPE, root_uuid, module.ROOT_LABEL, 2048, 4095, 0),
+        fixed[1],
+    ],
+    "wrong-verity-type.raw": [
+        fixed[0],
+        (2, linux, verity_uuid, module.ROOT_VERITY_LABEL, 4096, 6143,
+         module.ROOT_VERITY_ATTRIBUTES),
+    ],
+    "wrong-verity-label.raw": [
+        fixed[0],
+        (2, module.ROOT_VERITY_TYPE, verity_uuid, "root-verity", 4096, 6143,
+         module.ROOT_VERITY_ATTRIBUTES),
+    ],
+    "wrong-verity-attributes.raw": [
+        fixed[0],
+        (2, module.ROOT_VERITY_TYPE, verity_uuid, module.ROOT_VERITY_LABEL, 4096,
+         6143, 0),
+    ],
+    "gap.raw": [
+        fixed[0],
+        (2, module.ROOT_VERITY_TYPE, verity_uuid, module.ROOT_VERITY_LABEL, 4104,
+         6151, module.ROOT_VERITY_ATTRIBUTES),
+    ],
+    "misaligned-root-size.raw": [
+        (1, module.ROOT_TYPE, root_uuid, module.ROOT_LABEL, 2048, 4094,
+         module.ROOT_ATTRIBUTES),
+        (2, module.ROOT_VERITY_TYPE, verity_uuid, module.ROOT_VERITY_LABEL, 4095,
+         6142, module.ROOT_VERITY_ATTRIBUTES),
+    ],
+    "oversized-tail-gap.raw": [
+        fixed[0],
+        (2, module.ROOT_VERITY_TYPE, verity_uuid, module.ROOT_VERITY_LABEL, 4096,
+         8143, module.ROOT_VERITY_ATTRIBUTES),
+    ],
+    "wrong-root-size.raw": [
+        (1, module.ROOT_TYPE, root_uuid, module.ROOT_LABEL, 2048, 4103,
+         module.ROOT_ATTRIBUTES),
+        (2, module.ROOT_VERITY_TYPE, verity_uuid, module.ROOT_VERITY_LABEL, 4104,
+         8151, module.ROOT_VERITY_ATTRIBUTES),
+    ],
+    "wrong-verity-size.raw": [
+        fixed[0],
+        (2, module.ROOT_VERITY_TYPE, verity_uuid, module.ROOT_VERITY_LABEL, 4096,
+         8143, module.ROOT_VERITY_ATTRIBUTES),
+    ],
 }
 for name, partitions in bad.items():
     try:
@@ -96,17 +206,34 @@ for name, partitions in bad.items():
     else:
         raise SystemExit(f"accepted malformed GPT: {name}")
 
+for name, bad_hash in (
+    ("wrong-root-partuuid.raw", "1" + roothash[1:]),
+    ("wrong-verity-partuuid.raw", roothash[:-1] + "1"),
+):
+    try:
+        accepted(name, fixed, bad_hash)
+    except module.VerificationError:
+        pass
+    else:
+        raise SystemExit(f"accepted roothash/PARTUUID mismatch: {name}")
+
 for name, first_usable in (("legacy-lba34.raw", 34), ("drifted-lba2049.raw", 2049)):
     try:
-        accepted(name, [(1, root, "root", 2048, 4095, readonly)],
-                 first_usable=first_usable)
+        accepted(name, fixed, first_usable=first_usable)
     except module.VerificationError:
         pass
     else:
         raise SystemExit(f"accepted non-contract first usable LBA: {first_usable}")
 
+try:
+    accepted("wrong-disk-uuid.raw", fixed, disk_uuid=uuid.uuid4())
+except module.VerificationError:
+    pass
+else:
+    raise SystemExit("accepted non-contract GPT disk UUID")
+
 corrupt = pathlib.Path(scratch, "corrupt-backup.raw")
-image(corrupt, [(1, root, "root", 2048, 4095, readonly)])
+image(corrupt, fixed)
 with corrupt.open("r+b") as output:
     output.seek((sectors - 2) * module.SECTOR_SIZE)
     byte = output.read(1)
@@ -122,17 +249,71 @@ else:
 finally:
     os.close(descriptor)
 
-expected_device = os.makedev(7, 201)
-device_state = types.SimpleNamespace(
-    st_mode=stat.S_IFBLK | 0o600,
-    st_rdev=expected_device,
-    st_dev=1,
-    st_ino=2,
-)
+for name, offset in (
+    ("mbr-payload.raw", 0),
+    ("primary-gap-payload.raw", 34 * module.SECTOR_SIZE),
+    ("verity-prefix-payload.raw", fixed[1][4] * module.SECTOR_SIZE),
+    ("verity-tail-payload.raw", fixed[1][4] * module.SECTOR_SIZE
+     + module.verity_tree_end(synthetic_sizes[0] // module.VERITY_BLOCK_SIZE)),
+    ("tail-payload.raw", 8152 * module.SECTOR_SIZE),
+):
+    path = pathlib.Path(scratch, name)
+    image(path, fixed)
+    with path.open("r+b") as output:
+        output.seek(offset)
+        output.write(b"x")
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        module.inspect_gpt(descriptor)
+    except module.VerificationError:
+        pass
+    else:
+        raise SystemExit(f"accepted hidden payload in unused bytes: {name}")
+    finally:
+        os.close(descriptor)
+
+for name, offset, value in (
+    ("mbr-boot-flag.raw", 446, b"\x80"),
+    ("mbr-start-chs.raw", 447, b"\x01"),
+    ("mbr-end-chs.raw", 451, b"\xfe"),
+):
+    path = pathlib.Path(scratch, name)
+    image(path, fixed)
+    with path.open("r+b") as output:
+        output.seek(offset)
+        output.write(value)
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        module.inspect_gpt(descriptor)
+    except module.VerificationError:
+        pass
+    else:
+        raise SystemExit(f"accepted non-canonical protective MBR prefix: {name}")
+    finally:
+        os.close(descriptor)
+
+root_device = os.makedev(7, 201)
+verity_device = os.makedev(7, 202)
+device_states = {
+    73: types.SimpleNamespace(
+        st_mode=stat.S_IFBLK | 0o600,
+        st_rdev=root_device,
+        st_dev=1,
+        st_ino=2,
+    ),
+    74: types.SimpleNamespace(
+        st_mode=stat.S_IFBLK | 0o600,
+        st_rdev=verity_device,
+        st_dev=1,
+        st_ino=3,
+    ),
+}
 opened = []
+commands = []
 mounted = []
 original_open = module.os.open
 original_fstat = module.os.fstat
+original_run = module.subprocess.run
 original_libc = module.libc
 
 
@@ -144,64 +325,220 @@ class FakeLibc:
 
 
 try:
-    module.os.open = lambda path, flags: opened.append((path, flags)) or 73
-    module.os.fstat = lambda descriptor: device_state
-    descriptor, state = module.open_partition_device(
-        "/dev/loop0p1", os.major(expected_device), os.minor(expected_device)
+    descriptors = iter((73, 74))
+    module.os.open = lambda path, flags: opened.append((path, flags)) or next(descriptors)
+    module.os.fstat = lambda descriptor: device_states[descriptor]
+    root_descriptor, root_state = module.open_partition_device(
+        "/dev/loop0p1", os.major(root_device), os.minor(root_device)
     )
-    replacement_device = os.makedev(7, 202)
-    assert replacement_device != state[1]
+    verity_descriptor, verity_state = module.open_partition_device(
+        "/dev/loop0p2", os.major(verity_device), os.minor(verity_device)
+    )
+    module.subprocess.run = lambda *args, **kwargs: commands.append((args, kwargs))
+    partition = module.Partition(1, module.ROOT_TYPE, uuid.uuid4(), 0, 63, 0, "root")
+    module.verify_verity(
+        root_descriptor,
+        root_state,
+        verity_descriptor,
+        verity_state,
+        partition,
+        "0" * 64,
+    )
     module.libc = FakeLibc()
-    module.mount_root(descriptor, state, "/run/pinned-root")
+    module.mount_root(root_descriptor, root_state, "/run/pinned-root")
 finally:
     module.os.open = original_open
     module.os.fstat = original_fstat
+    module.subprocess.run = original_run
     module.libc = original_libc
 
-assert opened and opened[0][0] == "/dev/loop0p1"
-assert mounted and mounted[0][0] == b"/proc/self/fd/73"
+assert [item[0] for item in opened] == ["/dev/loop0p1", "/dev/loop0p2"]
+command, options = commands[0]
+assert command[0][-3:-1] == ["/proc/self/fd/73", "/proc/self/fd/74"]
+assert options["pass_fds"] == (73, 74)
+assert mounted[0][0] == b"/proc/self/fd/73"
+
+
+def reject_partition_state_swap(swapped_descriptor, label):
+    calls = {73: 0, 74: 0}
+
+    def changing_fstat(descriptor):
+        calls[descriptor] += 1
+        state = device_states[descriptor]
+        if descriptor == swapped_descriptor and calls[descriptor] > 1:
+            return types.SimpleNamespace(
+                st_mode=state.st_mode,
+                st_rdev=os.makedev(7, 250),
+                st_dev=state.st_dev,
+                st_ino=state.st_ino + 100,
+            )
+        return state
+
+    module.os.fstat = changing_fstat
+    module.subprocess.run = lambda *args, **kwargs: None
+    try:
+        module.verify_verity(73, root_state, 74, verity_state, partition, "0" * 64)
+    except module.VerificationError as error:
+        if label not in str(error):
+            raise
+    else:
+        raise SystemExit(f"accepted swapped {label} descriptor state")
+    finally:
+        module.os.fstat = original_fstat
+        module.subprocess.run = original_run
+
+
+reject_partition_state_swap(73, "root partition")
+reject_partition_state_swap(74, "verity partition")
+
+crypto = pathlib.Path(scratch, "crypto")
+crypto.mkdir()
+data = crypto / "data"
+hash_tree = crypto / "hash"
+root_hash_file = crypto / "roothash"
+data.write_bytes(bytes(range(256)) * 128)
+with hash_tree.open("wb") as output:
+    output.truncate(16 * module.VERITY_BLOCK_SIZE)
+subprocess.run(
+    [
+        module.VERITYSETUP,
+        "--no-superblock",
+        "--format=1",
+        f"--data-block-size={module.VERITY_BLOCK_SIZE}",
+        f"--hash-block-size={module.VERITY_BLOCK_SIZE}",
+        "--data-blocks=8",
+        f"--hash-offset={module.VERITY_HASH_OFFSET}",
+        "--hash=sha256",
+        f"--salt={module.VERITY_SALT}",
+        f"--root-hash-file={root_hash_file}",
+        "format",
+        data,
+        hash_tree,
+    ],
+    check=True,
+    stdout=subprocess.DEVNULL,
+)
+crypto_roothash = root_hash_file.read_text()
+partition = module.Partition(1, module.ROOT_TYPE, uuid.uuid4(), 0, 63, 0, "root")
+
+
+def verify_crypto(data_path, hash_path, supplied):
+    data_descriptor = os.open(data_path, os.O_RDONLY)
+    hash_descriptor = os.open(hash_path, os.O_RDONLY)
+    try:
+        module.verify_verity(
+            data_descriptor,
+            module.block_device_state(data_descriptor),
+            hash_descriptor,
+            module.block_device_state(hash_descriptor),
+            partition,
+            supplied,
+        )
+    finally:
+        os.close(hash_descriptor)
+        os.close(data_descriptor)
+
+
+verify_crypto(data, hash_tree, crypto_roothash)
+assert module.verity_tree_end(8) == 2 * module.VERITY_BLOCK_SIZE
+assert module.verity_tree_end(128) == 2 * module.VERITY_BLOCK_SIZE
+assert module.verity_tree_end(129) == 4 * module.VERITY_BLOCK_SIZE
+
+
+def verify_unused(path):
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        module.require_verity_unused_zero(
+            descriptor, 0, path.stat().st_size, 8,
+        )
+    finally:
+        os.close(descriptor)
+
+
+verify_unused(hash_tree)
+
+
+def flip(path, offset):
+    with path.open("r+b") as output:
+        output.seek(offset)
+        byte = output.read(1)
+        output.seek(-1, os.SEEK_CUR)
+        output.write(bytes([byte[0] ^ 1]))
+
+
+def rejected_crypto(name, mutate, supplied=crypto_roothash):
+    data_copy = crypto / f"{name}.data"
+    hash_copy = crypto / f"{name}.hash"
+    data_copy.write_bytes(data.read_bytes())
+    hash_copy.write_bytes(hash_tree.read_bytes())
+    mutate(data_copy, hash_copy)
+    try:
+        verify_crypto(data_copy, hash_copy, supplied)
+    except subprocess.CalledProcessError:
+        return
+    raise SystemExit(f"accepted cryptographically unbound input: {name}")
+
+
+rejected_crypto("data-mutation", lambda data_path, _hash_path: flip(data_path, 0))
+rejected_crypto(
+    "hash-mutation",
+    lambda _data_path, hash_path: flip(hash_path, module.VERITY_HASH_OFFSET),
+)
+rejected_crypto("roothash-mutation", lambda _data_path, _hash_path: None,
+                "1" + crypto_roothash[1:])
+
+for name, offset in (
+    ("nonzero-prefix", 0),
+    ("nonzero-trailing-byte", module.verity_tree_end(8)),
+    ("nonzero-final-byte", hash_tree.stat().st_size - 1),
+):
+    hash_copy = crypto / f"{name}.hash"
+    hash_copy.write_bytes(hash_tree.read_bytes())
+    flip(hash_copy, offset)
+    try:
+        verify_unused(hash_copy)
+    except module.VerificationError:
+        pass
+    else:
+        raise SystemExit(f"accepted nonzero unused verity bytes: {name}")
 PY
 
 mkdir "$scratch/paths"
 printf x >"$scratch/paths/image.raw"
 printf x >"$scratch/paths/manifest.tsv"
+printf '%064d' 0 >"$scratch/paths/roothash"
 ln -s image.raw "$scratch/paths/image-link.raw"
 ln -s manifest.tsv "$scratch/paths/manifest-link.tsv"
+ln -s roothash "$scratch/paths/roothash-link"
 ln -s paths "$scratch/paths-link"
-if "$verifier" --image "$scratch/paths/image-link.raw" --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+if "$verifier" --image "$scratch/paths/image-link.raw" --manifest "$scratch/paths/manifest.tsv" \
+    --roothash "$scratch/paths/roothash" 2>/dev/null; then
     fail "accepted symlinked image"
 fi
-if "$verifier" --image "$scratch/paths/image.raw" --manifest "$scratch/paths/manifest-link.tsv" 2>/dev/null; then
+if "$verifier" --image "$scratch/paths/image.raw" --manifest "$scratch/paths/manifest-link.tsv" \
+    --roothash "$scratch/paths/roothash" 2>/dev/null; then
     fail "accepted symlinked manifest"
 fi
-if "$verifier" --image "$scratch/paths-link/image.raw" --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+if "$verifier" --image "$scratch/paths/image.raw" --manifest "$scratch/paths/manifest.tsv" \
+    --roothash "$scratch/paths/roothash-link" 2>/dev/null; then
+    fail "accepted symlinked roothash"
+fi
+if "$verifier" --image "$scratch/paths-link/image.raw" --manifest "$scratch/paths/manifest.tsv" \
+    --roothash "$scratch/paths/roothash" 2>/dev/null; then
     fail "accepted symlinked path ancestor"
 fi
-if "$verifier" --image paths/image.raw --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+if "$verifier" --image paths/image.raw --manifest "$scratch/paths/manifest.tsv" \
+    --roothash "$scratch/paths/roothash" 2>/dev/null; then
     fail "accepted relative image path"
 fi
-if "$verifier" --image "$scratch/paths/../paths/image.raw" --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+if "$verifier" --image "$scratch/paths/../paths/image.raw" --manifest "$scratch/paths/manifest.tsv" \
+    --roothash "$scratch/paths/roothash" 2>/dev/null; then
     fail "accepted non-normalized image path"
 fi
-if "$verifier" --image "$scratch/paths//image.raw" --manifest "$scratch/paths/manifest.tsv" 2>/dev/null; then
+if "$verifier" --image "$scratch/paths//image.raw" --manifest "$scratch/paths/manifest.tsv" \
+    --roothash "$scratch/paths/roothash" 2>/dev/null; then
     fail "accepted duplicate path separator"
 fi
-
-mkdir "$scratch/hostile-path"
-cat >"$scratch/hostile-path/python3" <<EOF
-#!/usr/bin/env bash
-touch "$scratch/path-python-ran"
-exit 99
-EOF
-chmod +x "$scratch/hostile-path/python3"
-set +e
-PATH="$scratch/hostile-path:$PATH" "$verifier" \
-    --image "$scratch/paths/image.raw" --manifest "$scratch/paths/manifest.tsv" \
-    >/dev/null 2>&1
-status=$?
-set -e
-[[ "$status" != 99 && ! -e "$scratch/path-python-ran" ]] \
-    || fail "direct invocation used a PATH-selected Python interpreter"
 
 mkdir "$scratch/xattr-root"
 printf payload >"$scratch/xattr-root/file"
@@ -228,11 +565,13 @@ fi
 
 if [[ "${FINAL_ROOTFS_PRIVILEGED_TEST:-0}" == 1 ]]; then
     [[ "$(id -u)" == 0 ]] || fail "privileged test requested without root"
-    [[ -n "${FINAL_ROOTFS_TEST_IMAGE:-}" && -n "${FINAL_ROOTFS_TEST_MANIFEST:-}" ]] \
-        || fail "set FINAL_ROOTFS_TEST_IMAGE and FINAL_ROOTFS_TEST_MANIFEST"
+    [[ -n "${FINAL_ROOTFS_TEST_IMAGE:-}" && -n "${FINAL_ROOTFS_TEST_MANIFEST:-}" \
+        && -n "${FINAL_ROOTFS_TEST_ROOTHASH:-}" ]] \
+        || fail "set FINAL_ROOTFS_TEST_IMAGE, FINAL_ROOTFS_TEST_MANIFEST, and FINAL_ROOTFS_TEST_ROOTHASH"
     env -i PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
         LC_ALL=C LANG=C /usr/bin/python3 -I "$verifier" \
-        --image "$FINAL_ROOTFS_TEST_IMAGE" --manifest "$FINAL_ROOTFS_TEST_MANIFEST"
+        --image "$FINAL_ROOTFS_TEST_IMAGE" --manifest "$FINAL_ROOTFS_TEST_MANIFEST" \
+        --roothash "$FINAL_ROOTFS_TEST_ROOTHASH"
 else
     echo "SKIP: set FINAL_ROOTFS_PRIVILEGED_TEST=1 with produced image inputs" >&2
 fi

--- a/scripts/verify-final-rootfs.py
+++ b/scripts/verify-final-rootfs.py
@@ -34,6 +34,7 @@ PROTECTIVE_MBR_PREFIX = bytes.fromhex("00 00 02 00 ee ff ff ff")
 VERITY_BLOCK_SIZE = 4096
 VERITY_HASH_OFFSET = 4096
 VERITY_DIGEST_SIZE = 32
+ROOTHASH_HEX_SIZE = VERITY_DIGEST_SIZE * 2
 VERITY_SALT = "d8f43870af05f2fb613c2bb571f911da45cfa46a77e6efeabbdd5ed760ebabde"
 ROOT_PARTITION_SIZE = 3 * 1024**3
 ROOT_VERITY_PARTITION_SIZE = 256 * 1024**2
@@ -352,9 +353,9 @@ def inspect_gpt(descriptor):
 
 def read_roothash(descriptor):
     original = file_state(descriptor)
-    value = pread_exact(descriptor, 64, 0, "direct roothash")
-    if os.fstat(descriptor).st_size != 64:
-        fail("direct roothash must contain exactly 64 bytes")
+    value = pread_exact(descriptor, ROOTHASH_HEX_SIZE, 0, "direct roothash")
+    if os.fstat(descriptor).st_size != ROOTHASH_HEX_SIZE:
+        fail(f"direct roothash must contain exactly {ROOTHASH_HEX_SIZE} bytes")
     try:
         text = value.decode("ascii")
     except UnicodeDecodeError:

--- a/scripts/verify-final-rootfs.py
+++ b/scripts/verify-final-rootfs.py
@@ -26,7 +26,20 @@ FIRST_USABLE_LBA = 2048
 ROOT_TYPE = uuid.UUID("4f68bce3-e8cd-4db1-96e7-fbcaf984b709")
 ROOT_LABEL = "root"
 ROOT_ATTRIBUTES = 1 << 60
+ROOT_VERITY_TYPE = uuid.UUID("2c7357ed-ebd2-46d9-aec1-23d437ec2bf5")
+ROOT_VERITY_LABEL = "root-x86-64-verity"
+ROOT_VERITY_ATTRIBUTES = 1 << 60
+DISK_UUID = uuid.UUID("bd21aac6-0338-4a33-85d9-d14ccf6c5ea1")
+PROTECTIVE_MBR_PREFIX = bytes.fromhex("00 00 02 00 ee ff ff ff")
+VERITY_BLOCK_SIZE = 4096
+VERITY_HASH_OFFSET = 4096
+VERITY_DIGEST_SIZE = 32
+VERITY_SALT = "d8f43870af05f2fb613c2bb571f911da45cfa46a77e6efeabbdd5ed760ebabde"
+ROOT_PARTITION_SIZE = 3 * 1024**3
+ROOT_VERITY_PARTITION_SIZE = 256 * 1024**2
+RAW_IMAGE_SIZE = 3490729984
 PYTHON = "/usr/bin/python3"
+VERITYSETUP = "/usr/sbin/veritysetup"
 TRUSTED_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 LOOP_CTL_GET_FREE = 0x4C82
 LOOP_CONFIGURE = 0x4C0A
@@ -60,6 +73,12 @@ class Partition:
     last_lba: int
     attributes: int
     label: str
+
+
+@dataclass(frozen=True)
+class RootLayout:
+    root: Partition
+    verity: Partition
 
 
 def fail(message):
@@ -125,12 +144,58 @@ def pread_exact(descriptor, size, offset, context):
     return data
 
 
+def require_zero_region(descriptor, start, end, context):
+    if start > end:
+        fail(f"{context}: invalid bounds")
+    offset = start
+    while offset < end:
+        size = min(end - offset, 1024 * 1024)
+        data = pread_exact(descriptor, size, offset, context)
+        if any(data):
+            fail(f"{context}: contains nonzero bytes")
+        offset += size
+
+
+def partition_size_bytes(partition):
+    return (partition.last_lba - partition.first_lba + 1) * SECTOR_SIZE
+
+
+def verity_tree_end(data_blocks):
+    if data_blocks <= 0:
+        fail("dm-verity tree requires at least one data block")
+    hashes_per_block = VERITY_BLOCK_SIZE // VERITY_DIGEST_SIZE
+    level_blocks = (data_blocks + hashes_per_block - 1) // hashes_per_block
+    tree_blocks = 0
+    while True:
+        tree_blocks += level_blocks
+        if level_blocks == 1:
+            break
+        level_blocks = (level_blocks + hashes_per_block - 1) // hashes_per_block
+    return VERITY_HASH_OFFSET + tree_blocks * VERITY_BLOCK_SIZE
+
+
+def require_verity_unused_zero(descriptor, start, size, data_blocks):
+    tree_end = verity_tree_end(data_blocks)
+    if tree_end > size:
+        fail("root verity partition is too small for the exact dm-verity tree")
+    require_zero_region(
+        descriptor, start, start + VERITY_HASH_OFFSET,
+        "root verity 4096-byte prefix",
+    )
+    require_zero_region(
+        descriptor, start + tree_end, start + size,
+        "unused root verity partition tail",
+    )
+
+
 def crc32(data):
     return binascii.crc32(data) & 0xFFFFFFFF
 
 
 def protective_mbr(descriptor, sectors):
     mbr = pread_exact(descriptor, SECTOR_SIZE, 0, "protective MBR")
+    if mbr[:446] != b"\0" * 446:
+        fail("protective MBR: nonzero boot or reserved bytes")
     if mbr[510:512] != b"\x55\xaa":
         fail("protective MBR: missing signature")
     records = [mbr[446 + index * 16:462 + index * 16] for index in range(4)]
@@ -138,6 +203,8 @@ def protective_mbr(descriptor, sectors):
     expected_size = min(sectors - 1, 0xFFFFFFFF)
     if len(used) != 1 or used[0][4] != 0xEE:
         fail("protective MBR: hybrid or missing GPT partition")
+    if used[0][:8] != PROTECTIVE_MBR_PREFIX:
+        fail("protective MBR: non-canonical boot, CHS, or type bytes")
     if struct.unpack_from("<I", used[0], 8)[0] != 1:
         fail("protective MBR: GPT partition does not start at LBA 1")
     if struct.unpack_from("<I", used[0], 12)[0] != expected_size:
@@ -189,8 +256,8 @@ def decode_label(raw, context):
 def inspect_gpt(descriptor):
     original = file_state(descriptor)
     size = os.fstat(descriptor).st_size
-    if size < 68 * SECTOR_SIZE or size % SECTOR_SIZE:
-        fail("raw image has invalid 512-byte sector geometry")
+    if size != RAW_IMAGE_SIZE:
+        fail("raw image size does not match the fixed 3,490,729,984-byte contract")
     sectors = size // SECTOR_SIZE
     protective_mbr(descriptor, sectors)
     primary, entries = read_header(descriptor, 1, sectors, "primary GPT")
@@ -200,8 +267,8 @@ def inspect_gpt(descriptor):
         fail("GPT headers do not point to each other")
     if primary[7:10] != backup[7:10] or primary[9] != backup[9]:
         fail("GPT headers disagree")
-    if uuid.UUID(bytes_le=primary[9]).int == 0:
-        fail("GPT disk UUID is zero")
+    if uuid.UUID(bytes_le=primary[9]) != DISK_UUID:
+        fail("GPT disk UUID does not match the fixed seed-derived value")
     if primary[10] != 2 or backup[10] != sectors - 1 - entry_sectors:
         fail("GPT entry arrays are not in fixed locations")
     if primary[7] != FIRST_USABLE_LBA or primary[8] != sectors - entry_sectors - 2:
@@ -231,14 +298,78 @@ def inspect_gpt(descriptor):
     ordered = sorted(partitions, key=lambda item: item.first_lba)
     if any(left.last_lba >= right.first_lba for left, right in zip(ordered, ordered[1:])):
         fail("GPT partitions overlap")
-    typed = [partition for partition in partitions if partition.type_uuid == ROOT_TYPE]
-    labelled = [partition for partition in partitions if partition.label == ROOT_LABEL]
-    if len(typed) != 1 or len(labelled) != 1 or typed[0] != labelled[0]:
-        fail("GPT must contain exactly one root partition with the fixed type and label")
-    if typed[0].attributes != ROOT_ATTRIBUTES:
+    if len(partitions) != 2:
+        fail("GPT must contain exactly the root and root verity partitions")
+    root, verity = partitions
+    if root.number != 1 or root.type_uuid != ROOT_TYPE or root.label != ROOT_LABEL:
+        fail("GPT entry 1 is not the fixed root partition")
+    if root.attributes != ROOT_ATTRIBUTES:
         fail("root partition does not have the fixed read-only GPT attribute")
+    if verity.number != 2 or verity.type_uuid != ROOT_VERITY_TYPE \
+            or verity.label != ROOT_VERITY_LABEL:
+        fail("GPT entry 2 is not the fixed root verity partition")
+    if verity.attributes != ROOT_VERITY_ATTRIBUTES:
+        fail("root verity partition does not have the fixed read-only GPT attribute")
+    if root.first_lba != FIRST_USABLE_LBA or verity.first_lba != root.last_lba + 1:
+        fail("root and root verity partitions do not have fixed contiguous geometry")
+    if partition_size_bytes(root) != ROOT_PARTITION_SIZE:
+        fail("root partition size does not match the fixed 3 GiB contract")
+    if partition_size_bytes(verity) != ROOT_VERITY_PARTITION_SIZE:
+        fail("root verity partition size does not match the fixed 256 MiB contract")
+    sectors_per_block = VERITY_BLOCK_SIZE // SECTOR_SIZE
+    for partition in (root, verity):
+        sector_count = partition.last_lba - partition.first_lba + 1
+        if partition.first_lba % sectors_per_block or sector_count % sectors_per_block:
+            fail(f"{partition.label} partition is not aligned to verity blocks")
+    canonical_verity_last = (
+        (primary[8] + 1) // sectors_per_block * sectors_per_block - 1
+    )
+    if verity.last_lba != canonical_verity_last:
+        fail("root verity partition does not end at the canonical aligned boundary")
+    data_blocks = ROOT_PARTITION_SIZE // VERITY_BLOCK_SIZE
+    require_verity_unused_zero(
+        descriptor,
+        verity.first_lba * SECTOR_SIZE,
+        ROOT_VERITY_PARTITION_SIZE,
+        data_blocks,
+    )
+    primary_entries_end = (primary[10] + entry_sectors) * SECTOR_SIZE
+    require_zero_region(
+        descriptor,
+        primary_entries_end,
+        root.first_lba * SECTOR_SIZE,
+        "space before root partition",
+    )
+    require_zero_region(
+        descriptor,
+        (verity.last_lba + 1) * SECTOR_SIZE,
+        backup[10] * SECTOR_SIZE,
+        "alignment space after root verity partition",
+    )
     require_stable(descriptor, original, "raw image")
-    return typed[0]
+    return RootLayout(root, verity)
+
+
+def read_roothash(descriptor):
+    original = file_state(descriptor)
+    value = pread_exact(descriptor, 64, 0, "direct roothash")
+    if os.fstat(descriptor).st_size != 64:
+        fail("direct roothash must contain exactly 64 bytes")
+    try:
+        text = value.decode("ascii")
+    except UnicodeDecodeError:
+        fail("direct roothash is not ASCII")
+    if any(character not in "0123456789abcdef" for character in text):
+        fail("direct roothash is not canonical lowercase SHA-256 hex")
+    require_stable(descriptor, original, "direct roothash")
+    return text
+
+
+def require_roothash_partition_ids(layout, roothash):
+    if layout.root.unique_uuid != uuid.UUID(hex=roothash[:32]):
+        fail("root PARTUUID does not match the direct roothash")
+    if layout.verity.unique_uuid != uuid.UUID(hex=roothash[32:]):
+        fail("root verity PARTUUID does not match the direct roothash")
 
 
 def private_mount_namespace():
@@ -289,6 +420,11 @@ def open_partition_device(path, major, minor):
     return descriptor, state
 
 
+def require_partition_stable(descriptor, original, context):
+    if block_device_state(descriptor) != original:
+        fail(f"{context} block device changed during verification")
+
+
 def wait_for_partition(loop_number, partition):
     name = f"loop{loop_number}p{partition.number}"
     sysfs = Path("/sys/class/block") / name
@@ -307,7 +443,46 @@ def wait_for_partition(loop_number, partition):
             if error.errno not in (errno.ENOENT, errno.ENXIO, errno.ENODEV):
                 raise
         time.sleep(0.02)
-    fail("kernel did not expose the fixed root partition")
+    fail(f"kernel did not expose the fixed {partition.label} partition")
+
+
+def verify_verity(
+    root_descriptor,
+    root_state,
+    verity_descriptor,
+    verity_state,
+    root_partition,
+    roothash,
+):
+    sector_count = root_partition.last_lba - root_partition.first_lba + 1
+    data_blocks = sector_count * SECTOR_SIZE // VERITY_BLOCK_SIZE
+    environment = {"PATH": TRUSTED_PATH, "LC_ALL": "C", "LANG": "C"}
+    require_partition_stable(root_descriptor, root_state, "root partition")
+    require_partition_stable(verity_descriptor, verity_state, "verity partition")
+    subprocess.run(
+        [
+            VERITYSETUP,
+            "--no-superblock",
+            "--format=1",
+            f"--data-block-size={VERITY_BLOCK_SIZE}",
+            f"--hash-block-size={VERITY_BLOCK_SIZE}",
+            f"--data-blocks={data_blocks}",
+            f"--hash-offset={VERITY_HASH_OFFSET}",
+            "--hash=sha256",
+            f"--salt={VERITY_SALT}",
+            "verify",
+            f"/proc/self/fd/{root_descriptor}",
+            f"/proc/self/fd/{verity_descriptor}",
+            roothash,
+        ],
+        check=True,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        pass_fds=(root_descriptor, verity_descriptor),
+    )
+    require_partition_stable(root_descriptor, root_state, "root partition")
+    require_partition_stable(verity_descriptor, verity_state, "verity partition")
 
 
 def copy_manifest(descriptor, destination):
@@ -319,19 +494,22 @@ def copy_manifest(descriptor, destination):
 
 
 def mount_root(source_descriptor, source_state, target):
-    if block_device_state(source_descriptor) != source_state:
-        fail("partition block device changed before mount")
+    require_partition_stable(source_descriptor, source_state, "root partition")
     flags = MS_RDONLY | MS_NOSUID | MS_NODEV | MS_NOEXEC
     source = f"/proc/self/fd/{source_descriptor}"
     syscall(
         libc.mount(os.fsencode(source), os.fsencode(target), b"ext4", flags, b"noload"),
         "mount root partition read-only",
     )
+    require_partition_stable(source_descriptor, source_state, "root partition")
 
 
-def verify(image_descriptor, manifest_descriptor):
+def verify(image_descriptor, manifest_descriptor, roothash_descriptor):
     image_state = file_state(image_descriptor)
-    root_partition = inspect_gpt(image_descriptor)
+    roothash_state = file_state(roothash_descriptor)
+    layout = inspect_gpt(image_descriptor)
+    roothash = read_roothash(roothash_descriptor)
+    require_roothash_partition_ids(layout, roothash)
     private_mount_namespace()
     scratch = Path(tempfile.mkdtemp(prefix="final-rootfs-verify.", dir="/run"))
     marker = scratch / ".owned-by-final-rootfs-verifier"
@@ -340,19 +518,35 @@ def verify(image_descriptor, manifest_descriptor):
     mountpoint.mkdir(mode=0o700)
     mounted = False
     loop_descriptor = None
-    partition_descriptor = None
+    root_descriptor = None
+    verity_descriptor = None
     try:
         expected = scratch / "expected.tsv"
         actual = scratch / "actual.tsv"
         copy_manifest(manifest_descriptor, expected)
         loop_number, loop_descriptor = configure_loop(image_descriptor)
-        partition_descriptor, partition_state = wait_for_partition(
-            loop_number, root_partition
+        root_descriptor, root_partition_state = wait_for_partition(
+            loop_number, layout.root
         )
-        mount_root(partition_descriptor, partition_state, mountpoint)
+        verity_descriptor, verity_partition_state = wait_for_partition(
+            loop_number, layout.verity
+        )
+        verify_verity(
+            root_descriptor,
+            root_partition_state,
+            verity_descriptor,
+            verity_partition_state,
+            layout.root,
+            roothash,
+        )
+        require_partition_stable(
+            verity_descriptor, verity_partition_state, "verity partition"
+        )
+        mount_root(root_descriptor, root_partition_state, mountpoint)
         mounted = True
-        if block_device_state(partition_descriptor) != partition_state:
-            fail("partition block device changed during mount")
+        require_partition_stable(
+            verity_descriptor, verity_partition_state, "verity partition"
+        )
         tool = Path(__file__).resolve().with_name("rootfs_manifest.py")
         environment = {"PATH": TRUSTED_PATH, "LC_ALL": "C", "LANG": "C"}
         subprocess.run(
@@ -365,13 +559,22 @@ def verify(image_descriptor, manifest_descriptor):
             check=True,
             env=environment,
         )
+        require_partition_stable(
+            root_descriptor, root_partition_state, "root partition"
+        )
+        require_partition_stable(
+            verity_descriptor, verity_partition_state, "verity partition"
+        )
         require_stable(image_descriptor, image_state, "raw image")
+        require_stable(roothash_descriptor, roothash_state, "direct roothash")
     finally:
         if mounted:
             if libc.umount2(os.fsencode(mountpoint), 0) != 0:
                 libc.umount2(os.fsencode(mountpoint), MNT_DETACH)
-        if partition_descriptor is not None:
-            os.close(partition_descriptor)
+        if verity_descriptor is not None:
+            os.close(verity_descriptor)
+        if root_descriptor is not None:
+            os.close(root_descriptor)
         if loop_descriptor is not None:
             os.close(loop_descriptor)
         if marker.is_file() and marker.read_text() == f"{os.getpid()}\n":
@@ -382,19 +585,21 @@ def main():
     command = argparse.ArgumentParser(description="Verify a produced raw image rootfs")
     command.add_argument("--image", required=True)
     command.add_argument("--manifest", required=True)
+    command.add_argument("--roothash", required=True)
     arguments = command.parse_args()
-    image_descriptor = manifest_descriptor = None
+    image_descriptor = manifest_descriptor = roothash_descriptor = None
     try:
         image_descriptor = secure_open(arguments.image)
         manifest_descriptor = secure_open(arguments.manifest)
-        verify(image_descriptor, manifest_descriptor)
-        print("final raw image rootfs matches the canonical manifest")
+        roothash_descriptor = secure_open(arguments.roothash)
+        verify(image_descriptor, manifest_descriptor, roothash_descriptor)
+        print("final raw image rootfs and verity tree match measured inputs")
         return 0
     except (VerificationError, OSError, subprocess.CalledProcessError) as error:
         print(f"verify-final-rootfs: {error}", file=sys.stderr)
         return 2
     finally:
-        for descriptor in (manifest_descriptor, image_descriptor):
+        for descriptor in (roothash_descriptor, manifest_descriptor, image_descriptor):
             if descriptor is not None:
                 os.close(descriptor)
 


### PR DESCRIPTION
## Summary

- strengthen the existing final-rootfs verifier into the exact fixed raw-image gate
- pin the complete GPT geometry, root/verity PARTUUID binding, image length, and read-only root attributes
- verify the no-superblock SHA-256 dm-verity layout directly against the measured roothash
- hold the image and partition descriptors across inspection, verification, and read-only mount

## Fixed contract

- exactly one 3 GiB root partition and one 256 MiB verity-hash partition
- exact 3,490,729,984-byte raw image length and first usable LBA 2048
- exact partition types, order, starts, sizes, names, attributes, and roothash-derived PARTUUIDs
- zero-filled GPT gaps, verity prefix, and unused verity tail
- SHA-256, 4096-byte blocks, dm-verity format 1, and no verity superblock
- read-only loop devices plus ext4 `nosuid,nodev,noexec,noload`

The verifier uses fixed binary GPT offsets and kernel interfaces. It does not parse repart configuration or retain an old-image compatibility path.

## Fail-closed behavior

- pins both the raw image and partition objects and rejects replacement or state drift
- passes pinned `/proc/self/fd/N` objects to `veritysetup` and the read-only mount
- rejects malformed GPT headers/tables, extra partitions, wrong geometry, nonzero reserved regions, roothash/PARTUUID drift, verity corruption, symlink inputs, and unexpected xattrs

## Validation

- `python3 -m py_compile scripts/verify-final-rootfs.py`
- `bash -n scripts/test-final-rootfs-verifier.sh`
- `make test-final-rootfs-verifier`
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

Privileged end-to-end validation remains required on a newly produced no-superblock raw image. The preserved older image is intentionally rejected because its verity partition contains a superblock prefix.

## Ordering

This review is independent of #204 and #205 and may merge before or after them; three-way merge simulations are clean. It must merge before the final shipping cutover consumes this gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks the final raw rootfs verifier to an exact disk image contract and verity tree, including a fixed disk UUID and canonical protective MBR. Uses a direct 64-hex-byte roothash to bind PARTUUIDs and authenticate no-superblock dm-verity via `veritysetup`, while pinning devices and blocking hidden bytes.

- **New Features**
  - Enforces exact 3,490,729,984-byte image and fixed GPT: exactly two contiguous, 4096-byte aligned partitions (3 GiB `root`, 256 MiB `root-x86-64-verity`).
  - Pins GPT disk UUID (`bd21aac6-0338-4a33-85d9-d14ccf6c5ea1`) and a canonical protective MBR prefix; zeros all unused gaps to block hidden data.
  - Requires a direct roothash file with exactly 64 lowercase hex bytes; binds both `PARTUUID`s to it and rejects mismatches.
  - Verifies no-superblock dm-verity (format 1, SHA-256, 4096-byte blocks, 4096-byte hash offset) via `veritysetup verify` using only pinned `/proc/self/fd/*` descriptors; computes the hash-tree extent and enforces zero prefix/tail.
  - Pins and re-checks root and verity block devices before/after verification and mount; mounts ext4 with `ro,nosuid,nodev,noexec,noload`.
  - `Makefile` `verify-final-rootfs` now requires `FINAL_ROOTFS_ROOTHASH`; docs and tests updated.

- **Migration**
  - Provide `FINAL_ROOTFS_ROOTHASH` as a regular file containing exactly 64 lowercase hex bytes.
  - Ensure images match the fixed contract: exact size, two partitions as above, 4096-byte alignment, disk UUID `bd21aac6-0338-4a33-85d9-d14ccf6c5ea1`, canonical protective MBR, and zeroed gaps.
  - For tests, set `FINAL_ROOTFS_TEST_ROOTHASH` alongside `FINAL_ROOTFS_TEST_IMAGE` and `FINAL_ROOTFS_TEST_MANIFEST`. Older images with a verity superblock, non-zeroed gaps, non-canonical MBR, or mismatched geometry/UUIDs will be rejected.

<sup>Written for commit edf17ba22e467d586b34e2c751679d5954b5b5d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

