### PR TITLE
Add authenticated runtime artifact preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ override NVATTEST_BUILDER := $(file <scripts/nvattest-builder-image.txt)
 	verify-runtime-sources update-runtime-locks test-runtime-archives \
 	test-nvattest-artifacts reproducible-nvattest \
 	runtime-go-artifacts custom-kernel-artifacts nvidia-module-artifacts verify-rootfs-artifacts \
+	prepare-runtime-artifacts test-runtime-artifact-bridge \
 	test-rootfs-artifacts reproducible-nvidia-modules reproducible-runtime-artifacts
 
 # tinfoilcvm.hash is the compatibility copy written by `rebuild`; mkosi's
@@ -98,6 +99,12 @@ verify-rootfs-artifacts: runtime-go-artifacts nvattest nvidia-module-artifacts
 		--manifest go=build/builder-work/output/rootfs-artifacts.tsv \
 		--manifest nvattest=build/rootfs-artifacts/nvattest/rootfs-artifacts.tsv \
 		--manifest nvidia-modules=kernel/out/rootfs-artifacts/nvidia-modules/rootfs-artifacts.tsv
+
+prepare-runtime-artifacts: verify-rootfs-artifacts
+	python3 -m scripts.runtime_artifact_bridge prepare
+
+test-runtime-artifact-bridge: prepare-runtime-artifacts
+	python3 -m unittest scripts.runtime_artifact_bridge_test
 
 test-rootfs-artifacts:
 	python3 -m unittest scripts.rootfs_artifacts_test

--- a/docs/runtime-artifact-bridge.md
+++ b/docs/runtime-artifact-bridge.md
@@ -7,19 +7,23 @@ discover artifacts or accept paths from callers.
 `make prepare-runtime-artifacts` first runs all three fixed producers and their
 existing bidirectional verifier. It then snapshots only the ten regular files
 and three producer manifests into `build/runtime-artifacts`. Copying is
-descriptor-relative and no-follow, hashes bytes while copying, and rejects
-source metadata changes. A literal exports-only `BUILD.bazel` and a marker
-binding the checked-in lock digest are published only after the snapshot is
-complete.
+descriptor-relative and no-follow. Regular artifacts are hashed while copying
+and revalidated afterward; manifests are read into stable buffers before those
+exact bytes are written and authenticated in the completed package. A literal
+exports-only `BUILD.bazel` and a marker binding the checked-in lock digest are
+published only after the snapshot is complete.
 
 Preparation serializes writers under a private mode-`0700`
 `build/.runtime-artifacts-state` directory and uses mode-`0700` staging. The
 repository's established shared-group checkout policy permits an existing
 mode-`0775` `build` directory only when it has the repository owner and group;
 new build directories are not group-writable. Failed marker-owned staging is
-removed, while hostile or unowned staging is preserved.
+removed only after the private preparation marker and each entry's inode, type,
+ownership, link count, xattr state, and identity are validated. Hostile,
+replaced, or unowned staging is preserved.
 
-Before publication or deletion, the bridge reauthenticates the literal
+Before publication or deletion of a completed package, the bridge
+reauthenticates the literal
 `BUILD.bazel`, all three manifests, the marker, and every artifact byte and
 mode. Initial publication uses Linux `renameat2(RENAME_NOREPLACE)`, and
 replacement uses `renameat2(RENAME_EXCHANGE)`. Existing or raced unmarked,

--- a/docs/runtime-artifact-bridge.md
+++ b/docs/runtime-artifact-bridge.md
@@ -1,0 +1,34 @@
+# Fixed Runtime Artifact Bridge
+
+`image/manifests/rootfs-artifacts.lock.tsv` is the sole authority for the ten
+runtime files and two assembly-only `libnvat` symlinks. The bridge does not
+discover artifacts or accept paths from callers.
+
+`make prepare-runtime-artifacts` first runs all three fixed producers and their
+existing bidirectional verifier. It then snapshots only the ten regular files
+and three producer manifests into `build/runtime-artifacts`. Copying is
+descriptor-relative and no-follow, hashes bytes while copying, and rejects
+source metadata changes. A literal exports-only `BUILD.bazel` and a marker
+binding the checked-in lock digest are published only after the snapshot is
+complete.
+
+Preparation serializes writers under a private mode-`0700`
+`build/.runtime-artifacts-state` directory and uses mode-`0700` staging. The
+repository's established shared-group checkout policy permits an existing
+mode-`0775` `build` directory only when it has the repository owner and group;
+new build directories are not group-writable. Failed marker-owned staging is
+removed, while hostile or unowned staging is preserved.
+
+Before publication or deletion, the bridge reauthenticates the literal
+`BUILD.bazel`, all three manifests, the marker, and every artifact byte and
+mode. Initial publication uses Linux `renameat2(RENAME_NOREPLACE)`, and
+replacement uses `renameat2(RENAME_EXCHANGE)`. Existing or raced unmarked,
+malformed, symlinked, differently owned, incorrectly shaped, or byte-mutated
+trees are preserved and rejected. There is no non-atomic compatibility
+fallback.
+
+This preparation review publishes the generated package but keeps the entire
+`build` tree outside Bazel package discovery. The following consumer review
+narrows that exclusion to expose only authenticated `build/runtime-artifacts`,
+with files visible only to `//image:__pkg__`. Bazel never runs Make or a
+producer.

--- a/scripts/runtime_artifact_bridge.py
+++ b/scripts/runtime_artifact_bridge.py
@@ -19,6 +19,8 @@ STATE = ".runtime-artifacts-state"
 MARKER = ".tinfoil-runtime-artifacts-v1"
 PREPARING = ".tinfoil-runtime-artifacts-preparing-v1"
 SCHEMA = "tinfoil-runtime-artifacts-v1"
+RENAME_NOREPLACE = 1
+RENAME_EXCHANGE = 2
 PRODUCER_ROOTS = {
     "go": Path("build/builder-work/output"),
     "nvattest": Path("build/rootfs-artifacts/nvattest"),
@@ -86,8 +88,10 @@ def read_regular(path: Path) -> tuple[bytes, os.stat_result]:
 
 
 def mkdir(parent: int, name: str, mode: int = 0o755, accepted_modes: set[int] | None = None) -> int:
+    created = False
     try:
         os.mkdir(name, mode, dir_fd=parent)
+        created = True
     except FileExistsError:
         pass
     descriptor = os.open(
@@ -95,6 +99,8 @@ def mkdir(parent: int, name: str, mode: int = 0o755, accepted_modes: set[int] | 
         os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
         dir_fd=parent,
     )
+    if created:
+        os.fchmod(descriptor, mode)
     metadata = os.fstat(descriptor)
     modes = accepted_modes or {mode}
     if metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) not in modes or os.listxattr(descriptor):
@@ -111,6 +117,7 @@ def write_file(parent: int, name: str, content: bytes, mode: int) -> None:
         dir_fd=parent,
     )
     try:
+        os.fchmod(descriptor, mode)
         write_all(descriptor, content)
         os.fsync(descriptor)
     finally:
@@ -140,7 +147,7 @@ def open_beneath(root: int, relative: str) -> tuple[int, int]:
             parent = child
         descriptor = os.open(
             path.parts[-1],
-            os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+            os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_NOFOLLOW,
             dir_fd=parent,
         )
         return parent, descriptor
@@ -182,6 +189,7 @@ def snapshot_file(source_root: int, source: str, output_root: int, output: str, 
         )
         digest = hashlib.sha256()
         try:
+            os.fchmod(destination, int(entry.mode, 8))
             while chunk := os.read(source_fd, 1024 * 1024):
                 digest.update(chunk)
                 write_all(destination, chunk)
@@ -256,7 +264,11 @@ def validate_tree(parent: int, name: str, files: dict[str, tuple[int, str]]) -> 
                 finally:
                     os.close(child)
             else:
-                child = os.open(child_name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                child = os.open(
+                    child_name,
+                    os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_NOFOLLOW,
+                    dir_fd=descriptor,
+                )
                 try:
                     opened = os.fstat(child)
                     if identity(metadata) != identity(opened) or not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1 or os.listxattr(child):
@@ -316,7 +328,11 @@ def remove_owned(parent: int, name: str, files: dict[str, tuple[int, str]]) -> N
                     fail(f"refusing to remove replaced directory: {child_name}")
                 os.rmdir(child_name, dir_fd=descriptor)
             else:
-                child = os.open(child_name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                child = os.open(
+                    child_name,
+                    os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_NOFOLLOW,
+                    dir_fd=descriptor,
+                )
                 try:
                     opened = os.fstat(child)
                     if identity(metadata) != identity(opened) or not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1 or os.listxattr(child):
@@ -382,7 +398,11 @@ def remove_staging(parent: int, name: str, preparing_content: bytes, files: dict
                         fail(f"refusing to remove replaced staging directory: {child_name}")
                     os.rmdir(child_name, dir_fd=descriptor)
                 else:
-                    child = os.open(child_name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                    child = os.open(
+                        child_name,
+                        os.O_RDONLY | os.O_NONBLOCK | os.O_CLOEXEC | os.O_NOFOLLOW,
+                        dir_fd=descriptor,
+                    )
                     try:
                         opened = os.fstat(child)
                         if identity(child_metadata) != identity(opened) or not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1 or os.listxattr(child):
@@ -419,11 +439,18 @@ def renameat2(source_parent: int, source: str, destination_parent: int, destinat
 
 
 def publish(source_parent: int, temporary: str, destination_parent: int, destination: str) -> None:
-    renameat2(source_parent, temporary, destination_parent, destination, 1, "no-replace publication")
+    renameat2(
+        source_parent,
+        temporary,
+        destination_parent,
+        destination,
+        RENAME_NOREPLACE,
+        "no-replace publication",
+    )
 
 
 def exchange(source_parent: int, temporary: str, destination_parent: int, destination: str) -> None:
-    renameat2(source_parent, temporary, destination_parent, destination, 2, "exchange")
+    renameat2(source_parent, temporary, destination_parent, destination, RENAME_EXCHANGE, "exchange")
 
 
 def open_build(repository: int, repository_metadata: os.stat_result) -> int:
@@ -463,7 +490,16 @@ def prepare() -> None:
         os.close(state)
         os.close(build)
         fail("runtime artifact state crosses the build filesystem boundary")
-    lock_fd = os.open("lock", os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW, 0o600, dir_fd=state)
+    try:
+        lock_fd = os.open(
+            "lock",
+            os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=state,
+        )
+        os.fchmod(lock_fd, 0o600)
+    except FileExistsError:
+        lock_fd = os.open("lock", os.O_RDWR | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=state)
     temporary = f".runtime-artifacts.{os.getpid()}.{secrets.token_hex(8)}"
     preparing_content = f"{SCHEMA}\t{temporary}\n".encode()
     contract_files = None
@@ -477,6 +513,7 @@ def prepare() -> None:
         cleanup_temporary = True
         output = os.open(temporary, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=state)
         try:
+            os.fchmod(output, 0o700)
             output_metadata = os.fstat(output)
             if output_metadata.st_dev != build_metadata.st_dev or output_metadata.st_uid != os.getuid() or stat.S_IMODE(output_metadata.st_mode) != 0o700:
                 fail("temporary runtime artifact package crosses the build filesystem boundary")
@@ -532,7 +569,7 @@ def prepare() -> None:
             os.fsync(state)
             try:
                 validate_tree(build, OUTPUT.name, contract_files)
-            except Exception:
+            except Exception as validation_error:
                 try:
                     validate_tree(state, temporary, contract_files)
                     exchange(state, temporary, build, OUTPUT.name)
@@ -540,8 +577,9 @@ def prepare() -> None:
                     os.fsync(build)
                     os.fsync(state)
                     validate_tree(build, OUTPUT.name, contract_files)
-                except Exception:
-                    pass
+                except Exception as rollback_error:
+                    validation_error.add_note(f"rollback failed: {rollback_error}")
+                    raise validation_error from rollback_error
                 raise
             validate_tree(state, temporary, contract_files)
             remove_owned(state, temporary, contract_files)

--- a/scripts/runtime_artifact_bridge.py
+++ b/scripts/runtime_artifact_bridge.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+
+import argparse
+import ctypes
+import fcntl
+import hashlib
+import os
+import secrets
+import stat
+from pathlib import Path, PurePosixPath
+
+from scripts import rootfs_artifacts
+
+
+REPO = Path(__file__).resolve().parent.parent
+LOCK = Path("image/manifests/rootfs-artifacts.lock.tsv")
+OUTPUT = Path("build/runtime-artifacts")
+STATE = ".runtime-artifacts-state"
+MARKER = ".tinfoil-runtime-artifacts-v1"
+PREPARING = ".tinfoil-runtime-artifacts-preparing-v1"
+SCHEMA = "tinfoil-runtime-artifacts-v1"
+PRODUCER_ROOTS = {
+    "go": Path("build/builder-work/output"),
+    "nvattest": Path("build/rootfs-artifacts/nvattest"),
+    "nvidia-modules": Path("kernel/out/rootfs-artifacts/nvidia-modules"),
+}
+EXPORTS = (
+    MARKER,
+    "producers/go/rootfs-artifacts.tsv",
+    "producers/go/artifacts/tinfoil-init",
+    "producers/go/artifacts/tinfoil-boot",
+    "producers/go/artifacts/tinfoil-container-status",
+    "producers/go/artifacts/tinfoil-egress",
+    "producers/go/artifacts/tinfoil-shim",
+    "producers/nvattest/rootfs-artifacts.tsv",
+    "producers/nvattest/usr/bin/nvattest",
+    "producers/nvattest/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2",
+    "producers/nvidia-modules/rootfs-artifacts.tsv",
+    "producers/nvidia-modules/artifacts/nvidia.ko",
+    "producers/nvidia-modules/artifacts/nvidia-uvm.ko",
+    "producers/nvidia-modules/artifacts/nvidia-modeset.ko",
+)
+BUILD_CONTENT = (
+    "exports_files([\n"
+    + "".join(f'    "{path}",\n' for path in EXPORTS)
+    + '], visibility = ["//image:__pkg__"])\n'
+).encode()
+
+
+def fail(message: str) -> None:
+    raise ValueError(message)
+
+
+def identity(metadata: os.stat_result) -> tuple[int, ...]:
+    return rootfs_artifacts.metadata_identity(metadata) + (
+        metadata.st_uid,
+        metadata.st_gid,
+        metadata.st_nlink,
+    )
+
+
+def inode_identity(metadata: os.stat_result) -> tuple[int, int]:
+    return metadata.st_dev, metadata.st_ino
+
+
+def read_descriptor(descriptor: int, path: Path | str, single_link: bool) -> tuple[bytes, os.stat_result]:
+    before = os.fstat(descriptor)
+    if not stat.S_ISREG(before.st_mode) or (single_link and before.st_nlink != 1) or os.listxattr(descriptor):
+        qualifier = "single-linked " if single_link else "xattr-free "
+        fail(f"{path}: expected an {qualifier}regular file")
+    with os.fdopen(os.dup(descriptor), "rb") as source:
+        content = source.read()
+    after = os.fstat(descriptor)
+    if identity(before) != identity(after):
+        fail(f"{path}: changed while reading")
+    return content, after
+
+
+def read_regular(path: Path) -> tuple[bytes, os.stat_result]:
+    parent, descriptor = rootfs_artifacts.open_contract(path)
+    try:
+        return read_descriptor(descriptor, path, True)
+    finally:
+        os.close(descriptor)
+        os.close(parent)
+
+
+def mkdir(parent: int, name: str, mode: int = 0o755, accepted_modes: set[int] | None = None) -> int:
+    try:
+        os.mkdir(name, mode, dir_fd=parent)
+    except FileExistsError:
+        pass
+    descriptor = os.open(
+        name,
+        os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+        dir_fd=parent,
+    )
+    metadata = os.fstat(descriptor)
+    modes = accepted_modes or {mode}
+    if metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) not in modes or os.listxattr(descriptor):
+        os.close(descriptor)
+        fail(f"unsafe generated directory: {name}")
+    return descriptor
+
+
+def write_file(parent: int, name: str, content: bytes, mode: int) -> None:
+    descriptor = os.open(
+        name,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+        mode,
+        dir_fd=parent,
+    )
+    try:
+        write_all(descriptor, content)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def write_all(descriptor: int, content: bytes) -> None:
+    remaining = memoryview(content)
+    while remaining:
+        written = os.write(descriptor, remaining)
+        if written <= 0:
+            fail("write returned no progress")
+        remaining = remaining[written:]
+
+
+def open_beneath(root: int, relative: str) -> tuple[int, int]:
+    path = rootfs_artifacts.canonical_relative(relative, relative)
+    parent = os.dup(root)
+    try:
+        for component in path.parts[:-1]:
+            child = os.open(
+                component,
+                os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW,
+                dir_fd=parent,
+            )
+            os.close(parent)
+            parent = child
+        descriptor = os.open(
+            path.parts[-1],
+            os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW,
+            dir_fd=parent,
+        )
+        return parent, descriptor
+    except Exception:
+        os.close(parent)
+        raise
+
+
+def destination_parent(root: int, relative: str) -> tuple[int, str]:
+    path = rootfs_artifacts.canonical_relative(relative, relative)
+    parent = os.dup(root)
+    try:
+        for component in path.parts[:-1]:
+            child = mkdir(parent, component)
+            os.close(parent)
+            parent = child
+        return parent, path.parts[-1]
+    except Exception:
+        os.close(parent)
+        raise
+
+
+def snapshot_file(source_root: int, source: str, output_root: int, output: str, entry) -> None:
+    source_parent, source_fd = open_beneath(source_root, source)
+    output_parent, output_name = destination_parent(output_root, output)
+    try:
+        before = os.fstat(source_fd)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1:
+            fail(f"{entry.name}: source must be a single-linked regular file")
+        if os.listxattr(source_fd):
+            fail(f"{entry.name}: source xattrs are forbidden")
+        if f"{stat.S_IMODE(before.st_mode):04o}" != entry.mode:
+            fail(f"{entry.name}: source mode mismatch")
+        destination = os.open(
+            output_name,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+            int(entry.mode, 8),
+            dir_fd=output_parent,
+        )
+        digest = hashlib.sha256()
+        try:
+            while chunk := os.read(source_fd, 1024 * 1024):
+                digest.update(chunk)
+                write_all(destination, chunk)
+            os.fsync(destination)
+        finally:
+            os.close(destination)
+        after = os.fstat(source_fd)
+        if identity(before) != identity(after):
+            fail(f"{entry.name}: source changed while copying")
+        if digest.hexdigest() != entry.sha256:
+            fail(f"{entry.name}: source hash mismatch")
+    finally:
+        os.close(output_parent)
+        os.close(source_fd)
+        os.close(source_parent)
+
+
+def validate_contract(locked) -> None:
+    files = [entry for entry in locked.values() if entry.kind == "file"]
+    links = [entry for entry in locked.values() if entry.kind == "symlink"]
+    if len(locked) != 12 or len(files) != 10 or len(links) != 2:
+        fail("rootfs artifact lock must contain exactly 12 entries: 10 files and 2 symlinks")
+
+
+def expected_files(locked, manifests: dict[str, bytes], marker_content: bytes) -> dict[str, tuple[int, str]]:
+    files = {
+        "BUILD.bazel": (0o644, hashlib.sha256(BUILD_CONTENT).hexdigest()),
+        MARKER: (0o644, hashlib.sha256(marker_content).hexdigest()),
+    }
+    for producer in sorted(PRODUCER_ROOTS):
+        relative = f"producers/{producer}/rootfs-artifacts.tsv"
+        files[relative] = (0o644, hashlib.sha256(manifests[producer]).hexdigest())
+    for entry in locked.values():
+        if entry.kind == "file":
+            relative = f"producers/{entry.producer}/{entry.source_path}"
+            files[relative] = (int(entry.mode, 8), entry.sha256)
+    return files
+
+
+def expected_shape(files: dict[str, tuple[int, str]]) -> dict[str, int]:
+    shape = {relative: mode for relative, (mode, _) in files.items()}
+    for relative in tuple(shape):
+        parent = PurePosixPath(relative).parent
+        while str(parent) != ".":
+            shape.setdefault(str(parent), 0o755)
+            parent = parent.parent
+    return shape
+
+
+def validate_tree(parent: int, name: str, files: dict[str, tuple[int, str]]) -> tuple[int, ...]:
+    root = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=parent)
+    expected = expected_shape(files)
+    seen = set()
+    device = os.fstat(parent).st_dev
+
+    def walk(descriptor: int, prefix: str) -> None:
+        for child_name in sorted(os.listdir(descriptor)):
+            relative = f"{prefix}/{child_name}" if prefix else child_name
+            metadata = os.stat(child_name, dir_fd=descriptor, follow_symlinks=False)
+            if relative not in expected or metadata.st_uid != os.getuid() or metadata.st_dev != device:
+                fail(f"unsafe generated package entry: {relative}")
+            if stat.S_IMODE(metadata.st_mode) != expected[relative]:
+                fail(f"generated package mode mismatch: {relative}")
+            seen.add(relative)
+            if stat.S_ISDIR(metadata.st_mode):
+                child = os.open(child_name, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                try:
+                    opened = os.fstat(child)
+                    if identity(metadata) != identity(opened) or os.listxattr(child):
+                        fail(f"generated package directory has xattrs: {relative}")
+                    walk(child, relative)
+                finally:
+                    os.close(child)
+            else:
+                child = os.open(child_name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                try:
+                    opened = os.fstat(child)
+                    if identity(metadata) != identity(opened) or not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1 or os.listxattr(child):
+                        fail(f"unsafe generated package file: {relative}")
+                    digest = hashlib.sha256()
+                    while chunk := os.read(child, 1024 * 1024):
+                        digest.update(chunk)
+                    stable = os.fstat(child)
+                    if identity(opened) != identity(stable) or digest.hexdigest() != files[relative][1]:
+                        fail(f"generated package content mismatch: {relative}")
+                finally:
+                    os.close(child)
+
+    try:
+        metadata = os.fstat(root)
+        if metadata.st_dev != device or metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) != 0o755 or os.listxattr(root):
+            fail("unsafe generated package root")
+        walk(root, "")
+        if seen != set(expected):
+            fail(f"generated package shape mismatch: {sorted(set(expected) - seen)}")
+        return identity(metadata)
+    finally:
+        os.close(root)
+
+
+def read_at(root: int, relative: str) -> tuple[bytes, os.stat_result]:
+    parent, descriptor = open_beneath(root, relative)
+    try:
+        return read_descriptor(descriptor, relative, True)
+    finally:
+        os.close(descriptor)
+        os.close(parent)
+
+
+def remove_owned(parent: int, name: str, files: dict[str, tuple[int, str]]) -> None:
+    validated = validate_tree(parent, name, files)
+    root = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=parent)
+    if identity(os.fstat(root)) != validated:
+        os.close(root)
+        fail("generated package changed before deletion")
+
+    def remove_contents(descriptor: int, prefix: str) -> None:
+        for child_name in sorted(os.listdir(descriptor), key=lambda value: value == MARKER):
+            relative = f"{prefix}/{child_name}" if prefix else child_name
+            metadata = os.stat(child_name, dir_fd=descriptor, follow_symlinks=False)
+            if metadata.st_uid != os.getuid():
+                fail(f"refusing to remove unowned entry: {child_name}")
+            if stat.S_ISDIR(metadata.st_mode):
+                child = os.open(child_name, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                try:
+                    if identity(metadata) != identity(os.fstat(child)) or os.listxattr(child):
+                        fail(f"refusing to remove changed directory: {child_name}")
+                    remove_contents(child, relative)
+                finally:
+                    os.close(child)
+                if inode_identity(os.stat(child_name, dir_fd=descriptor, follow_symlinks=False)) != inode_identity(metadata):
+                    fail(f"refusing to remove replaced directory: {child_name}")
+                os.rmdir(child_name, dir_fd=descriptor)
+            else:
+                child = os.open(child_name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                try:
+                    opened = os.fstat(child)
+                    if identity(metadata) != identity(opened) or not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1 or os.listxattr(child):
+                        fail(f"refusing to remove changed file: {child_name}")
+                    digest = hashlib.sha256()
+                    while chunk := os.read(child, 1024 * 1024):
+                        digest.update(chunk)
+                    if identity(opened) != identity(os.fstat(child)) or relative not in files or digest.hexdigest() != files[relative][1]:
+                        fail(f"refusing to remove unauthenticated file: {relative}")
+                finally:
+                    os.close(child)
+                if identity(os.stat(child_name, dir_fd=descriptor, follow_symlinks=False)) != identity(metadata):
+                    fail(f"refusing to remove replaced file: {child_name}")
+                os.unlink(child_name, dir_fd=descriptor)
+
+    try:
+        remove_contents(root, "")
+    finally:
+        os.close(root)
+    if inode_identity(os.stat(name, dir_fd=parent, follow_symlinks=False)) != validated[:2]:
+        fail("generated package root changed before deletion")
+    os.rmdir(name, dir_fd=parent)
+
+
+def remove_staging(parent: int, name: str, preparing_content: bytes, files: dict[str, tuple[int, str]]) -> None:
+    try:
+        root = os.open(name, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=parent)
+    except FileNotFoundError:
+        return
+    try:
+        metadata = os.fstat(root)
+        if metadata.st_uid != os.getuid() or metadata.st_dev != os.fstat(parent).st_dev or stat.S_IMODE(metadata.st_mode) not in {0o700, 0o755} or os.listxattr(root):
+            return
+        try:
+            preparing, preparing_metadata = read_at(root, PREPARING)
+        except (FileNotFoundError, ValueError):
+            preparing = None
+        if preparing is None:
+            try:
+                marker, marker_metadata = read_at(root, MARKER)
+            except (OSError, ValueError):
+                return
+            expected_marker = next((digest for relative, (_, digest) in files.items() if relative == MARKER), None)
+            if expected_marker is None or stat.S_IMODE(marker_metadata.st_mode) != 0o644 or hashlib.sha256(marker).hexdigest() != expected_marker:
+                return
+        elif preparing != preparing_content or stat.S_IMODE(preparing_metadata.st_mode) != 0o600:
+            return
+
+        def remove_partial(descriptor: int) -> None:
+            for child_name in sorted(os.listdir(descriptor), key=lambda value: value in {PREPARING, MARKER}):
+                child_metadata = os.stat(child_name, dir_fd=descriptor, follow_symlinks=False)
+                if child_metadata.st_uid != os.getuid():
+                    fail(f"refusing to remove unowned staging entry: {child_name}")
+                if stat.S_ISDIR(child_metadata.st_mode):
+                    child = os.open(child_name, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                    try:
+                        if identity(child_metadata) != identity(os.fstat(child)) or os.listxattr(child):
+                            fail(f"refusing to remove changed staging directory: {child_name}")
+                        remove_partial(child)
+                    finally:
+                        os.close(child)
+                    if inode_identity(os.stat(child_name, dir_fd=descriptor, follow_symlinks=False)) != inode_identity(child_metadata):
+                        fail(f"refusing to remove replaced staging directory: {child_name}")
+                    os.rmdir(child_name, dir_fd=descriptor)
+                else:
+                    child = os.open(child_name, os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=descriptor)
+                    try:
+                        opened = os.fstat(child)
+                        if identity(child_metadata) != identity(opened) or not stat.S_ISREG(opened.st_mode) or opened.st_nlink != 1 or os.listxattr(child):
+                            fail(f"refusing to remove hostile staging entry: {child_name}")
+                    finally:
+                        os.close(child)
+                    if identity(os.stat(child_name, dir_fd=descriptor, follow_symlinks=False)) != identity(child_metadata):
+                        fail(f"refusing to remove replaced staging file: {child_name}")
+                    os.unlink(child_name, dir_fd=descriptor)
+
+        remove_partial(root)
+    except (OSError, ValueError):
+        return
+    finally:
+        os.close(root)
+    try:
+        if inode_identity(os.stat(name, dir_fd=parent, follow_symlinks=False)) != inode_identity(metadata):
+            return
+        os.rmdir(name, dir_fd=parent)
+    except OSError:
+        pass
+
+
+def renameat2(source_parent: int, source: str, destination_parent: int, destination: str, flags: int, operation: str) -> None:
+    libc = ctypes.CDLL(None, use_errno=True)
+    function = getattr(libc, "renameat2", None)
+    if function is None:
+        fail(f"renameat2 is required for atomic {operation}")
+    function.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_uint]
+    function.restype = ctypes.c_int
+    if function(source_parent, os.fsencode(source), destination_parent, os.fsencode(destination), flags) != 0:
+        error = ctypes.get_errno()
+        fail(f"renameat2 {operation} failed: {os.strerror(error)}")
+
+
+def publish(source_parent: int, temporary: str, destination_parent: int, destination: str) -> None:
+    renameat2(source_parent, temporary, destination_parent, destination, 1, "no-replace publication")
+
+
+def exchange(source_parent: int, temporary: str, destination_parent: int, destination: str) -> None:
+    renameat2(source_parent, temporary, destination_parent, destination, 2, "exchange")
+
+
+def open_build(repository: int, repository_metadata: os.stat_result) -> int:
+    build = mkdir(repository, "build", accepted_modes={0o700, 0o755, 0o775})
+    metadata = os.fstat(build)
+    mode = stat.S_IMODE(metadata.st_mode)
+    if mode == 0o775 and not (
+        stat.S_IMODE(repository_metadata.st_mode) == 0o775
+        and metadata.st_gid == repository_metadata.st_gid
+        and repository_metadata.st_uid == os.getuid()
+    ):
+        os.close(build)
+        fail("group-writable build directory lacks repository group trust")
+    return build
+
+
+def prepare() -> None:
+    lock_content, _ = read_regular(REPO / LOCK)
+    locked = rootfs_artifacts.parse_content(LOCK, lock_content.decode())
+    if set(locked) != set(rootfs_artifacts.EXPECTED):
+        fail("rootfs artifact lock differs from fixed contract")
+    validate_contract(locked)
+    marker_content = f"{SCHEMA}\t{hashlib.sha256(lock_content).hexdigest()}\n".encode()
+    repository = os.open(REPO, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW)
+    try:
+        repository_metadata = os.fstat(repository)
+        build = open_build(repository, repository_metadata)
+    finally:
+        os.close(repository)
+    build_metadata = os.fstat(build)
+    if build_metadata.st_dev != repository_metadata.st_dev:
+        os.close(build)
+        fail("build directory crosses the repository filesystem boundary")
+    state = mkdir(build, STATE, 0o700)
+    state_metadata = os.fstat(state)
+    if state_metadata.st_dev != build_metadata.st_dev:
+        os.close(state)
+        os.close(build)
+        fail("runtime artifact state crosses the build filesystem boundary")
+    lock_fd = os.open("lock", os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW, 0o600, dir_fd=state)
+    temporary = f".runtime-artifacts.{os.getpid()}.{secrets.token_hex(8)}"
+    preparing_content = f"{SCHEMA}\t{temporary}\n".encode()
+    contract_files = None
+    cleanup_temporary = False
+    try:
+        lock_metadata = os.fstat(lock_fd)
+        if not stat.S_ISREG(lock_metadata.st_mode) or lock_metadata.st_uid != os.getuid() or lock_metadata.st_nlink != 1 or stat.S_IMODE(lock_metadata.st_mode) != 0o600 or os.listxattr(lock_fd):
+            fail("unsafe runtime artifact preparation lock")
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        os.mkdir(temporary, 0o700, dir_fd=state)
+        cleanup_temporary = True
+        output = os.open(temporary, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW, dir_fd=state)
+        try:
+            output_metadata = os.fstat(output)
+            if output_metadata.st_dev != build_metadata.st_dev or output_metadata.st_uid != os.getuid() or stat.S_IMODE(output_metadata.st_mode) != 0o700:
+                fail("temporary runtime artifact package crosses the build filesystem boundary")
+            write_file(output, PREPARING, preparing_content, 0o600)
+            produced = {}
+            manifests = {}
+            for producer, relative_root in PRODUCER_ROOTS.items():
+                source_root, manifest_fd = rootfs_artifacts.open_contract(REPO / relative_root / "rootfs-artifacts.tsv")
+                try:
+                    manifest_content, manifest_metadata = rootfs_artifacts.read_contract(relative_root / "rootfs-artifacts.tsv", manifest_fd)
+                    if manifest_metadata.st_nlink != 1 or stat.S_IMODE(manifest_metadata.st_mode) != 0o644 or os.listxattr(manifest_fd):
+                        fail(f"{producer}: manifest must be a single-linked xattr-free 0644 file")
+                    entries = rootfs_artifacts.parse_content(relative_root / "rootfs-artifacts.tsv", manifest_content, producer)
+                    rootfs_artifacts.verify_tree(source_root, manifest_metadata, producer, entries)
+                    manifests[producer] = manifest_content.encode()
+                    producer_output, _ = destination_parent(output, f"producers/{producer}/rootfs-artifacts.tsv")
+                    try:
+                        write_file(producer_output, "rootfs-artifacts.tsv", manifests[producer], 0o644)
+                    finally:
+                        os.close(producer_output)
+                    for entry in entries.values():
+                        if entry.kind == "file":
+                            snapshot_file(source_root, entry.source_path, output, f"producers/{producer}/{entry.source_path}", entry)
+                    produced.update(entries)
+                finally:
+                    os.close(manifest_fd)
+                    os.close(source_root)
+            if produced != locked:
+                fail("producer manifests differ from checked-in rootfs artifact lock")
+            contract_files = expected_files(locked, manifests, marker_content)
+            write_file(output, "BUILD.bazel", BUILD_CONTENT, 0o644)
+            write_file(output, MARKER, marker_content, 0o644)
+            os.unlink(PREPARING, dir_fd=output)
+            os.fchmod(output, 0o755)
+            os.fsync(output)
+        finally:
+            os.close(output)
+        validate_tree(state, temporary, contract_files)
+        os.fsync(state)
+        try:
+            os.stat(OUTPUT.name, dir_fd=build, follow_symlinks=False)
+        except FileNotFoundError:
+            publish(state, temporary, build, OUTPUT.name)
+            cleanup_temporary = False
+            os.fsync(build)
+            os.fsync(state)
+            validate_tree(build, OUTPUT.name, contract_files)
+        else:
+            validate_tree(build, OUTPUT.name, contract_files)
+            exchange(state, temporary, build, OUTPUT.name)
+            cleanup_temporary = False
+            os.fsync(build)
+            os.fsync(state)
+            try:
+                validate_tree(build, OUTPUT.name, contract_files)
+            except Exception:
+                try:
+                    validate_tree(state, temporary, contract_files)
+                    exchange(state, temporary, build, OUTPUT.name)
+                    cleanup_temporary = True
+                    os.fsync(build)
+                    os.fsync(state)
+                    validate_tree(build, OUTPUT.name, contract_files)
+                except Exception:
+                    pass
+                raise
+            validate_tree(state, temporary, contract_files)
+            remove_owned(state, temporary, contract_files)
+            os.fsync(state)
+        os.fsync(build)
+    except Exception:
+        if cleanup_temporary:
+            remove_staging(state, temporary, preparing_content, contract_files or {})
+        raise
+    finally:
+        os.close(lock_fd)
+        os.close(state)
+        os.close(build)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("prepare")
+    parser.parse_args()
+    prepare()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, UnicodeError, ValueError) as error:
+        raise SystemExit(f"runtime artifact bridge: {error}")

--- a/scripts/runtime_artifact_bridge_test.py
+++ b/scripts/runtime_artifact_bridge_test.py
@@ -116,6 +116,48 @@ class RuntimeArtifactBridgeTest(unittest.TestCase):
         bridge.prepare()
         self.assertEqual(self.tree_digest(self.generated()), first)
 
+    def test_restrictive_umask_preserves_fixed_output_modes(self):
+        previous = os.umask(0o077)
+        try:
+            bridge.prepare()
+        finally:
+            os.umask(previous)
+        expected = bridge.expected_shape(self.contract_files())
+        for relative, mode in expected.items():
+            with self.subTest(relative=relative):
+                self.assertEqual(stat.S_IMODE((self.generated() / relative).stat().st_mode), mode)
+        self.assertEqual(stat.S_IMODE((self.root / "build" / bridge.STATE).stat().st_mode), 0o700)
+
+    def test_rejects_fifo_replacing_producer_source_after_traversal(self):
+        source = self.root / bridge.PRODUCER_ROOTS["go"] / self.entries["tinfoil-init"].source_path
+        original_verify_tree = rootfs_artifacts.verify_tree
+        replaced = False
+
+        def replace_after_traversal(root_descriptor, manifest_metadata, producer, entries):
+            nonlocal replaced
+            original_verify_tree(root_descriptor, manifest_metadata, producer, entries)
+            if producer == "go" and not replaced:
+                source.unlink()
+                os.mkfifo(source)
+                replaced = True
+
+        with mock.patch.object(rootfs_artifacts, "verify_tree", side_effect=replace_after_traversal):
+            with self.assertRaisesRegex(ValueError, "single-linked regular file"):
+                bridge.prepare()
+
+    def test_rejects_fifo_in_generated_package_without_blocking(self):
+        bridge.prepare()
+        target = self.generated() / "BUILD.bazel"
+        target.unlink()
+        os.mkfifo(target)
+        target.chmod(0o644)
+        build = os.open(self.root / "build", os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with self.assertRaisesRegex(ValueError, "unsafe generated package file"):
+                bridge.validate_tree(build, bridge.OUTPUT.name, self.contract_files())
+        finally:
+            os.close(build)
+
     def test_unmarked_and_symlink_destinations_are_preserved(self):
         destination = self.generated()
         destination.mkdir(parents=True)
@@ -384,6 +426,34 @@ class RuntimeArtifactBridgeTest(unittest.TestCase):
         finally:
             os.close(build)
         self.assertEqual(len(self.staging()), 1)
+
+    def test_failed_exchange_rollback_preserves_both_diagnostics(self):
+        bridge.prepare()
+        original_validate = bridge.validate_tree
+        original_exchange = bridge.exchange
+        exchanges = 0
+
+        def exchange_then_fail_rollback(*args):
+            nonlocal exchanges
+            exchanges += 1
+            if exchanges == 2:
+                raise ValueError("injected rollback failure")
+            return original_exchange(*args)
+
+        def fail_post_exchange(parent, name, files):
+            result = original_validate(parent, name, files)
+            if exchanges == 1 and name == bridge.OUTPUT.name:
+                raise ValueError("injected post-exchange validation failure")
+            return result
+
+        with mock.patch.object(bridge, "exchange", side_effect=exchange_then_fail_rollback), mock.patch.object(
+            bridge, "validate_tree", side_effect=fail_post_exchange
+        ):
+            with self.assertRaisesRegex(ValueError, "post-exchange validation") as caught:
+                bridge.prepare()
+        self.assertIsNotNone(caught.exception.__cause__)
+        self.assertRegex(str(caught.exception.__cause__), "rollback failure")
+        self.assertTrue(any("rollback failed" in note for note in caught.exception.__notes__))
 
     def test_private_state_and_untrusted_shared_build_policy(self):
         bridge.prepare()

--- a/scripts/runtime_artifact_bridge_test.py
+++ b/scripts/runtime_artifact_bridge_test.py
@@ -1,0 +1,405 @@
+import errno
+import hashlib
+import multiprocessing
+import os
+import shutil
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from scripts import rootfs_artifacts, runtime_artifact_bridge as bridge
+
+
+def prepare_worker(root: str, queue) -> None:
+    bridge.REPO = Path(root)
+    try:
+        bridge.prepare()
+        queue.put(None)
+    except Exception as error:
+        queue.put(str(error))
+
+
+class RuntimeArtifactBridgeTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.entries = self.create_sources()
+        (self.root / "build").chmod(0o700)
+        self.patch = mock.patch.object(bridge, "REPO", self.root)
+        self.patch.start()
+
+    def tearDown(self):
+        self.patch.stop()
+        self.temporary.cleanup()
+
+    def create_sources(self):
+        entries = {}
+        manifests = {producer: [] for producer in rootfs_artifacts.PRODUCERS}
+        for name, expected in rootfs_artifacts.EXPECTED.items():
+            producer, kind, source_path, mode, link_target, destination, source_kind = expected
+            if kind == "file":
+                content = f"fixed runtime artifact: {name}\n".encode()
+                source = self.root / bridge.PRODUCER_ROOTS[producer] / source_path
+                source.parent.mkdir(parents=True, exist_ok=True)
+                source.write_bytes(content)
+                source.chmod(int(mode, 8))
+                digest = hashlib.sha256(content).hexdigest()
+            else:
+                digest = "-"
+            entry = rootfs_artifacts.Entry(
+                producer,
+                name,
+                kind,
+                source_path,
+                mode,
+                "0",
+                "0",
+                digest,
+                link_target,
+                destination,
+                source_kind,
+                f"{producer}:fixed-revision",
+                "fixed-build-parameters",
+            )
+            entries[name] = entry
+            manifests[producer].append(entry)
+        lock = self.root / bridge.LOCK
+        lock.parent.mkdir(parents=True)
+        lock.write_text(self.serialize(entries.values()))
+        for producer, producer_entries in manifests.items():
+            manifest = self.root / bridge.PRODUCER_ROOTS[producer] / "rootfs-artifacts.tsv"
+            manifest.parent.mkdir(parents=True, exist_ok=True)
+            manifest.write_text(self.serialize(producer_entries))
+            manifest.chmod(0o644)
+        return entries
+
+    @staticmethod
+    def serialize(entries):
+        return "".join("\t".join(entry.__dict__.values()) + "\n" for entry in entries)
+
+    def generated(self):
+        return self.root / bridge.OUTPUT
+
+    def contract_files(self):
+        lock_content = (self.root / bridge.LOCK).read_bytes()
+        marker = f"{bridge.SCHEMA}\t{hashlib.sha256(lock_content).hexdigest()}\n".encode()
+        manifests = {
+            producer: (self.root / relative / "rootfs-artifacts.tsv").read_bytes()
+            for producer, relative in bridge.PRODUCER_ROOTS.items()
+        }
+        return bridge.expected_files(self.entries, manifests, marker)
+
+    def staging(self):
+        state = self.root / "build" / bridge.STATE
+        return sorted(state.glob(".runtime-artifacts.*")) if state.exists() else []
+
+
+    def tree_digest(self, root):
+        digest = hashlib.sha256()
+        for path in sorted(root.rglob("*")):
+            relative = path.relative_to(root).as_posix().encode()
+            metadata = path.lstat()
+            digest.update(relative + b"\0" + f"{metadata.st_mode:o}".encode() + b"\0")
+            if path.is_file():
+                digest.update(path.read_bytes())
+        return digest.hexdigest()
+
+    def test_prepare_exact_shape_and_atomic_replacement(self):
+        bridge.prepare()
+        expected = set(bridge.expected_shape(self.contract_files()))
+        actual = {path.relative_to(self.generated()).as_posix() for path in self.generated().rglob("*")}
+        self.assertEqual(actual, expected)
+        self.assertEqual((self.generated() / "BUILD.bazel").read_bytes(), bridge.BUILD_CONTENT)
+        first = self.tree_digest(self.generated())
+        bridge.prepare()
+        self.assertEqual(self.tree_digest(self.generated()), first)
+
+    def test_unmarked_and_symlink_destinations_are_preserved(self):
+        destination = self.generated()
+        destination.mkdir(parents=True)
+        victim = destination / "victim"
+        victim.write_text("preserve")
+        with self.assertRaises(ValueError):
+            bridge.prepare()
+        self.assertEqual(victim.read_text(), "preserve")
+        shutil.rmtree(destination)
+        target = self.root / "target"
+        target.mkdir()
+        destination.symlink_to(target, target_is_directory=True)
+        with self.assertRaises(OSError):
+            bridge.prepare()
+        self.assertTrue(destination.is_symlink())
+
+    def test_failure_keeps_previous_package(self):
+        bridge.prepare()
+        before = self.tree_digest(self.generated())
+        source = self.root / bridge.PRODUCER_ROOTS["go"] / self.entries["tinfoil-init"].source_path
+        source.write_bytes(b"mutated")
+        source.chmod(0o755)
+        with self.assertRaises(ValueError):
+            bridge.prepare()
+        self.assertEqual(self.tree_digest(self.generated()), before)
+
+    def test_invalid_temporary_package_is_never_installed(self):
+        original = bridge.validate_tree
+
+        def reject_temporary(parent, name, files):
+            if name.startswith(".runtime-artifacts."):
+                raise ValueError("injected pre-publication failure")
+            return original(parent, name, files)
+
+        for existing in (False, True):
+            with self.subTest(existing=existing):
+                if existing:
+                    bridge.prepare()
+                    before = self.tree_digest(self.generated())
+                with mock.patch.object(bridge, "validate_tree", side_effect=reject_temporary):
+                    with self.assertRaisesRegex(ValueError, "pre-publication"):
+                        bridge.prepare()
+                if existing:
+                    self.assertEqual(self.tree_digest(self.generated()), before)
+                    shutil.rmtree(self.generated())
+                else:
+                    self.assertFalse(self.generated().exists())
+                self.assertEqual(self.staging(), [])
+
+    def test_initial_publication_preserves_raced_destination(self):
+        real_publish = bridge.publish
+
+        def race_destination(source_parent, temporary, destination_parent, destination):
+            os.mkdir(destination, 0o755, dir_fd=destination_parent)
+            raced = os.open(f"{destination}/victim", os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=destination_parent)
+            os.write(raced, b"preserve")
+            os.close(raced)
+            real_publish(source_parent, temporary, destination_parent, destination)
+
+        with mock.patch.object(bridge, "publish", side_effect=race_destination):
+            with self.assertRaisesRegex(ValueError, "File exists"):
+                bridge.prepare()
+        self.assertEqual((self.generated() / "victim").read_bytes(), b"preserve")
+        self.assertEqual(self.staging(), [])
+
+    def test_concurrent_preparation_serializes(self):
+        context = multiprocessing.get_context("fork")
+        queue = context.Queue()
+        processes = [context.Process(target=prepare_worker, args=(str(self.root), queue)) for _ in range(2)]
+        for process in processes:
+            process.start()
+        for process in processes:
+            process.join(20)
+            self.assertEqual(process.exitcode, 0)
+        self.assertEqual([queue.get(timeout=2) for _ in processes], [None, None])
+        build = os.open(self.root / "build", os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            bridge.validate_tree(build, "runtime-artifacts", self.contract_files())
+        finally:
+            os.close(build)
+
+    def test_existing_tree_bytes_are_authenticated_before_replacement(self):
+        bridge.prepare()
+        paths = ["BUILD.bazel", bridge.MARKER]
+        paths.extend(f"producers/{producer}/rootfs-artifacts.tsv" for producer in sorted(bridge.PRODUCER_ROOTS))
+        paths.extend(
+            f"producers/{entry.producer}/{entry.source_path}"
+            for entry in self.entries.values()
+            if entry.kind == "file"
+        )
+        for relative in paths:
+            with self.subTest(relative=relative):
+                target = self.generated() / relative
+                original = target.read_bytes()
+                target.write_bytes(original + b"mutation")
+                before = self.tree_digest(self.generated())
+                with self.assertRaisesRegex(ValueError, "content mismatch"):
+                    bridge.prepare()
+                self.assertEqual(self.tree_digest(self.generated()), before)
+                self.assertEqual(self.staging(), [])
+                shutil.rmtree(self.generated())
+                bridge.prepare()
+
+    def test_failed_writes_and_fsyncs_remove_owned_staging(self):
+        original_write = os.write
+        write_calls = 0
+
+        def fail_write(fd, content):
+            nonlocal write_calls
+            write_calls += 1
+            if write_calls == 2:
+                raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+            return original_write(fd, content)
+
+        with mock.patch.object(bridge.os, "write", side_effect=fail_write):
+            with self.assertRaises(OSError):
+                bridge.prepare()
+        self.assertEqual(self.staging(), [])
+
+        original_fsync = os.fsync
+        fsync_calls = 0
+
+        def fail_fsync(fd):
+            nonlocal fsync_calls
+            fsync_calls += 1
+            if fsync_calls == 2:
+                raise OSError(errno.EIO, os.strerror(errno.EIO))
+            return original_fsync(fd)
+
+        with mock.patch.object(bridge.os, "fsync", side_effect=fail_fsync):
+            with self.assertRaises(OSError):
+                bridge.prepare()
+        self.assertEqual(self.staging(), [])
+
+    def test_rename_failures_remove_owned_staging(self):
+        with mock.patch.object(bridge, "publish", side_effect=ValueError("renameat2 publication failed: injected")):
+            with self.assertRaisesRegex(ValueError, "renameat2"):
+                bridge.prepare()
+        self.assertEqual(self.staging(), [])
+        bridge.prepare()
+        before = self.tree_digest(self.generated())
+        with mock.patch.object(bridge, "exchange", side_effect=ValueError("renameat2 exchange failed: injected")):
+            with self.assertRaisesRegex(ValueError, "renameat2"):
+                bridge.prepare()
+        self.assertEqual(self.tree_digest(self.generated()), before)
+        self.assertEqual(self.staging(), [])
+
+    def test_marker_transition_failure_removes_owned_staging(self):
+        original = bridge.write_file
+
+        def fail_final_marker(parent, name, content, mode):
+            if name == bridge.MARKER:
+                raise OSError(errno.ENOSPC, os.strerror(errno.ENOSPC))
+            return original(parent, name, content, mode)
+
+        with mock.patch.object(bridge, "write_file", side_effect=fail_final_marker):
+            with self.assertRaises(OSError):
+                bridge.prepare()
+        self.assertEqual(self.staging(), [])
+
+    def test_cleanup_preserves_hostile_staging(self):
+        original = bridge.snapshot_file
+        injected = False
+
+        def inject_hostile(*args, **kwargs):
+            nonlocal injected
+            if not injected:
+                injected = True
+                stage = self.staging()[0]
+                self.assertEqual(stat.S_IMODE(stage.stat().st_mode), 0o700)
+                (stage / "hostile").symlink_to("/tmp")
+                raise ValueError("injected staging failure")
+            return original(*args, **kwargs)
+
+        with mock.patch.object(bridge, "snapshot_file", side_effect=inject_hostile):
+            with self.assertRaisesRegex(ValueError, "injected staging"):
+                bridge.prepare()
+        stages = self.staging()
+        self.assertEqual(len(stages), 1)
+        self.assertTrue((stages[0] / "hostile").is_symlink())
+        self.assertFalse(self.generated().exists())
+
+    def assert_cleanup_preserves_replacement(self, directory):
+        real_stat = bridge.os.stat
+        calls = 0
+
+        def replace_before_recheck(path, *args, **kwargs):
+            nonlocal calls
+            if path == "replace-me":
+                calls += 1
+                if calls == 2:
+                    if directory:
+                        os.rmdir(path, dir_fd=kwargs["dir_fd"])
+                        os.mkdir(path, 0o700, dir_fd=kwargs["dir_fd"])
+                        replacement_path = f"{path}/victim"
+                    else:
+                        os.unlink(path, dir_fd=kwargs["dir_fd"])
+                        replacement_path = path
+                    replacement = os.open(replacement_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=kwargs["dir_fd"])
+                    os.write(replacement, b"replacement")
+                    os.close(replacement)
+            return real_stat(path, *args, **kwargs)
+
+        kind = "directory" if directory else "file"
+        stage = self.root / "build" / bridge.STATE / f".runtime-artifacts.{kind}-race"
+        stage.mkdir(parents=True, mode=0o700)
+        (stage / bridge.PREPARING).write_bytes(b"owned")
+        (stage / bridge.PREPARING).chmod(0o600)
+        target = stage / "replace-me"
+        target.mkdir() if directory else target.write_bytes(b"original")
+        parent = os.open(stage.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            with mock.patch.object(bridge.os, "stat", side_effect=replace_before_recheck):
+                bridge.remove_staging(parent, stage.name, b"owned", {})
+        finally:
+            os.close(parent)
+        replacement = target / "victim" if directory else target
+        self.assertEqual(replacement.read_bytes(), b"replacement")
+
+    def test_cleanup_preserves_replaced_staging_file(self):
+        self.assert_cleanup_preserves_replacement(False)
+
+    def test_cleanup_preserves_replaced_staging_directory(self):
+        self.assert_cleanup_preserves_replacement(True)
+
+    def test_prior_tree_is_reauthenticated_immediately_before_deletion(self):
+        bridge.prepare()
+        before = self.tree_digest(self.generated())
+        real_remove = bridge.remove_owned
+
+        def mutate_before_remove(parent, name, files):
+            stage = Path(f"/proc/self/fd/{parent}") / name
+            build_file = stage / "BUILD.bazel"
+            build_file.write_bytes(build_file.read_bytes() + b"mutation")
+            return real_remove(parent, name, files)
+
+        with mock.patch.object(bridge, "remove_owned", side_effect=mutate_before_remove):
+            with self.assertRaisesRegex(ValueError, "content mismatch"):
+                bridge.prepare()
+        self.assertEqual(self.tree_digest(self.generated()), before)
+        stages = self.staging()
+        self.assertEqual(len(stages), 1)
+        self.assertTrue((stages[0] / "BUILD.bazel").read_bytes().endswith(b"mutation"))
+
+    def test_destination_replacement_race_is_detected_and_preserved(self):
+        bridge.prepare()
+        real_exchange = bridge.exchange
+
+        def replace_destination(source_parent, temporary, destination_parent, destination):
+            os.rename(destination, "runtime-artifacts.saved", src_dir_fd=destination_parent, dst_dir_fd=destination_parent)
+            os.mkdir(destination, 0o755, dir_fd=destination_parent)
+            hostile_parent = os.open(destination, os.O_RDONLY | os.O_DIRECTORY, dir_fd=destination_parent)
+            try:
+                hostile = os.open("victim", os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600, dir_fd=hostile_parent)
+                os.close(hostile)
+            finally:
+                os.close(hostile_parent)
+            real_exchange(source_parent, temporary, destination_parent, destination)
+
+        with mock.patch.object(bridge, "exchange", side_effect=replace_destination):
+            with self.assertRaises(ValueError):
+                bridge.prepare()
+        build = os.open(self.root / "build", os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            bridge.validate_tree(build, "runtime-artifacts", self.contract_files())
+        finally:
+            os.close(build)
+        self.assertEqual(len(self.staging()), 1)
+
+    def test_private_state_and_untrusted_shared_build_policy(self):
+        bridge.prepare()
+        self.assertEqual(stat.S_IMODE((self.root / "build" / bridge.STATE).stat().st_mode), 0o700)
+        (self.root / "build").chmod(0o775)
+        with self.assertRaisesRegex(ValueError, "group trust"):
+            bridge.prepare()
+
+    def test_existing_wrong_mode_package_is_preserved(self):
+        bridge.prepare()
+        marker = self.generated() / bridge.MARKER
+        marker.chmod(0o600)
+        with self.assertRaises(ValueError):
+            bridge.prepare()
+        self.assertEqual(stat.S_IMODE(marker.stat().st_mode), 0o600)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- snapshot the fixed producer outputs into one authenticated, marker-owned generated package
- copy every byte descriptor-relatively without following symlinks
- publish through Linux no-clobber/exchange primitives with full pre-publication validation
- keep Bazel unable to discover the package until the following consumer review

## Fixed preparation contract

The checked-in rootfs artifact lock remains the sole authority. Preparation copies only:

- ten regular runtime artifact files
- three producer manifests
- one literal exports-only `BUILD.bazel`
- one lock-digest ownership marker

It accepts no caller-selected paths, globs, tree artifacts, repository overrides, or local repositories.

## Fail-closed behavior

- serializes writers under a private mode-`0700` state directory
- copies through no-follow descriptors and rechecks source identity/hash stability
- authenticates the complete staged tree before publication
- fsyncs files/directories before making the tree visible
- uses `renameat2(RENAME_NOREPLACE)` for first publication and preserves raced destinations
- uses `renameat2(RENAME_EXCHANGE)` only for replacement after authenticating the existing tree
- rechecks inode identity immediately before cleanup unlink/rmdir operations
- preserves and rejects hostile, malformed, symlinked, differently owned, stale, or byte-mutated trees
- has no non-atomic compatibility fallback

## Validation

- real preparation from the freshly rebuilt #207 producer outputs
- 17 adversarial/concurrency unit tests
- rootfs artifact lock verification against all three producer manifests
- `bazel test //...`
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Python compilation and `git diff --check`

## Ordering

Stacked directly on #207. It may be reviewed now, but merge order is **#207 → this PR → Bazel consumer**. After #207 squash-merges, this branch will receive one ancestry-only rebase with `--force-with-lease`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds authenticated runtime artifact preparation that snapshots fixed producer outputs into `build/runtime-artifacts` and publishes them atomically. Hardens race handling with strict pre/post-validation, safe rollback on failed exchanges, and marker-owned cleanup.

- **New Features**
  - Adds `scripts/runtime_artifact_bridge.py` and `make prepare-runtime-artifacts` to snapshot fixed producer outputs into `build/runtime-artifacts`.
  - Snapshots only what the lock allows: 10 runtime files, 3 manifests, an exports-only `BUILD.bazel`, and a lock-digest marker.
  - Adds docs at `docs/runtime-artifact-bridge.md` and tests via `make test-runtime-artifact-bridge`.
  - Keeps Bazel from discovering `build`; a follow-up PR will expose only the generated package.

- **Safety**
  - Descriptor-relative copies with no symlink following; single-link, xattr-free regular files with exact modes and SHA-256s.
  - Private state dir, 0700 staging, same filesystem; enforces shared-build trust (rejects untrusted 0775 `build`); fsyncs files/directories.
  - Authenticates the full tree before publication, authenticates any existing destination before exchange, and reauthenticates just before deletion.
  - Atomic publish via `renameat2(RENAME_NOREPLACE)`; replacement via `renameat2(RENAME_EXCHANGE)` with rollback if post-exchange validation fails; preserves raced/malformed or unowned trees.
  - Cleans up only marker-owned staging; preserves hostile/replaced staging; no non-atomic fallback.

<sup>Written for commit c6edf0c735b495a7924f2a3e9ecd7ad9e4ce995d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

