### PR TITLE
Add fixed Bazel runtime artifact consumer

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,7 @@
-build
+build/builder-cache
+build/builder-pkgcache
+build/builder-work
+build/builder-workspace
+build/rootfs-artifacts
 kernel/build
 kernel/out

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ prepare-runtime-artifacts: verify-rootfs-artifacts
 
 test-runtime-artifact-bridge: prepare-runtime-artifacts
 	python3 -m unittest scripts.runtime_artifact_bridge_test
+	./scripts/test-runtime-artifact-bridge.sh
 
 test-rootfs-artifacts:
 	python3 -m unittest scripts.rootfs_artifacts_test

--- a/docs/runtime-artifact-bridge.md
+++ b/docs/runtime-artifact-bridge.md
@@ -27,8 +27,21 @@ malformed, symlinked, differently owned, incorrectly shaped, or byte-mutated
 trees are preserved and rejected. There is no non-atomic compatibility
 fallback.
 
-This preparation review publishes the generated package but keeps the entire
-`build` tree outside Bazel package discovery. The following consumer review
-narrows that exclusion to expose only authenticated `build/runtime-artifacts`,
-with files visible only to `//image:__pkg__`. Bazel never runs Make or a
-producer.
+The generated package exposes files only to `//image:__pkg__`. Bazel never
+runs Make or a producer. A clean build therefore fails until preparation is
+explicitly completed. `.bazelignore` excludes the other Make/mkosi producer
+trees so `bazel test //...` does not traverse privileged cache content while
+the exact `build/runtime-artifacts` package remains visible.
+
+`//image:runtime-artifact-members` independently checks the marker, lock,
+three manifests, ten file hashes and modes, fixed provenance, destinations,
+and the exact two symlink declarations. It emits only:
+
+- `runtime-artifact-members.tar`, containing twelve byte-sorted members with
+  locked modes, ownership `0:0`, timestamp zero, and no directory, hardlink,
+  device, xattr, or PAX records;
+- `runtime-artifact-members.tsv`, using the canonical eight-field rootfs
+  manifest format.
+
+This prerequisite deliberately performs no final rootfs assembly or shipping
+wiring.

--- a/docs/runtime-artifact-producers.md
+++ b/docs/runtime-artifact-producers.md
@@ -23,6 +23,8 @@ modules. Its reproducibility target builds two independent custom-kernel source
 and output roots before comparing module artifacts byte-for-byte.
 
 These targets do not assemble a rootfs or alter the mkosi shipping path.
-The generated `build`, `kernel/build`, and `kernel/out` trees are excluded from
-Git and Bazel package discovery so producer caches cannot become source inputs
-or break normal `bazel test //...` validation.
+Generated producer trees remain excluded from Git and Bazel package discovery.
+The consumer exposes only the authenticated `build/runtime-artifacts` package;
+all other `build` subtrees plus `kernel/build` and `kernel/out` remain excluded
+so producer caches cannot become source inputs or break normal
+`bazel test //...` validation.

--- a/image/BUILD.bazel
+++ b/image/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "runtime_archive_lock_check",
     "runtime_package_inputs_manifest",
 )
+load(":runtime_artifacts.bzl", "runtime_artifacts")
 load(":runtime_package_inputs.bzl", "RUNTIME_PACKAGE_INPUTS")
 
 _CA_CERTIFICATES_SOURCE_ID = "ca-certificates_20260223_amd64"
@@ -100,4 +101,8 @@ runtime_package_inputs_manifest(
 filegroup(
     name = "runtime-package-member-archives",
     srcs = [":" + source_id + "_members" for source_id in RUNTIME_PACKAGE_INPUTS],
+)
+
+runtime_artifacts(
+    name = "runtime-artifact-members",
 )

--- a/image/runtime_artifacts.bzl
+++ b/image/runtime_artifacts.bzl
@@ -1,0 +1,63 @@
+_ARTIFACTS = [
+    ("libnvat.so.1.2.2", "_libnvat"),
+    ("nvattest", "_nvattest"),
+    ("nvidia-modeset.ko", "_nvidia_modeset"),
+    ("nvidia-uvm.ko", "_nvidia_uvm"),
+    ("nvidia.ko", "_nvidia"),
+    ("tinfoil-boot", "_tinfoil_boot"),
+    ("tinfoil-container-status", "_tinfoil_container_status"),
+    ("tinfoil-egress", "_tinfoil_egress"),
+    ("tinfoil-init", "_tinfoil_init"),
+    ("tinfoil-shim", "_tinfoil_shim"),
+]
+
+
+def _runtime_artifacts_impl(ctx):
+    archive = ctx.actions.declare_file("runtime-artifact-members.tar")
+    manifest = ctx.actions.declare_file("runtime-artifact-members.tsv")
+    arguments = [
+        "archive",
+        "--lock", ctx.file._lock.path,
+        "--marker", ctx.file._marker.path,
+    ]
+    for source in ctx.files._manifests:
+        arguments.extend(["--manifest", source.path])
+    artifact_files = []
+    for name, attribute in _ARTIFACTS:
+        source = getattr(ctx.file, attribute)
+        artifact_files.append(source)
+        arguments.extend(["--file-name", name, "--file", source.path])
+    arguments.extend(["--output-tar", archive.path, "--output-manifest", manifest.path])
+    ctx.actions.run(
+        executable = ctx.executable._tool,
+        arguments = arguments,
+        inputs = depset([ctx.file._lock, ctx.file._marker] + ctx.files._manifests + artifact_files),
+        outputs = [archive, manifest],
+        mnemonic = "RuntimeArtifactMembers",
+    )
+    return [DefaultInfo(files = depset([archive, manifest]))]
+
+
+runtime_artifacts = rule(
+    implementation = _runtime_artifacts_impl,
+    attrs = {
+        "_libnvat": attr.label(default = "//build/runtime-artifacts:producers/nvattest/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2", allow_single_file = True),
+        "_lock": attr.label(default = "//image:manifests/rootfs-artifacts.lock.tsv", allow_single_file = True),
+        "_manifests": attr.label_list(default = [
+            "//build/runtime-artifacts:producers/go/rootfs-artifacts.tsv",
+            "//build/runtime-artifacts:producers/nvattest/rootfs-artifacts.tsv",
+            "//build/runtime-artifacts:producers/nvidia-modules/rootfs-artifacts.tsv",
+        ], allow_files = True),
+        "_marker": attr.label(default = "//build/runtime-artifacts:.tinfoil-runtime-artifacts-v1", allow_single_file = True),
+        "_nvattest": attr.label(default = "//build/runtime-artifacts:producers/nvattest/usr/bin/nvattest", allow_single_file = True),
+        "_nvidia": attr.label(default = "//build/runtime-artifacts:producers/nvidia-modules/artifacts/nvidia.ko", allow_single_file = True),
+        "_nvidia_modeset": attr.label(default = "//build/runtime-artifacts:producers/nvidia-modules/artifacts/nvidia-modeset.ko", allow_single_file = True),
+        "_nvidia_uvm": attr.label(default = "//build/runtime-artifacts:producers/nvidia-modules/artifacts/nvidia-uvm.ko", allow_single_file = True),
+        "_tinfoil_boot": attr.label(default = "//build/runtime-artifacts:producers/go/artifacts/tinfoil-boot", allow_single_file = True),
+        "_tinfoil_container_status": attr.label(default = "//build/runtime-artifacts:producers/go/artifacts/tinfoil-container-status", allow_single_file = True),
+        "_tinfoil_egress": attr.label(default = "//build/runtime-artifacts:producers/go/artifacts/tinfoil-egress", allow_single_file = True),
+        "_tinfoil_init": attr.label(default = "//build/runtime-artifacts:producers/go/artifacts/tinfoil-init", allow_single_file = True),
+        "_tinfoil_shim": attr.label(default = "//build/runtime-artifacts:producers/go/artifacts/tinfoil-shim", allow_single_file = True),
+        "_tool": attr.label(default = "//scripts:runtime_artifact_bridge", cfg = "exec", executable = True),
+    },
+)

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -3,6 +3,35 @@ package(default_visibility = ["//visibility:public"])
 exports_files(["compare_runtime_package_lock.sh"])
 
 py_library(
+    name = "rootfs-artifact-contract",
+    srcs = [
+        "__init__.py",
+        "rootfs_artifacts.py",
+        "rootfs_manifest.py",
+    ],
+    imports = [".."],
+)
+
+py_binary(
+    name = "runtime_artifact_bridge",
+    srcs = ["runtime_artifact_bridge.py"],
+    legacy_create_init = 0,
+    main = "runtime_artifact_bridge.py",
+    deps = [":rootfs-artifact-contract"],
+)
+
+py_test(
+    name = "runtime-artifact-bridge-test",
+    srcs = ["runtime_artifact_bridge_test.py"],
+    legacy_create_init = 0,
+    main = "runtime_artifact_bridge_test.py",
+    deps = [
+        ":rootfs-artifact-contract",
+        ":runtime_artifact_bridge",
+    ],
+)
+
+py_library(
     name = "runtime_archive_lib",
     srcs = [
         "__init__.py",

--- a/scripts/runtime_artifact_bridge.py
+++ b/scripts/runtime_artifact_bridge.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python3
 
 import argparse
+import base64
 import ctypes
 import fcntl
 import hashlib
+import io
 import os
 import secrets
 import stat
+import tarfile
 from pathlib import Path, PurePosixPath
 
-from scripts import rootfs_artifacts
+from scripts import rootfs_artifacts, rootfs_manifest
 
 
 REPO = Path(__file__).resolve().parent.parent
@@ -83,6 +86,14 @@ def read_regular(path: Path) -> tuple[bytes, os.stat_result]:
     finally:
         os.close(descriptor)
         os.close(parent)
+
+
+def read_bazel_input(path: Path) -> tuple[bytes, os.stat_result]:
+    descriptor = os.open(path, os.O_RDONLY | os.O_CLOEXEC)
+    try:
+        return read_descriptor(descriptor, path, False)
+    finally:
+        os.close(descriptor)
 
 
 def mkdir(parent: int, name: str, mode: int = 0o755, accepted_modes: set[int] | None = None) -> int:
@@ -557,16 +568,112 @@ def prepare() -> None:
         os.close(build)
 
 
+def archive(args) -> None:
+    lock_content, _ = read_bazel_input(Path(args.lock))
+    locked = rootfs_artifacts.parse_content(Path(args.lock), lock_content.decode())
+    if set(locked) != set(rootfs_artifacts.EXPECTED):
+        fail("rootfs artifact lock differs from fixed contract")
+    validate_contract(locked)
+    expected_marker = f"{SCHEMA}\t{hashlib.sha256(lock_content).hexdigest()}\n".encode()
+    marker, marker_metadata = read_bazel_input(Path(args.marker))
+    if marker != expected_marker or stat.S_IMODE(marker_metadata.st_mode) != 0o644:
+        fail("generated runtime artifact marker does not match the checked-in lock")
+    produced = {}
+    for producer, manifest_path in zip(sorted(PRODUCER_ROOTS), args.manifest, strict=True):
+        content, metadata = read_bazel_input(Path(manifest_path))
+        if stat.S_IMODE(metadata.st_mode) != 0o644:
+            fail(f"{producer}: generated manifest mode mismatch")
+        entries = rootfs_artifacts.parse_content(Path(manifest_path), content.decode(), producer)
+        produced.update(entries)
+    if produced != locked or set(locked) != set(rootfs_artifacts.EXPECTED):
+        fail("generated manifests differ from the checked-in rootfs artifact lock")
+    regular = sorted((entry for entry in locked.values() if entry.kind == "file"), key=lambda entry: entry.name)
+    if [entry.name for entry in regular] != sorted(args.file_name):
+        fail("Bazel runtime artifact inputs differ from the fixed file set")
+    payloads = {}
+    for name, path in zip(args.file_name, args.file, strict=True):
+        entry = locked[name]
+        content, metadata = read_bazel_input(Path(path))
+        if stat.S_IMODE(metadata.st_mode) != int(entry.mode, 8) or hashlib.sha256(content).hexdigest() != entry.sha256:
+            fail(f"{name}: generated runtime artifact differs from lock")
+        payloads[name] = content
+    ordered = sorted(locked.values(), key=lambda entry: entry.destination.encode())
+    manifest_entries = []
+    archive_buffer = io.BytesIO()
+    with tarfile.open(fileobj=archive_buffer, mode="w", format=tarfile.USTAR_FORMAT) as bundle:
+        for entry in ordered:
+            member = tarfile.TarInfo(entry.destination.removeprefix("/"))
+            member.mode = int(entry.mode, 8)
+            member.uid = member.gid = 0
+            member.uname = member.gname = ""
+            member.mtime = 0
+            member.pax_headers = {}
+            if entry.kind == "file":
+                content = payloads[entry.name]
+                member.type = tarfile.REGTYPE
+                member.size = len(content)
+                bundle.addfile(member, io.BytesIO(content))
+                manifest_content = f"sha256:{entry.sha256}"
+            else:
+                member.type = tarfile.SYMTYPE
+                member.linkname = entry.link_target
+                member.size = 0
+                bundle.addfile(member)
+                manifest_content = f"target64:{base64.b64encode(entry.link_target.encode()).decode()}"
+            manifest_entries.append(rootfs_manifest.Entry(entry.destination, entry.kind, entry.mode, "0", "0", manifest_content, "-", "-"))
+    manifest_content = rootfs_manifest.serialize(manifest_entries)
+    with tarfile.open(fileobj=io.BytesIO(archive_buffer.getvalue()), mode="r:") as bundle:
+        members = bundle.getmembers()
+        if len(members) != len(ordered):
+            fail("runtime artifact archive member count mismatch")
+        for member, entry, manifest_entry in zip(members, ordered, manifest_entries, strict=True):
+            if (
+                member.name != entry.destination[1:]
+                or member.mode != int(entry.mode, 8)
+                or member.uid != 0
+                or member.gid != 0
+                or member.mtime != 0
+                or member.pax_headers
+                or manifest_entry.path != entry.destination
+            ):
+                fail(f"{entry.name}: runtime artifact archive metadata mismatch")
+            if entry.kind == "file":
+                extracted = bundle.extractfile(member)
+                if not member.isfile() or extracted is None or extracted.read() != payloads[entry.name]:
+                    fail(f"{entry.name}: runtime artifact archive payload mismatch")
+            elif not member.issym() or member.linkname != entry.link_target:
+                fail(f"{entry.name}: runtime artifact archive symlink mismatch")
+    for path, content in ((Path(args.output_tar), archive_buffer.getvalue()), (Path(args.output_manifest), manifest_content)):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.{secrets.token_hex(6)}")
+        with open(temporary, "xb") as output:
+            output.write(content)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser("prepare")
-    parser.parse_args()
-    prepare()
+    archive_parser = subparsers.add_parser("archive")
+    archive_parser.add_argument("--lock", required=True)
+    archive_parser.add_argument("--marker", required=True)
+    archive_parser.add_argument("--manifest", action="append", required=True)
+    archive_parser.add_argument("--file-name", action="append", required=True)
+    archive_parser.add_argument("--file", action="append", required=True)
+    archive_parser.add_argument("--output-tar", required=True)
+    archive_parser.add_argument("--output-manifest", required=True)
+    args = parser.parse_args()
+    if args.command == "prepare":
+        prepare()
+    else:
+        archive(args)
 
 
 if __name__ == "__main__":
     try:
         main()
-    except (OSError, UnicodeError, ValueError) as error:
+    except (OSError, UnicodeError, ValueError, tarfile.TarError) as error:
         raise SystemExit(f"runtime artifact bridge: {error}")

--- a/scripts/runtime_artifact_bridge_test.py
+++ b/scripts/runtime_artifact_bridge_test.py
@@ -1,15 +1,17 @@
+import argparse
 import errno
 import hashlib
 import multiprocessing
 import os
 import shutil
 import stat
+import tarfile
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
-from scripts import rootfs_artifacts, runtime_artifact_bridge as bridge
+from scripts import rootfs_artifacts, rootfs_manifest, runtime_artifact_bridge as bridge
 
 
 def prepare_worker(root: str, queue) -> None:
@@ -95,6 +97,18 @@ class RuntimeArtifactBridgeTest(unittest.TestCase):
         state = self.root / "build" / bridge.STATE
         return sorted(state.glob(".runtime-artifacts.*")) if state.exists() else []
 
+    def archive_arguments(self, suffix=""):
+        generated = self.generated()
+        names = sorted(name for name, entry in self.entries.items() if entry.kind == "file")
+        return argparse.Namespace(
+            lock=str(self.root / bridge.LOCK),
+            marker=str(generated / bridge.MARKER),
+            manifest=[str(generated / "producers" / producer / "rootfs-artifacts.tsv") for producer in sorted(bridge.PRODUCER_ROOTS)],
+            file_name=names,
+            file=[str(generated / "producers" / self.entries[name].producer / self.entries[name].source_path) for name in names],
+            output_tar=str(self.root / f"members{suffix}.tar"),
+            output_manifest=str(self.root / f"members{suffix}.tsv"),
+        )
 
     def tree_digest(self, root):
         digest = hashlib.sha256()
@@ -218,6 +232,34 @@ class RuntimeArtifactBridgeTest(unittest.TestCase):
                 self.assertEqual(self.staging(), [])
                 shutil.rmtree(self.generated())
                 bridge.prepare()
+
+    def test_write_all_retries_short_writes(self):
+        target = self.root / "short-write"
+        descriptor = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        original = os.write
+
+        def short_write(fd, content):
+            return original(fd, content[:3])
+
+        try:
+            with mock.patch.object(bridge.os, "write", side_effect=short_write):
+                bridge.write_all(descriptor, b"complete payload")
+        finally:
+            os.close(descriptor)
+        self.assertEqual(target.read_bytes(), b"complete payload")
+
+    def test_write_all_fails_closed_on_zero_and_io_errors(self):
+        descriptor = os.open(self.root / "failed-write", os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with mock.patch.object(bridge.os, "write", return_value=0):
+                with self.assertRaisesRegex(ValueError, "no progress"):
+                    bridge.write_all(descriptor, b"payload")
+            for error in (errno.ENOSPC, errno.EIO):
+                with self.subTest(error=error), mock.patch.object(bridge.os, "write", side_effect=OSError(error, os.strerror(error))):
+                    with self.assertRaises(OSError):
+                        bridge.write_all(descriptor, b"payload")
+        finally:
+            os.close(descriptor)
 
     def test_failed_writes_and_fsyncs_remove_owned_staging(self):
         original_write = os.write
@@ -391,6 +433,40 @@ class RuntimeArtifactBridgeTest(unittest.TestCase):
         (self.root / "build").chmod(0o775)
         with self.assertRaisesRegex(ValueError, "group trust"):
             bridge.prepare()
+
+    def test_archive_is_exact_and_reproducible(self):
+        bridge.prepare()
+        first = self.archive_arguments("-one")
+        second = self.archive_arguments("-two")
+        bridge.archive(first)
+        bridge.archive(second)
+        self.assertEqual(Path(first.output_tar).read_bytes(), Path(second.output_tar).read_bytes())
+        self.assertEqual(Path(first.output_manifest).read_bytes(), Path(second.output_manifest).read_bytes())
+        manifest = rootfs_manifest.parse_manifest(Path(first.output_manifest))
+        self.assertEqual(set(manifest), {entry.destination for entry in self.entries.values()})
+        with tarfile.open(first.output_tar, "r:") as bundle:
+            members = bundle.getmembers()
+        ordered = sorted(self.entries.values(), key=lambda entry: entry.destination.encode())
+        self.assertEqual([member.name for member in members], [entry.destination[1:] for entry in ordered])
+        for member, entry in zip(members, ordered, strict=True):
+            self.assertEqual((member.uid, member.gid, member.mode, member.mtime), (0, 0, int(entry.mode, 8), 0))
+            self.assertFalse(member.pax_headers)
+            self.assertEqual(member.issym(), entry.kind == "symlink")
+
+    def test_archive_rejects_mutation_and_lock_drift(self):
+        bridge.prepare()
+        arguments = self.archive_arguments()
+        artifact = Path(arguments.file[0])
+        artifact.write_bytes(b"mutated")
+        artifact.chmod(int(self.entries[arguments.file_name[0]].mode, 8))
+        with self.assertRaises(ValueError):
+            bridge.archive(arguments)
+        shutil.rmtree(self.generated())
+        bridge.prepare()
+        with open(self.root / bridge.LOCK, "ab") as lock:
+            lock.write(b"# drift\n")
+        with self.assertRaises(ValueError):
+            bridge.archive(self.archive_arguments("-drift"))
 
     def test_existing_wrong_mode_package_is_preserved(self):
         bridge.prepare()

--- a/scripts/test-runtime-artifact-bridge.sh
+++ b/scripts/test-runtime-artifact-bridge.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -euo pipefail
+
+repo_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)
+temporary=$(mktemp -d)
+trap 'rm -rf -- "$temporary"' EXIT
+
+grep -Fqx 'prepare-runtime-artifacts: verify-rootfs-artifacts' "$repo_dir/Makefile"
+grep -Fqx $'\tpython3 -m scripts.runtime_artifact_bridge prepare' "$repo_dir/Makefile"
+if grep -En 'glob\(|select\(|local_repository|new_local_repository|local_path_override|override_repository|os\.environ|tree_artifact' \
+    "$repo_dir/image/runtime_artifacts.bzl" "$repo_dir/scripts/runtime_artifact_bridge.py"; then
+    echo "runtime artifact bridge contains a forbidden generic mechanism" >&2
+    exit 1
+fi
+if grep -En 'glob\(|select\(|load\(' "$repo_dir/build/runtime-artifacts/BUILD.bazel"; then
+    echo "generated runtime artifact package is not exports-only" >&2
+    exit 1
+fi
+
+mkdir "$temporary/clean"
+cp -a "$repo_dir/.bazelrc" "$repo_dir/.bazelversion" "$repo_dir/BUILD.bazel" \
+    "$repo_dir/MODULE.bazel" "$repo_dir/MODULE.bazel.lock" "$repo_dir/image" \
+    "$repo_dir/scripts" "$temporary/clean/"
+if (cd "$temporary/clean" && bazel --batch --output_base="$temporary/clean-output" build --symlink_prefix=/ \
+    //image:runtime-artifact-members) >"$temporary/clean.log" 2>&1; then
+    echo "clean Bazel build unexpectedly succeeded without explicit preparation" >&2
+    exit 1
+fi
+grep -Fq '//build/runtime-artifacts' "$temporary/clean.log"
+rm -rf -- "$temporary/clean-output"
+
+for output in one two; do
+    bazel --batch --output_base="$temporary/$output" build --symlink_prefix=/ //image:runtime-artifact-members
+    bazel_bin=$(bazel --batch --output_base="$temporary/$output" info bazel-bin)
+    cp "$bazel_bin/image/runtime-artifact-members.tar" "$temporary/$output.tar"
+    cp "$bazel_bin/image/runtime-artifact-members.tsv" "$temporary/$output.tsv"
+    rm -rf -- "${temporary:?}/$output"
+done
+cmp "$temporary/one.tar" "$temporary/two.tar"
+cmp "$temporary/one.tsv" "$temporary/two.tsv"
+
+mkdir "$temporary/drift"
+cp -a "$repo_dir/.bazelrc" "$repo_dir/.bazelversion" "$repo_dir/BUILD.bazel" \
+    "$repo_dir/MODULE.bazel" "$repo_dir/MODULE.bazel.lock" "$repo_dir/image" \
+    "$repo_dir/scripts" "$temporary/drift/"
+mkdir "$temporary/drift/build"
+cp -a "$repo_dir/build/runtime-artifacts" "$temporary/drift/build/"
+printf '# lock drift\n' >> "$temporary/drift/image/manifests/rootfs-artifacts.lock.tsv"
+if (cd "$temporary/drift" && bazel --batch --output_base="$temporary/drift-output" build --symlink_prefix=/ \
+    //image:runtime-artifact-members) >"$temporary/drift.log" 2>&1; then
+    echo "Bazel bridge accepted a changed checked-in lock" >&2
+    exit 1
+fi
+grep -Fq 'marker does not match' "$temporary/drift.log"
+rm -rf -- "$temporary/drift-output"
+
+mkdir "$temporary/mutation"
+cp -a "$repo_dir/.bazelrc" "$repo_dir/.bazelversion" "$repo_dir/BUILD.bazel" \
+    "$repo_dir/MODULE.bazel" "$repo_dir/MODULE.bazel.lock" "$repo_dir/image" \
+    "$repo_dir/scripts" "$temporary/mutation/"
+mkdir "$temporary/mutation/build"
+cp -a "$repo_dir/build/runtime-artifacts" "$temporary/mutation/build/"
+printf 'mutation' >> "$temporary/mutation/build/runtime-artifacts/producers/go/artifacts/tinfoil-init"
+if (cd "$temporary/mutation" && bazel --batch --output_base="$temporary/mutation-output" build --symlink_prefix=/ \
+    //image:runtime-artifact-members) >"$temporary/mutation.log" 2>&1; then
+    echo "Bazel bridge accepted a generated artifact mutation" >&2
+    exit 1
+fi
+grep -Fq 'differs from lock' "$temporary/mutation.log"
+rm -rf -- "$temporary/mutation-output"


### PR DESCRIPTION
## Summary

- expose only the authenticated `build/runtime-artifacts` package to Bazel
- independently reauthenticate every producer byte, manifest, mode, provenance field, destination, and symlink declaration
- emit one exact deterministic 12-member USTAR archive and canonical rootfs manifest
- reject clean Bazel use until explicit Make-owned preparation has completed

## Fixed consumer contract

The generated package contains literal file labels only. There are no globs, tree artifacts, environment-selected paths, repository overrides, or generic local repositories.

`//image:runtime-artifact-members` emits exactly:

- `runtime-artifact-members.tar`: twelve sorted members, locked modes, ownership `0:0`, timestamp zero, and no directory, hardlink, special, xattr, sparse, or PAX records
- `runtime-artifact-members.tsv`: the canonical eight-field realized-rootfs manifest

The two libnvat links are assembly declarations authenticated against the lock; they are not followed from producer output.

## Fail-closed behavior

- a clean checkout fails because the generated package is absent
- marker/lock mismatch, missing or extra files, manifest drift, byte or mode mutation, provenance drift, destination drift, and symlink declaration drift are rejected
- `.bazelignore` exposes only `build/runtime-artifacts`; all producer caches remain excluded
- no Make command or producer runs inside Bazel

## Validation

- 21 focused preparation/consumer adversarial tests
- two independent Bazel output roots produced byte-identical TAR and TSV outputs
- lock-drift and generated-byte mutation rejection
- clean-checkout failure test
- `bazel test //...` (6 tests)
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Python compilation, shell syntax, and `git diff --check`

Current exact output hashes:

- TAR: `d45570045d606357042c7bc0c117f465c8ca6aa4fd64aaa15476e9b4a100f6ee`
- TSV: `df79cb4067b7e75b37d3f9b7baa981caec061dc8d02c94ee36981d6adecdfedd`

## Ordering

Stacked on #208. Required merge order is **#207 → #208 → this PR**. It may be reviewed now; after each parent squash-merges, the remaining child receives one ancestry-only rebase with `--force-with-lease`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fixed Bazel consumer that exposes only the authenticated `build/runtime-artifacts` package and emits a deterministic USTAR archive and canonical rootfs manifest.

- **New Features**
  - Added Starlark rule `runtime_artifacts` and target `//image:runtime-artifact-members` to verify marker/lock/manifests and emit `runtime-artifact-members.tar` and `.tsv`.
  - Implemented `scripts/runtime_artifact_bridge.py archive` to reauthenticate every file, mode, provenance, destination, and the two symlink declarations; writes a 12-member USTAR archive with 0:0 ownership, mtime 0, and no PAX/xattrs.
  - Tightened `.bazelignore` to expose only `build/runtime-artifacts`; producer caches remain excluded.
  - Added Python and shell tests to enforce determinism, fail-closed behavior, and reject lock drift and byte/mode mutations; wired into `make test-runtime-artifact-bridge`.

- **Migration**
  - Run `make prepare-runtime-artifacts` before building `//image:runtime-artifact-members`; Bazel will not run producers.

<sup>Written for commit e5dce1efcce36b96e5fec0c82a6456bbc5c015d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

