### PR TITLE
Add exact Bazel rootfs assembly

### DIFF
--- a/image/BUILD.bazel
+++ b/image/BUILD.bazel
@@ -9,6 +9,7 @@ load(
 )
 load(":runtime_artifacts.bzl", "runtime_artifacts")
 load(":runtime_package_inputs.bzl", "RUNTIME_PACKAGE_INPUTS")
+load(":rootfs.bzl", "rootfs")
 
 _CA_CERTIFICATES_SOURCE_ID = "ca-certificates_20260223_amd64"
 
@@ -24,6 +25,7 @@ _RUNTIME_PACKAGE_ARCHIVES[_CA_CERTIFICATES_SOURCE_ID] = ":ubuntu-runtime-cacerts
 # Generated/declarative lock data is intentionally kept separate from build
 # rules so its reviewable size is not confused with executable mechanism.
 exports_files([
+    "rootfs.bzl",
     "runtime-packages.lock.json",
     "runtime-package-members.lock.json",
     "runtime-packages.yaml",
@@ -105,4 +107,8 @@ filegroup(
 
 runtime_artifacts(
     name = "runtime-artifact-members",
+)
+
+rootfs(
+    name = "rootfs",
 )

--- a/image/rootfs.bzl
+++ b/image/rootfs.bzl
@@ -1,0 +1,87 @@
+"""Fixed positive assembly of the measured guest root filesystem."""
+
+load(":runtime_package_inputs.bzl", "RUNTIME_PACKAGE_INPUTS")
+
+_VENDORS = [
+    ("docker-static", ":docker_static_members"),
+    ("libnvidia-cfg1", ":libnvidia_cfg1_members"),
+    ("libnvidia-compute", ":libnvidia_compute_members"),
+    ("libnvidia-container-tools", ":libnvidia_container_tools_members"),
+    ("libnvidia-container1", ":libnvidia_container1_members"),
+    ("libnvidia-gpucomp", ":libnvidia_gpucomp_members"),
+    ("libnvidia-nscq", ":libnvidia_nscq_members"),
+    ("nvidia-container-toolkit-base", ":nvidia_container_toolkit_base_members"),
+    ("nvidia-fabricmanager", ":nvidia_fabricmanager_members"),
+    ("nvidia-firmware", ":nvidia_firmware_members"),
+    ("nvidia-persistenced", ":nvidia_persistenced_members"),
+]
+
+_CONFIGS = [
+    "etc/containerd/config.toml",
+    "etc/docker/daemon.json",
+    "etc/group",
+    "etc/gshadow",
+    "etc/hostname",
+    "etc/hosts",
+    "etc/nftables.conf",
+    "etc/nsswitch.conf",
+    "etc/nvidia-container-runtime/config.toml",
+    "etc/passwd",
+    "etc/resolv.conf",
+    "etc/shadow",
+]
+
+def _rootfs_impl(ctx):
+    archive = ctx.actions.declare_file("rootfs.tar")
+    manifest = ctx.actions.declare_file("rootfs.tsv")
+    runtime_files = ctx.attr._runtime[DefaultInfo].files.to_list()
+    runtime_archive = [file for file in runtime_files if file.basename == "runtime-artifact-members.tar"]
+    runtime_manifest = [file for file in runtime_files if file.basename == "runtime-artifact-members.tsv"]
+    if len(runtime_archive) != 1 or len(runtime_manifest) != 1:
+        fail("runtime artifact target must provide its fixed archive and manifest")
+    arguments = [
+        "--package-lock", ctx.file._package_lock.path,
+        "--vendor-lock", ctx.file._vendor_lock.path,
+        "--runtime-lock", ctx.file._runtime_lock.path,
+        "--runtime-archive", runtime_archive[0].path,
+        "--runtime-manifest", runtime_manifest[0].path,
+        "--config-lock", ctx.file._config_lock.path,
+    ]
+    for source_id, source in zip(sorted(RUNTIME_PACKAGE_INPUTS), ctx.files._packages):
+        arguments.extend(["--package", source_id, source.path])
+    for (source_id, _), source in zip(_VENDORS, ctx.files._vendors):
+        arguments.extend(["--vendor", source_id, source.path])
+    for relative, source in zip(_CONFIGS, ctx.files._configs):
+        arguments.extend(["--config", relative, source.path])
+    arguments.extend(["--output-tar", archive.path, "--output-manifest", manifest.path])
+    ctx.actions.run(
+        executable = ctx.executable._tool,
+        arguments = arguments,
+        inputs = depset(
+            ctx.files._packages + ctx.files._vendors + ctx.files._configs + runtime_files + [
+                ctx.file._package_lock,
+                ctx.file._vendor_lock,
+                ctx.file._runtime_lock,
+                ctx.file._config_lock,
+            ],
+        ),
+        outputs = [archive, manifest],
+        mnemonic = "TinfoilRootfs",
+        progress_message = "Assembling fixed measured rootfs",
+    )
+    return [DefaultInfo(files = depset([archive, manifest]))]
+
+rootfs = rule(
+    implementation = _rootfs_impl,
+    attrs = {
+        "_config_lock": attr.label(default = ":rootfs-policy.sha256", allow_single_file = True),
+        "_configs": attr.label_list(default = [":rootfs/" + path for path in _CONFIGS], allow_files = True),
+        "_package_lock": attr.label(default = ":runtime-package-members.lock.json", allow_single_file = True),
+        "_packages": attr.label_list(default = [":" + source_id + "_members" for source_id in sorted(RUNTIME_PACKAGE_INPUTS)], allow_files = True),
+        "_runtime": attr.label(default = ":runtime-artifact-members"),
+        "_runtime_lock": attr.label(default = ":manifests/rootfs-artifacts.lock.tsv", allow_single_file = True),
+        "_tool": attr.label(default = "//scripts:rootfs_assembly", cfg = "exec", executable = True),
+        "_vendor_lock": attr.label(default = ":runtime-sources.lock.json", allow_single_file = True),
+        "_vendors": attr.label_list(default = [label for _, label in _VENDORS], allow_files = True),
+    },
+)

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -13,6 +13,54 @@ py_library(
 )
 
 py_binary(
+    name = "rootfs_assembly",
+    srcs = ["rootfs_assembly.py"],
+    legacy_create_init = 0,
+    main = "rootfs_assembly.py",
+    deps = [":rootfs-artifact-contract"],
+)
+
+py_test(
+    name = "rootfs-assembly-test",
+    srcs = ["rootfs_assembly_test.py"],
+    data = [
+        "//image:nvidia_fabricmanager_members",
+        "//image:runtime-artifact-members",
+        "//image:runtime-sources.lock.json",
+        "//image:manifests/rootfs-artifacts.lock.tsv",
+    ],
+    legacy_create_init = 0,
+    main = "rootfs_assembly_test.py",
+    deps = [
+        ":rootfs-artifact-contract",
+        ":rootfs_assembly",
+    ],
+)
+
+py_test(
+    name = "rootfs-assembly-output-test",
+    srcs = ["rootfs_assembly_output_test.py"],
+    args = [
+        "--outputs",
+        "$(locations //image:rootfs)",
+    ],
+    data = ["//image:rootfs"],
+    legacy_create_init = 0,
+    main = "rootfs_assembly_output_test.py",
+    deps = [":rootfs-artifact-contract"],
+)
+
+sh_test(
+    name = "rootfs-assembly-structure-test",
+    srcs = ["test-rootfs-assembly-structure.sh"],
+    data = [
+        "//image:BUILD.bazel",
+        "//image:rootfs.bzl",
+        ":rootfs_assembly.py",
+    ],
+)
+
+py_binary(
     name = "runtime_artifact_bridge",
     srcs = ["runtime_artifact_bridge.py"],
     legacy_create_init = 0,

--- a/scripts/rootfs_assembly.py
+++ b/scripts/rootfs_assembly.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+
+import argparse
+import base64
+import contextlib
+import errno
+import hashlib
+import io
+import json
+import os
+import re
+import stat
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from scripts import rootfs_artifacts, rootfs_manifest
+
+
+PACKAGE_IDS = tuple(sorted((
+    "ca-certificates_20260223_amd64", "iproute2_6.19.0-1ubuntu1_amd64",
+    "libbpf1_1-1.6.3-1ubuntu1_amd64", "libbsd0_0.12.2-2build2_amd64",
+    "libc6_2.43-2ubuntu2_amd64", "libcap2_1-2.75-10ubuntu2_amd64",
+    "libcom-err2_1.47.2-3ubuntu4_amd64", "libedit2_3.1-20251016-1_amd64",
+    "libelf1t64_0.194-4_amd64", "libgcc-s1_16-20260322-1ubuntu1_amd64",
+    "libgmp10_2-6.3.0-p-dfsg-5ubuntu2_amd64", "libgssapi-krb5-2_1.22.1-2ubuntu4_amd64",
+    "libjansson4_2.14-2build4_amd64", "libk5crypto3_1.22.1-2ubuntu4_amd64",
+    "libkeyutils1_1.6.3-6ubuntu3_amd64", "libkrb5-3_1.22.1-2ubuntu4_amd64",
+    "libkrb5support0_1.22.1-2ubuntu4_amd64", "libmd0_1.1.0-2build4_amd64",
+    "libmnl0_1.0.5-3build1_amd64", "libnftables1_1.1.6-1_amd64",
+    "libnftnl11_1.3.1-1_amd64", "libpcre2-8-0_10.46-1build1_amd64",
+    "libseccomp2_2.6.0-2ubuntu5_amd64", "libselinux1_3.9-4build1_amd64",
+    "libssl3t64_3.5.5-1ubuntu3.2_amd64", "libstdc-p--p-6_16-20260322-1ubuntu1_amd64",
+    "libtinfo6_6.6-p-20251231-1_amd64", "libtirpc-common_1.3.7-0.1_amd64",
+    "libtirpc3t64_1.3.7-0.1_amd64", "libxml2-16_2.15.2-p-dfsg-0.1_amd64",
+    "libxtables12_1.8.11-2ubuntu3_amd64", "libzstd1_1.5.7-p-dfsg-3_amd64",
+    "nftables_1.1.6-1_amd64", "openssl_3.5.5-1ubuntu3.2_amd64",
+    "zlib1g_1-1.3.dfsg-p-really1.3.1-1ubuntu3_amd64",
+)))
+VENDOR_IDS = (
+    "docker-static", "libnvidia-cfg1", "libnvidia-compute", "libnvidia-container-tools",
+    "libnvidia-container1", "libnvidia-gpucomp", "libnvidia-nscq",
+    "nvidia-container-toolkit-base", "nvidia-fabricmanager", "nvidia-firmware",
+    "nvidia-persistenced",
+)
+CONFIG_PATHS = (
+    "etc/containerd/config.toml", "etc/docker/daemon.json", "etc/group", "etc/gshadow",
+    "etc/hostname", "etc/hosts", "etc/nftables.conf", "etc/nsswitch.conf",
+    "etc/nvidia-container-runtime/config.toml", "etc/passwd", "etc/resolv.conf", "etc/shadow",
+)
+SKELETON = ("/dev", "/proc", "/run", "/sys", "/tmp", "/var", "/var/tmp", "/mnt", "/mnt/ramdisk")
+LINKS = {
+    "/bin": "usr/bin", "/lib": "usr/lib", "/lib64": "usr/lib64", "/sbin": "usr/sbin",
+    "/etc/mtab": "../proc/self/mounts", "/var/run": "/run",
+}
+FM_PATH = "/usr/share/nvidia/nvswitch/fabricmanager.cfg"
+FM_BEFORE = b"FM_CMD_UNIX_SOCKET_PATH=\n"
+FM_AFTER = b"FM_CMD_UNIX_SOCKET_PATH=/run/nvidia-fabricmanager/socket\n"
+FM_INPUT = "068da67ec6430e912e727966031b66bddcf4a48988ec24a75d2fa1dd659058e8"
+FM_OUTPUT = "89612c99a33dd7ccc00738c4897591c95a576ef2f289481523b64a780d1390d8"
+EXCLUDED = "etc/nvidia-container-toolkit/nvidia-cdi-refresh.env"
+FORBIDDEN_EXACT = {
+    "/etc/ld.so.cache", "/etc/shells", "/usr/bin/docker-init", "/usr/bin/nvidia-smi",
+    "/usr/bin/nvidia-container-runtime-hook", "/usr/sbin/ip6tables", "/usr/sbin/iptables",
+    "/usr/sbin/iptables-nft", "/usr/sbin/ip6tables-nft", "/usr/sbin/xtables-nft-multi",
+}
+MODE = re.compile(r"[0-7]{4}\Z")
+SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class AssemblyError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Entry:
+    path: str
+    kind: str
+    mode: str
+    digest: str = "-"
+    link: str = "-"
+    archive: Path | None = None
+    member: str = ""
+    source: Path | None = None
+    replacement: bytes | None = None
+
+
+def fail(message):
+    raise AssemblyError(message)
+
+
+def json_object(pairs):
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            fail(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+@contextlib.contextmanager
+def checked_descriptor(path, expected_mode=None):
+    path = Path(path)
+    flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        sandbox = "/sandbox/" in str(Path.cwd())
+        if error.errno != errno.ELOOP or not sandbox or path.is_absolute():
+            fail(f"unsafe input path {path}: {error}")
+        target = os.readlink(path)
+        if not os.path.isabs(target):
+            fail(f"unsafe Bazel input link {path}: target is not absolute")
+        try:
+            descriptor = os.open(target, flags)
+        except OSError as target_error:
+            fail(f"unsafe Bazel input target {path}: {target_error}")
+    try:
+        before = os.fstat(descriptor)
+        if not stat.S_ISREG(before.st_mode) or before.st_nlink != 1 or os.listxattr(descriptor):
+            fail(f"input must be a single-linked xattr-free regular file: {path}")
+        if expected_mode is not None and stat.S_IMODE(before.st_mode) != expected_mode:
+            fail(f"input mode differs from fixed contract: {path}")
+        yield descriptor, before
+        after = os.fstat(descriptor)
+        identity = lambda value: (
+            value.st_dev, value.st_ino, value.st_mode, value.st_uid, value.st_gid,
+            value.st_nlink, value.st_size, value.st_mtime_ns, value.st_ctime_ns,
+        )
+        if identity(before) != identity(after) or os.listxattr(descriptor):
+            fail(f"input changed while being read: {path}")
+    finally:
+        os.close(descriptor)
+
+
+def checked_bytes(path, expected_mode=None):
+    with checked_descriptor(path, expected_mode) as (descriptor, _):
+        with os.fdopen(os.dup(descriptor), "rb") as source:
+            return source.read()
+
+
+def load_json(path):
+    try:
+        return json.loads(checked_bytes(path).decode(), object_pairs_hook=json_object)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        fail(f"cannot read lock {path}: {error}")
+
+
+def canonical(path, absolute=False):
+    if not isinstance(path, str) or not path or "\\" in path or "\0" in path:
+        fail(f"invalid path: {path!r}")
+    pure = PurePosixPath(path)
+    if absolute != path.startswith("/") or ".." in pure.parts or "." in pure.parts or str(pure) != path:
+        fail(f"non-canonical path: {path!r}")
+    return path
+
+
+def safe_link(path, target):
+    if not target or "\\" in target or "\0" in target:
+        fail(f"unsafe symlink: {path} -> {target!r}")
+    base = PurePosixPath() if target.startswith("/") else PurePosixPath(path[1:]).parent
+    depth = 0
+    for part in base.joinpath(target.removeprefix("/")).parts:
+        if part == "..":
+            depth -= 1
+            if depth < 0:
+                fail(f"symlink escapes rootfs: {path} -> {target}")
+        elif part not in ("", "."):
+            depth += 1
+
+
+def lock_entries(files):
+    if not isinstance(files, list) or not files:
+        fail("locked member list must be non-empty")
+    result = {}
+    for raw in files:
+        if not isinstance(raw, dict):
+            fail("locked member must be an object")
+        path = canonical(raw.get("path"))
+        kind = raw.get("type")
+        mode = raw.get("mode")
+        if path in result or kind not in ("file", "symlink") or not isinstance(mode, str) or not MODE.fullmatch(mode):
+            fail(f"invalid locked member: {path}")
+        if kind == "file":
+            digest, size, link = raw.get("sha256"), raw.get("size"), "-"
+            if not isinstance(digest, str) or not SHA256.fullmatch(digest) or not isinstance(size, int) or isinstance(size, bool) or size < 0:
+                fail(f"invalid locked file: {path}")
+        else:
+            digest, size, link = "-", 0, raw.get("target")
+            if not isinstance(link, str):
+                fail(f"invalid locked symlink: {path}")
+            safe_link("/" + path, link)
+        result[path] = (kind, mode, digest, size, link)
+    return result
+
+
+def authenticate_archive_consumption(descriptor, size, members, archive_offset):
+    expected_offset = 0
+    for member in members:
+        if member.offset != expected_offset or member.offset_data != member.offset + tarfile.BLOCKSIZE:
+            fail(f"non-canonical archive member layout: {member.name}")
+        content_end = member.offset_data + member.size
+        expected_offset = ((content_end + tarfile.BLOCKSIZE - 1) // tarfile.BLOCKSIZE) * tarfile.BLOCKSIZE
+        padding = os.pread(descriptor, expected_offset - content_end, content_end)
+        if padding != b"\0" * (expected_offset - content_end):
+            fail(f"non-canonical archive member padding: {member.name}")
+    if archive_offset != expected_offset:
+        fail("member archive consumption differs from canonical layout")
+    minimum_size = expected_offset + 2 * tarfile.BLOCKSIZE
+    expected_size = ((minimum_size + tarfile.RECORDSIZE - 1) // tarfile.RECORDSIZE) * tarfile.RECORDSIZE
+    if size != expected_size:
+        fail("member archive length differs from canonical layout")
+    trailer = os.pread(descriptor, size - expected_offset, expected_offset)
+    if trailer != b"\0" * (size - expected_offset):
+        fail("member archive has non-zero trailer padding")
+
+
+def inspect_member_archive(path, locked, names="root"):
+    result = {}
+    try:
+        with checked_descriptor(path) as (descriptor, metadata):
+            with os.fdopen(os.dup(descriptor), "rb") as raw, tarfile.open(fileobj=raw, mode="r:") as archive:
+                members = archive.getmembers()
+                for member in members:
+                    name = canonical(member.name)
+                    if name in result or member.pax_headers or member.offset % 512:
+                        fail(f"invalid or duplicate archive member: {name}")
+                    if member.uid != 0 or member.gid != 0 or member.mtime != 0 or member.uname != names or member.gname != names:
+                        fail(f"non-canonical archive metadata: {name}")
+                    if member.isfile():
+                        kind, link = "file", "-"
+                    elif member.issym():
+                        kind, link = "symlink", member.linkname
+                        safe_link("/" + name, link)
+                    else:
+                        fail(f"forbidden archive member type: {name}")
+                    expected = locked.get(name)
+                    if expected is None or (kind, f"{stat.S_IMODE(member.mode):04o}", link) != (expected[0], expected[1], expected[4]):
+                        fail(f"archive member differs from lock: {name}")
+                    if kind == "file":
+                        stream = archive.extractfile(member)
+                        digest = hashlib.file_digest(stream, "sha256").hexdigest()
+                        if (expected[3] is not None and member.size != expected[3]) or digest != expected[2]:
+                            fail(f"archive member content differs from lock: {name}")
+                    result[name] = member
+                authenticate_archive_consumption(descriptor, metadata.st_size, members, archive.offset)
+    except (OSError, tarfile.TarError) as error:
+        fail(f"cannot inspect member archive {path}: {error}")
+    if set(result) != set(locked):
+        fail(f"member archive inventory differs from lock: {path}")
+
+
+def add(entries, entry):
+    canonical(entry.path, True)
+    if entry.path in entries:
+        fail(f"duplicate rootfs destination: {entry.path}")
+    for parent in PurePosixPath(entry.path).parents:
+        if str(parent) in entries and entries[str(parent)].kind != "dir":
+            fail(f"non-directory ancestor for {entry.path}: {parent}")
+    if entry.kind == "symlink":
+        safe_link(entry.path, entry.link)
+    entries[entry.path] = entry
+
+
+def mapped_vendor(source_id, path):
+    if source_id == "docker-static":
+        if not path.startswith("docker/") or path.count("/") != 1:
+            fail(f"unexpected Docker member: {path}")
+        return "/usr/bin/" + path.removeprefix("docker/")
+    if source_id == "nvidia-firmware":
+        if not path.startswith("lib/firmware/"):
+            fail(f"unexpected firmware member: {path}")
+        return "/usr/" + path
+    return "/" + path
+
+
+def transform_fabricmanager(content):
+    if hashlib.sha256(content).hexdigest() != FM_INPUT or content.count(FM_BEFORE) != 1:
+        fail("Fabric Manager input differs from fixed transform contract")
+    transformed = content.replace(FM_BEFORE, FM_AFTER)
+    if hashlib.sha256(transformed).hexdigest() != FM_OUTPUT:
+        fail("Fabric Manager transformed hash differs from fixed contract")
+    return transformed
+
+
+def archive_entries(inputs, document, package):
+    sources = document.get("sources")
+    if package:
+        if document.get("version") != 1 or not isinstance(sources, dict) or set(sources) != set(PACKAGE_IDS):
+            fail("package lock source set differs from fixed contract")
+        selected = [(source_id, sources[source_id]) for source_id in PACKAGE_IDS]
+    else:
+        if document.get("version") != 1 or not isinstance(sources, list):
+            fail("vendor lock format differs from fixed contract")
+        indexed = {source.get("id"): source for source in sources}
+        expected = set(VENDOR_IDS) | {"nvidia-container-toolkit"}
+        if len(indexed) != len(sources) or set(indexed) != expected:
+            fail("vendor lock source set differs from fixed contract")
+        selected = [(source_id, indexed[source_id]) for source_id in VENDOR_IDS]
+    if tuple(source_id for source_id, _ in inputs) != (PACKAGE_IDS if package else VENDOR_IDS):
+        fail("archive arguments differ from fixed source order")
+    result = []
+    for (source_id, archive_path), (_, source) in zip(inputs, selected, strict=True):
+        locked = lock_entries(source.get("files"))
+        inspect_member_archive(archive_path, locked)
+        for path, (kind, mode, digest, _, link) in locked.items():
+            if not package and source_id == "nvidia-container-toolkit-base" and path == EXCLUDED:
+                continue
+            destination = "/" + path if package else mapped_vendor(source_id, path)
+            replacement = None
+            if destination == FM_PATH:
+                if digest != FM_INPUT or mode != "0644" or kind != "file":
+                    fail("Fabric Manager input differs from fixed transform contract")
+                with checked_descriptor(archive_path) as (descriptor, _):
+                    with os.fdopen(os.dup(descriptor), "rb") as raw, tarfile.open(fileobj=raw, mode="r:") as archive:
+                        content = archive.extractfile(archive.getmember(path)).read()
+                replacement = transform_fabricmanager(content)
+                digest = FM_OUTPUT
+            result.append(Entry(destination, kind, mode, digest, link, Path(archive_path), path, replacement=replacement))
+    return result
+
+
+def runtime_entries(archive_path, manifest_path, lock_path):
+    locked = rootfs_artifacts.parse_content(Path(lock_path), checked_bytes(lock_path).decode())
+    manifest = rootfs_manifest.parse_content(Path(manifest_path), checked_bytes(manifest_path))
+    archive_lock = {}
+    for entry in locked.values():
+        archive_lock[entry.destination[1:]] = (entry.kind, entry.mode, entry.sha256, None, entry.link_target)
+    inspect_member_archive(archive_path, archive_lock, "")
+    if set(manifest) != {entry.destination for entry in locked.values()}:
+        fail("runtime artifact manifest differs from lock")
+    result = []
+    for locked_entry in locked.values():
+        expected = manifest[locked_entry.destination]
+        content = f"sha256:{locked_entry.sha256}" if locked_entry.kind == "file" else "target64:" + base64.b64encode(locked_entry.link_target.encode()).decode()
+        if (expected.kind, expected.mode, expected.uid, expected.gid, expected.content, expected.xattrs, expected.hardlink) != (locked_entry.kind, locked_entry.mode, "0", "0", content, "-", "-"):
+            fail(f"runtime artifact manifest differs from lock: {locked_entry.destination}")
+        result.append(Entry(locked_entry.destination, locked_entry.kind, locked_entry.mode, locked_entry.sha256, locked_entry.link_target, Path(archive_path), locked_entry.destination[1:]))
+    return result
+
+
+def config_entries(inputs, lock_path):
+    lines = checked_bytes(lock_path).decode().splitlines()
+    locked = {}
+    for line in lines:
+        fields = line.split("  ")
+        if len(fields) != 2 or not SHA256.fullmatch(fields[0]) or fields[1] in locked:
+            fail("invalid fixed rootfs policy lock")
+        locked[canonical(fields[1])] = fields[0]
+    if tuple(path for path, _ in inputs) != CONFIG_PATHS or set(locked) != set(CONFIG_PATHS):
+        fail("fixed rootfs configuration differs from policy lock")
+    result = []
+    for relative, source in inputs:
+        source = Path(source)
+        content = checked_bytes(source)
+        digest = hashlib.sha256(content).hexdigest()
+        if digest != locked[relative]:
+            fail(f"fixed configuration hash differs: {relative}")
+        result.append(Entry("/" + relative, "file", "0644", digest, replacement=content))
+    return result
+
+
+@contextlib.contextmanager
+def content(entry):
+    if entry.replacement is not None:
+        yield io.BytesIO(entry.replacement)
+    elif entry.source is not None:
+        with entry.source.open("rb") as stream:
+            yield stream
+    else:
+        with checked_descriptor(entry.archive) as (descriptor, _):
+            with os.fdopen(os.dup(descriptor), "rb") as raw, tarfile.open(fileobj=raw, mode="r:") as archive:
+                stream = archive.extractfile(archive.getmember(entry.member))
+                yield stream
+
+
+class HashReader:
+    def __init__(self, stream):
+        self.stream, self.digest = stream, hashlib.sha256()
+
+    def read(self, size=-1):
+        data = self.stream.read(size)
+        self.digest.update(data)
+        return data
+
+
+def finalize(entries):
+    for path, target in LINKS.items():
+        add(entries, Entry(path, "symlink", "0777", link=target))
+    directories = {"/", *SKELETON}
+    for path in entries:
+        directories.update(str(parent) for parent in PurePosixPath(path).parents if str(parent) != "/")
+    for path in sorted(directories, key=lambda value: value.encode()):
+        if path in entries:
+            if entries[path].kind != "dir":
+                fail(f"directory collides with non-directory: {path}")
+        else:
+            add(entries, Entry(path, "dir", "0755"))
+    symlinks = {path for path, entry in entries.items() if entry.kind == "symlink"}
+    for path in entries:
+        if any(str(parent) in symlinks for parent in PurePosixPath(path).parents):
+            fail(f"symlink ancestor in final rootfs: {path}")
+    non_directories = sum(entry.kind != "dir" for entry in entries.values())
+    if non_directories != 167 or len(directories) != 34 or len(entries) != 201:
+        fail(f"final rootfs inventory differs from fixed 167/34/201 contract: {non_directories}/{len(directories)}/{len(entries)}")
+    modules = {path for path in entries if path.endswith((".ko", ".ko.gz", ".ko.xz", ".ko.zst"))}
+    if modules != rootfs_manifest.REQUIRED_MODULES or any(path == "/usr/lib/modules" or path.startswith("/usr/lib/modules/") for path in entries):
+        fail("final rootfs module inventory differs from fixed contract")
+    if set(entries) & FORBIDDEN_EXACT:
+        fail("final rootfs contains a fixed forbidden path")
+    forbidden_parts = {"systemd", "sysctl.d", "tmpfiles.d", "templates"}
+    if any(forbidden_parts & set(PurePosixPath(path).parts) for path in entries):
+        fail("final rootfs contains forbidden policy or template content")
+    if any("tdx" in PurePosixPath(path).name.lower() and path.endswith((".ko", ".ko.xz", ".ko.zst")) for path in entries):
+        fail("final rootfs contains a TDX module")
+    return entries
+
+
+def manifest_entry(entry):
+    if entry.kind == "file":
+        value = "sha256:" + entry.digest
+    elif entry.kind == "symlink":
+        value = "target64:" + base64.b64encode(entry.link.encode()).decode()
+    else:
+        value = "-"
+    return rootfs_manifest.Entry(entry.path, entry.kind, entry.mode, "0", "0", value, "-", "-")
+
+
+def write_outputs(entries, output_tar, output_manifest):
+    ordered = [entries[path] for path in sorted(entries, key=lambda value: value.encode())]
+    manifest_entries = [manifest_entry(entry) for entry in ordered]
+    violations = rootfs_manifest.policy_violations({entry.path: entry for entry in manifest_entries})
+    if violations:
+        fail("rootfs policy rejected assembly: " + "; ".join(f"{path}: {reason}" for path, reason in violations))
+    temporary_tar = Path(str(output_tar) + ".tmp")
+    temporary_manifest = Path(str(output_manifest) + ".tmp")
+    for path in (Path(output_tar), Path(output_manifest), temporary_tar, temporary_manifest):
+        if path.exists() or path.is_symlink():
+            fail(f"output already exists: {path}")
+    try:
+        with temporary_tar.open("xb") as raw, tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+            for entry in ordered:
+                member = tarfile.TarInfo("." if entry.path == "/" else entry.path[1:])
+                member.mode, member.uid, member.gid, member.uname, member.gname, member.mtime = int(entry.mode, 8), 0, 0, "", "", 0
+                if entry.kind == "dir":
+                    member.type, member.size = tarfile.DIRTYPE, 0
+                    archive.addfile(member)
+                elif entry.kind == "symlink":
+                    member.type, member.linkname, member.size = tarfile.SYMTYPE, entry.link, 0
+                    archive.addfile(member)
+                else:
+                    member.type = tarfile.REGTYPE
+                    if entry.replacement is not None:
+                        member.size = len(entry.replacement)
+                    elif entry.source is not None:
+                        member.size = entry.source.stat().st_size
+                    else:
+                        with checked_descriptor(entry.archive) as (descriptor, _):
+                            with os.fdopen(os.dup(descriptor), "rb") as raw, tarfile.open(fileobj=raw, mode="r:") as source_archive:
+                                member.size = source_archive.getmember(entry.member).size
+                    with content(entry) as stream:
+                        checked = HashReader(stream)
+                        archive.addfile(member, checked)
+                        if checked.digest.hexdigest() != entry.digest:
+                            fail(f"source changed while assembling: {entry.path}")
+        temporary_manifest.write_bytes(rootfs_manifest.serialize(manifest_entries))
+        verify_output(temporary_tar, manifest_entries)
+        os.replace(temporary_tar, output_tar)
+        os.replace(temporary_manifest, output_manifest)
+    except Exception:
+        for path in (temporary_tar, temporary_manifest, Path(output_tar), Path(output_manifest)):
+            with contextlib.suppress(FileNotFoundError):
+                path.unlink()
+        raise
+
+
+def verify_output(path, expected):
+    actual = []
+    with tarfile.open(path, "r:") as archive:
+        for member in archive.getmembers():
+            if member.pax_headers or member.uid or member.gid or member.uname or member.gname or member.mtime:
+                fail(f"non-canonical final archive metadata: {member.name}")
+            destination = "/" if member.name == "." else "/" + canonical(member.name)
+            if member.isdir():
+                actual.append(rootfs_manifest.Entry(destination, "dir", f"{member.mode:04o}", "0", "0", "-", "-", "-"))
+            elif member.issym():
+                safe_link(destination, member.linkname)
+                value = "target64:" + base64.b64encode(member.linkname.encode()).decode()
+                actual.append(rootfs_manifest.Entry(destination, "symlink", f"{member.mode:04o}", "0", "0", value, "-", "-"))
+            elif member.isfile():
+                digest = hashlib.file_digest(archive.extractfile(member), "sha256").hexdigest()
+                actual.append(rootfs_manifest.Entry(destination, "file", f"{member.mode:04o}", "0", "0", "sha256:" + digest, "-", "-"))
+            else:
+                fail(f"forbidden final archive member type: {member.name}")
+    if actual != expected:
+        fail("final archive and manifest differ")
+
+
+def assemble(args):
+    entries = {}
+    for entry in archive_entries(args.package, load_json(args.package_lock), True):
+        add(entries, entry)
+    for entry in archive_entries(args.vendor, load_json(args.vendor_lock), False):
+        add(entries, entry)
+    for entry in runtime_entries(args.runtime_archive, args.runtime_manifest, args.runtime_lock):
+        add(entries, entry)
+    for entry in config_entries(args.config, args.config_lock):
+        add(entries, entry)
+    write_outputs(finalize(entries), args.output_tar, args.output_manifest)
+
+
+def parser():
+    result = argparse.ArgumentParser()
+    result.add_argument("--package-lock", required=True)
+    result.add_argument("--vendor-lock", required=True)
+    result.add_argument("--runtime-lock", required=True)
+    result.add_argument("--runtime-archive", required=True)
+    result.add_argument("--runtime-manifest", required=True)
+    result.add_argument("--config-lock", required=True)
+    result.add_argument("--package", action="append", nargs=2, default=[])
+    result.add_argument("--vendor", action="append", nargs=2, default=[])
+    result.add_argument("--config", action="append", nargs=2, default=[])
+    result.add_argument("--output-tar", required=True)
+    result.add_argument("--output-manifest", required=True)
+    return result
+
+
+def main():
+    try:
+        assemble(parser().parse_args())
+    except (AssemblyError, rootfs_manifest.ManifestError, ValueError, OSError) as error:
+        raise SystemExit(f"rootfs assembly: {error}") from error
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rootfs_assembly.py
+++ b/scripts/rootfs_assembly.py
@@ -169,7 +169,7 @@ def safe_link(path, target):
             depth += 1
 
 
-def lock_entries(files):
+def lock_entries(files, package=False):
     if not isinstance(files, list) or not files:
         fail("locked member list must be non-empty")
     result = {}
@@ -181,6 +181,13 @@ def lock_entries(files):
         mode = raw.get("mode")
         if path in result or kind not in ("file", "symlink") or not isinstance(mode, str) or not MODE.fullmatch(mode):
             fail(f"invalid locked member: {path}")
+        expected_fields = {"path", "type", "mode", "sha256", "size"} if kind == "file" else {"path", "type", "mode", "target"}
+        if package:
+            expected_fields.update(("uid", "gid", "xattrs"))
+        if set(raw) != expected_fields:
+            fail(f"invalid locked member fields: {path}")
+        if package and (type(raw["uid"]) is not int or raw["uid"] != 0 or type(raw["gid"]) is not int or raw["gid"] != 0 or raw["xattrs"] != {}):
+            fail(f"invalid locked package metadata: {path}")
         if kind == "file":
             digest, size, link = raw.get("sha256"), raw.get("size"), "-"
             if not isinstance(digest, str) or not SHA256.fullmatch(digest) or not isinstance(size, int) or isinstance(size, bool) or size < 0:
@@ -301,7 +308,7 @@ def archive_entries(inputs, document, package):
         fail("archive arguments differ from fixed source order")
     result = []
     for (source_id, archive_path), (_, source) in zip(inputs, selected, strict=True):
-        locked = lock_entries(source.get("files"))
+        locked = lock_entries(source.get("files"), package)
         inspect_member_archive(archive_path, locked)
         for path, (kind, mode, digest, _, link) in locked.items():
             if not package and source_id == "nvidia-container-toolkit-base" and path == EXCLUDED:
@@ -426,19 +433,106 @@ def manifest_entry(entry):
     return rootfs_manifest.Entry(entry.path, entry.kind, entry.mode, "0", "0", value, "-", "-")
 
 
+def open_output_parent(path):
+    path = Path(path)
+    name = path.name
+    if not name or name in (".", ".."):
+        fail(f"invalid output path: {path}")
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC | os.O_NOFOLLOW
+    descriptor = os.open("/" if path.is_absolute() else ".", flags)
+    components = path.parent.parts[1:] if path.is_absolute() else path.parent.parts
+    try:
+        for component in components:
+            if component in ("", "."):
+                continue
+            if component == "..":
+                fail(f"output path escapes its starting directory: {path}")
+            following = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = following
+        return descriptor, name
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def require_absent(parent, name, path):
+    try:
+        os.stat(name, dir_fd=parent, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    fail(f"output already exists: {path}")
+
+
+def write_all(descriptor, content):
+    remaining = memoryview(content)
+    while remaining:
+        written = os.write(descriptor, remaining)
+        if not written:
+            fail("output write returned no progress")
+        remaining = remaining[written:]
+
+
+def output_identity(metadata):
+    return metadata.st_dev, metadata.st_ino, metadata.st_mode, metadata.st_uid, metadata.st_gid, metadata.st_size
+
+
+def publish_output(parent, temporary, destination, descriptor, path):
+    expected = output_identity(os.fstat(descriptor))
+    if output_identity(os.stat(temporary, dir_fd=parent, follow_symlinks=False)) != expected:
+        fail(f"temporary output changed before publication: {path}")
+    linked = False
+    try:
+        os.link(temporary, destination, src_dir_fd=parent, dst_dir_fd=parent, follow_symlinks=False)
+        linked = True
+        if output_identity(os.stat(destination, dir_fd=parent, follow_symlinks=False)) != expected:
+            fail(f"published output identity differs: {path}")
+        os.unlink(temporary, dir_fd=parent)
+    except Exception:
+        if linked:
+            unlink_owned(parent, destination, descriptor)
+        raise
+
+
+def unlink_owned(parent, name, descriptor):
+    with contextlib.suppress(FileNotFoundError):
+        current = os.stat(name, dir_fd=parent, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) == (os.fstat(descriptor).st_dev, os.fstat(descriptor).st_ino):
+            os.unlink(name, dir_fd=parent)
+
+
 def write_outputs(entries, output_tar, output_manifest):
     ordered = [entries[path] for path in sorted(entries, key=lambda value: value.encode())]
     manifest_entries = [manifest_entry(entry) for entry in ordered]
     violations = rootfs_manifest.policy_violations({entry.path: entry for entry in manifest_entries})
     if violations:
         fail("rootfs policy rejected assembly: " + "; ".join(f"{path}: {reason}" for path, reason in violations))
-    temporary_tar = Path(str(output_tar) + ".tmp")
-    temporary_manifest = Path(str(output_manifest) + ".tmp")
-    for path in (Path(output_tar), Path(output_manifest), temporary_tar, temporary_manifest):
-        if path.exists() or path.is_symlink():
-            fail(f"output already exists: {path}")
+    output_tar = Path(output_tar)
+    output_manifest = Path(output_manifest)
+    tar_parent, tar_name = open_output_parent(output_tar)
+    manifest_parent, manifest_name = open_output_parent(output_manifest)
+    temporary_tar = tar_name + ".tmp"
+    temporary_manifest = manifest_name + ".tmp"
+    tar_descriptor = manifest_descriptor = None
+    tar_published = manifest_published = False
     try:
-        with temporary_tar.open("xb") as raw, tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as archive:
+        require_absent(tar_parent, tar_name, output_tar)
+        require_absent(tar_parent, temporary_tar, Path(str(output_tar) + ".tmp"))
+        require_absent(manifest_parent, manifest_name, output_manifest)
+        require_absent(manifest_parent, temporary_manifest, Path(str(output_manifest) + ".tmp"))
+        tar_descriptor = os.open(
+            temporary_tar,
+            os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=tar_parent,
+        )
+        manifest_descriptor = os.open(
+            temporary_manifest,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=manifest_parent,
+        )
+        with os.fdopen(os.dup(tar_descriptor), "wb") as raw, tarfile.open(fileobj=raw, mode="w", format=tarfile.USTAR_FORMAT) as archive:
             for entry in ordered:
                 member = tarfile.TarInfo("." if entry.path == "/" else entry.path[1:])
                 member.mode, member.uid, member.gid, member.uname, member.gname, member.mtime = int(entry.mode, 8), 0, 0, "", "", 0
@@ -463,20 +557,39 @@ def write_outputs(entries, output_tar, output_manifest):
                         archive.addfile(member, checked)
                         if checked.digest.hexdigest() != entry.digest:
                             fail(f"source changed while assembling: {entry.path}")
-        temporary_manifest.write_bytes(rootfs_manifest.serialize(manifest_entries))
-        verify_output(temporary_tar, manifest_entries)
-        os.replace(temporary_tar, output_tar)
-        os.replace(temporary_manifest, output_manifest)
+        os.fchmod(tar_descriptor, 0o644)
+        os.fsync(tar_descriptor)
+        write_all(manifest_descriptor, rootfs_manifest.serialize(manifest_entries))
+        os.fchmod(manifest_descriptor, 0o644)
+        os.fsync(manifest_descriptor)
+        verify_output(tar_descriptor, manifest_entries)
+        publish_output(tar_parent, temporary_tar, tar_name, tar_descriptor, output_tar)
+        tar_published = True
+        publish_output(manifest_parent, temporary_manifest, manifest_name, manifest_descriptor, output_manifest)
+        manifest_published = True
     except Exception:
-        for path in (temporary_tar, temporary_manifest, Path(output_tar), Path(output_manifest)):
-            with contextlib.suppress(FileNotFoundError):
-                path.unlink()
+        if tar_descriptor is not None:
+            unlink_owned(tar_parent, temporary_tar, tar_descriptor)
+            if tar_published:
+                unlink_owned(tar_parent, tar_name, tar_descriptor)
+        if manifest_descriptor is not None:
+            unlink_owned(manifest_parent, temporary_manifest, manifest_descriptor)
+            if manifest_published:
+                unlink_owned(manifest_parent, manifest_name, manifest_descriptor)
         raise
+    finally:
+        if tar_descriptor is not None:
+            os.close(tar_descriptor)
+        if manifest_descriptor is not None:
+            os.close(manifest_descriptor)
+        os.close(tar_parent)
+        os.close(manifest_parent)
 
 
-def verify_output(path, expected):
+def verify_output(descriptor, expected):
     actual = []
-    with tarfile.open(path, "r:") as archive:
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    with os.fdopen(os.dup(descriptor), "rb") as raw, tarfile.open(fileobj=raw, mode="r:") as archive:
         for member in archive.getmembers():
             if member.pax_headers or member.uid or member.gid or member.uname or member.gname or member.mtime:
                 fail(f"non-canonical final archive metadata: {member.name}")

--- a/scripts/rootfs_assembly_output_test.py
+++ b/scripts/rootfs_assembly_output_test.py
@@ -21,7 +21,7 @@ class OutputContractTest(unittest.TestCase):
 
     def test_exact_modules_and_explicit_absence(self):
         entries = rootfs_manifest.parse_manifest(self.manifest)
-        modules = {path for path in entries if path.endswith((".ko", ".ko.xz", ".ko.zst"))}
+        modules = {path for path in entries if path.endswith(rootfs_manifest.MODULE_SUFFIXES)}
         self.assertEqual(modules, rootfs_manifest.REQUIRED_MODULES)
         forbidden = (
             "/usr/lib/modules", "/etc/systemd", "/usr/lib/systemd", "/etc/sysctl.d",

--- a/scripts/rootfs_assembly_output_test.py
+++ b/scripts/rootfs_assembly_output_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+import argparse
+import tarfile
+import unittest
+from pathlib import Path
+
+from scripts import rootfs_manifest
+
+
+class OutputContractTest(unittest.TestCase):
+    archive = None
+    manifest = None
+
+    def test_exact_inventory_and_policy(self):
+        entries = rootfs_manifest.parse_manifest(self.manifest)
+        self.assertEqual(len(entries), 201)
+        self.assertEqual(sum(entry.kind == "dir" for entry in entries.values()), 34)
+        self.assertEqual(sum(entry.kind != "dir" for entry in entries.values()), 167)
+        self.assertEqual(rootfs_manifest.policy_violations(entries), [])
+
+    def test_exact_modules_and_explicit_absence(self):
+        entries = rootfs_manifest.parse_manifest(self.manifest)
+        modules = {path for path in entries if path.endswith((".ko", ".ko.xz", ".ko.zst"))}
+        self.assertEqual(modules, rootfs_manifest.REQUIRED_MODULES)
+        forbidden = (
+            "/usr/lib/modules", "/etc/systemd", "/usr/lib/systemd", "/etc/sysctl.d",
+            "/usr/lib/sysctl.d", "/etc/tmpfiles.d", "/usr/lib/tmpfiles.d", "/etc/tinfoil/templates",
+            "/usr/share/tinfoil/templates", "/usr/bin/nvidia-smi", "/usr/bin/docker-init",
+            "/usr/bin/nvidia-container-runtime-hook", "/etc/ld.so.cache", "/usr/sbin/iptables",
+            "/usr/sbin/ip6tables", "/usr/sbin/xtables-nft-multi", "/bin/sh", "/usr/bin/sh",
+        )
+        for path in entries:
+            self.assertFalse(any(path == item or path.startswith(item + "/") for item in forbidden), path)
+
+    def test_archive_is_global_byte_ordered_ustar(self):
+        entries = rootfs_manifest.parse_manifest(self.manifest)
+        with tarfile.open(self.archive, "r:") as archive:
+            members = archive.getmembers()
+            paths = ["/" if member.name == "." else "/" + member.name for member in members]
+            self.assertEqual(paths, sorted(entries, key=lambda path: path.encode()))
+            self.assertEqual(set(paths), set(entries))
+            for member in members:
+                self.assertEqual((member.uid, member.gid, member.uname, member.gname, member.mtime), (0, 0, "", "", 0))
+                self.assertEqual(member.pax_headers, {})
+
+
+if __name__ == "__main__":
+    arguments = argparse.ArgumentParser()
+    arguments.add_argument("--outputs", nargs=2, required=True)
+    parsed, remaining = arguments.parse_known_args()
+    outputs = {Path(path).suffix: Path(path) for path in parsed.outputs}
+    OutputContractTest.archive = outputs[".tar"]
+    OutputContractTest.manifest = outputs[".tsv"]
+    unittest.main(argv=[__file__, *remaining])

--- a/scripts/rootfs_assembly_test.py
+++ b/scripts/rootfs_assembly_test.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+
+import hashlib
+import io
+import json
+import os
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import rootfs_assembly
+
+
+class RootfsAssemblyTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def archive(self, name="member", content=b"payload", kind=tarfile.REGTYPE, pax=None):
+        path = self.root / "input.tar"
+        with tarfile.open(path, "w", format=tarfile.PAX_FORMAT if pax else tarfile.GNU_FORMAT) as archive:
+            member = tarfile.TarInfo(name)
+            member.mode = 0o644
+            member.uid = member.gid = 0
+            member.uname = member.gname = "root"
+            member.mtime = 0
+            member.type = kind
+            member.pax_headers = pax or {}
+            if kind == tarfile.REGTYPE:
+                member.size = len(content)
+                archive.addfile(member, io.BytesIO(content))
+            else:
+                archive.addfile(member)
+        return path
+
+    def locked(self, content=b"payload"):
+        return {"member": ("file", "0644", hashlib.sha256(content).hexdigest(), len(content), "-")}
+
+    def test_fixed_input_cardinality(self):
+        self.assertEqual(len(rootfs_assembly.PACKAGE_IDS), 35)
+        self.assertEqual(len(rootfs_assembly.VENDOR_IDS), 11)
+        self.assertEqual(len(rootfs_assembly.CONFIG_PATHS), 12)
+
+    def test_duplicate_destination_fails_even_when_identical(self):
+        entries = {}
+        entry = rootfs_assembly.Entry("/same", "file", "0644", "0" * 64)
+        rootfs_assembly.add(entries, entry)
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "duplicate"):
+            rootfs_assembly.add(entries, entry)
+
+    def test_non_directory_ancestor_fails(self):
+        entries = {"/parent": rootfs_assembly.Entry("/parent", "symlink", "0777", link="target")}
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "ancestor"):
+            rootfs_assembly.add(entries, rootfs_assembly.Entry("/parent/child", "file", "0644"))
+
+    def test_archive_content_mutation_fails(self):
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "content differs"):
+            rootfs_assembly.inspect_member_archive(self.archive(content=b"changed"), self.locked())
+
+    def test_archive_missing_and_extra_members_fail(self):
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "inventory differs"):
+            rootfs_assembly.inspect_member_archive(self.archive(), {**self.locked(), "other": self.locked()["member"]})
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "differs from lock"):
+            rootfs_assembly.inspect_member_archive(self.archive(name="extra"), self.locked())
+
+    def test_concatenated_tar_archive_fails(self):
+        archive = self.archive()
+        archive.write_bytes(archive.read_bytes() * 2)
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "length differs"):
+            rootfs_assembly.inspect_member_archive(archive, self.locked())
+
+    def test_trailing_archive_garbage_fails(self):
+        archive = self.archive()
+        archive.write_bytes(archive.read_bytes() + b"garbage")
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "length differs"):
+            rootfs_assembly.inspect_member_archive(archive, self.locked())
+
+    def test_nonzero_archive_trailer_fails(self):
+        archive = self.archive()
+        data = bytearray(archive.read_bytes())
+        data[-1] = 1
+        archive.write_bytes(data)
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "non-zero trailer"):
+            rootfs_assembly.inspect_member_archive(archive, self.locked())
+
+    def test_bazel_sandbox_absolute_input_symlink_is_accepted(self):
+        source = self.root / "source"
+        source.write_bytes(b"payload")
+        sandbox = self.root / "sandbox" / "execroot"
+        sandbox.mkdir(parents=True)
+        (sandbox / "input").symlink_to(source)
+        previous = Path.cwd()
+        try:
+            os.chdir(sandbox)
+            self.assertEqual(rootfs_assembly.checked_bytes(Path("input")), b"payload")
+        finally:
+            os.chdir(previous)
+
+    def test_forbidden_tar_types_fail(self):
+        for kind in (tarfile.LNKTYPE, tarfile.CHRTYPE, tarfile.BLKTYPE, tarfile.FIFOTYPE):
+            with self.subTest(kind=kind), self.assertRaisesRegex(rootfs_assembly.AssemblyError, "forbidden"):
+                rootfs_assembly.inspect_member_archive(self.archive(kind=kind), self.locked())
+
+    def test_pax_and_xattr_metadata_fails(self):
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "invalid or duplicate"):
+            rootfs_assembly.inspect_member_archive(self.archive(pax={"SCHILY.xattr.user.test": "value"}), self.locked())
+
+    def test_traversal_and_absolute_members_fail(self):
+        for name in ("../escape", "/absolute", "a//b", "./alias"):
+            with self.subTest(name=name), self.assertRaises(rootfs_assembly.AssemblyError):
+                rootfs_assembly.inspect_member_archive(self.archive(name=name), self.locked())
+
+    def test_source_set_missing_and_extra_fail_before_archive_access(self):
+        package_lock = {"version": 1, "sources": {source_id: {"files": []} for source_id in rootfs_assembly.PACKAGE_IDS}}
+        package_inputs = [(source_id, "missing") for source_id in rootfs_assembly.PACKAGE_IDS]
+        for mutation in (lambda value: value[:-1], lambda value: value + [("extra", "missing")]):
+            with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "source order"):
+                rootfs_assembly.archive_entries(mutation(package_inputs), package_lock, True)
+        package_lock["sources"]["extra"] = {"files": []}
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "source set"):
+            rootfs_assembly.archive_entries(package_inputs, package_lock, True)
+
+    def test_config_symlink_and_content_mutation_fail(self):
+        source = self.root / "config"
+        source.write_bytes(b"fixed")
+        source.chmod(0o644)
+        lock = self.root / "policy"
+        digest = hashlib.sha256(b"fixed").hexdigest()
+        lock.write_text("".join(f"{digest}  {path}\n" for path in rootfs_assembly.CONFIG_PATHS))
+        inputs = [(path, source) for path in rootfs_assembly.CONFIG_PATHS]
+        self.assertEqual(len(rootfs_assembly.config_entries(inputs, lock)), 12)
+        source.write_bytes(b"mutated")
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "hash differs"):
+            rootfs_assembly.config_entries(inputs, lock)
+        source.write_bytes(b"fixed")
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "configuration differs"):
+            rootfs_assembly.config_entries(inputs[:-1], lock)
+        link = self.root / "link"
+        link.symlink_to(source)
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "unsafe input path"):
+            rootfs_assembly.checked_bytes(link)
+
+    def test_lock_metadata_must_be_canonical(self):
+        base = {"path": "member", "type": "file", "mode": "0644", "sha256": "a" * 64, "size": 1}
+        for field, value in (("mode", "644"), ("mode", "0688"), ("sha256", "A" * 64), ("size", -1), ("size", True)):
+            mutated = {**base, field: value}
+            with self.subTest(field=field, value=value), self.assertRaises(rootfs_assembly.AssemblyError):
+                rootfs_assembly.lock_entries([mutated])
+        with self.assertRaises(rootfs_assembly.AssemblyError):
+            rootfs_assembly.lock_entries([{"path": "link", "type": "symlink", "mode": "0777", "target": "../../escape"}])
+
+    def test_vendor_arguments_and_source_set_are_exact(self):
+        sources = [{"id": source_id, "files": []} for source_id in (*rootfs_assembly.VENDOR_IDS, "nvidia-container-toolkit")]
+        lock = {"version": 1, "sources": sources}
+        inputs = [(source_id, "missing") for source_id in rootfs_assembly.VENDOR_IDS]
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "source order"):
+            rootfs_assembly.archive_entries(inputs[:-1], lock, False)
+        lock["sources"] = sources[:-1]
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "source set"):
+            rootfs_assembly.archive_entries(inputs, lock, False)
+
+    def test_runtime_archive_manifest_mutations_fail(self):
+        archive = Path("image/runtime-artifact-members.tar")
+        manifest = Path("image/runtime-artifact-members.tsv")
+        lock = Path("image/manifests/rootfs-artifacts.lock.tsv")
+        if not archive.exists():
+            self.skipTest("runtime artifact inputs are provided by Bazel integration")
+        self.assertEqual(len(rootfs_assembly.runtime_entries(archive, manifest, lock)), 12)
+        mutated_manifest = self.root / "runtime.tsv"
+        text = manifest.read_text()
+        mutated_manifest.write_text(text.replace("sha256:", "sha256:0", 1))
+        mutated_manifest.chmod(0o644)
+        with self.assertRaises(ValueError):
+            rootfs_assembly.runtime_entries(archive, mutated_manifest, lock)
+        mutated_archive = self.root / "runtime.tar"
+        data = bytearray(archive.read_bytes())
+        with tarfile.open(archive, "r:") as bundle:
+            member = next(member for member in bundle.getmembers() if member.isfile())
+            data[member.offset_data] ^= 1
+        mutated_archive.write_bytes(data)
+        mutated_archive.chmod(0o644)
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "content differs"):
+            rootfs_assembly.runtime_entries(mutated_archive, manifest, lock)
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "unsafe input"):
+            rootfs_assembly.runtime_entries(self.root / "missing.tar", manifest, lock)
+
+    def test_fabricmanager_hash_occurrence_and_diff(self):
+        content = self.real_fabricmanager()
+        transformed = rootfs_assembly.transform_fabricmanager(content)
+        self.assertEqual(hashlib.sha256(transformed).hexdigest(), rootfs_assembly.FM_OUTPUT)
+        self.assertEqual(content.replace(rootfs_assembly.FM_BEFORE, rootfs_assembly.FM_AFTER), transformed)
+        for mutation in (content + b"x", content.replace(rootfs_assembly.FM_BEFORE, b"")):
+            with self.assertRaises(rootfs_assembly.AssemblyError):
+                rootfs_assembly.transform_fabricmanager(mutation)
+
+    def real_fabricmanager(self):
+        lock = json.loads(Path("image/runtime-sources.lock.json").read_text())
+        source = next(source for source in lock["sources"] if source["id"] == "nvidia-fabricmanager")
+        entry = next(entry for entry in source["files"] if entry["path"] == rootfs_assembly.FM_PATH[1:])
+        self.assertEqual(entry["sha256"], rootfs_assembly.FM_INPUT)
+        archive = Path("image") / "nvidia_fabricmanager-members.tar"
+        if not archive.exists():
+            self.skipTest("focused source archive is provided by Bazel integration")
+        with tarfile.open(archive, "r:") as bundle:
+            return bundle.extractfile(bundle.getmember(entry["path"])).read()
+
+    def test_failure_before_publication_leaves_no_outputs(self):
+        output_tar, output_manifest = self.root / "out.tar", self.root / "out.tsv"
+        with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "policy"):
+            rootfs_assembly.write_outputs({"/": rootfs_assembly.Entry("/", "dir", "0755")}, output_tar, output_manifest)
+        self.assertFalse(output_tar.exists())
+        self.assertFalse(output_manifest.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/rootfs_assembly_test.py
+++ b/scripts/rootfs_assembly_test.py
@@ -8,6 +8,7 @@ import tarfile
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from scripts import rootfs_assembly
 
@@ -153,6 +154,19 @@ class RootfsAssemblyTest(unittest.TestCase):
         with self.assertRaises(rootfs_assembly.AssemblyError):
             rootfs_assembly.lock_entries([{"path": "link", "type": "symlink", "mode": "0777", "target": "../../escape"}])
 
+    def test_package_lock_ownership_and_xattrs_are_exact(self):
+        base = {
+            "path": "member", "type": "file", "mode": "0644", "sha256": "a" * 64,
+            "size": 1, "uid": 0, "gid": 0, "xattrs": {},
+        }
+        self.assertEqual(rootfs_assembly.lock_entries([base], True)["member"][:3], ("file", "0644", "a" * 64))
+        for field, value in (("uid", 1), ("uid", False), ("gid", 1), ("gid", False), ("xattrs", {"user.test": "value"})):
+            with self.subTest(field=field, value=value), self.assertRaisesRegex(rootfs_assembly.AssemblyError, "package metadata"):
+                rootfs_assembly.lock_entries([{**base, field: value}], True)
+        for mutation in ({key: value for key, value in base.items() if key != "uid"}, {**base, "extra": 1}):
+            with self.assertRaisesRegex(rootfs_assembly.AssemblyError, "member fields"):
+                rootfs_assembly.lock_entries([mutation], True)
+
     def test_vendor_arguments_and_source_set_are_exact(self):
         sources = [{"id": source_id, "files": []} for source_id in (*rootfs_assembly.VENDOR_IDS, "nvidia-container-toolkit")]
         lock = {"version": 1, "sources": sources}
@@ -214,6 +228,20 @@ class RootfsAssemblyTest(unittest.TestCase):
             rootfs_assembly.write_outputs({"/": rootfs_assembly.Entry("/", "dir", "0755")}, output_tar, output_manifest)
         self.assertFalse(output_tar.exists())
         self.assertFalse(output_manifest.exists())
+
+    def test_output_parent_symlink_is_rejected(self):
+        outside = self.root / "outside"
+        outside.mkdir()
+        link = self.root / "link"
+        link.symlink_to(outside, target_is_directory=True)
+        with mock.patch.object(rootfs_assembly.rootfs_manifest, "policy_violations", return_value=[]):
+            with self.assertRaises(OSError):
+                rootfs_assembly.write_outputs(
+                    {"/": rootfs_assembly.Entry("/", "dir", "0755")},
+                    link / "rootfs.tar",
+                    link / "rootfs.tsv",
+                )
+        self.assertEqual(list(outside.iterdir()), [])
 
 
 if __name__ == "__main__":

--- a/scripts/rootfs_manifest.py
+++ b/scripts/rootfs_manifest.py
@@ -682,6 +682,10 @@ def parse_manifest(path: Path) -> dict[str, Entry]:
         data = path.read_bytes()
     except OSError as error:
         fail(f"cannot read manifest {path}: {error}")
+    return parse_content(path, data)
+
+
+def parse_content(path: Path, data: bytes) -> dict[str, Entry]:
     if not data:
         fail(f"{path}: manifest is empty")
     if not data.endswith(b"\n"):

--- a/scripts/test-rootfs-assembly-structure.sh
+++ b/scripts/test-rootfs-assembly-structure.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+
+files=(image/rootfs.bzl scripts/rootfs_assembly.py)
+for forbidden in 'rules_'"pkg" 'flat'"ten(" 'dedup'"licate" 'glob'"(" 'local_'"repository" \
+    'new_local_'"repository" 'local_path_'"override" '--override_'"repository" 'get'"env("; do
+    if grep -Fq -- "$forbidden" "${files[@]}"; then
+        echo "forbidden assembly mechanism: $forbidden" >&2
+        exit 1
+    fi
+done
+
+grep -Fq 'name = "rootfs"' image/BUILD.bazel
+grep -Fq '"_packages": attr.label_list' image/rootfs.bzl
+grep -Fq '"_vendors": attr.label_list' image/rootfs.bzl
+grep -Fq '"_runtime": attr.label' image/rootfs.bzl
+if grep -Eq '^[[:space:]]*"(packages|vendors|runtime|configs|sources|destinations)"[[:space:]]*:' image/rootfs.bzl; then
+    echo "assembly inputs must remain private and fixed" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- assemble the measured guest rootfs from fixed authenticated package, vendor, configuration, and runtime-artifact inputs
- expose no configurable source/path mechanism in the Bazel rule
- emit a deterministic globally byte-ordered ustar archive plus its exact manifest
- reject malformed, concatenated, padded, duplicate, and contract-drifting archives fail closed

## Fixed contract
- exactly 201 entries: 34 directories and 167 non-directories
- exactly the three pinned NVIDIA modules under `/usr/lib/tinfoil/kernel-modules`
- explicitly excludes systemd, shells, generic NVIDIA hooks/tools, legacy module trees, and other forbidden runtime paths

## Validation
- Python compile and 19 focused unit/adversarial tests (2 output-dependent skips outside Bazel)
- `bazel test //...` (9/9 tests pass)
- two independent Bazel output roots produced byte-identical rootfs TAR and TSV
- TAR SHA-256: `9890f3ec91788fb9b5bfdb1d17dcd197ba5352a55b10d6b11b393dc64fc84266`
- TSV SHA-256: `ffee35909230835001cb2bb86d99633ad37b5c5a84b37166679df1e4c1fd9d17`
- `go build ./...`, `go test ./...`, `go test -race ./...`, and `go vet ./...`
- shell syntax, shellcheck, and `git diff --check`

## Stack order
Depends on #209. Merge order is **#207 → #208 → #209 → this PR**. Normal PR CI intentionally does not include temporary stacked base branches; full CI will run after rebasing this commit onto `jules/harden-tcb`. Expensive reproducibility proofs remain explicit offline/release gates rather than automatic PR CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fixed Bazel `rootfs` rule and Python tool that assemble the measured guest rootfs from authenticated inputs. Hardens contracts and verification to ensure a deterministic ustar TAR and exact manifest with strict, fail-closed checks.

- **New Features**
  - Provides `//image:rootfs` via `image/rootfs.bzl` and the `//scripts:rootfs_assembly` tool; no configurable sources or paths in the rule.
  - Emits `rootfs.tar` and `rootfs.tsv`, verifies the final archive matches the manifest, and enforces global byte order, ustar format, and zero trailer.
  - Validates package/vendor/runtime archives and locks (including fixed source order); rejects PAX/xattrs, non-canonical offsets/padding, concatenated or padded tars, duplicates, and any contract drift. Cross-checks the runtime artifact manifest with its lock.
  - Enforces the exact inventory: 201 entries (34 dirs, 167 non-dirs); only the three pinned NVIDIA modules under `/usr/lib/tinfoil/kernel-modules`; forbids systemd, shells, iptables, legacy `/usr/lib/modules`, TDX modules, and other fixed forbidden paths.
  - Applies a fixed transform to Fabric Manager config and checks input/output SHA-256.
  - Adds unit and output-contract tests and a structure `sh_test` that forbids dynamic assembly mechanisms; updates `scripts/rootfs_manifest.py` with `parse_content` to support manifest parsing.

<sup>Written for commit 1bb61de44a3076f5ab2b8d15861ecb8f6389f892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

