### PR TITLE
Test the measured containerd policy path

### DIFF
--- a/scripts/test-containerd-config.sh
+++ b/scripts/test-containerd-config.sh
@@ -15,7 +15,7 @@ fi
 
 repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 containerd="$1"
-config="$repo_dir/mkosi.extra/etc/containerd/config.toml"
+config="$repo_dir/image/rootfs/etc/containerd/config.toml"
 scratch="$(mktemp -d /tmp/tinfoil-containerd-policy.XXXXXX)"
 active_pid=""
 
@@ -51,7 +51,7 @@ if [[ "$actual_config_sha256" != "$expected_config_digest" ]]; then
     echo "containerd config digest mismatch" >&2
     exit 1
 fi
-if [[ -e "$repo_dir/mkosi.extra/etc/containerd/conf.d" ]]; then
+if [[ -e "$repo_dir/image/rootfs/etc/containerd/conf.d" ]]; then
     echo "containerd drop-in directory is not part of the measured policy" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary
- point the containerd policy test at the additive measured rootfs config
- check the measured config directory for forbidden drop-ins
- leave the byte-identical legacy copy untouched for the later shipping cutover

## Review boundary
This is a two-line test-only path correction. It is independent of the ordered #207-#211 artifact stack and may merge at any time.

## Validation
- confirmed the legacy and measured config files are byte-identical on `jules/harden-tcb`
- `bash -n scripts/test-containerd-config.sh`
- `git diff --check`

The host provides containerd 2.2.2 rather than the pinned 2.2.4 binary, so the full runtime policy test correctly stopped at its version gate. The shipping integration was previously validated with the extracted pinned binary.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point the test to the measured rootfs `containerd` config and enforce the policy by failing if `conf.d` drop-ins exist. The legacy config remains unchanged for the later shipping cutover.

<sup>Written for commit 65bdf26f0bbda67c7acdfe38786615c2c6630ef3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

