### PR TITLE
Irreversibly lock kernel module loading

### DIFF
--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -94,18 +94,19 @@ type serviceControl interface {
 }
 
 type lifecycleDeps struct {
-	services serviceControl
-	oneShot  func(context.Context, supervisor.Command) error
-	nvidia   func(context.Context) error
-	setupFS  func(pidruntime.LogFunc) error
-	sysctls  func(pidruntime.LogFunc) error
-	ramdisk  func(pidruntime.LogFunc) error
-	limits   func() error
-	syslog   func(context.Context)
-	exists   func(string) (bool, error)
-	timeout  time.Duration
-	term     time.Duration
-	kill     time.Duration
+	services    serviceControl
+	oneShot     func(context.Context, supervisor.Command) error
+	nvidia      func(context.Context) error
+	lockModules func() error
+	setupFS     func(pidruntime.LogFunc) error
+	sysctls     func(pidruntime.LogFunc) error
+	ramdisk     func(pidruntime.LogFunc) error
+	limits      func() error
+	syslog      func(context.Context)
+	exists      func(string) (bool, error)
+	timeout     time.Duration
+	term        time.Duration
+	kill        time.Duration
 }
 
 func run(parent context.Context) error {
@@ -129,15 +130,16 @@ func run(parent context.Context) error {
 				},
 			)
 		},
-		setupFS: pidruntime.SetupFilesystems,
-		sysctls: pidruntime.ApplySysctls,
-		ramdisk: pidruntime.SetupRamdisk,
-		limits:  hardening.ApplyRuntimeLimits,
-		syslog:  startOptionalSyslogSink,
-		exists:  pathExists,
-		timeout: bootTimeout,
-		term:    serviceTermGrace,
-		kill:    serviceKillGrace,
+		lockModules: hardening.LockKernelModules,
+		setupFS:     pidruntime.SetupFilesystems,
+		sysctls:     pidruntime.ApplySysctls,
+		ramdisk:     pidruntime.SetupRamdisk,
+		limits:      hardening.ApplyRuntimeLimits,
+		syslog:      startOptionalSyslogSink,
+		exists:      pathExists,
+		timeout:     bootTimeout,
+		term:        serviceTermGrace,
+		kill:        serviceKillGrace,
 	}
 	return runLifecycle(parent, deps, readiness)
 }
@@ -175,6 +177,9 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	}
 	if err := deps.nvidia(bootCtx); err != nil {
 		return err
+	}
+	if err := deps.lockModules(); err != nil {
+		return fmt.Errorf("lock kernel modules: %w", err)
 	}
 	if err := deps.oneShot(bootCtx, command("nftables", "/usr/sbin/nft", "-f", "/etc/nftables.conf")); err != nil {
 		return err

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -83,14 +83,15 @@ func newLifecycleHarness() *lifecycleHarness {
 	harness.services.observe = harness.readiness.Update
 	noSetup := func(pidruntime.LogFunc) error { return nil }
 	harness.deps = lifecycleDeps{
-		services: harness.services,
-		oneShot:  func(context.Context, supervisor.Command) error { return nil },
-		nvidia:   func(context.Context) error { return nil },
-		setupFS:  noSetup,
-		sysctls:  noSetup,
-		ramdisk:  noSetup,
-		limits:   func() error { return nil },
-		syslog:   func(context.Context) {},
+		services:    harness.services,
+		oneShot:     func(context.Context, supervisor.Command) error { return nil },
+		nvidia:      func(context.Context) error { return nil },
+		lockModules: func() error { return nil },
+		setupFS:     noSetup,
+		sysctls:     noSetup,
+		ramdisk:     noSetup,
+		limits:      func() error { return nil },
+		syslog:      func(context.Context) {},
 		exists: func(path string) (bool, error) {
 			return harness.existing[path], nil
 		},
@@ -416,6 +417,10 @@ func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
 		record("nvidia-bootstrap")
 		return nil
 	}
+	harness.deps.lockModules = func() error {
+		record("module-lock")
+		return nil
+	}
 	harness.services.onStart = record
 	parent, cancel := context.WithCancel(context.Background())
 	result := make(chan error, 1)
@@ -431,9 +436,37 @@ func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
 	defer mu.Unlock()
 	loopback := slices.Index(events, "loopback")
 	bootstrap := slices.Index(events, "nvidia-bootstrap")
+	lock := slices.Index(events, "module-lock")
+	nftables := slices.Index(events, "nftables")
 	containerd := slices.Index(events, containerdName)
-	if loopback < 0 || bootstrap != loopback+1 || containerd <= bootstrap {
+	if loopback < 0 || bootstrap != loopback+1 || lock != bootstrap+1 || nftables != lock+1 || containerd <= nftables {
 		t.Fatalf("startup events = %v", events)
+	}
+}
+
+func TestModuleLockFailureStopsBootBeforeServices(t *testing.T) {
+	harness := newLifecycleHarness()
+	lockErr := errors.New("module lock failed")
+	var mu sync.Mutex
+	var events []string
+	harness.deps.oneShot = func(_ context.Context, command supervisor.Command) error {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, command.Name)
+		return nil
+	}
+	harness.deps.lockModules = func() error { return lockErr }
+	err := runLifecycle(context.Background(), harness.deps, harness.readiness)
+	if !errors.Is(err, lockErr) {
+		t.Fatalf("runLifecycle error = %v, want module lock failure", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if slices.Contains(events, "nftables") {
+		t.Fatalf("nftables ran despite module lock failure: %v", events)
+	}
+	if len(harness.services.started) != 0 {
+		t.Fatalf("services started despite module lock failure: %v", harness.services.started)
 	}
 }
 

--- a/tinfoil/internal/pid1/hardening/module_lock.go
+++ b/tinfoil/internal/pid1/hardening/module_lock.go
@@ -1,0 +1,71 @@
+package hardening
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const modulesDisabledPath = "/proc/sys/kernel/modules_disabled"
+
+// LockKernelModules irreversibly closes the kernel module-loading interface
+// before general services start. The kernel enforces the transition globally
+// and checks it before CAP_SYS_MODULE, so no later process can load or
+// unload a module regardless of its capabilities.
+func LockKernelModules() error {
+	return lockKernelModules(linuxModuleLockKernel{})
+}
+
+type moduleLockKernel interface {
+	writeModulesDisabled([]byte) (int, error)
+	readModulesDisabled() ([]byte, error)
+}
+
+func lockKernelModules(kernel moduleLockKernel) error {
+	value := []byte("1\n")
+	written, err := kernel.writeModulesDisabled(value)
+	if err != nil {
+		return fmt.Errorf("write %s: %w", modulesDisabledPath, err)
+	}
+	if written != len(value) {
+		return fmt.Errorf("write %s: wrote %d of %d bytes", modulesDisabledPath, written, len(value))
+	}
+	state, err := kernel.readModulesDisabled()
+	if err != nil {
+		return fmt.Errorf("read back %s: %w", modulesDisabledPath, err)
+	}
+	if strings.TrimSpace(string(state)) != "1" {
+		return fmt.Errorf("verify %s: got %q, want 1", modulesDisabledPath, strings.TrimSpace(string(state)))
+	}
+	return nil
+}
+
+type linuxModuleLockKernel struct{}
+
+func (linuxModuleLockKernel) writeModulesDisabled(value []byte) (int, error) {
+	descriptor, err := unix.Open(modulesDisabledPath, unix.O_WRONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return 0, err
+	}
+	written, writeErr := unix.Write(descriptor, value)
+	closeErr := unix.Close(descriptor)
+	if writeErr != nil {
+		return written, writeErr
+	}
+	return written, closeErr
+}
+
+func (linuxModuleLockKernel) readModulesDisabled() ([]byte, error) {
+	descriptor, err := unix.Open(modulesDisabledPath, unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return nil, err
+	}
+	buffer := make([]byte, 16)
+	read, readErr := unix.Read(descriptor, buffer)
+	closeErr := unix.Close(descriptor)
+	if readErr != nil {
+		return nil, readErr
+	}
+	return buffer[:read], closeErr
+}

--- a/tinfoil/internal/pid1/hardening/module_lock_test.go
+++ b/tinfoil/internal/pid1/hardening/module_lock_test.go
@@ -1,0 +1,77 @@
+package hardening
+
+import (
+	"errors"
+	"slices"
+	"testing"
+)
+
+func TestLockKernelModules(t *testing.T) {
+	kernel := &fakeModuleLockKernel{readback: []byte("1\n")}
+	if err := lockKernelModules(kernel); err != nil {
+		t.Fatal(err)
+	}
+	wantCalls := []string{"write:1\n", "read-modules-disabled"}
+	if !slices.Equal(kernel.calls, wantCalls) {
+		t.Fatalf("calls = %q, want %q", kernel.calls, wantCalls)
+	}
+}
+
+func TestLockKernelModulesRejectsUnverifiedState(t *testing.T) {
+	kernel := &fakeModuleLockKernel{readback: []byte("0\n")}
+	err := lockKernelModules(kernel)
+	if err == nil || !slices.Equal(kernel.calls, []string{"write:1\n", "read-modules-disabled"}) {
+		t.Fatalf("lockKernelModules = %v, calls = %v", err, kernel.calls)
+	}
+}
+
+func TestLockKernelModulesRejectsShortWrite(t *testing.T) {
+	kernel := &fakeModuleLockKernel{writeCount: 1, readback: []byte("1\n")}
+	err := lockKernelModules(kernel)
+	if err == nil || !slices.Equal(kernel.calls, []string{"write:1\n"}) {
+		t.Fatalf("lockKernelModules = %v, calls = %v", err, kernel.calls)
+	}
+}
+
+func TestLockKernelModulesFailsClosedOnFileErrors(t *testing.T) {
+	for _, failCall := range []string{"write:1\n", "read-modules-disabled"} {
+		t.Run(failCall, func(t *testing.T) {
+			kernel := &fakeModuleLockKernel{readback: []byte("1\n"), failCall: failCall}
+			if err := lockKernelModules(kernel); err == nil {
+				t.Fatal("lockKernelModules succeeded")
+			}
+		})
+	}
+}
+
+type fakeModuleLockKernel struct {
+	calls      []string
+	readback   []byte
+	writeCount int
+	failCall   string
+}
+
+func (k *fakeModuleLockKernel) record(call string) error {
+	k.calls = append(k.calls, call)
+	if call == k.failCall {
+		return errors.New("injected failure")
+	}
+	return nil
+}
+
+func (k *fakeModuleLockKernel) writeModulesDisabled(value []byte) (int, error) {
+	if err := k.record("write:" + string(value)); err != nil {
+		return 0, err
+	}
+	if k.writeCount != 0 {
+		return k.writeCount, nil
+	}
+	return len(value), nil
+}
+
+func (k *fakeModuleLockKernel) readModulesDisabled() ([]byte, error) {
+	if err := k.record("read-modules-disabled"); err != nil {
+		return nil, err
+	}
+	return k.readback, nil
+}


### PR DESCRIPTION
## Summary
- irreversibly set and verify `kernel.modules_disabled=1` after the complete NVIDIA/no-GPU bootstrap
- fail boot before nftables, containerd, Docker, or measured workload processing if the transition cannot be verified

## Security contract
The measured root contains the only accepted NVIDIA module inventory. Once that fixed inventory has loaded, `modules_disabled=1` closes the kernel module interface globally and irreversibly. The kernel checks this sysctl before `CAP_SYS_MODULE`, so every later process — regardless of its capability sets — is unable to load or unload modules, including kernel-initiated `request_module` autoloading. No generic loader, alias expansion, dependency parser, or compatibility fallback is added.

## Design note
An earlier revision of this PR also dropped `CAP_SYS_MODULE` from PID 1 via a staged re-exec (capability operations are per-thread and Go is multithreaded before `main`). That machinery was removed as redundant complexity: the sysctl is the enforcement boundary and the capability bit is inert once it is set. Per-service capability bounding already applies to all supervised services. If capability hygiene is wanted later, the cleaner shape is locking from the initrd before PID 1 execs, which is gated on the validated NVIDIA bring-up ordering (persistenced between core and UVM loads).

## Validation
- `gofmt`
- `go build ./...`
- `go test ./...`
- `go test -race -count=2 ./cmd/init ./internal/pid1/hardening`
- `go vet ./...`
- `git diff --check`
- lifecycle ordering test asserts loopback → NVIDIA bootstrap → module lock → nftables → containerd exactly; a lock failure provably stops boot before nftables and any service

## Merge / hardware notes
- Independent of the direct model-volume PR and safe to review in parallel.
- Exact-artifact Box3 and single-GPU B300 validation will be run on an integration tip before promotion.
- `CONFIG_MODULE_UNLOAD=y` is intentionally unchanged; disabling it will be a separate kernel-contract PR after NVIDIA hardware evidence.
