### PR TITLE
Restore fixed PID1 service isolation

### DIFF
--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/signal"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -510,6 +511,12 @@ func execService(
 	apply func(hardening.Service) error,
 	execFn func(string, []string, []string) error,
 ) error {
+	// Mount namespaces belong to the calling OS thread. Keep this self-exec
+	// child pinned from before policy application through the final exec so
+	// every later hardening step and the service inherit the restricted view.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	if len(args) < 3 || args[1] != "--" {
 		return errors.New("usage: --exec-service <policy> -- <path> [args...]")
 	}

--- a/tinfoil/internal/pid1/hardening/filesystems_linux.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux.go
@@ -1,0 +1,66 @@
+package hardening
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func (linuxServiceKernel) restrictFilesystems() error {
+	return restrictServiceFilesystems(linuxFilesystemKernel{})
+}
+
+type filesystemKernel interface {
+	unshare(int) error
+	mount(string, string, string, uintptr, string) error
+}
+
+type linuxFilesystemKernel struct{}
+
+func (linuxFilesystemKernel) unshare(flags int) error {
+	return unix.Unshare(flags)
+}
+
+func (linuxFilesystemKernel) mount(source, target, filesystemType string, flags uintptr, data string) error {
+	return unix.Mount(source, target, filesystemType, flags, data)
+}
+
+func restrictServiceFilesystems(kernel filesystemKernel) error {
+	if err := kernel.unshare(unix.CLONE_NEWNS); err != nil {
+		return fmt.Errorf("unshare mount namespace: %w", err)
+	}
+	if err := kernel.mount("", "/", "", unix.MS_REC|unix.MS_PRIVATE, ""); err != nil {
+		return fmt.Errorf("make mounts private: %w", err)
+	}
+	if err := mountRestrictedProc(kernel); err != nil {
+		return err
+	}
+	for _, target := range []string{"/dev", "/sys"} {
+		if err := mountEmptyReadOnly(kernel, target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func mountRestrictedProc(kernel filesystemKernel) error {
+	flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
+	if err := kernel.mount("proc", "/proc", "proc", flags, "hidepid=2,subset=pid"); err != nil {
+		return fmt.Errorf("mount restricted /proc: %w", err)
+	}
+	if err := kernel.mount("", "/proc", "", flags|unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("remount restricted /proc read-only: %w", err)
+	}
+	return nil
+}
+
+func mountEmptyReadOnly(kernel filesystemKernel, target string) error {
+	flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
+	if err := kernel.mount("tmpfs", target, "tmpfs", flags, "size=4k,nr_inodes=1,mode=0555"); err != nil {
+		return fmt.Errorf("mount empty %s: %w", target, err)
+	}
+	if err := kernel.mount("", target, "", flags|unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("remount %s read-only: %w", target, err)
+	}
+	return nil
+}

--- a/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
@@ -1,0 +1,84 @@
+package hardening
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+type mountCall struct {
+	source         string
+	target         string
+	filesystemType string
+	flags          uintptr
+	data           string
+}
+
+type fakeFilesystemKernel struct {
+	failAt int
+	err    error
+	calls  []mountCall
+}
+
+func (kernel *fakeFilesystemKernel) unshare(flags int) error {
+	kernel.calls = append(kernel.calls, mountCall{source: "unshare", flags: uintptr(flags)})
+	if kernel.failAt == len(kernel.calls) {
+		return kernel.err
+	}
+	return nil
+}
+
+func (kernel *fakeFilesystemKernel) mount(source, target, filesystemType string, flags uintptr, data string) error {
+	kernel.calls = append(kernel.calls, mountCall{
+		source:         source,
+		target:         target,
+		filesystemType: filesystemType,
+		flags:          flags,
+		data:           data,
+	})
+	if kernel.failAt == len(kernel.calls) {
+		return kernel.err
+	}
+	return nil
+}
+
+func TestRestrictServiceFilesystemsUsesFixedPrivateReadOnlyLayout(t *testing.T) {
+	kernel := &fakeFilesystemKernel{}
+	if err := restrictServiceFilesystems(kernel); err != nil {
+		t.Fatalf("restrictServiceFilesystems: %v", err)
+	}
+
+	baseFlags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
+	want := []mountCall{
+		{source: "unshare", flags: unix.CLONE_NEWNS},
+		{target: "/", flags: unix.MS_REC | unix.MS_PRIVATE},
+		{source: "proc", target: "/proc", filesystemType: "proc", flags: baseFlags, data: "hidepid=2,subset=pid"},
+		{target: "/proc", flags: baseFlags | unix.MS_REMOUNT | unix.MS_RDONLY},
+		{source: "tmpfs", target: "/dev", filesystemType: "tmpfs", flags: baseFlags, data: "size=4k,nr_inodes=1,mode=0555"},
+		{target: "/dev", flags: baseFlags | unix.MS_REMOUNT | unix.MS_RDONLY},
+		{source: "tmpfs", target: "/sys", filesystemType: "tmpfs", flags: baseFlags, data: "size=4k,nr_inodes=1,mode=0555"},
+		{target: "/sys", flags: baseFlags | unix.MS_REMOUNT | unix.MS_RDONLY},
+	}
+	if !reflect.DeepEqual(kernel.calls, want) {
+		t.Fatalf("filesystem calls =\n%#v\nwant\n%#v", kernel.calls, want)
+	}
+}
+
+func TestRestrictServiceFilesystemsFailsClosedAtEveryStep(t *testing.T) {
+	for failAt := 1; failAt <= 8; failAt++ {
+		t.Run(fmt.Sprint(failAt), func(t *testing.T) {
+			stepErr := errors.New("step failed")
+			kernel := &fakeFilesystemKernel{failAt: failAt, err: stepErr}
+			err := restrictServiceFilesystems(kernel)
+			if !errors.Is(err, stepErr) {
+				t.Fatalf("error = %v, want %v", err, stepErr)
+			}
+			if len(kernel.calls) != failAt {
+				t.Fatalf("calls = %d, want %d", len(kernel.calls), failAt)
+			}
+		})
+	}
+}

--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -35,6 +35,15 @@ type servicePolicy struct {
 	allowedSocketDomains []uint32
 }
 
+// kernelManagementSyscalls are denied for every hardened service, including
+// the privileged one-shot boot helper. Most are a deliberate second layer over
+// controls enforced elsewhere (module loading via kernel.modules_disabled, bpf/
+// perf via sysctl, mount/kexec via dropped capabilities): denying them keeps
+// each service protected even if another mechanism regresses. Three are the
+// sole control at this layer and are load-bearing on their own: the keyring
+// syscalls (add_key/request_key/keyctl) and io_uring, which is denied because
+// its ring submits file and socket operations the kernel executes without a
+// syscall the rest of this filter could inspect.
 var kernelManagementSyscalls = []uint32{
 	unix.SYS_ACCT,
 	unix.SYS_ADD_KEY,
@@ -42,6 +51,9 @@ var kernelManagementSyscalls = []uint32{
 	unix.SYS_DELETE_MODULE,
 	unix.SYS_FINIT_MODULE,
 	unix.SYS_INIT_MODULE,
+	unix.SYS_IO_URING_ENTER,
+	unix.SYS_IO_URING_REGISTER,
+	unix.SYS_IO_URING_SETUP,
 	unix.SYS_IOPERM,
 	unix.SYS_IOPL,
 	unix.SYS_KEXEC_FILE_LOAD,

--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -29,33 +29,98 @@ const (
 type servicePolicy struct {
 	noNewPrivileges      bool
 	boundCapabilities    []int
+	restrictFilesystems  bool
+	deniedSyscalls       []uint32
+	restrictNamespaceOps bool
 	allowedSocketDomains []uint32
 }
 
-// A nil boundCapabilities list deliberately preserves the inherited bounding
-// set. Boot still performs model-pack mounts and device-mapper and nftables
-// operations, so the current image does not establish a narrower safe set for
-// it. A non-nil empty list means that no capabilities are permitted.
+var kernelManagementSyscalls = []uint32{
+	unix.SYS_ACCT,
+	unix.SYS_ADD_KEY,
+	unix.SYS_BPF,
+	unix.SYS_DELETE_MODULE,
+	unix.SYS_FINIT_MODULE,
+	unix.SYS_INIT_MODULE,
+	unix.SYS_IOPERM,
+	unix.SYS_IOPL,
+	unix.SYS_KEXEC_FILE_LOAD,
+	unix.SYS_KEXEC_LOAD,
+	unix.SYS_KEYCTL,
+	unix.SYS_OPEN_BY_HANDLE_AT,
+	unix.SYS_PERF_EVENT_OPEN,
+	unix.SYS_PROCESS_VM_READV,
+	unix.SYS_PROCESS_VM_WRITEV,
+	unix.SYS_PTRACE,
+	unix.SYS_QUOTACTL,
+	unix.SYS_QUOTACTL_FD,
+	unix.SYS_REBOOT,
+	unix.SYS_REQUEST_KEY,
+	unix.SYS_SWAPOFF,
+	unix.SYS_SWAPON,
+	unix.SYS_USERFAULTFD,
+}
+
+var restrictedServiceSyscalls = append([]uint32{
+	unix.SYS_CHROOT,
+	unix.SYS_CLONE3,
+	unix.SYS_FANOTIFY_INIT,
+	unix.SYS_FSCONFIG,
+	unix.SYS_FSMOUNT,
+	unix.SYS_FSOPEN,
+	unix.SYS_FSPICK,
+	unix.SYS_MKNOD,
+	unix.SYS_MKNODAT,
+	unix.SYS_MOUNT,
+	unix.SYS_MOUNT_SETATTR,
+	unix.SYS_MOVE_MOUNT,
+	unix.SYS_NAME_TO_HANDLE_AT,
+	unix.SYS_OPEN_TREE,
+	unix.SYS_OPEN_TREE_ATTR,
+	unix.SYS_PIVOT_ROOT,
+	unix.SYS_SETDOMAINNAME,
+	unix.SYS_SETHOSTNAME,
+	unix.SYS_SETNS,
+	unix.SYS_UMOUNT2,
+	unix.SYS_UNSHARE,
+}, kernelManagementSyscalls...)
+
+// A non-nil empty boundCapabilities list means that no capabilities are
+// permitted. Boot is a one-shot privileged helper: its fixed set covers
+// device-mapper/mount operations, nftables, and mapper-node creation.
 func policyFor(service Service) (servicePolicy, bool) {
 	switch service {
 	case ServiceBoot:
-		return servicePolicy{noNewPrivileges: true}, true
+		return servicePolicy{
+			noNewPrivileges:   true,
+			boundCapabilities: []int{unix.CAP_SYS_ADMIN, unix.CAP_NET_ADMIN, unix.CAP_MKNOD},
+			deniedSyscalls:    kernelManagementSyscalls,
+		}, true
 	case ServiceContainerStatus:
 		return servicePolicy{
 			noNewPrivileges:      true,
 			boundCapabilities:    []int{},
+			restrictFilesystems:  true,
+			deniedSyscalls:       restrictedServiceSyscalls,
+			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_UNIX},
 		}, true
 	case ServiceEgress:
 		return servicePolicy{
 			noNewPrivileges:      true,
 			boundCapabilities:    []int{unix.CAP_NET_ADMIN},
+			restrictFilesystems:  true,
+			deniedSyscalls:       restrictedServiceSyscalls,
+			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6, unix.AF_NETLINK},
 		}, true
 	case ServiceShim:
 		return servicePolicy{
 			noNewPrivileges:      true,
 			boundCapabilities:    []int{unix.CAP_NET_BIND_SERVICE},
+			restrictFilesystems:  true,
+			deniedSyscalls:       restrictedServiceSyscalls,
+			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6},
 		}, true
 	default:
@@ -71,16 +136,23 @@ func ApplyService(service Service) error {
 }
 
 type serviceKernel interface {
+	restrictFilesystems() error
 	dropBoundingCapability(int) error
 	setCapabilities([2]unix.CapUserData) error
 	setNoNewPrivileges() error
-	restrictSocketDomains([]uint32) error
+	restrictSyscalls([]uint32, bool, []uint32) error
 }
 
 func applyService(kernel serviceKernel, service Service) error {
 	policy, ok := policyFor(service)
 	if !ok {
 		return fmt.Errorf("unknown service hardening policy %q", service)
+	}
+
+	if policy.restrictFilesystems {
+		if err := kernel.restrictFilesystems(); err != nil {
+			return fmt.Errorf("restrict filesystems for %s: %w", service, err)
+		}
 	}
 
 	if policy.boundCapabilities != nil {
@@ -112,9 +184,13 @@ func applyService(kernel serviceKernel, service Service) error {
 			return fmt.Errorf("set no_new_privileges for %s: %w", service, err)
 		}
 	}
-	if policy.allowedSocketDomains != nil {
-		if err := kernel.restrictSocketDomains(policy.allowedSocketDomains); err != nil {
-			return fmt.Errorf("restrict socket domains for %s: %w", service, err)
+	if policy.deniedSyscalls != nil || policy.restrictNamespaceOps || policy.allowedSocketDomains != nil {
+		if err := kernel.restrictSyscalls(
+			policy.deniedSyscalls,
+			policy.restrictNamespaceOps,
+			policy.allowedSocketDomains,
+		); err != nil {
+			return fmt.Errorf("restrict syscalls for %s: %w", service, err)
 		}
 	}
 	return nil

--- a/tinfoil/internal/pid1/hardening/hardening_test.go
+++ b/tinfoil/internal/pid1/hardening/hardening_test.go
@@ -13,21 +13,32 @@ import (
 func TestServicePoliciesAreExact(t *testing.T) {
 	want := map[Service]servicePolicy{
 		ServiceBoot: {
-			noNewPrivileges: true,
+			noNewPrivileges:   true,
+			boundCapabilities: []int{unix.CAP_SYS_ADMIN, unix.CAP_NET_ADMIN, unix.CAP_MKNOD},
+			deniedSyscalls:    kernelManagementSyscalls,
 		},
 		ServiceContainerStatus: {
 			noNewPrivileges:      true,
 			boundCapabilities:    []int{},
+			restrictFilesystems:  true,
+			deniedSyscalls:       restrictedServiceSyscalls,
+			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_UNIX},
 		},
 		ServiceEgress: {
 			noNewPrivileges:      true,
 			boundCapabilities:    []int{unix.CAP_NET_ADMIN},
+			restrictFilesystems:  true,
+			deniedSyscalls:       restrictedServiceSyscalls,
+			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6, unix.AF_NETLINK},
 		},
 		ServiceShim: {
 			noNewPrivileges:      true,
 			boundCapabilities:    []int{unix.CAP_NET_BIND_SERVICE},
+			restrictFilesystems:  true,
+			deniedSyscalls:       restrictedServiceSyscalls,
+			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6},
 		},
 	}
@@ -78,7 +89,7 @@ func TestPackCapabilitiesRejectsOutOfRangeValues(t *testing.T) {
 	}
 }
 
-func TestApplyServiceAppliesCapabilitiesThenNoNewPrivilegesThenSocketPolicy(t *testing.T) {
+func TestApplyServiceAppliesFilesystemsCapabilitiesAndSeccompInOrder(t *testing.T) {
 	kernel := &fakeServiceKernel{last: 13}
 	if err := applyService(kernel, ServiceEgress); err != nil {
 		t.Fatalf("applyService: %v", err)
@@ -95,21 +106,40 @@ func TestApplyServiceAppliesCapabilitiesThenNoNewPrivilegesThenSocketPolicy(t *t
 	if kernel.capabilityData != wantData {
 		t.Fatalf("capability data = %#v, want %#v", kernel.capabilityData, wantData)
 	}
-	if got := kernel.calls[len(kernel.calls)-1]; got != "restrict-sockets" {
-		t.Fatalf("last call = %q, want restrict-sockets; all calls: %v", got, kernel.calls)
+	if kernel.calls[0] != "restrict-filesystems" {
+		t.Fatalf("first call = %q, want restrict-filesystems; all calls: %v", kernel.calls[0], kernel.calls)
+	}
+	if got := kernel.calls[len(kernel.calls)-1]; got != "restrict-syscalls" {
+		t.Fatalf("last call = %q, want restrict-syscalls; all calls: %v", got, kernel.calls)
 	}
 	if want := []uint32{unix.AF_INET, unix.AF_INET6, unix.AF_NETLINK}; !reflect.DeepEqual(kernel.socketDomains, want) {
 		t.Fatalf("socket domains = %v, want %v", kernel.socketDomains, want)
 	}
+	if !reflect.DeepEqual(kernel.deniedSyscalls, restrictedServiceSyscalls) || !kernel.restrictNamespaceOps {
+		t.Fatalf("seccomp policy = denied %v namespaces %t", kernel.deniedSyscalls, kernel.restrictNamespaceOps)
+	}
 }
 
-func TestApplyServiceBootOnlySetsNoNewPrivileges(t *testing.T) {
+func TestApplyServiceBootUsesOnlyRequiredCapabilitiesAndKernelDenylist(t *testing.T) {
 	kernel := &fakeServiceKernel{last: 63}
 	if err := applyService(kernel, ServiceBoot); err != nil {
 		t.Fatalf("applyService: %v", err)
 	}
-	if want := []string{"no-new-privileges"}; !reflect.DeepEqual(kernel.calls, want) {
-		t.Fatalf("calls = %v, want %v", kernel.calls, want)
+	wantData, err := packCapabilities([]int{unix.CAP_SYS_ADMIN, unix.CAP_NET_ADMIN, unix.CAP_MKNOD})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if kernel.capabilityData != wantData {
+		t.Fatalf("capability data = %#v, want %#v", kernel.capabilityData, wantData)
+	}
+	if kernel.calls[0] == "restrict-filesystems" {
+		t.Fatalf("boot unexpectedly restricted filesystems: %v", kernel.calls)
+	}
+	if got := kernel.calls[len(kernel.calls)-1]; got != "restrict-syscalls" {
+		t.Fatalf("last call = %q, want restrict-syscalls", got)
+	}
+	if !reflect.DeepEqual(kernel.deniedSyscalls, kernelManagementSyscalls) || kernel.restrictNamespaceOps {
+		t.Fatalf("boot seccomp policy = denied %v namespaces %t", kernel.deniedSyscalls, kernel.restrictNamespaceOps)
 	}
 }
 
@@ -136,28 +166,28 @@ func TestApplyServiceStopsAtFirstKernelFailure(t *testing.T) {
 	if !errors.Is(err, dropErr) {
 		t.Fatalf("applyService error = %v, want %v", err, dropErr)
 	}
-	want := []string{"drop:0"}
+	want := []string{"restrict-filesystems", "drop:0"}
 	if !reflect.DeepEqual(kernel.calls, want) {
 		t.Fatalf("calls after failure = %v, want %v", kernel.calls, want)
 	}
 }
 
-func TestApplyServiceStopsAtSocketRestrictionFailure(t *testing.T) {
+func TestApplyServiceStopsAtSyscallRestrictionFailure(t *testing.T) {
 	restrictErr := errors.New("seccomp denied")
 	kernel := &fakeServiceKernel{
-		last:               unix.CAP_NET_BIND_SERVICE,
-		restrictSocketsErr: restrictErr,
+		last:                unix.CAP_NET_BIND_SERVICE,
+		restrictSyscallsErr: restrictErr,
 	}
 	err := applyService(kernel, ServiceShim)
 	if !errors.Is(err, restrictErr) {
 		t.Fatalf("applyService error = %v, want %v", err, restrictErr)
 	}
-	if got := kernel.calls[len(kernel.calls)-1]; got != "restrict-sockets" {
-		t.Fatalf("last call after socket restriction failure = %q, want restrict-sockets", got)
+	if got := kernel.calls[len(kernel.calls)-1]; got != "restrict-syscalls" {
+		t.Fatalf("last call after syscall restriction failure = %q, want restrict-syscalls", got)
 	}
 }
 
-func TestApplyServiceDoesNotRestrictSocketsAfterNoNewPrivilegesFailure(t *testing.T) {
+func TestApplyServiceDoesNotRestrictSyscallsAfterNoNewPrivilegesFailure(t *testing.T) {
 	noNewPrivilegesErr := errors.New("prctl denied")
 	kernel := &fakeServiceKernel{
 		last:               unix.CAP_NET_BIND_SERVICE,
@@ -270,17 +300,25 @@ func TestApplyRuntimeLimitsFailsWhenVerificationStaysBelowFloor(t *testing.T) {
 }
 
 type fakeServiceKernel struct {
-	last               int
-	dropFailureAt      *int
-	dropCapabilityErr  error
-	capabilityErr      error
-	noNewPrivilegesErr error
-	restrictSocketsErr error
+	last                   int
+	dropFailureAt          *int
+	dropCapabilityErr      error
+	capabilityErr          error
+	noNewPrivilegesErr     error
+	restrictFilesystemsErr error
+	restrictSyscallsErr    error
 
-	calls          []string
-	dropped        []int
-	capabilityData [2]unix.CapUserData
-	socketDomains  []uint32
+	calls                []string
+	dropped              []int
+	capabilityData       [2]unix.CapUserData
+	deniedSyscalls       []uint32
+	restrictNamespaceOps bool
+	socketDomains        []uint32
+}
+
+func (kernel *fakeServiceKernel) restrictFilesystems() error {
+	kernel.calls = append(kernel.calls, "restrict-filesystems")
+	return kernel.restrictFilesystemsErr
 }
 
 func (kernel *fakeServiceKernel) dropBoundingCapability(capability int) error {
@@ -306,10 +344,16 @@ func (kernel *fakeServiceKernel) setNoNewPrivileges() error {
 	return kernel.noNewPrivilegesErr
 }
 
-func (kernel *fakeServiceKernel) restrictSocketDomains(domains []uint32) error {
-	kernel.calls = append(kernel.calls, "restrict-sockets")
+func (kernel *fakeServiceKernel) restrictSyscalls(
+	denied []uint32,
+	restrictNamespaceOps bool,
+	domains []uint32,
+) error {
+	kernel.calls = append(kernel.calls, "restrict-syscalls")
+	kernel.deniedSyscalls = append([]uint32(nil), denied...)
+	kernel.restrictNamespaceOps = restrictNamespaceOps
 	kernel.socketDomains = append([]uint32(nil), domains...)
-	return kernel.restrictSocketsErr
+	return kernel.restrictSyscallsErr
 }
 
 type rlimitSet struct {

--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64.go
@@ -11,10 +11,24 @@ const (
 	seccompDataNumberOffset = 0
 	seccompDataArchOffset   = 4
 	seccompDataArg0Offset   = 16
+	x32SyscallBit           = 0x40000000
 )
 
-func (linuxServiceKernel) restrictSocketDomains(domains []uint32) error {
-	filters := socketDomainFilters(domains)
+const namespaceCloneFlags = unix.CLONE_NEWCGROUP |
+	unix.CLONE_NEWIPC |
+	unix.CLONE_NEWNET |
+	unix.CLONE_NEWNS |
+	unix.CLONE_NEWPID |
+	unix.CLONE_NEWTIME |
+	unix.CLONE_NEWUSER |
+	unix.CLONE_NEWUTS
+
+func (linuxServiceKernel) restrictSyscalls(
+	denied []uint32,
+	restrictNamespaceOps bool,
+	domains []uint32,
+) error {
+	filters := serviceSeccompFilters(denied, restrictNamespaceOps, domains)
 	program := unix.SockFprog{
 		Len:    uint16(len(filters)),
 		Filter: &filters[0],
@@ -31,23 +45,44 @@ func (linuxServiceKernel) restrictSocketDomains(domains []uint32) error {
 	return nil
 }
 
-func socketDomainFilters(domains []uint32) []unix.SockFilter {
+func serviceSeccompFilters(denied []uint32, restrictNamespaceOps bool, domains []uint32) []unix.SockFilter {
 	filters := []unix.SockFilter{
 		{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataArchOffset},
 		{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jt: 1, K: unix.AUDIT_ARCH_X86_64},
 		{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_KILL_PROCESS},
 		{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataNumberOffset},
-		{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: uint8(2*len(domains) + 2), K: unix.SYS_SOCKET},
-		{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataArg0Offset},
+		{Code: unix.BPF_JMP | unix.BPF_JGE | unix.BPF_K, Jf: 1, K: x32SyscallBit},
+		{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.ENOSYS)},
 	}
-	for _, domain := range domains {
+	for _, number := range denied {
 		filters = append(filters,
-			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: 1, K: domain},
-			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ALLOW},
+			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: 1, K: number},
+			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM)},
 		)
 	}
-	return append(filters,
-		unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.EAFNOSUPPORT)},
-		unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ALLOW},
-	)
+	if restrictNamespaceOps {
+		filters = append(filters,
+			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: 3, K: unix.SYS_CLONE},
+			unix.SockFilter{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataArg0Offset},
+			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JSET | unix.BPF_K, Jf: 1, K: namespaceCloneFlags},
+			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM)},
+			unix.SockFilter{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataNumberOffset},
+		)
+	}
+	if domains != nil {
+		filters = append(filters,
+			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: uint8(2*len(domains) + 2), K: unix.SYS_SOCKET},
+			unix.SockFilter{Code: unix.BPF_LD | unix.BPF_W | unix.BPF_ABS, K: seccompDataArg0Offset},
+		)
+		for _, domain := range domains {
+			filters = append(filters,
+				unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: 1, K: domain},
+				unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ALLOW},
+			)
+		}
+		filters = append(filters,
+			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.EAFNOSUPPORT)},
+		)
+	}
+	return append(filters, unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ALLOW})
 }

--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
@@ -116,8 +116,12 @@ func TestServiceDangerousSyscalls(t *testing.T) {
 			_, _, errno = unix.RawSyscall(unix.SYS_FINIT_MODULE, ^uintptr(0), 0, 0)
 		case "mount":
 			_, _, errno = unix.RawSyscall6(unix.SYS_MOUNT, 0, 0, 0, 0, 0, 0)
-		case "io-uring":
+		case "io-uring-setup":
 			_, _, errno = unix.RawSyscall(unix.SYS_IO_URING_SETUP, 0, 0, 0)
+		case "io-uring-enter":
+			_, _, errno = unix.RawSyscall6(unix.SYS_IO_URING_ENTER, 0, 0, 0, 0, 0, 0)
+		case "io-uring-register":
+			_, _, errno = unix.RawSyscall(unix.SYS_IO_URING_REGISTER, 0, 0, 0)
 		case "namespace-clone":
 			_, _, errno = unix.RawSyscall6(unix.SYS_CLONE, uintptr(unix.CLONE_NEWNS), 0, 0, 0, 0, 0)
 		case "x32":
@@ -142,8 +146,10 @@ func TestServiceDangerousSyscalls(t *testing.T) {
 		operation string
 	}{
 		{name: "boot-cannot-load-modules", service: ServiceBoot, operation: "finit-module"},
-		{name: "boot-cannot-io-uring", service: ServiceBoot, operation: "io-uring"},
-		{name: "shim-cannot-io-uring", service: ServiceShim, operation: "io-uring"},
+		{name: "boot-cannot-io-uring-setup", service: ServiceBoot, operation: "io-uring-setup"},
+		{name: "shim-cannot-io-uring-setup", service: ServiceShim, operation: "io-uring-setup"},
+		{name: "egress-cannot-io-uring-enter", service: ServiceEgress, operation: "io-uring-enter"},
+		{name: "status-cannot-io-uring-register", service: ServiceContainerStatus, operation: "io-uring-register"},
 		{name: "shim-cannot-mount", service: ServiceShim, operation: "mount"},
 		{name: "egress-cannot-clone-namespace", service: ServiceEgress, operation: "namespace-clone"},
 		{name: "status-rejects-x32", service: ServiceContainerStatus, operation: "x32"},

--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
@@ -116,6 +116,8 @@ func TestServiceDangerousSyscalls(t *testing.T) {
 			_, _, errno = unix.RawSyscall(unix.SYS_FINIT_MODULE, ^uintptr(0), 0, 0)
 		case "mount":
 			_, _, errno = unix.RawSyscall6(unix.SYS_MOUNT, 0, 0, 0, 0, 0, 0)
+		case "io-uring":
+			_, _, errno = unix.RawSyscall(unix.SYS_IO_URING_SETUP, 0, 0, 0)
 		case "namespace-clone":
 			_, _, errno = unix.RawSyscall6(unix.SYS_CLONE, uintptr(unix.CLONE_NEWNS), 0, 0, 0, 0, 0)
 		case "x32":
@@ -140,6 +142,8 @@ func TestServiceDangerousSyscalls(t *testing.T) {
 		operation string
 	}{
 		{name: "boot-cannot-load-modules", service: ServiceBoot, operation: "finit-module"},
+		{name: "boot-cannot-io-uring", service: ServiceBoot, operation: "io-uring"},
+		{name: "shim-cannot-io-uring", service: ServiceShim, operation: "io-uring"},
 		{name: "shim-cannot-mount", service: ServiceShim, operation: "mount"},
 		{name: "egress-cannot-clone-namespace", service: ServiceEgress, operation: "namespace-clone"},
 		{name: "status-rejects-x32", service: ServiceContainerStatus, operation: "x32"},

--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
@@ -29,7 +29,11 @@ func TestServiceSocketDomains(t *testing.T) {
 		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
 			os.Exit(23)
 		}
-		if err := (linuxServiceKernel{}).restrictSocketDomains(policy.allowedSocketDomains); err != nil {
+		if err := (linuxServiceKernel{}).restrictSyscalls(
+			policy.deniedSyscalls,
+			policy.restrictNamespaceOps,
+			policy.allowedSocketDomains,
+		); err != nil {
 			os.Exit(24)
 		}
 		socketType := unix.SOCK_STREAM | unix.SOCK_CLOEXEC
@@ -82,6 +86,74 @@ func TestServiceSocketDomains(t *testing.T) {
 			)
 			if output, err := command.CombinedOutput(); err != nil {
 				t.Fatalf("socket-domain child failed: %v: %s", err, output)
+			}
+		})
+	}
+}
+
+func TestServiceDangerousSyscalls(t *testing.T) {
+	if os.Getenv("TINFOIL_DANGEROUS_SYSCALL_CHILD") == "1" {
+		service := Service(os.Getenv("TINFOIL_SYSCALL_SERVICE"))
+		operation := os.Getenv("TINFOIL_SYSCALL_OPERATION")
+		policy, ok := policyFor(service)
+		if !ok {
+			os.Exit(30)
+		}
+		if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+			os.Exit(31)
+		}
+		if err := (linuxServiceKernel{}).restrictSyscalls(
+			policy.deniedSyscalls,
+			policy.restrictNamespaceOps,
+			policy.allowedSocketDomains,
+		); err != nil {
+			os.Exit(32)
+		}
+
+		var errno syscall.Errno
+		switch operation {
+		case "finit-module":
+			_, _, errno = unix.RawSyscall(unix.SYS_FINIT_MODULE, ^uintptr(0), 0, 0)
+		case "mount":
+			_, _, errno = unix.RawSyscall6(unix.SYS_MOUNT, 0, 0, 0, 0, 0, 0)
+		case "namespace-clone":
+			_, _, errno = unix.RawSyscall6(unix.SYS_CLONE, uintptr(unix.CLONE_NEWNS), 0, 0, 0, 0, 0)
+		case "x32":
+			_, _, errno = unix.RawSyscall(uintptr(x32SyscallBit|unix.SYS_GETPID), 0, 0, 0)
+		default:
+			os.Exit(33)
+		}
+
+		want := syscall.EPERM
+		if operation == "x32" {
+			want = syscall.ENOSYS
+		}
+		if errno != want {
+			os.Exit(34)
+		}
+		os.Exit(0)
+	}
+
+	tests := []struct {
+		name      string
+		service   Service
+		operation string
+	}{
+		{name: "boot-cannot-load-modules", service: ServiceBoot, operation: "finit-module"},
+		{name: "shim-cannot-mount", service: ServiceShim, operation: "mount"},
+		{name: "egress-cannot-clone-namespace", service: ServiceEgress, operation: "namespace-clone"},
+		{name: "status-rejects-x32", service: ServiceContainerStatus, operation: "x32"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			command := exec.Command(os.Args[0], "-test.run=^TestServiceDangerousSyscalls$")
+			command.Env = append(os.Environ(),
+				"TINFOIL_DANGEROUS_SYSCALL_CHILD=1",
+				"TINFOIL_SYSCALL_SERVICE="+string(test.service),
+				"TINFOIL_SYSCALL_OPERATION="+test.operation,
+			)
+			if output, err := command.CombinedOutput(); err != nil {
+				t.Fatalf("dangerous-syscall child failed: %v: %s", err, output)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- restore private mount namespaces for long-lived Tinfoil services with restricted read-only `/proc` and empty read-only `/dev` and `/sys`
- add fixed dangerous-syscall restrictions, namespace-clone argument filtering, and explicit x32 rejection while preserving current socket-family filters
- narrow the one-shot `tinfoil-boot` helper to `CAP_SYS_ADMIN`, `CAP_NET_ADMIN`, and `CAP_MKNOD`

## Scope
This PR hardens `tinfoil-boot`, `tinfoil-container-status`, `tinfoil-egress`, and `tinfoil-shim`. Docker and containerd remain a separate review boundary. It does not restore systemd policy or a generic sandbox mechanism.

## Validation
- `gofmt`
- focused `go test -race`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Merge / hardware notes
- Independent of the direct model-volume and module-lock PRs; review can proceed in parallel.
- Do not merge until exact-artifact Box3 testing covers static networking, nftables, MWP/EMWP mounting, shim TLS/readiness, egress refresh, and Docker status publication.
- The integration tip will then receive one-B300 INF14 validation for `nvattest`, CDI, and workload startup under the reduced capability/filesystem views.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores fixed PID1 service isolation with private mount namespaces and a locked-down filesystem, and adds a stricter seccomp policy with tighter capability bounds, including an explicit `io_uring` ban. Pins hardening to one OS thread so the restricted mount view persists across exec; applies isolation to `tinfoil-container-status`, `tinfoil-egress`, and `tinfoil-shim`, and narrows `tinfoil-boot` to the minimum capabilities.

- New Features
  - Mount isolation: private mount NS; read-only `/proc` (hidepid=2, subset=pid); empty read-only `/dev` and `/sys`; thread-pinned through exec for correct inheritance.
  - Seccomp: deny kernel-management syscalls (including all `io_uring` ops); reject x32 syscalls; block namespace `clone` flags; keep socket domain allowlists (others return EAFNOSUPPORT).
  - Capabilities: `tinfoil-boot` limited to `CAP_SYS_ADMIN`, `CAP_NET_ADMIN`, `CAP_MKNOD`; `tinfoil-egress` keeps `CAP_NET_ADMIN`; `tinfoil-shim` keeps `CAP_NET_BIND_SERVICE`; `tinfoil-container-status` runs without caps.
  - Tests: cover filesystem layout, syscall denylist, namespace filtering, socket filters, policy ordering, and `io_uring_{setup,enter,register}` denial across all services.

<sup>Written for commit a9c4c9dabec7e28f3a29a9899a9de5188c397fad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

