### PR TITLE
Reduce Docker runtime payload

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -178,7 +178,7 @@
   "moduleExtensions": {
     "//image:runtime_sources.bzl%runtime_sources": {
       "general": {
-        "bzlTransitiveDigest": "IU+1YKnwwtvV77a4qcfDIYj77tUf+pAiIMVbIswxZ0o=",
+        "bzlTransitiveDigest": "mF2eV4slSMEbCIO+MjMBgMciOSkZb9UUI2fFj3BPwNA=",
         "usagesDigest": "ZhxnUxFkNDXMRlHkZ0sEOIsJVy8V8BOOqt1yt9cZEgI=",
         "recordedFileInputs": {
           "@@//image/runtime-sources.lock.json": "b577d13cc0b5e0b433b758ae761594039cf0ffa20724a1c1387d8503ab3e3c36"
@@ -189,7 +189,7 @@
           "runtime_source_docker_static": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {
-              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"payload\",\n    srcs = glob([\"**\"], exclude = [\"BUILD.bazel\", \"REPO.bazel\"]),\n)\n",
+              "build_file_content": "package(default_visibility = [\"//visibility:public\"])\n\nfilegroup(\n    name = \"payload\",\n    srcs = [\n        \"containerd\",\n        \"containerd-shim-runc-v2\",\n        \"dockerd\",\n        \"runc\",\n    ],\n)\n",
               "sha256": "34eea64e9c3435f5af1b760827a56a561cd67fc2d6e9cd1813b8bb1e3ff7930b",
               "strip_prefix": "docker",
               "urls": [

--- a/image/BUILD.bazel
+++ b/image/BUILD.bazel
@@ -36,6 +36,13 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "container-runtime-rootfs-contract-test",
+    srcs = ["//scripts:test-container-runtime-rootfs.sh"],
+    args = ["$(location :docker-static-rootfs-layer)"],
+    data = [":docker-static-rootfs-layer"],
+)
+
 filegroup(
     name = "runtime-package-layers",
     srcs = ["@ubuntu_runtime//:packages"],
@@ -111,6 +118,17 @@ pkg_files(
     attributes = pkg_attributes(mode = "0755", uid = 0, gid = 0),
     prefix = "usr/bin",
     strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_tar(
+    name = "docker-static-rootfs-layer",
+    srcs = [":docker-static-payload"],
+    extension = "tar",
+    mtime = 0,
+    out = "docker-static-rootfs-layer.tar",
+    owner = "0.0",
+    portable_mtime = False,
+    stamp = 0,
 )
 
 pkg_files(
@@ -194,7 +212,6 @@ pkg_mklink(
 pkg_tar(
     name = "runtime-overlay",
     srcs = [
-        ":docker-static-payload",
         ":libnvat",
         ":link-lib64",
         ":link-libnvat-soname",
@@ -221,6 +238,7 @@ pkg_tar(
 pkg_tar(
     name = "rootfs",
     deps = [
+        ":docker-static-rootfs-layer",
         ":nvidia-package-layers",
         ":runtime-package-layers",
         ":ubuntu-runtime-cacerts",

--- a/image/runtime_sources.bzl
+++ b/image/runtime_sources.bzl
@@ -21,6 +21,19 @@ filegroup(
 )
 """
 
+_DOCKER_STATIC_PAYLOAD_BUILD = """package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "payload",
+    srcs = [
+        "containerd",
+        "containerd-shim-runc-v2",
+        "dockerd",
+        "runc",
+    ],
+)
+"""
+
 
 def _repository_name(source_id):
     return "runtime_source_" + source_id.replace("-", "_")
@@ -88,9 +101,12 @@ def _runtime_sources_impl(module_ctx):
             strip_prefix = source.get("strip_prefix", "")
             if type(strip_prefix) != "string":
                 fail("runtime tar source %s has a non-string strip_prefix" % source_id)
+            payload_build = _TAR_PAYLOAD_BUILD
+            if source_id == "docker-static":
+                payload_build = _DOCKER_STATIC_PAYLOAD_BUILD
             http_archive(
                 name = repository_name,
-                build_file_content = _TAR_PAYLOAD_BUILD,
+                build_file_content = payload_build,
                 sha256 = sha256,
                 strip_prefix = strip_prefix,
                 urls = [url],

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,3 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["compare_runtime_package_lock.sh"])
+exports_files([
+    "compare_runtime_package_lock.sh",
+    "test-container-runtime-rootfs.sh",
+])

--- a/scripts/test-container-runtime-rootfs.sh
+++ b/scripts/test-container-runtime-rootfs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: $0 /path/to/docker-static-rootfs-layer.tar" >&2
+    exit 2
+fi
+
+archive="$1"
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+required=(
+    containerd
+    containerd-shim-runc-v2
+    dockerd
+    runc
+)
+forbidden=(
+    ctr
+    docker
+    docker-init
+    docker-proxy
+)
+
+members="$scratch/members"
+tar -tf "$archive" >"$members"
+
+for executable in "${required[@]}"; do
+    path="usr/bin/$executable"
+    if [[ "$(grep -Fxc "$path" "$members")" -ne 1 ]]; then
+        echo "$path must appear exactly once in the packaged rootfs layer" >&2
+        exit 1
+    fi
+    tar -xf "$archive" -C "$scratch" "$path"
+    if [[ ! -f "$scratch/$path" || -L "$scratch/$path" || ! -x "$scratch/$path" ]]; then
+        echo "$path must be an executable regular file" >&2
+        exit 1
+    fi
+done
+
+for executable in "${forbidden[@]}"; do
+    path="usr/bin/$executable"
+    if grep -Fqx "$path" "$members"; then
+        echo "$path must not be present in the packaged rootfs layer" >&2
+        exit 1
+    fi
+done


### PR DESCRIPTION
## Summary
- curate the pinned Docker static archive to the four executables used by the measured guest
- ship only `dockerd`, `containerd`, `containerd-shim-runc-v2`, and `runc`
- reject Docker CLI, `ctr`, `docker-init`, and `docker-proxy` in a packaged-layer contract test

## TCB impact
The measured Docker static payload falls from approximately 225 MiB to 160 MiB (about 65 MiB removed). The fixed guest disables Docker's userland proxy, never shells out to the Docker/ctr CLIs, and does not request Docker's init helper.

## Validation
- `go build ./...`
- `go test ./...`
- focused race tests
- `go vet ./...`
- `bazel test //image:runtime-package-lock-test //image:container-runtime-rootfs-contract-test`
- `bazel build //image:docker-static-rootfs-layer`
- exact producer-membership comparison
- `git diff --check`

## Merge gate
Independent of #218-#221, but qualify the exact image on Box3 before merge: container create/start/stop, bridge networking, both egress modes, model bind mounts, restart supervision, and clean shutdown.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trimmed the Docker runtime rootfs to only the required executables and added a contract test to enforce the smaller payload. Reduces the measured Docker static payload from ~225 MiB to ~160 MiB.

- **New Features**
  - Curated Docker static archive to include only containerd, containerd-shim-runc-v2, dockerd, and runc.
  - Built a dedicated rootfs layer `:docker-static-rootfs-layer` via `pkg_tar`, included in `:rootfs` and removed from `:runtime-overlay`.
  - Added `:container-runtime-rootfs-contract-test` using `scripts/test-container-runtime-rootfs.sh` to require those four binaries and forbid `ctr`, `docker`, `docker-init`, and `docker-proxy`.

<sup>Written for commit 617c5553674834df04d7b74352e8c62926d81e45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

