### PR TITLE
Set no_new_privs on container daemons

### DIFF
--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -183,14 +183,14 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 
 	if err := deps.services.Start(bootCtx, supervisor.Service{
 		Name: containerdName, Required: true, Restart: true,
-		Command: command(containerdName, "/usr/bin/containerd"),
+		Command: hardenedCommand(hardening.ServiceContainerd, "/usr/bin/containerd"),
 		Ready:   endpointReady("unix", containerdSocket, containerdReadyLimit),
 	}); err != nil {
 		return err
 	}
 	if err := deps.services.Start(bootCtx, supervisor.Service{
 		Name: dockerName, Required: true, Restart: true,
-		Command: command(dockerName, "/usr/bin/dockerd",
+		Command: hardenedCommand(hardening.ServiceDocker, "/usr/bin/dockerd",
 			"-H", "unix://"+dockerSocket, "--containerd="+containerdSocket),
 		Ready: endpointReady("unix", dockerSocket, dockerReadyLimit),
 	}); err != nil {

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -434,6 +435,39 @@ func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
 	containerd := slices.Index(events, containerdName)
 	if loopback < 0 || bootstrap != loopback+1 || containerd <= bootstrap {
 		t.Fatalf("startup events = %v", events)
+	}
+}
+
+func TestLifecycleHardensContainerDaemons(t *testing.T) {
+	harness := newLifecycleHarness()
+	parent, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- runLifecycle(parent, harness.deps, harness.readiness) }()
+	if ready := receiveTest(t, harness.ready); !ready {
+		t.Fatal("lifecycle did not become ready")
+	}
+	cancel()
+	if err := receiveTest(t, result); err != nil {
+		t.Fatal(err)
+	}
+
+	harness.services.mu.Lock()
+	defer harness.services.mu.Unlock()
+	want := map[string]supervisor.Command{
+		containerdName: hardenedCommand(hardening.ServiceContainerd, "/usr/bin/containerd"),
+		dockerName: hardenedCommand(hardening.ServiceDocker, "/usr/bin/dockerd",
+			"-H", "unix://"+dockerSocket, "--containerd="+containerdSocket),
+	}
+	for _, service := range harness.services.started {
+		if command, ok := want[service.Name]; ok {
+			if !reflect.DeepEqual(service.Command, command) {
+				t.Errorf("%s command = %#v, want %#v", service.Name, service.Command, command)
+			}
+			delete(want, service.Name)
+		}
+	}
+	if len(want) != 0 {
+		t.Fatalf("container services not started: %v", want)
 	}
 }
 

--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -21,7 +21,9 @@ type Service string
 
 const (
 	ServiceBoot            Service = "tinfoil-boot"
+	ServiceContainerd      Service = "containerd"
 	ServiceContainerStatus Service = "tinfoil-container-status"
+	ServiceDocker          Service = "dockerd"
 	ServiceEgress          Service = "tinfoil-egress"
 	ServiceShim            Service = "tinfoil-shim"
 )
@@ -39,6 +41,8 @@ type servicePolicy struct {
 func policyFor(service Service) (servicePolicy, bool) {
 	switch service {
 	case ServiceBoot:
+		return servicePolicy{noNewPrivileges: true}, true
+	case ServiceContainerd, ServiceDocker:
 		return servicePolicy{noNewPrivileges: true}, true
 	case ServiceContainerStatus:
 		return servicePolicy{

--- a/tinfoil/internal/pid1/hardening/hardening_test.go
+++ b/tinfoil/internal/pid1/hardening/hardening_test.go
@@ -15,10 +15,16 @@ func TestServicePoliciesAreExact(t *testing.T) {
 		ServiceBoot: {
 			noNewPrivileges: true,
 		},
+		ServiceContainerd: {
+			noNewPrivileges: true,
+		},
 		ServiceContainerStatus: {
 			noNewPrivileges:      true,
 			boundCapabilities:    []int{},
 			allowedSocketDomains: []uint32{unix.AF_UNIX},
+		},
+		ServiceDocker: {
+			noNewPrivileges: true,
 		},
 		ServiceEgress: {
 			noNewPrivileges:      true,
@@ -103,19 +109,23 @@ func TestApplyServiceAppliesCapabilitiesThenNoNewPrivilegesThenSocketPolicy(t *t
 	}
 }
 
-func TestApplyServiceBootOnlySetsNoNewPrivileges(t *testing.T) {
-	kernel := &fakeServiceKernel{last: 63}
-	if err := applyService(kernel, ServiceBoot); err != nil {
-		t.Fatalf("applyService: %v", err)
-	}
-	if want := []string{"no-new-privileges"}; !reflect.DeepEqual(kernel.calls, want) {
-		t.Fatalf("calls = %v, want %v", kernel.calls, want)
+func TestApplyServiceNoNewPrivilegesOnlyPolicies(t *testing.T) {
+	for _, service := range []Service{ServiceBoot, ServiceContainerd, ServiceDocker} {
+		t.Run(string(service), func(t *testing.T) {
+			kernel := &fakeServiceKernel{last: 63}
+			if err := applyService(kernel, service); err != nil {
+				t.Fatalf("applyService: %v", err)
+			}
+			if want := []string{"no-new-privileges"}; !reflect.DeepEqual(kernel.calls, want) {
+				t.Fatalf("calls = %v, want %v", kernel.calls, want)
+			}
+		})
 	}
 }
 
 func TestApplyServiceRejectsUnknownPolicyWithoutKernelChanges(t *testing.T) {
 	kernel := &fakeServiceKernel{last: 63}
-	err := applyService(kernel, Service("containerd"))
+	err := applyService(kernel, Service("unknown"))
 	if err == nil || !strings.Contains(err.Error(), "unknown service hardening policy") {
 		t.Fatalf("applyService error = %v, want unknown-policy error", err)
 	}


### PR DESCRIPTION
## Summary
- launch `containerd` and `dockerd` through fixed PID1 hardening policies
- set irreversible `no_new_privs` before either daemon execs
- preserve current capabilities, filesystem, socket, syscall, and device behavior

## Scope
This is intentionally the smallest safe daemon-isolation step. Capability/seccomp/filesystem restrictions would propagate through `runc` into workloads and need separate evidence before they can be fixed safely.

## Validation
- focused hardening/lifecycle tests
- focused race tests
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Merge order and gate
Review may proceed in parallel, but merge #220 first. This branch overlaps #220's PID1 hardening files and must then be rebased. Before merge, qualify the rebased exact image on Box3 and verify daemon `NoNewPrivs: 1`, container lifecycle, bridge/egress behavior, model mounts, restart supervision, and shutdown.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Harden container daemons by starting `containerd` and `dockerd` via PID1 hardening with irreversible no_new_privs. This blocks privilege escalation without changing capabilities, seccomp, filesystem, sockets, or devices.

- **New Features**
  - Launch `containerd` and `dockerd` with `hardenedCommand(...)`, applying `hardening.ServiceContainerd` and `hardening.ServiceDocker` to set `no_new_privs=1`.
  - Extend `hardening` policy to cover both daemons (NNP only) and add tests for lifecycle commands and policy application.

<sup>Written for commit 4bfa8b754ec5c3f5d45dbc1b965e93c98d5c66bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

