### PR TITLE
Pin exact NVIDIA module paths

### DIFF
--- a/tinfoil/internal/nvidia/modules.go
+++ b/tinfoil/internal/nvidia/modules.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"golang.org/x/sys/unix"
 )
@@ -23,23 +22,23 @@ const (
 
 type modulePolicy struct {
 	kernelName string
-	candidates [2]string
+	fileName   string
 	parameters string
 }
 
 var (
 	coreModule = modulePolicy{
 		kernelName: "nvidia",
-		candidates: [2]string{"nvidia.ko.zst", "nvidia.ko"},
+		fileName:   "nvidia.ko",
 		parameters: nvidiaCoreParameters,
 	}
 	uvmModule = modulePolicy{
 		kernelName: "nvidia_uvm",
-		candidates: [2]string{"nvidia-uvm.ko.zst", "nvidia-uvm.ko"},
+		fileName:   "nvidia-uvm.ko",
 	}
 	modesetModule = modulePolicy{
 		kernelName: "nvidia_modeset",
-		candidates: [2]string{"nvidia-modeset.ko.zst", "nvidia-modeset.ko"},
+		fileName:   "nvidia-modeset.ko",
 	}
 )
 
@@ -92,37 +91,19 @@ func loadModule(policy modulePolicy, deps dependencies) error {
 		return nil
 	}
 
-	var missing []string
-	for _, candidate := range policy.candidates {
-		path, err := fixedModulePath(deps.moduleRoot, candidate)
-		if err != nil {
-			return fmt.Errorf("resolve fixed candidate for %s: %w", policy.kernelName, err)
-		}
-		if _, err := deps.stat(path); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				missing = append(missing, path)
-				continue
-			}
-			return fmt.Errorf("%s stat %s: %w", policy.kernelName, path, err)
-		}
-
-		flags := 0
-		if strings.HasSuffix(candidate, ".ko.zst") {
-			flags = unix.MODULE_INIT_COMPRESSED_FILE
-		}
-		err = deps.finitModule(path, policy.parameters, flags)
-		if err == nil || errors.Is(err, unix.EEXIST) {
-			return nil
-		}
-		return fmt.Errorf("%s finit_module %s: %w", policy.kernelName, path, err)
+	path, err := fixedModulePath(deps.moduleRoot, policy.fileName)
+	if err != nil {
+		return fmt.Errorf("resolve fixed path for %s: %w", policy.kernelName, err)
+	}
+	if _, err := deps.stat(path); err != nil {
+		return fmt.Errorf("%s stat %s: %w", policy.kernelName, path, err)
 	}
 
-	return fmt.Errorf(
-		"no fixed NVIDIA module candidate for %s under %s (missing: %s)",
-		policy.kernelName,
-		deps.moduleRoot,
-		strings.Join(missing, ", "),
-	)
+	err = deps.finitModule(path, policy.parameters, 0)
+	if err == nil || errors.Is(err, unix.EEXIST) {
+		return nil
+	}
+	return fmt.Errorf("%s finit_module %s: %w", policy.kernelName, path, err)
 }
 
 func fixedModulePath(root, candidate string) (string, error) {
@@ -146,9 +127,7 @@ func fixedModulePath(root, candidate string) (string, error) {
 
 func fixedNVIDIACandidate(candidate string) bool {
 	switch candidate {
-	case "nvidia.ko.zst", "nvidia.ko",
-		"nvidia-uvm.ko.zst", "nvidia-uvm.ko",
-		"nvidia-modeset.ko.zst", "nvidia-modeset.ko":
+	case "nvidia.ko", "nvidia-uvm.ko", "nvidia-modeset.ko":
 		return true
 	default:
 		return false

--- a/tinfoil/internal/nvidia/modules_test.go
+++ b/tinfoil/internal/nvidia/modules_test.go
@@ -44,11 +44,11 @@ func testDependencies(
 
 func loadedName(path string) string {
 	switch filepath.Base(path) {
-	case "nvidia.ko", "nvidia.ko.zst":
+	case "nvidia.ko":
 		return "nvidia"
-	case "nvidia-uvm.ko", "nvidia-uvm.ko.zst":
+	case "nvidia-uvm.ko":
 		return "nvidia_uvm"
-	case "nvidia-modeset.ko", "nvidia-modeset.ko.zst":
+	case "nvidia-modeset.ko":
 		return "nvidia_modeset"
 	default:
 		return ""
@@ -69,9 +69,8 @@ func TestFixedInventoriesLoadOnlyOrderedNVIDIAModules(t *testing.T) {
 			name:      "core",
 			inventory: []modulePolicy{coreModule},
 			want: []finitCall{{
-				path:       "/modules/nvidia.ko.zst",
+				path:       "/modules/nvidia.ko",
 				parameters: coreParameters,
-				flags:      unix.MODULE_INIT_COMPRESSED_FILE,
 			}},
 		},
 		{
@@ -79,13 +78,11 @@ func TestFixedInventoriesLoadOnlyOrderedNVIDIAModules(t *testing.T) {
 			inventory: []modulePolicy{coreModule, uvmModule},
 			want: []finitCall{
 				{
-					path:       "/modules/nvidia.ko.zst",
+					path:       "/modules/nvidia.ko",
 					parameters: coreParameters,
-					flags:      unix.MODULE_INIT_COMPRESSED_FILE,
 				},
 				{
-					path:  "/modules/nvidia-uvm.ko.zst",
-					flags: unix.MODULE_INIT_COMPRESSED_FILE,
+					path: "/modules/nvidia-uvm.ko",
 				},
 			},
 		},
@@ -94,13 +91,11 @@ func TestFixedInventoriesLoadOnlyOrderedNVIDIAModules(t *testing.T) {
 			inventory: []modulePolicy{coreModule, modesetModule},
 			want: []finitCall{
 				{
-					path:       "/modules/nvidia.ko.zst",
+					path:       "/modules/nvidia.ko",
 					parameters: coreParameters,
-					flags:      unix.MODULE_INIT_COMPRESSED_FILE,
 				},
 				{
-					path:  "/modules/nvidia-modeset.ko.zst",
-					flags: unix.MODULE_INIT_COMPRESSED_FILE,
+					path: "/modules/nvidia-modeset.ko",
 				},
 			},
 		},
@@ -110,10 +105,10 @@ func TestFixedInventoriesLoadOnlyOrderedNVIDIAModules(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			loaded := map[string]bool{}
 			files := map[string]bool{
-				"/modules/nvidia.ko.zst":         true,
-				"/modules/nvidia-uvm.ko.zst":     true,
-				"/modules/nvidia-modeset.ko.zst": true,
-				"/modules/not-nvidia.ko.zst":     true,
+				"/modules/nvidia.ko":         true,
+				"/modules/nvidia-uvm.ko":     true,
+				"/modules/nvidia-modeset.ko": true,
+				"/modules/not-nvidia.ko":     true,
 			}
 			var got []finitCall
 			deps := testDependencies(loaded, files, func(path, parameters string, flags int) error {
@@ -136,75 +131,31 @@ func TestFixedInventoriesLoadOnlyOrderedNVIDIAModules(t *testing.T) {
 	}
 }
 
-func TestFinitModuleCompressionFlagAndCandidateOrder(t *testing.T) {
-	tests := []struct {
-		name      string
-		files     map[string]bool
-		wantPath  string
-		wantFlags int
-		wantStats []string
-	}{
-		{
-			name: "compressed preferred",
-			files: map[string]bool{
-				"/modules/nvidia.ko.zst": true,
-				"/modules/nvidia.ko":     true,
-			},
-			wantPath:  "/modules/nvidia.ko.zst",
-			wantFlags: unix.MODULE_INIT_COMPRESSED_FILE,
-			wantStats: []string{
-				"/modules/nvidia.ko.zst",
-			},
-		},
-		{
-			name: "uncompressed fallback",
-			files: map[string]bool{
-				"/modules/nvidia.ko": true,
-			},
-			wantPath:  "/modules/nvidia.ko",
-			wantFlags: 0,
-			wantStats: []string{
-				"/modules/nvidia.ko.zst",
-				"/modules/nvidia.ko",
-			},
-		},
+func TestFinitModuleUsesExactUncompressedPath(t *testing.T) {
+	files := map[string]bool{
+		"/modules/nvidia.ko":     true,
+		"/modules/nvidia.ko.zst": true,
 	}
+	var gotCall finitCall
+	deps := testDependencies(map[string]bool{}, files, func(path, parameters string, flags int) error {
+		gotCall = finitCall{path: path, parameters: parameters, flags: flags}
+		return nil
+	})
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			var gotCall finitCall
-			var gotStats []string
-			deps := testDependencies(map[string]bool{}, test.files, func(path, parameters string, flags int) error {
-				gotCall = finitCall{path: path, parameters: parameters, flags: flags}
-				return nil
-			})
-			stat := deps.stat
-			deps.stat = func(path string) (os.FileInfo, error) {
-				if !strings.HasPrefix(path, "/sys/module/") {
-					gotStats = append(gotStats, path)
-				}
-				return stat(path)
-			}
-
-			if err := loadInventory("core", deps, coreModule); err != nil {
-				t.Fatalf("loadInventory: %v", err)
-			}
-			if gotCall.path != test.wantPath || gotCall.flags != test.wantFlags {
-				t.Fatalf("finit_module call = %#v, want path %q flags %d", gotCall, test.wantPath, test.wantFlags)
-			}
-			if !reflect.DeepEqual(gotStats, test.wantStats) {
-				t.Fatalf("candidate stat order = %q, want %q", gotStats, test.wantStats)
-			}
-		})
+	if err := loadInventory("core", deps, coreModule); err != nil {
+		t.Fatalf("loadInventory: %v", err)
+	}
+	if gotCall.path != "/modules/nvidia.ko" || gotCall.flags != 0 {
+		t.Fatalf("finit_module call = %#v, want exact uncompressed module with no flags", gotCall)
 	}
 }
 
 func TestFixedModulePathAllowsOnlyMeasuredInventory(t *testing.T) {
-	path, err := fixedModulePath(nvidiaModuleRoot, "nvidia-uvm.ko.zst")
+	path, err := fixedModulePath(nvidiaModuleRoot, "nvidia-uvm.ko")
 	if err != nil {
 		t.Fatalf("fixedModulePath: %v", err)
 	}
-	const want = "/usr/lib/tinfoil/kernel-modules/nvidia-uvm.ko.zst"
+	const want = "/usr/lib/tinfoil/kernel-modules/nvidia-uvm.ko"
 	if path != want {
 		t.Fatalf("fixedModulePath = %q, want %q", path, want)
 	}
@@ -214,6 +165,9 @@ func TestFixedModulePathAllowsOnlyMeasuredInventory(t *testing.T) {
 		"../nvidia.ko",
 		"updates/dkms/nvidia.ko",
 		"nvidia-drm.ko",
+		"nvidia.ko.zst",
+		"nvidia-uvm.ko.zst",
+		"nvidia-modeset.ko.zst",
 		"nvidia-peermem.ko.zst",
 	} {
 		t.Run(fmt.Sprintf("candidate_%q", candidate), func(t *testing.T) {
@@ -254,8 +208,8 @@ func TestAlreadyLoadedModulesAreSafe(t *testing.T) {
 func TestLoadInventoryPropagatesFailuresInOrder(t *testing.T) {
 	loadErr := errors.New("bad vermagic")
 	files := map[string]bool{
-		"/modules/nvidia.ko.zst":     true,
-		"/modules/nvidia-uvm.ko.zst": true,
+		"/modules/nvidia.ko":     true,
+		"/modules/nvidia-uvm.ko": true,
 	}
 	var calls []string
 	deps := testDependencies(map[string]bool{}, files, func(path, _ string, _ int) error {
@@ -276,7 +230,7 @@ func TestLoadInventoryPropagatesFailuresInOrder(t *testing.T) {
 		}
 	}
 	wantCalls := []string{
-		"/modules/nvidia.ko.zst",
+		"/modules/nvidia.ko",
 	}
 	if !reflect.DeepEqual(calls, wantCalls) {
 		t.Fatalf("finit_module calls after failure = %q, want %q", calls, wantCalls)


### PR DESCRIPTION
## Summary
- replace the two-form `.ko.zst`/`.ko` loader policy with one exact uncompressed path per NVIDIA module
- load only `nvidia.ko`, `nvidia-uvm.ko`, and `nvidia-modeset.ko`
- always call `finit_module` without the compressed-file flag
- reject compressed and non-inventory paths in tests

## Rationale
The pinned producer already emits exactly three uncompressed modules under `/usr/lib/tinfoil/kernel-modules`. Keeping a compressed compatibility form creates an unnecessary runtime mechanism and weakens the fixed measured contract. This is also a clean precursor to deterministic module signing.

## Validation
- `go test ./internal/nvidia`
- `go test -race ./internal/nvidia`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Merge gate
Independent source change, but exercise the fixed loader on one B300/H200 before merge. It does not enable signing or IBT.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin exact, uncompressed NVIDIA module paths and load only `nvidia.ko`, `nvidia-uvm.ko`, and `nvidia-modeset.ko`. Removes `.ko.zst` support and always calls `finit_module` without compressed-file flags to harden the measured contract and prepare for deterministic signing.

- **Refactors**
  - Replace candidate arrays with a single exact file name per module.
  - Resolve paths under `/usr/lib/tinfoil/kernel-modules` and call `finit_module` with flags `0` (still tolerates `EEXIST`).
  - Restrict `fixedNVIDIACandidate` to the three uncompressed files; reject compressed and non-inventory names.
  - Update tests to require exact uncompressed paths and no compressed-file flags.

<sup>Written for commit 96d6a1ac1a5b2252c14ba5636f137f997e34e3be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

