### PR TITLE
Use kernel mount IDs in the initrd

### DIFF
--- a/tinfoil/cmd/initrd/main.go
+++ b/tinfoil/cmd/initrd/main.go
@@ -162,11 +162,15 @@ func mountInitrdFilesystems() error {
 }
 
 func mountIfNeeded(source, target, fstype string, flags uintptr, data string) error {
-	if isMountPoint(target) {
-		return nil
-	}
 	if err := os.MkdirAll(target, 0755); err != nil {
 		return err
+	}
+	mounted, err := isMountPoint(target, unix.Statx)
+	if err != nil {
+		return fmt.Errorf("check mount point %s: %w", target, err)
+	}
+	if mounted {
+		return nil
 	}
 	if err := unix.Mount(source, target, fstype, flags, data); err != nil {
 		if errors.Is(err, unix.EBUSY) {
@@ -177,21 +181,22 @@ func mountIfNeeded(source, target, fstype string, flags uintptr, data string) er
 	return nil
 }
 
-func isMountPoint(target string) bool {
-	file, err := os.Open("/proc/self/mountinfo")
-	if err != nil {
-		return false
-	}
-	defer file.Close()
+type statxFunc func(int, string, int, int, *unix.Statx_t) error
 
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) >= 5 && fields[4] == target {
-			return true
-		}
+func isMountPoint(target string, statx statxFunc) (bool, error) {
+	target = filepath.Clean(target)
+	parent := filepath.Dir(target)
+	var targetStat, parentStat unix.Statx_t
+	if err := statx(unix.AT_FDCWD, target, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &targetStat); err != nil {
+		return false, err
 	}
-	return false
+	if err := statx(unix.AT_FDCWD, parent, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_MNT_ID, &parentStat); err != nil {
+		return false, err
+	}
+	if targetStat.Mask&unix.STATX_MNT_ID == 0 || parentStat.Mask&unix.STATX_MNT_ID == 0 {
+		return false, errors.New("kernel omitted STATX_MNT_ID")
+	}
+	return targetStat.Mnt_id != parentStat.Mnt_id, nil
 }
 
 func cmdlineValue(name string) (string, error) {

--- a/tinfoil/cmd/initrd/main_test.go
+++ b/tinfoil/cmd/initrd/main_test.go
@@ -4,11 +4,14 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestPinnedVeritySaltMatchesRepartSeed(t *testing.T) {
@@ -98,6 +101,54 @@ func TestCmdlineValueFromRejectsAmbiguity(t *testing.T) {
 	}
 	if _, err := cmdlineValueFrom("console=hvc0", "roothash"); !os.IsNotExist(err) {
 		t.Fatalf("missing roothash error = %v, want os.ErrNotExist", err)
+	}
+}
+
+func TestIsMountPointUsesKernelMountIDs(t *testing.T) {
+	tests := []struct {
+		name      string
+		targetID  uint64
+		parentID  uint64
+		mask      uint32
+		want      bool
+		wantError bool
+	}{
+		{name: "mounted", targetID: 8, parentID: 1, mask: unix.STATX_MNT_ID, want: true},
+		{name: "same mount", targetID: 1, parentID: 1, mask: unix.STATX_MNT_ID},
+		{name: "missing mount id", targetID: 8, parentID: 1, wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			statx := func(_ int, path string, _ int, _ int, stat *unix.Statx_t) error {
+				stat.Mask = test.mask
+				if path == "/run" {
+					stat.Mnt_id = test.targetID
+				} else if path == "/" {
+					stat.Mnt_id = test.parentID
+				} else {
+					t.Fatalf("unexpected statx path %q", path)
+				}
+				return nil
+			}
+
+			got, err := isMountPoint("/run", statx)
+			if (err != nil) != test.wantError {
+				t.Fatalf("isMountPoint error = %v, wantError %v", err, test.wantError)
+			}
+			if got != test.want {
+				t.Fatalf("isMountPoint = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestIsMountPointPropagatesStatxErrors(t *testing.T) {
+	want := errors.New("statx failed")
+	_, err := isMountPoint("/run", func(int, string, int, int, *unix.Statx_t) error {
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("isMountPoint error = %v, want %v", err, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove `/proc/self/mountinfo` parsing from the measured initrd
- identify existing mounts through the pinned Linux 7.0 `statx(STATX_MNT_ID)` contract
- fail closed when `statx` fails or the kernel omits mount IDs
- preserve current direct mount behavior and `EBUSY` handling

## Rationale
The initrd supports one pinned custom kernel. A generic text parser for mount state is unnecessary when the kernel exposes the exact mount identity directly.

## Validation
- `go test ./cmd/initrd`
- `go test -race ./cmd/initrd`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Merge gate
Independent of the open PID1/model/NVIDIA branches. Qualify one exact Box3 boot to confirm `/dev`, `/proc`, `/sys`, and `/run` setup and measured-root handoff.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use kernel mount IDs to detect existing mounts in the initrd for more reliable and secure boot behavior. Removes `/proc/self/mountinfo` parsing and fails closed if mount IDs are unavailable.

- **Refactors**
  - Replace mount detection with `statx(STATX_MNT_ID)` and drop the text parser.
  - Fail closed on `statx` errors or missing mount IDs; keep direct mount and `EBUSY` behavior.
  - Inject `statx` into `isMountPoint` for tests; add unit tests for mount ID paths and error propagation.

<sup>Written for commit d284ccf81f61fd9879f8a6a934bcb9420a414318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

