### PR TITLE
Harden device-mapper ioctl bounds

### DIFF
--- a/tinfoil/cmd/initrd/main.go
+++ b/tinfoil/cmd/initrd/main.go
@@ -312,7 +312,7 @@ func isBlockDevice(path string) bool {
 	return info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0
 }
 
-func createMeasuredRoot(lengthSectors uint64, params string) (devicemapper.Info, error) {
+func createMeasuredRoot(lengthSectors uint64, params string) (result devicemapper.Info, resultErr error) {
 	control, err := devicemapper.OpenControl()
 	if err != nil {
 		return devicemapper.Info{}, err
@@ -325,6 +325,14 @@ func createMeasuredRoot(lengthSectors uint64, params string) (devicemapper.Info,
 	if _, err := devicemapper.CreateReadOnly(control, dmName); err != nil {
 		return devicemapper.Info{}, err
 	}
+	cleanup := true
+	defer func() {
+		if cleanup {
+			if err := devicemapper.Remove(control, dmName); err != nil {
+				resultErr = errors.Join(resultErr, fmt.Errorf("cleaning up measured root device: %w", err))
+			}
+		}
+	}()
 	if err := devicemapper.LoadReadOnlyVerityTable(control, dmName, lengthSectors, params); err != nil {
 		return devicemapper.Info{}, err
 	}
@@ -345,6 +353,7 @@ func createMeasuredRoot(lengthSectors uint64, params string) (devicemapper.Info,
 	if err := devicemapper.EnsureBlockNode(dmRootNode, info.Dev); err != nil {
 		return devicemapper.Info{}, err
 	}
+	cleanup = false
 	return info, nil
 }
 

--- a/tinfoil/internal/devicemapper/devicemapper.go
+++ b/tinfoil/internal/devicemapper/devicemapper.go
@@ -23,12 +23,14 @@ const (
 
 	controlDevicePath = "/sys/class/misc/device-mapper/dev"
 	ioctlSize         = 312
+	ioctlDataOffset   = 305
 	ioctlDataStart    = ioctlSize
 	targetSpecSize    = 40
 	nameOffset        = 48
 	devOffset         = 40
 	targetSpecAlign   = 8
 	maxNameLen        = 127
+	maxIOCTLSize      = 16 * 1024
 	dmSectorSizeBytes = 512
 
 	encryptedModelCipher          = "aes-xts-plain64"
@@ -155,8 +157,11 @@ func EnsureBlockNode(path string, dev uint64) error {
 
 // CheckVersion verifies and returns the kernel's ioctl protocol version.
 func CheckVersion(control *os.File) (Version, error) {
-	buf := baseBuffer(ioctlSize, "")
-	if err := ioctl(control, versionIOCTL, buf); err != nil {
+	buf, err := baseBuffer(ioctlSize, "")
+	if err != nil {
+		return Version{}, err
+	}
+	if err := ioctl(control, versionIOCTL, buf, 0); err != nil {
 		return Version{}, fmt.Errorf("device-mapper version ioctl failed: %w", err)
 	}
 	version := Version{
@@ -175,9 +180,12 @@ func CreateReadOnly(control *os.File, name string) (Info, error) {
 	if err := validateName(name); err != nil {
 		return Info{}, err
 	}
-	buf := baseBuffer(16*1024, name)
+	buf, err := baseBuffer(maxIOCTLSize, name)
+	if err != nil {
+		return Info{}, err
+	}
 	setFlags(buf, readOnlyFlag|existsFlag)
-	if err := ioctl(control, devCreateIOCTL, buf); err != nil {
+	if err := ioctl(control, devCreateIOCTL, buf, 0); err != nil {
 		return Info{}, fmt.Errorf("device-mapper create %s failed: %w", name, err)
 	}
 	return infoFromBuffer(buf), nil
@@ -194,7 +202,7 @@ func LoadReadOnlyVerityTable(control *os.File, name string, lengthSectors uint64
 	if err != nil {
 		return err
 	}
-	if err := ioctl(control, tableLoadIOCTL, buf); err != nil {
+	if err := ioctl(control, tableLoadIOCTL, buf, 1); err != nil {
 		return fmt.Errorf("device-mapper table load %s failed: %w", name, err)
 	}
 	return nil
@@ -212,7 +220,7 @@ func LoadReadOnlyCryptTable(control *os.File, name string, lengthSectors uint64,
 		return err
 	}
 	defer zeroBytes(buf)
-	if err := ioctl(control, tableLoadIOCTL, buf); err != nil {
+	if err := ioctl(control, tableLoadIOCTL, buf, 1); err != nil {
 		return fmt.Errorf("device-mapper table load %s failed: %w", name, err)
 	}
 	return nil
@@ -223,9 +231,12 @@ func ResumeReadOnly(control *os.File, name string) error {
 	if err := validateName(name); err != nil {
 		return err
 	}
-	buf := baseBuffer(2*1024, name)
+	buf, err := baseBuffer(2*1024, name)
+	if err != nil {
+		return err
+	}
 	setFlags(buf, readOnlyFlag|existsFlag)
-	if err := ioctl(control, devSuspendIOCTL, buf); err != nil {
+	if err := ioctl(control, devSuspendIOCTL, buf, 1); err != nil {
 		return fmt.Errorf("device-mapper resume %s failed: %w", name, err)
 	}
 	return nil
@@ -236,9 +247,12 @@ func Status(control *os.File, name string) (Info, error) {
 	if err := validateName(name); err != nil {
 		return Info{}, err
 	}
-	buf := baseBuffer(16*1024, name)
+	buf, err := baseBuffer(maxIOCTLSize, name)
+	if err != nil {
+		return Info{}, err
+	}
 	setFlags(buf, existsFlag)
-	if err := ioctl(control, devStatusIOCTL, buf); err != nil {
+	if err := ioctl(control, devStatusIOCTL, buf, 1); err != nil {
 		return Info{}, fmt.Errorf("device-mapper status %s failed: %w", name, err)
 	}
 	info := infoFromBuffer(buf)
@@ -253,9 +267,12 @@ func Remove(control *os.File, name string) error {
 	if err := validateName(name); err != nil {
 		return err
 	}
-	buf := baseBuffer(ioctlSize, name)
+	buf, err := baseBuffer(ioctlSize, name)
+	if err != nil {
+		return err
+	}
 	setFlags(buf, existsFlag)
-	if err := ioctl(control, devRemoveIOCTL, buf); err != nil {
+	if err := ioctl(control, devRemoveIOCTL, buf, 0); err != nil {
 		return fmt.Errorf("device-mapper remove %s failed: %w", name, err)
 	}
 	if err := os.Remove(MapperNode(name)); err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -340,9 +357,9 @@ func validateName(name string) error {
 	return nil
 }
 
-func baseBuffer(size int, name string) []byte {
-	if size < ioctlSize {
-		size = ioctlSize
+func baseBuffer(size int, name string) ([]byte, error) {
+	if size < ioctlSize || size > maxIOCTLSize || size%targetSpecAlign != 0 {
+		return nil, fmt.Errorf("invalid device-mapper ioctl buffer size %d", size)
 	}
 	buf := make([]byte, size)
 	binary.LittleEndian.PutUint32(buf[0:4], versionMajor)
@@ -351,7 +368,7 @@ func baseBuffer(size int, name string) []byte {
 	binary.LittleEndian.PutUint32(buf[12:16], uint32(len(buf)))
 	binary.LittleEndian.PutUint32(buf[16:20], ioctlDataStart)
 	putCString(buf[nameOffset:nameOffset+128], name)
-	return buf
+	return buf, nil
 }
 
 func tableLoadBuffer(name string, lengthSectors uint64, targetType, params string) ([]byte, error) {
@@ -359,14 +376,24 @@ func tableLoadBuffer(name string, lengthSectors uint64, targetType, params strin
 }
 
 func tableLoadBufferBytes(name string, lengthSectors uint64, targetType string, params []byte) ([]byte, error) {
+	if lengthSectors == 0 {
+		return nil, fmt.Errorf("invalid zero-length device-mapper target")
+	}
 	if targetType == "" || len(targetType) >= 16 || strings.IndexByte(targetType, 0) >= 0 {
 		return nil, fmt.Errorf("invalid device-mapper target type %q", targetType)
 	}
 	if bytesIndexByte(params, 0) >= 0 {
 		return nil, fmt.Errorf("device-mapper target parameters contain NUL")
 	}
+	maxParamsSize := maxIOCTLSize - ioctlSize - targetSpecSize - 1
+	if len(params) > maxParamsSize {
+		return nil, fmt.Errorf("device-mapper target parameters are too large: %d bytes", len(params))
+	}
 	targetSize := align(targetSpecSize+len(params)+1, targetSpecAlign)
-	buf := baseBuffer(ioctlSize+targetSize, name)
+	buf, err := baseBuffer(ioctlSize+targetSize, name)
+	if err != nil {
+		return nil, err
+	}
 	setFlags(buf, readOnlyFlag|existsFlag)
 	binary.LittleEndian.PutUint32(buf[20:24], 1)
 
@@ -392,10 +419,47 @@ func infoFromBuffer(buf []byte) Info {
 	}
 }
 
-func ioctl(control *os.File, request uintptr, buf []byte) error {
+func ioctl(control *os.File, request uintptr, buf []byte, maxTargetCount uint32) error {
+	if err := validateIOCTLRequest(buf, maxTargetCount); err != nil {
+		return fmt.Errorf("invalid device-mapper ioctl request: %w", err)
+	}
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, control.Fd(), request, uintptr(unsafe.Pointer(&buf[0])))
 	if errno != 0 {
 		return errno
+	}
+	return validateIOCTLResponse(buf, maxTargetCount)
+}
+
+func validateIOCTLRequest(buf []byte, maxTargetCount uint32) error {
+	if err := validateIOCTLBuffer(buf, maxTargetCount); err != nil {
+		return err
+	}
+	dataSize := binary.LittleEndian.Uint32(buf[12:16])
+	if uint64(dataSize) != uint64(len(buf)) {
+		return fmt.Errorf("invalid ioctl request data size %d for %d-byte buffer", dataSize, len(buf))
+	}
+	return nil
+}
+
+func validateIOCTLResponse(buf []byte, maxTargetCount uint32) error {
+	return validateIOCTLBuffer(buf, maxTargetCount)
+}
+
+func validateIOCTLBuffer(buf []byte, maxTargetCount uint32) error {
+	if len(buf) < ioctlSize || len(buf) > maxIOCTLSize || len(buf)%targetSpecAlign != 0 {
+		return fmt.Errorf("invalid ioctl buffer size %d", len(buf))
+	}
+	dataSize := binary.LittleEndian.Uint32(buf[12:16])
+	if dataSize < ioctlDataOffset || uint64(dataSize) > uint64(len(buf)) {
+		return fmt.Errorf("invalid ioctl data size %d for %d-byte buffer", dataSize, len(buf))
+	}
+	dataStart := binary.LittleEndian.Uint32(buf[16:20])
+	if dataStart != ioctlDataStart {
+		return fmt.Errorf("invalid ioctl data start %d for data size %d", dataStart, dataSize)
+	}
+	targetCount := binary.LittleEndian.Uint32(buf[20:24])
+	if targetCount > maxTargetCount {
+		return fmt.Errorf("invalid ioctl target count %d, maximum %d", targetCount, maxTargetCount)
 	}
 	return nil
 }

--- a/tinfoil/internal/devicemapper/devicemapper_test.go
+++ b/tinfoil/internal/devicemapper/devicemapper_test.go
@@ -205,3 +205,94 @@ func cString(buf []byte) string {
 	}
 	return string(buf)
 }
+
+func TestTableLoadBufferBounds(t *testing.T) {
+	maxParamsSize := maxIOCTLSize - ioctlSize - targetSpecSize - 1
+	buf, err := tableLoadBuffer("root", 1, "verity", strings.Repeat("x", maxParamsSize))
+	if err != nil {
+		t.Fatalf("maximum target parameters rejected: %v", err)
+	}
+	if len(buf) != maxIOCTLSize {
+		t.Fatalf("maximum table buffer size = %d, want %d", len(buf), maxIOCTLSize)
+	}
+
+	for name, tc := range map[string]struct {
+		length uint64
+		params string
+	}{
+		"zero length":      {length: 0, params: "valid"},
+		"oversized params": {length: 1, params: strings.Repeat("x", maxParamsSize+1)},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := tableLoadBuffer("root", tc.length, "verity", tc.params); err == nil {
+				t.Fatal("invalid table geometry accepted")
+			}
+		})
+	}
+}
+
+func TestBaseBufferBounds(t *testing.T) {
+	for _, size := range []int{ioctlSize, 2 * 1024, maxIOCTLSize} {
+		if _, err := baseBuffer(size, "root"); err != nil {
+			t.Fatalf("valid buffer size %d rejected: %v", size, err)
+		}
+	}
+	for _, size := range []int{ioctlSize - 1, ioctlSize + 1, maxIOCTLSize + targetSpecAlign} {
+		if _, err := baseBuffer(size, "root"); err == nil {
+			t.Fatalf("invalid buffer size %d accepted", size)
+		}
+	}
+}
+
+func TestValidateIOCTLResponseBounds(t *testing.T) {
+	valid, err := baseBuffer(ioctlSize, "root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateIOCTLResponse(valid, 0); err != nil {
+		t.Fatalf("valid response rejected: %v", err)
+	}
+	kernelEmpty := append([]byte(nil), valid...)
+	binary.LittleEndian.PutUint32(kernelEmpty[12:16], ioctlDataOffset)
+	if err := validateIOCTLResponse(kernelEmpty, 0); err != nil {
+		t.Fatalf("kernel empty response rejected: %v", err)
+	}
+	if err := validateIOCTLRequest(kernelEmpty, 0); err == nil {
+		t.Fatal("short kernel response accepted as a request")
+	}
+
+	for name, mutate := range map[string]func([]byte){
+		"short data size": func(buf []byte) {
+			binary.LittleEndian.PutUint32(buf[12:16], ioctlDataOffset-1)
+		},
+		"oversized data size": func(buf []byte) {
+			binary.LittleEndian.PutUint32(buf[12:16], ioctlSize+targetSpecAlign)
+		},
+		"short data start": func(buf []byte) {
+			binary.LittleEndian.PutUint32(buf[16:20], ioctlDataStart-targetSpecAlign)
+		},
+		"oversized data start": func(buf []byte) {
+			binary.LittleEndian.PutUint32(buf[16:20], ioctlDataStart+targetSpecAlign)
+		},
+		"too many targets": func(buf []byte) {
+			binary.LittleEndian.PutUint32(buf[20:24], 2)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			buf := append([]byte(nil), valid...)
+			mutate(buf)
+			if err := validateIOCTLResponse(buf, 1); err == nil {
+				t.Fatal("invalid ioctl response accepted")
+			}
+		})
+	}
+
+	oneTarget := append([]byte(nil), valid...)
+	binary.LittleEndian.PutUint32(oneTarget[20:24], 1)
+	if err := validateIOCTLResponse(oneTarget, 1); err != nil {
+		t.Fatalf("single-target response rejected: %v", err)
+	}
+	if err := validateIOCTLResponse(oneTarget, 0); err == nil {
+		t.Fatal("unexpected target accepted for zero-target response")
+	}
+}


### PR DESCRIPTION
## Summary
- cap every device-mapper ioctl buffer at a fixed 16 KiB
- reject zero-length targets, oversized parameters, arithmetic/alignment failures, and malformed kernel response bounds
- bound response target counts to the one-target contract
- add direct device removal and clean up partially-created initrd mappings on failure

## Rationale
The minimal device-mapper package is now shared by measured-root and model-volume setup. Its fixed surface should also have fixed geometry and response bounds rather than trusting lengths returned through the ioctl buffer.

## Validation
- focused device-mapper boundary tests
- focused race tests
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Merge order
Review in parallel now. To avoid retriggering #221's current review, merge #221 first, then rebase this branch over the updated `jules/harden-tcb` and resolve the shared `Remove`/table-buffer implementation here. Do not merge both without that rebase. The resulting exact integration image must pass measured-root plus plaintext and encrypted model-volume qualification.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened device-mapper ioctl handling with a strict 16 KiB cap, per-call target limits, and request/response header checks that accept kernel header-only replies. Added safe device removal and initrd cleanup; bounds now also cover the crypt table path and byte-param table builder.

- **New Features**
  - Added `Remove` to delete a device-mapper device and its `/dev/mapper` node.
  - `createMeasuredRoot` defers cleanup and removes the device on error.

- **Bug Fixes**
  - Capped all ioctl buffers at 16 KiB; `baseBuffer` validates size/alignment and returns errors.
  - Enforced exact target counts per ioctl and split validation so requests require full sizes while responses allow header-only kernel replies; applied to create/status/remove/resume and both verity and crypt table loads.
  - Rejected zero-length targets, NUL in params, and oversized parameters; bounds apply to both string and byte-param builders. Expanded tests for buffer bounds, kernel header replies, and target count checks.

<sup>Written for commit 25954a5294ee710823ad39e3c89e8aa1cf8f2f34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

