### PR TITLE
Remove privileged boot maintenance commands

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -312,38 +312,6 @@ type egressFileEntry struct {
 	Allow []string `yaml:"allow"`
 }
 
-// loadConfigFromRamdisk reads config directly from ramdisk without verification (for debugging)
-func loadConfigFromRamdisk() (*Config, error) {
-	data, err := os.ReadFile(boot.ConfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("reading config from ramdisk: %w", err)
-	}
-
-	var config Config
-	if err := yaml.Unmarshal(data, &config); err != nil {
-		return nil, fmt.Errorf("parsing config: %w", err)
-	}
-	if err := validateConfigShape(&config); err != nil {
-		return nil, err
-	}
-	if err := validateModelCount(len(config.Models)); err != nil {
-		return nil, err
-	}
-
-	shimCfg, err := shimconfig.Decode(&config.ShimRaw)
-	if err != nil {
-		return nil, fmt.Errorf("parsing shim config: %w", err)
-	}
-	shimCfg.ExpectedGPUs = config.GPUs
-	config.ShimCfg = shimCfg
-
-	if err := validateNetwork(&config); err != nil {
-		return nil, fmt.Errorf("network config: %w", err)
-	}
-
-	return &config, nil
-}
-
 func loadExternalConfig() error {
 	externalDiskPath, err := device.ExternalConfigDisk()
 	if err != nil {

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -13,27 +13,18 @@ import (
 	"tinfoil/internal/nvidia"
 )
 
-type notifyContextFunc func(context.Context, ...os.Signal) (context.Context, context.CancelFunc)
-
 func init() {
 	log.SetFlags(0)
 }
 
 func main() {
-	command := ""
-	if len(os.Args) > 1 {
-		command = os.Args[1]
+	if err := validateInvocation(os.Args); err != nil {
+		log.Printf("Failed: %v", err)
+		os.Exit(1)
 	}
-	ctx, stop := commandContext(command, signal.NotifyContext)
-	defer stop()
 
-	if len(os.Args) > 1 {
-		if err := runSubcommand(ctx, os.Args[1]); err != nil {
-			log.Printf("Failed: %v", err)
-			os.Exit(1)
-		}
-		return
-	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
 
 	log.Println("Tinfoil boot starting")
 
@@ -45,51 +36,9 @@ func main() {
 	log.Println("Tinfoil boot complete")
 }
 
-func commandContext(command string, notify notifyContextFunc) (context.Context, context.CancelFunc) {
-	if command == "models" {
-		return context.Background(), func() {}
-	}
-	return notify(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-}
-
-func runSubcommand(ctx context.Context, cmd string) error {
-	switch cmd {
-	case "containers", "models":
-	default:
-		return fmt.Errorf("unknown command: %s\nUsage: tinfoil-boot [containers|models]", cmd)
-	}
-
-	config, err := loadConfigFromRamdisk()
-	if err != nil {
-		return fmt.Errorf("loading config from ramdisk: %w", err)
-	}
-
-	switch cmd {
-	case "containers":
-		externalConfig, err := getExternalConfig()
-		if err != nil {
-			return fmt.Errorf("loading external config: %w", err)
-		}
-		// Manual re-run must fetch vault secrets, they're not persisted on disk.
-		if config.VaultURL != "" {
-			log.Println("Fetching vault secrets")
-			if err := fetchVaultSecrets(config, externalConfig); err != nil {
-				return fmt.Errorf("vault secret fetch failed: %w", err)
-			}
-		}
-		log.Println("Setting up registry authentication")
-		if err := setupRegistryAuth(externalConfig); err != nil {
-			return fmt.Errorf("registry auth setup failed: %w", err)
-		}
-		log.Println("Launching containers")
-		return launchContainers(ctx, config, externalConfig)
-	case "models":
-		externalConfig, err := getExternalConfig()
-		if err != nil {
-			return fmt.Errorf("loading external config: %w", err)
-		}
-		log.Println("Mounting models")
-		return mountModels(config, externalConfig)
+func validateInvocation(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("tinfoil-boot does not accept arguments; reboot or redeploy to relaunch containers or remount models")
 	}
 	return nil
 }

--- a/tinfoil/cmd/boot/main_test.go
+++ b/tinfoil/cmd/boot/main_test.go
@@ -1,44 +1,18 @@
 package main
 
 import (
-	"context"
-	"os"
-	"reflect"
-	"syscall"
 	"testing"
 )
 
-func TestCommandContextLeavesModelsSignalsAtDefaults(t *testing.T) {
-	notifyCalled := false
-	ctx, stop := commandContext("models", func(context.Context, ...os.Signal) (context.Context, context.CancelFunc) {
-		notifyCalled = true
-		return context.WithCancel(context.Background())
-	})
-	defer stop()
-	if notifyCalled {
-		t.Fatal("models command captured process signals")
+func TestValidateInvocation(t *testing.T) {
+	if err := validateInvocation([]string{"tinfoil-boot"}); err != nil {
+		t.Fatalf("normal boot invocation failed: %v", err)
 	}
-	if ctx.Done() != nil {
-		t.Fatal("models command received a cancellable context")
-	}
-}
 
-func TestCommandContextCapturesSignalsForCancellableBootPaths(t *testing.T) {
-	for _, command := range []string{"", "containers"} {
+	for _, command := range []string{"containers", "models", "unknown"} {
 		t.Run(command, func(t *testing.T) {
-			var gotSignals []os.Signal
-			ctx, stop := commandContext(command, func(parent context.Context, signals ...os.Signal) (context.Context, context.CancelFunc) {
-				gotSignals = append(gotSignals, signals...)
-				return context.WithCancel(parent)
-			})
-			if !reflect.DeepEqual(gotSignals, []os.Signal{syscall.SIGTERM, syscall.SIGINT}) {
-				t.Fatalf("captured signals = %v", gotSignals)
-			}
-			stop()
-			select {
-			case <-ctx.Done():
-			default:
-				t.Fatal("signal stop did not cancel command context")
+			if err := validateInvocation([]string{"tinfoil-boot", command}); err == nil {
+				t.Fatalf("maintenance command %q was accepted", command)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- remove the `tinfoil-boot containers` and `tinfoil-boot models` maintenance re-entry paths
- remove `loadConfigFromRamdisk`, which reparsed the mutable ramdisk configuration without repeating measured-config verification
- reject all arguments so reboot or redeploy is the only supported container relaunch or model remount mechanism
- preserve the normal measured, no-argument boot path

This is intentionally deletion-heavy: 123 lines removed and 14 added.

## Invocation audit

No repository or infra-harness automation invokes these subcommands. The only external references found are stale operator examples in `infra-harness/CLAUDE.md`; that repository is outside this focused branch's ownership.

## Validation

- `gofmt`
- `go test ./cmd/boot`
- `go test -race ./cmd/boot`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Risk

Operators can no longer manually relaunch containers or remount models inside a running guest. That is deliberate: recovery now requires reboot or redeploy through the measured boot path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `tinfoil-boot containers` and `tinfoil-boot models` maintenance paths to enforce a single, measured no-argument boot. This also removes the unverified ramdisk config path and requires reboot or redeploy for relaunch/remount.

- **Refactors**
  - Deleted `containers` and `models` subcommands.
  - Removed `loadConfigFromRamdisk` (unverified config parsing).
  - `tinfoil-boot` now rejects all CLI arguments.
  - Simplified signal handling; normal boot uses `signal.NotifyContext`.

- **Migration**
  - Remove any scripts or docs that call `tinfoil-boot containers` or `tinfoil-boot models`.
  - To relaunch containers or remount models, reboot or redeploy through the measured boot path.

<sup>Written for commit c0fa937489699cd924567ae23487e953c4d643a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

