### PR TITLE
Use a fixed measured chain for HTTP-01

### DIFF
--- a/image/rootfs/etc/nftables.conf
+++ b/image/rootfs/etc/nftables.conf
@@ -3,6 +3,10 @@
 flush ruleset
 
 table inet tinfoil {
+    # HTTP-01 is opened temporarily by tinfoil-boot and then flushed closed.
+    chain http01 {
+    }
+
     chain input {
         type filter hook input priority 0; policy drop;
 
@@ -12,11 +16,13 @@ table inet tinfoil {
         # Established/related (return traffic for outbound connections)
         ct state established,related accept
 
+        jump http01
+
         # ICMP/ICMPv6 (network diagnostics)
         ip protocol icmp accept
         meta l4proto ipv6-icmp accept
 
-        # Shim TLS port (always open; boot may add more via `nft add rule`)
+        # Shim TLS port (always open)
         tcp dport 443 accept
     }
 

--- a/image/rootfs/etc/nftables.conf
+++ b/image/rootfs/etc/nftables.conf
@@ -19,8 +19,8 @@ table inet tinfoil {
         jump http01
 
         # ICMP/ICMPv6 (network diagnostics)
-        ip protocol icmp accept
-        meta l4proto ipv6-icmp accept
+        ip protocol 1 accept
+        meta l4proto 58 accept
 
         # Shim TLS port (always open)
         tcp dport 443 accept

--- a/tinfoil/cmd/boot/cert.go
+++ b/tinfoil/cmd/boot/cert.go
@@ -5,12 +5,10 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
-	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/go-acme/lego/v4/lego"
@@ -103,20 +101,22 @@ func obtainCertificate(id *NodeIdentity, att *verifier.Document, shimCfg *shimco
 		if shimCfg.TLSChallengeMode == "http" {
 			httpChallengeDomains = []string{id.Domain}
 			listenPort = boot.HTTPChallengePort
-			closeFW, err := openHTTP01Firewall(listenPort)
+		}
+		requestCertificate := func() (*tls.Certificate, error) {
+			mgr, err := tlsutil.NewCertProxyManager(
+				domains, boot.CacheDir, shimCfg.ControlPlane, id.TLSKey,
+				httpChallengeDomains, listenPort, certAuthToken,
+			)
 			if err != nil {
-				return fmt.Errorf("opening HTTP-01 firewall: %w", err)
+				return nil, fmt.Errorf("creating cert proxy manager: %w", err)
 			}
-			defer closeFW()
+			return retryCertificate(mgr.Certificate, certProxyRetryInterval)
 		}
-		mgr, err := tlsutil.NewCertProxyManager(
-			domains, boot.CacheDir, shimCfg.ControlPlane, id.TLSKey,
-			httpChallengeDomains, listenPort, certAuthToken,
-		)
-		if err != nil {
-			return fmt.Errorf("creating cert proxy manager: %w", err)
+		if shimCfg.TLSChallengeMode == "http" {
+			cert, err = withHTTP01Firewall(requestCertificate)
+		} else {
+			cert, err = requestCertificate()
 		}
-		cert, err = retryCertificate(mgr.Certificate, certProxyRetryInterval)
 		if err != nil {
 			return fmt.Errorf("obtaining cert via cert-proxy: %w", err)
 		}
@@ -181,24 +181,19 @@ func writeTLSArtifacts(cert *tls.Certificate, key *ecdsa.PrivateKey) error {
 	return nil
 }
 
-var nftHandleRE = regexp.MustCompile(`# handle (\d+)`)
+func withHTTP01Firewall(requestCertificate func() (*tls.Certificate, error)) (*tls.Certificate, error) {
+	return withHTTP01FirewallWith(runNft, requestCertificate)
+}
 
-func openHTTP01Firewall(port int) (func(), error) {
-	// nft delete rule wants a handle, not a match expression.
-	args := []string{"--echo", "--handle", "add", "rule", "inet", "tinfoil", "input", "tcp", "dport", strconv.Itoa(port), "accept"}
-	out, err := exec.Command("nft", args...).CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("nft %v: %w (%s)", args, err, out)
+func withHTTP01FirewallWith(run func(string) error, requestCertificate func() (*tls.Certificate, error)) (cert *tls.Certificate, retErr error) {
+	if err := run("add rule inet tinfoil http01 tcp dport 80 accept\n"); err != nil {
+		return nil, fmt.Errorf("opening HTTP-01 firewall: %w", err)
 	}
-	m := nftHandleRE.FindSubmatch(out)
-	if m == nil {
-		return nil, fmt.Errorf("nft add rule returned no handle: %s", out)
-	}
-	handle := string(m[1])
-	return func() {
-		del := []string{"delete", "rule", "inet", "tinfoil", "input", "handle", handle}
-		if out, err := exec.Command("nft", del...).CombinedOutput(); err != nil {
-			log.Printf("warning: nft delete HTTP-01 rule (handle %s) failed: %v (%s)", handle, err, out)
+	defer func() {
+		if err := run("flush chain inet tinfoil http01\n"); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("closing HTTP-01 firewall: %w", err))
 		}
-	}, nil
+	}()
+
+	return requestCertificate()
 }

--- a/tinfoil/cmd/boot/cert_test.go
+++ b/tinfoil/cmd/boot/cert_test.go
@@ -116,6 +116,8 @@ func TestMeasuredFirewallDefinesHTTP01Chain(t *testing.T) {
 	for _, contract := range []string{
 		"chain http01 {\n    }",
 		"jump http01",
+		"ip protocol 1 accept",
+		"meta l4proto 58 accept",
 	} {
 		if !strings.Contains(text, contract) {
 			t.Fatalf("measured firewall policy does not contain %q", contract)
@@ -123,5 +125,10 @@ func TestMeasuredFirewallDefinesHTTP01Chain(t *testing.T) {
 	}
 	if strings.Contains(text, "tcp dport 80 accept") {
 		t.Fatal("measured firewall policy opens HTTP-01 before certificate issuance")
+	}
+	for _, protocolName := range []string{"ip protocol icmp", "l4proto ipv6-icmp"} {
+		if strings.Contains(text, protocolName) {
+			t.Fatalf("measured firewall policy depends on protocol-name parsing: %q", protocolName)
+		}
 	}
 }

--- a/tinfoil/cmd/boot/cert_test.go
+++ b/tinfoil/cmd/boot/cert_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestWithHTTP01FirewallUsesFixedMeasuredChain(t *testing.T) {
+	var events []string
+	wantCert := &tls.Certificate{}
+
+	cert, err := withHTTP01FirewallWith(func(script string) error {
+		events = append(events, script)
+		return nil
+	}, func() (*tls.Certificate, error) {
+		events = append(events, "request certificate")
+		return wantCert, nil
+	})
+	if err != nil {
+		t.Fatalf("withHTTP01FirewallWith() error = %v", err)
+	}
+	if cert != wantCert {
+		t.Fatalf("withHTTP01FirewallWith() certificate = %p, want %p", cert, wantCert)
+	}
+
+	wantEvents := []string{
+		"add rule inet tinfoil http01 tcp dport 80 accept\n",
+		"request certificate",
+		"flush chain inet tinfoil http01\n",
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %#v, want %#v", events, wantEvents)
+	}
+}
+
+func TestWithHTTP01FirewallDoesNotRequestCertificateWhenOpeningFails(t *testing.T) {
+	openErr := errors.New("open failed")
+	requested := false
+
+	_, err := withHTTP01FirewallWith(func(script string) error {
+		if script != "add rule inet tinfoil http01 tcp dport 80 accept\n" {
+			t.Fatalf("script = %q", script)
+		}
+		return openErr
+	}, func() (*tls.Certificate, error) {
+		requested = true
+		return nil, nil
+	})
+	if !errors.Is(err, openErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, openErr)
+	}
+	if requested {
+		t.Fatal("certificate request ran after firewall opening failed")
+	}
+}
+
+func TestWithHTTP01FirewallFailsClosedWhenCleanupFails(t *testing.T) {
+	cleanupErr := errors.New("flush failed")
+	call := 0
+
+	cert, err := withHTTP01FirewallWith(func(string) error {
+		call++
+		if call == 2 {
+			return cleanupErr
+		}
+		return nil
+	}, func() (*tls.Certificate, error) {
+		return &tls.Certificate{}, nil
+	})
+	if cert == nil {
+		t.Fatal("certificate = nil")
+	}
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, cleanupErr)
+	}
+	if !strings.Contains(err.Error(), "closing HTTP-01 firewall") {
+		t.Fatalf("error = %q, want cleanup context", err)
+	}
+}
+
+func TestWithHTTP01FirewallPreservesRequestAndCleanupFailures(t *testing.T) {
+	requestErr := errors.New("request failed")
+	cleanupErr := errors.New("flush failed")
+	call := 0
+
+	_, err := withHTTP01FirewallWith(func(string) error {
+		call++
+		if call == 2 {
+			return cleanupErr
+		}
+		return nil
+	}, func() (*tls.Certificate, error) {
+		return nil, requestErr
+	})
+	if !errors.Is(err, requestErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, requestErr)
+	}
+	if !errors.Is(err, cleanupErr) {
+		t.Fatalf("error = %v, want wrapped %v", err, cleanupErr)
+	}
+}
+
+func TestMeasuredFirewallDefinesHTTP01Chain(t *testing.T) {
+	policyPath := filepath.Join("..", "..", "..", "image", "rootfs", "etc", "nftables.conf")
+	policy, err := os.ReadFile(policyPath)
+	if err != nil {
+		t.Fatalf("reading %s: %v", policyPath, err)
+	}
+
+	text := string(policy)
+	for _, contract := range []string{
+		"chain http01 {\n    }",
+		"jump http01",
+	} {
+		if !strings.Contains(text, contract) {
+			t.Fatalf("measured firewall policy does not contain %q", contract)
+		}
+	}
+	if strings.Contains(text, "tcp dport 80 accept") {
+		t.Fatal("measured firewall policy opens HTTP-01 before certificate issuance")
+	}
+}


### PR DESCRIPTION
## Summary

- define an empty `inet tinfoil http01` chain in the measured nftables policy and jump to it from the fixed input chain
- open HTTP-01 with one fixed port-80 rule and close it by flushing the fixed chain
- remove `nft --echo --handle` output parsing and dynamic rule-handle state
- propagate chain cleanup failure so certificate boot/readiness fails closed instead of continuing with port 80 open

## Validation

- `gofmt`
- `go build ./...`
- `go test ./...`
- `go test -race ./cmd/boot -run 'TestWithHTTP01Firewall|TestMeasuredFirewallDefinesHTTP01Chain' -count=1`
- `go vet ./...`
- `sudo nft --check --file image/rootfs/etc/nftables.conf`
- isolated network-namespace lifecycle: load measured policy, add fixed HTTP-01 rule, flush fixed chain, verify port-80 rule is absent
- `git diff --check`

## Merge dependencies

None. This is based directly on `jules/harden-tcb` and is independent of the currently open hardening PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches HTTP-01 handling to a fixed, measured nftables chain and closes it by flushing, so port 80 opens predictably and fails closed on errors. Also hardens the measured policy by using numeric ICMP protocol values to avoid name parsing differences.

- **Refactors**
  - Define an empty `http01` chain in the measured policy and jump to it from the fixed `input` chain; manage HTTP-01 by adding a single `tcp dport 80 accept` rule to that chain and closing by flushing it via `withHTTP01Firewall`.
  - Add tests to verify chain usage, that the measured policy stays closed by default, and that numeric ICMP protocol entries are used.

- **Bug Fixes**
  - Propagate chain cleanup errors so certificate boot/readiness fails closed (no lingering port 80).
  - Use protocol numbers (`ip protocol 1`, `meta l4proto 58`) to avoid nft protocol-name parsing differences.

<sup>Written for commit 9418f91ead708683f31db0d732c3090cb5d4d2d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

