### PR TITLE
Fail closed on egress DNS refresh errors

### DIFF
--- a/tinfoil/cmd/egress/main.go
+++ b/tinfoil/cmd/egress/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"os/signal"
@@ -12,7 +13,7 @@ import (
 
 type egressRunner interface {
 	Configured() bool
-	Run(context.Context, func(error))
+	Run(context.Context) error
 }
 
 func init() {
@@ -45,9 +46,9 @@ func runWith(ctx context.Context, load func() (egressRunner, error)) error {
 	}
 	// Boot owns the readiness-gating initial population. This service only
 	// refreshes the already-populated sets at the fixed engine interval.
-	engine.Run(ctx, func(err error) {
-		log.Printf("refresh failed: %v", err)
-	})
+	if err := engine.Run(ctx); err != nil {
+		return fmt.Errorf("refreshing allow sets: %w", err)
+	}
 	log.Println("shutting down")
 	return nil
 }

--- a/tinfoil/cmd/egress/main_test.go
+++ b/tinfoil/cmd/egress/main_test.go
@@ -9,15 +9,29 @@ import (
 type fakeRunner struct {
 	configured bool
 	runCalls   int
+	runErr     error
 }
 
 func (f *fakeRunner) Configured() bool {
 	return f.configured
 }
 
-func (f *fakeRunner) Run(ctx context.Context, _ func(error)) {
+func (f *fakeRunner) Run(ctx context.Context) error {
 	f.runCalls++
+	if f.runErr != nil {
+		return f.runErr
+	}
 	<-ctx.Done()
+	return nil
+}
+
+func TestRunWithPropagatesRefreshFailure(t *testing.T) {
+	wantErr := errors.New("refresh failed")
+	runner := &fakeRunner{configured: true, runErr: wantErr}
+	err := runWith(context.Background(), func() (egressRunner, error) { return runner, nil })
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("runWith error = %v, want %v", err, wantErr)
+	}
 }
 
 func TestRunWithStartsRefreshLoopWithoutInitialPopulation(t *testing.T) {

--- a/tinfoil/internal/egress/egress.go
+++ b/tinfoil/internal/egress/egress.go
@@ -2,6 +2,7 @@ package egress
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -98,20 +99,47 @@ func (e *Engine) Refresh(ctx context.Context) error {
 	return nil
 }
 
-// Run refreshes at the daemon interval until ctx is canceled.
-func (e *Engine) Run(ctx context.Context, refreshFailed func(error)) {
+// Run refreshes at the daemon interval until ctx is canceled. A failed
+// periodic refresh clears every configured allow set in one nft transaction
+// before returning the failure to the daemon.
+func (e *Engine) Run(ctx context.Context) error {
 	ticker := time.NewTicker(e.interval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case <-ticker.C:
-			if err := e.Refresh(ctx); err != nil && refreshFailed != nil {
-				refreshFailed(err)
+			if err := e.Refresh(ctx); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
+				if clearErr := e.clear(); clearErr != nil {
+					return errors.Join(err, clearErr)
+				}
+				return err
 			}
 		}
 	}
+}
+
+func (e *Engine) clear() error {
+	names := make([]string, 0, len(e.config.Networks))
+	for name := range e.config.Networks {
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil
+	}
+	sort.Strings(names)
+	var script strings.Builder
+	for _, name := range names {
+		fmt.Fprintf(&script, "flush set inet tinfoil %s%s\n", containernet.AllowSetPrefix, name)
+	}
+	if out, err := e.nft.apply(script.String()); err != nil {
+		return fmt.Errorf("clearing egress allow sets: %w (%s)", err, out)
+	}
+	return nil
 }
 
 func loadConfig(path string) (*config, error) {

--- a/tinfoil/internal/egress/egress_test.go
+++ b/tinfoil/internal/egress/egress_test.go
@@ -98,3 +98,87 @@ func TestRefreshThreadsCancellationIntoResolution(t *testing.T) {
 		t.Fatalf("Refresh() error = %v, want context cancellation", err)
 	}
 }
+
+func TestRunClearsAllSetsAndReturnsRefreshFailure(t *testing.T) {
+	wantErr := errors.New("DNS unavailable")
+	applyCalls := 0
+	engine := &Engine{
+		config: &config{Networks: map[string]network{
+			"zeta":  {Allow: []string{"zeta.example"}},
+			"alpha": {Allow: []string{"alpha.example"}},
+		}},
+		resolve: func(context.Context, []string) ([]string, error) {
+			return nil, wantErr
+		},
+		nft: nftClient{apply: func(script string) ([]byte, error) {
+			applyCalls++
+			want := "flush set inet tinfoil allow-alpha\n" +
+				"flush set inet tinfoil allow-zeta\n"
+			if script != want {
+				t.Fatalf("nft script = %q, want %q", script, want)
+			}
+			return nil, nil
+		}},
+		interval: time.Nanosecond,
+	}
+
+	err := engine.Run(context.Background())
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("Run() error = %v, want %v", err, wantErr)
+	}
+	if applyCalls != 1 {
+		t.Fatalf("nft apply calls = %d, want 1", applyCalls)
+	}
+}
+
+func TestRunReturnsRefreshAndClearFailures(t *testing.T) {
+	refreshErr := errors.New("DNS unavailable")
+	clearErr := errors.New("exit status 1")
+	engine := &Engine{
+		config: &config{Networks: map[string]network{
+			"control": {Allow: []string{"api.example"}},
+		}},
+		resolve: func(context.Context, []string) ([]string, error) {
+			return nil, refreshErr
+		},
+		nft: nftClient{apply: func(string) ([]byte, error) {
+			return []byte("permission denied"), clearErr
+		}},
+		interval: time.Nanosecond,
+	}
+
+	err := engine.Run(context.Background())
+	if !errors.Is(err, refreshErr) {
+		t.Fatalf("Run() error = %v, want refresh failure", err)
+	}
+	if !errors.Is(err, clearErr) {
+		t.Fatalf("Run() error = %v, want clear failure", err)
+	}
+	if !strings.Contains(err.Error(), "clearing egress allow sets") ||
+		!strings.Contains(err.Error(), "permission denied") {
+		t.Fatalf("Run() error = %v, want clear context and nft output", err)
+	}
+}
+
+func TestRunCancellationDoesNotChangeNftState(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	engine := &Engine{
+		config: &config{Networks: map[string]network{
+			"control": {Allow: []string{"api.example"}},
+		}},
+		resolve: func(context.Context, []string) ([]string, error) {
+			t.Fatal("resolve called after cancellation")
+			return nil, nil
+		},
+		nft: nftClient{apply: func(string) ([]byte, error) {
+			t.Fatal("nft called after cancellation")
+			return nil, nil
+		}},
+		interval: time.Hour,
+	}
+
+	if err := engine.Run(ctx); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- clear every configured allowlist nft set in one deterministic transaction when a periodic refresh fails
- return the refresh failure after a successful clear so `tinfoil-egress` exits instead of retaining stale authorization and continuing
- return both refresh and clear failures when nft cannot clear the sets
- preserve boot-owned synchronous initial allowlist population before readiness

## Fixed contract

The daemon derives the complete fixed set list from the measured egress config, sorts it, and sends one `nft -f -` transaction containing only `flush set inet tinfoil allow-<network>` statements. There is no nft output parser or generic rule mechanism.

A shutdown cancellation does not mutate nft state. Any non-cancellation periodic refresh failure attempts the all-set clear and then fails the daemon. PID1's existing supervisor may restart the failed service, but stale addresses have already been removed when the clear succeeds.

## Validation

- `gofmt` check on changed Go files
- `go build ./...`
- `go test ./...`
- `go test -race ./internal/egress ./cmd/egress`
- `go vet ./...`
- `git diff --check`
- focused packages repeated with `go test -count=20 ./internal/egress ./cmd/egress`

## Stack / merge order

1. Merge #220 first.
2. Then retarget this PR to `jules/harden-tcb` if #220's commits are preserved in the target history.
3. If #220 is squash-merged, rebase this branch onto the updated `jules/harden-tcb`, drop the old #220 parent commits, and push with `--force-with-lease`.

A rebase rewrites this commit and will rerun CI and automated review; repository settings may also dismiss existing approvals. Prefer a base retarget without rewriting when the resulting diff contains only this PR. If a clean rebase is required after a squash merge, reviewers should expect one final review/check refresh.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail closed on periodic DNS refresh errors: clear all configured allowlist sets via `nft` and return the error so `tinfoil-egress` exits. This prevents stale authorization and leaves `nft` unchanged on clean shutdown.

- **Bug Fixes**
  - On refresh error, run one deterministic `nft -f -` script (sorted network names) to `flush set inet tinfoil allow-<network>`, then return the refresh error.
  - If the clear fails, return a joined error with both refresh and clear failures and include `nft` output.
  - Cancellation does not mutate `nft`; boot-owned initial allowlist population is preserved.

- **Refactors**
  - `egressRunner.Run(ctx)` now returns an error; `main` propagates it (“refreshing allow sets”) instead of using a callback.
  - Removed the refresh failure callback; no rule parsing in the engine.

<sup>Written for commit 1a7a29f3e5fef117dc79bceb9e3cc13cc80fec9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

