### PR TITLE
Restrict container privilege inputs

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -109,15 +109,14 @@ type Container struct {
 	// Secrets: list of keys to lookup from external-config.yml (sensitive)
 	Secrets []string `yaml:"secrets,omitempty"`
 
-	Volumes     []string    `yaml:"volumes,omitempty"` // "source:target[:opts]"
-	Devices     []string    `yaml:"devices,omitempty"`
-	CapAdd      []string    `yaml:"cap_add,omitempty"`
-	SecurityOpt []string    `yaml:"security_opt,omitempty"`
-	Runtime     string      `yaml:"runtime,omitempty"`  // e.g., "nvidia"
-	Networks    []string    `yaml:"networks,omitempty"` // names of entries in top-level `networks:`
-	IPC         string      `yaml:"ipc,omitempty"`      // e.g., "host"
-	PidMode     string      `yaml:"pid,omitempty"`      // "host" for host PID namespace
-	GPUs        interface{} `yaml:"gpus,omitempty"`     // "all", "0,1,2,3", or count (int)
+	Volumes  []string    `yaml:"volumes,omitempty"` // "source:target[:opts]"
+	Devices  []string    `yaml:"devices,omitempty"`
+	CapAdd   []string    `yaml:"cap_add,omitempty"`
+	Runtime  string      `yaml:"runtime,omitempty"`  // e.g., "nvidia"
+	Networks []string    `yaml:"networks,omitempty"` // names of entries in top-level `networks:`
+	IPC      string      `yaml:"ipc,omitempty"`      // e.g., "host"
+	PidMode  string      `yaml:"pid,omitempty"`      // "host" for host PID namespace
+	GPUs     interface{} `yaml:"gpus,omitempty"`     // "all", "0,1,2,3", or count (int)
 
 	// Resource limits
 	ShmSize string            `yaml:"shm_size,omitempty"` // "2g"
@@ -134,6 +133,8 @@ type Container struct {
 	StopSignal  string       `yaml:"stop_signal,omitempty"`  // "SIGTERM", "SIGQUIT"
 	StopTimeout *int         `yaml:"stop_timeout,omitempty"` // seconds
 	Healthcheck *Healthcheck `yaml:"healthcheck,omitempty"`
+
+	inputFields containerInputFields
 }
 
 // Healthcheck defines container health monitoring

--- a/tinfoil/cmd/boot/config_shape.go
+++ b/tinfoil/cmd/boot/config_shape.go
@@ -52,7 +52,6 @@ func validateContainerShape(index int, container *Container) error {
 		{name: "volumes", count: len(container.Volumes)},
 		{name: "devices", count: len(container.Devices)},
 		{name: "cap_add", count: len(container.CapAdd)},
-		{name: "security_opt", count: len(container.SecurityOpt)},
 		{name: "networks", count: len(container.Networks)},
 	}
 	for _, list := range lists {
@@ -65,6 +64,9 @@ func validateContainerShape(index int, container *Container) error {
 	}
 	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
 		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
+	}
+	if err := validateContainerInputPolicy(index, container); err != nil {
+		return err
 	}
 	for envIndex, item := range container.Env {
 		switch value := item.(type) {

--- a/tinfoil/cmd/boot/container_input_policy.go
+++ b/tinfoil/cmd/boot/container_input_policy.go
@@ -77,10 +77,6 @@ func allowedContainerCapability(capability string) bool {
 	switch capability {
 	case "CHOWN", "DAC_OVERRIDE", "IPC_LOCK", "KILL", "NET_BIND_SERVICE", "SETGID", "SETUID", "SYS_NICE", "SYS_RESOURCE":
 		return true
-	// SYS_ADMIN remains a temporary exception for the production document
-	// conversion workload and should be removed after workload qualification.
-	case "SYS_ADMIN":
-		return true
 	default:
 		return false
 	}

--- a/tinfoil/cmd/boot/container_input_policy.go
+++ b/tinfoil/cmd/boot/container_input_policy.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type containerInputFields struct {
+	privileged  bool
+	capDrop     bool
+	securityOpt bool
+}
+
+func (c *Container) UnmarshalYAML(node *yaml.Node) error {
+	var fields containerInputFields
+	if node.Kind == yaml.MappingNode {
+		for index := 0; index < len(node.Content); index += 2 {
+			switch node.Content[index].Value {
+			case "privileged":
+				fields.privileged = true
+			case "cap_drop":
+				fields.capDrop = true
+			case "security_opt":
+				fields.securityOpt = true
+			}
+		}
+	}
+	type rawContainer Container
+	var raw rawContainer
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	*c = Container(raw)
+	c.inputFields = fields
+	return nil
+}
+
+func validateContainerInputPolicy(index int, container *Container) error {
+	fields := container.inputFields
+	if fields.privileged {
+		return fmt.Errorf("containers[%d].privileged is unsupported", index)
+	}
+	if fields.capDrop {
+		return fmt.Errorf("containers[%d].cap_drop is unsupported", index)
+	}
+	if fields.securityOpt {
+		return fmt.Errorf("containers[%d].security_opt is unsupported", index)
+	}
+	if container.PidMode != "" {
+		return fmt.Errorf("containers[%d].pid is unsupported", index)
+	}
+	if len(container.Devices) != 0 {
+		return fmt.Errorf("containers[%d].devices is unsupported", index)
+	}
+	if container.IPC != "" && container.IPC != "private" && container.IPC != "host" {
+		return fmt.Errorf("containers[%d].ipc must be private or host", index)
+	}
+	for volumeIndex, volume := range container.Volumes {
+		source, _, found := strings.Cut(volume, ":")
+		if !found || !validNamedVolume(source) {
+			return fmt.Errorf("containers[%d].volumes[%d] must use a named volume source", index, volumeIndex)
+		}
+	}
+	for capabilityIndex, capability := range container.CapAdd {
+		if !allowedContainerCapability(capability) {
+			return fmt.Errorf("containers[%d].cap_add[%d] capability %q is unsupported", index, capabilityIndex, capability)
+		}
+	}
+	return nil
+}
+
+func allowedContainerCapability(capability string) bool {
+	switch capability {
+	case "CHOWN", "DAC_OVERRIDE", "IPC_LOCK", "KILL", "NET_BIND_SERVICE", "SETGID", "SETUID", "SYS_NICE", "SYS_RESOURCE":
+		return true
+	// SYS_ADMIN remains a temporary exception for the production document
+	// conversion workload and should be removed after workload qualification.
+	case "SYS_ADMIN":
+		return true
+	default:
+		return false
+	}
+}
+
+func validNamedVolume(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	for index := 0; index < len(name); index++ {
+		character := name[index]
+		if character >= 'a' && character <= 'z' || character >= 'A' && character <= 'Z' || character >= '0' && character <= '9' {
+			continue
+		}
+		if index > 0 && (character == '_' || character == '.' || character == '-') {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/tinfoil/cmd/boot/container_input_policy.go
+++ b/tinfoil/cmd/boot/container_input_policy.go
@@ -18,6 +18,8 @@ func (c *Container) UnmarshalYAML(node *yaml.Node) error {
 	if node.Kind == yaml.MappingNode {
 		for index := 0; index < len(node.Content); index += 2 {
 			switch node.Content[index].Value {
+			case "<<":
+				return fmt.Errorf("container YAML merge keys are unsupported")
 			case "privileged":
 				fields.privileged = true
 			case "cap_drop":

--- a/tinfoil/cmd/boot/container_input_policy_test.go
+++ b/tinfoil/cmd/boot/container_input_policy_test.go
@@ -23,7 +23,6 @@ containers:
       - NET_BIND_SERVICE
       - SETGID
       - SETUID
-      - SYS_ADMIN
       - SYS_NICE
       - SYS_RESOURCE
 `)
@@ -52,6 +51,7 @@ func TestContainerInputPolicyRejectsUnsupportedInputs(t *testing.T) {
 		{name: "slash bind", body: "volumes: [data/cache:/cache]", want: "named volume source"},
 		{name: "docker socket", body: "volumes: [/var/run/docker.sock:/var/run/docker.sock]", want: "named volume source"},
 		{name: "anonymous volume", body: "volumes: [/data]", want: "named volume source"},
+		{name: "sys admin", body: "cap_add: [SYS_ADMIN]", want: `capability "SYS_ADMIN" is unsupported`},
 		{name: "sys module", body: "cap_add: [SYS_MODULE]", want: `capability "SYS_MODULE" is unsupported`},
 		{name: "cap prefix alias", body: "cap_add: [CAP_CHOWN]", want: `capability "CAP_CHOWN" is unsupported`},
 	}

--- a/tinfoil/cmd/boot/container_input_policy_test.go
+++ b/tinfoil/cmd/boot/container_input_policy_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestContainerInputPolicyPreservesKnownProductionInputs(t *testing.T) {
+	config := decodePolicyConfig(t, `
+containers:
+  - name: workload
+    image: example.invalid/workload
+    ipc: host
+    volumes:
+      - execsock:/run/execsock
+    cap_add:
+      - CHOWN
+      - DAC_OVERRIDE
+      - IPC_LOCK
+      - KILL
+      - NET_BIND_SERVICE
+      - SETGID
+      - SETUID
+      - SYS_ADMIN
+      - SYS_NICE
+      - SYS_RESOURCE
+`)
+	if err := validateConfigShape(&config); err != nil {
+		t.Fatalf("validateConfigShape rejected known production inputs: %v", err)
+	}
+}
+
+func TestContainerInputPolicyRejectsUnsupportedInputs(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "host pid", body: "pid: host", want: ".pid is unsupported"},
+		{name: "device", body: "devices: [/dev/kvm]", want: ".devices is unsupported"},
+		{name: "privileged true", body: "privileged: true", want: ".privileged is unsupported"},
+		{name: "privileged false", body: "privileged: false", want: ".privileged is unsupported"},
+		{name: "cap drop", body: "cap_drop: [NET_RAW]", want: ".cap_drop is unsupported"},
+		{name: "empty cap drop", body: "cap_drop: []", want: ".cap_drop is unsupported"},
+		{name: "security opt", body: "security_opt: [seccomp=unconfined]", want: ".security_opt is unsupported"},
+		{name: "empty security opt", body: "security_opt: []", want: ".security_opt is unsupported"},
+		{name: "shared ipc", body: "ipc: shareable", want: ".ipc must be private or host"},
+		{name: "absolute bind", body: "volumes: [/:/host]", want: "named volume source"},
+		{name: "relative bind", body: "volumes: [./data:/data]", want: "named volume source"},
+		{name: "slash bind", body: "volumes: [data/cache:/cache]", want: "named volume source"},
+		{name: "docker socket", body: "volumes: [/var/run/docker.sock:/var/run/docker.sock]", want: "named volume source"},
+		{name: "anonymous volume", body: "volumes: [/data]", want: "named volume source"},
+		{name: "sys module", body: "cap_add: [SYS_MODULE]", want: `capability "SYS_MODULE" is unsupported`},
+		{name: "cap prefix alias", body: "cap_add: [CAP_CHOWN]", want: `capability "CAP_CHOWN" is unsupported`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := decodePolicyConfig(t, "containers:\n  - name: workload\n    image: example.invalid/workload\n    "+test.body+"\n")
+			err := validateConfigShape(&config)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateConfigShape error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidNamedVolume(t *testing.T) {
+	for _, name := range []string{"execsock", "a", "model-cache.v2", "cache_1"} {
+		if !validNamedVolume(name) {
+			t.Errorf("validNamedVolume(%q) = false", name)
+		}
+	}
+	for _, name := range []string{"", ".", "..", "./data", "../data", "data/cache", "/data", "-cache", "cache:name"} {
+		if validNamedVolume(name) {
+			t.Errorf("validNamedVolume(%q) = true", name)
+		}
+	}
+}
+
+func decodePolicyConfig(t *testing.T, data string) Config {
+	t.Helper()
+	var config Config
+	if err := yaml.Unmarshal([]byte(data), &config); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	return config
+}

--- a/tinfoil/cmd/boot/container_input_policy_test.go
+++ b/tinfoil/cmd/boot/container_input_policy_test.go
@@ -66,6 +66,28 @@ func TestContainerInputPolicyRejectsUnsupportedInputs(t *testing.T) {
 	}
 }
 
+func TestContainerInputPolicyRejectsYAMLMergeKeysBeforeDecode(t *testing.T) {
+	tests := []struct {
+		name  string
+		merge string
+	}{
+		{name: "privileged", merge: "{privileged: true}"},
+		{name: "cap drop", merge: "{cap_drop: [NET_RAW]}"},
+		{name: "security opt", merge: "{security_opt: [seccomp=unconfined]}"},
+		{name: "otherwise supported fields", merge: "{ipc: host}"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			data := "containers:\n  - name: workload\n    image: example.invalid/workload\n    <<: " + test.merge + "\n"
+			var config Config
+			err := yaml.Unmarshal([]byte(data), &config)
+			if err == nil || !strings.Contains(err.Error(), "container YAML merge keys are unsupported") {
+				t.Fatalf("yaml.Unmarshal error = %v, want merge-key rejection", err)
+			}
+		})
+	}
+}
+
 func TestValidNamedVolume(t *testing.T) {
 	for _, name := range []string{"execsock", "a", "model-cache.v2", "cache_1"} {
 		if !validNamedVolume(name) {

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -397,11 +396,6 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		}
 	}
 
-	// Security defaults per container-security-defaults.md.
-	secOpts := c.SecurityOpt
-	if !slices.Contains(secOpts, "no-new-privileges:true") {
-		secOpts = append(append([]string(nil), c.SecurityOpt...), "no-new-privileges:true")
-	}
 	pidsLimit := c.PidsLimit
 	if pidsLimit == nil {
 		n := defaultPidsLimit
@@ -417,7 +411,7 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		PidMode:        container.PidMode(c.PidMode),
 		CapAdd:         c.CapAdd,
 		CapDrop:        []string{"ALL"},
-		SecurityOpt:    secOpts,
+		SecurityOpt:    []string{"no-new-privileges:true"},
 		ReadonlyRootfs: c.ReadOnly == nil || *c.ReadOnly,
 		Tmpfs:          c.Tmpfs,
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},


### PR DESCRIPTION
## Summary

- reject host PID namespace, raw device mappings, caller security options, `privileged`, and `cap_drop`
- accept only private/default or host IPC, named-volume sources, and the exact capability set used by known production configurations
- keep `CapDrop: ALL` and `no-new-privileges:true` as fixed measured runtime policy rather than caller-controlled inputs

## Fixed contract

Known production inputs remain supported:

- `ipc: host`
- named volume `execsock:/run/execsock`
- `CHOWN`, `DAC_OVERRIDE`, `IPC_LOCK`, `KILL`, `NET_BIND_SERVICE`, `SETGID`, `SETUID`, `SYS_ADMIN`, `SYS_NICE`, and `SYS_RESOURCE`

`SYS_ADMIN` is retained only as a documented temporary exception for the production document-conversion workload. Removing it requires separate workload evidence.

This intentionally rejects old qualification/debug configurations that use `pid: host`, host bind mounts, Docker socket mounts, raw devices, `SYS_PTRACE`, `SYS_CHROOT`, or other unreviewed capabilities. Qualification should use injected SSH and host-side evidence instead.

## Validation

- `gofmt`
- focused config tests
- focused race tests
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

## Review and merge notes

This is based directly on `jules/harden-tcb` and has no technical dependency on #228. Both PRs touch `tinfoil/cmd/boot/config.go`, but in separate areas: this PR changes the container schema while #228 removes the maintenance config reload path. If #228 lands first, rebase this PR before merge; any conflict should be small and should preserve both deletions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts container inputs to prevent privilege escalation and locks down runtime defaults. Rejects YAML merge keys and caller control of sensitive fields; enforces CapDrop: ALL and `no-new-privileges:true`, and removes `SYS_ADMIN` from allowed capabilities.

- **Migration**
  - Remove `privileged`, `cap_drop`, and `security_opt` from container configs.
  - Do not use `pid: host` or `devices: [...]`.
  - Use named volumes only (e.g., `execsock:/run/execsock`); no bind mounts.
  - Set `ipc` to `host` or `private` only.
  - Limit `cap_add` to: CHOWN, DAC_OVERRIDE, IPC_LOCK, KILL, NET_BIND_SERVICE, SETGID, SETUID, SYS_NICE, SYS_RESOURCE.

<sup>Written for commit 44a324f40b6fc9268fd40379194744839b99b1e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

