### PR TITLE
Preserve PID1 child groups after reap

### DIFF
--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -58,12 +58,13 @@ type processBackend interface {
 // Process is a child whose status is owned by Manager. Wait may be called by
 // multiple observers; all receive the same result.
 type Process struct {
+	pid   int
 	child backendProcess
 	done  chan struct{}
 	exit  Exit
 }
 
-func (p *Process) PID() int              { return p.child.pid() }
+func (p *Process) PID() int              { return p.pid }
 func (p *Process) Done() <-chan struct{} { return p.done }
 
 func (p *Process) Wait(ctx context.Context) (Exit, error) {
@@ -135,8 +136,9 @@ func (m *Manager) Start(command Command) (*Process, error) {
 			reply <- startResponse{err: err}
 			return
 		}
-		process := &Process{child: child, done: make(chan struct{})}
-		children[child.pid()] = process
+		pid := child.pid()
+		process := &Process{pid: pid, child: child, done: make(chan struct{})}
+		children[pid] = process
 		reply <- startResponse{process: process}
 	}
 	response := <-reply
@@ -205,7 +207,7 @@ func (osBackend) start(command Command) (backendProcess, error) {
 	if err != nil {
 		return nil, fmt.Errorf("start %s: %w", command.Name, err)
 	}
-	return osChild{process: process}, nil
+	return osChild{process: process, processID: process.Pid}, nil
 }
 
 func (osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
@@ -214,18 +216,21 @@ func (osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
 	return pid, status, err
 }
 
-type osChild struct{ process *os.Process }
+type osChild struct {
+	process   *os.Process
+	processID int
+}
 
-func (p osChild) pid() int { return p.process.Pid }
+func (p osChild) pid() int { return p.processID }
 func (p osChild) signal(sig syscall.Signal) error {
-	err := syscall.Kill(-p.process.Pid, sig)
+	err := syscall.Kill(-p.processID, sig)
 	if errors.Is(err, syscall.ESRCH) {
 		return os.ErrProcessDone
 	}
 	return err
 }
 func (p osChild) groupAlive() (bool, error) {
-	err := syscall.Kill(-p.process.Pid, 0)
+	err := syscall.Kill(-p.processID, 0)
 	if errors.Is(err, syscall.ESRCH) {
 		return false, nil
 	}

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -26,20 +26,25 @@ type Command struct {
 
 // Exit is the wait status collected for a child.
 type Exit struct {
+	Name   string
 	PID    int
 	Status syscall.WaitStatus
 }
 
 func (e Exit) Err() error {
+	identity := fmt.Sprintf("pid %d", e.PID)
+	if e.Name != "" {
+		identity = fmt.Sprintf("%s (pid %d)", e.Name, e.PID)
+	}
 	switch {
 	case e.Status.Exited() && e.Status.ExitStatus() == 0:
 		return nil
 	case e.Status.Exited():
-		return fmt.Errorf("pid %d exited with status %d", e.PID, e.Status.ExitStatus())
+		return fmt.Errorf("%s exited with status %d", identity, e.Status.ExitStatus())
 	case e.Status.Signaled():
-		return fmt.Errorf("pid %d killed by %s", e.PID, e.Status.Signal())
+		return fmt.Errorf("%s killed by %s", identity, e.Status.Signal())
 	default:
-		return fmt.Errorf("pid %d ended with wait status %#x", e.PID, uint32(e.Status))
+		return fmt.Errorf("%s ended with wait status %#x", identity, uint32(e.Status))
 	}
 }
 
@@ -59,6 +64,7 @@ type processBackend interface {
 // multiple observers; all receive the same result.
 type Process struct {
 	pid   int
+	name  string
 	child backendProcess
 	done  chan struct{}
 	exit  Exit
@@ -137,7 +143,7 @@ func (m *Manager) Start(command Command) (*Process, error) {
 			return
 		}
 		pid := child.pid()
-		process := &Process{pid: pid, child: child, done: make(chan struct{})}
+		process := &Process{pid: pid, name: command.Name, child: child, done: make(chan struct{})}
 		children[pid] = process
 		reply <- startResponse{process: process}
 	}
@@ -177,6 +183,7 @@ func (m *Manager) reapChildren(children map[int]*Process) {
 			m.logf("reaped adopted child pid=%d status=%#x", pid, uint32(status))
 			continue
 		}
+		exit.Name = process.name
 		delete(children, pid)
 		process.complete(exit)
 		if err := process.child.release(); err != nil {

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -34,6 +34,7 @@ type fakeBackend struct {
 type fakeProcess struct {
 	backend      *fakeBackend
 	id           int
+	pgid         int
 	name         string
 	exited       bool
 	groupRunning bool
@@ -59,7 +60,7 @@ func (b *fakeBackend) start(command Command) (backendProcess, error) {
 		return nil, err
 	}
 	b.nextPID++
-	child := &fakeProcess{backend: b, id: b.nextPID, name: command.Name, groupRunning: true}
+	child := &fakeProcess{backend: b, id: b.nextPID, pgid: b.nextPID, name: command.Name, groupRunning: true}
 	b.children[child.id] = child
 	b.started <- child.id
 	return child, nil
@@ -89,8 +90,11 @@ func (b *fakeBackend) exit(pid int, status syscall.WaitStatus) {
 	b.sigchld <- syscall.SIGCHLD
 }
 
-func (p *fakeProcess) pid() int       { return p.id }
-func (p *fakeProcess) release() error { return nil }
+func (p *fakeProcess) pid() int { return p.id }
+func (p *fakeProcess) release() error {
+	p.id = -1
+	return nil
+}
 func (p *fakeProcess) signal(signal syscall.Signal) error {
 	p.backend.signaled <- fmt.Sprintf("%s:%s", p.name, signal)
 	p.backend.mu.Lock()
@@ -105,7 +109,7 @@ func (p *fakeProcess) signal(signal syscall.Signal) error {
 		return os.ErrProcessDone
 	}
 	if !exited && (signal == syscall.SIGKILL || (signal == syscall.SIGTERM && exitOnTERM)) {
-		p.backend.exit(p.id, syscall.WaitStatus(uint32(signal)&0x7f))
+		p.backend.exit(p.pgid, syscall.WaitStatus(uint32(signal)&0x7f))
 	}
 	return nil
 }
@@ -146,6 +150,9 @@ func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
 	oneShotExit, err := oneShot.Wait(context.Background())
 	if err != nil || oneShotExit.Status.ExitStatus() != 3 {
 		t.Fatalf("one-shot wait = (%+v, %v)", oneShotExit, err)
+	}
+	if oneShot.PID() != oneShotExit.PID {
+		t.Fatalf("released one-shot pid = %d, want %d", oneShot.PID(), oneShotExit.PID)
 	}
 	logsMu.Lock()
 	defer logsMu.Unlock()

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -151,6 +151,12 @@ func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
 	if err != nil || oneShotExit.Status.ExitStatus() != 3 {
 		t.Fatalf("one-shot wait = (%+v, %v)", oneShotExit, err)
 	}
+	if oneShotExit.Name != "one-shot" {
+		t.Fatalf("one-shot exit name = %q", oneShotExit.Name)
+	}
+	if got := oneShotExit.Err().Error(); !strings.Contains(got, "one-shot (pid ") {
+		t.Fatalf("one-shot error lacks command identity: %q", got)
+	}
 	if oneShot.PID() != oneShotExit.PID {
 		t.Fatalf("released one-shot pid = %d, want %d", oneShot.PID(), oneShotExit.PID)
 	}


### PR DESCRIPTION
## Summary
- cache each managed child PID independently of `os.Process.Release`
- retain the immutable process-group ID used for TERM/KILL and liveness checks
- model release-time PID invalidation in supervisor tests

## Why
Box3 exact-artifact qualification showed that `os.Process.Release` changes `Process.Pid` to `-1` after the leader is reaped. PID1 retained the process object to drain daemon descendants, then attempted process-group operations using the mutated PID. This could report `pid -1 did not exit after SIGKILL` and target the wrong process group.

## Validation
- gofmt
- `go build ./...`
- `go test ./...`
- focused race tests for supervisor and init
- `go vet ./...`
- `git diff --check`

Do not merge automatically; Box3 exact-artifact qualification is in progress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves immutable child PID and process group after reap so signals and liveness checks target the right group. Adds command names to exit results and errors for clearer diagnostics.

- **Bug Fixes**
  - Cache the child PID at start and return it via `Process.PID()`; keep an immutable process-group ID (`processID`) in `osChild` for signal and liveness operations.
  - Include the command name in `Exit` and in error messages; propagate it on reap for clearer logs.
  - Update tests to model PID invalidation on release and verify the reported PID matches the exit PID; fake backend uses a stable pgid for signaling.

<sup>Written for commit e0c3d7399bc4b66635a4cf7cfe29b9f191296531. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

