### PR TITLE
Report bounded fixed boot-stage failures from PID1

### DIFF
--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -531,7 +531,7 @@ func runOneShot(ctx context.Context, manager *supervisor.Manager, cmd supervisor
 	}
 	exit, waitErr := process.Wait(ctx)
 	if waitErr == nil {
-		return exit.Err()
+		return annotateOneShotFailure(cmd.Name, exit.Err(), boot.Load)
 	}
 	_ = process.Signal(syscall.SIGTERM)
 	timer := time.NewTimer(grace)
@@ -543,6 +543,25 @@ func runOneShot(ctx context.Context, manager *supervisor.Manager, cmd supervisor
 		_, _ = process.Wait(context.Background())
 	}
 	return fmt.Errorf("%s interrupted: %w", cmd.Name, waitErr)
+}
+
+func annotateOneShotFailure(
+	commandName string,
+	failure error,
+	loadState func() (*boot.State, error),
+) error {
+	if failure == nil || commandName != string(hardening.ServiceBoot) {
+		return failure
+	}
+	state, err := loadState()
+	if err != nil {
+		return failure
+	}
+	summary, ok := state.FailureSummary()
+	if !ok {
+		return failure
+	}
+	return fmt.Errorf("%w; %s", failure, summary)
 }
 
 func endpointReady(network, address string, limit time.Duration) func(context.Context) error {

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -488,6 +488,64 @@ func TestStartupFailureDrainsStartedServices(t *testing.T) {
 	}
 }
 
+func TestAnnotateOneShotFailureIncludesFixedBootStage(t *testing.T) {
+	failure := errors.New("boot child exited")
+	state := &boot.State{Stages: []boot.Stage{{
+		Name:   boot.StageNetwork,
+		Status: boot.StatusFailed,
+		Detail: "route rejected",
+	}}}
+
+	got := annotateOneShotFailure(string(hardening.ServiceBoot), failure, func() (*boot.State, error) {
+		return state, nil
+	})
+	if !errors.Is(got, failure) {
+		t.Fatalf("annotated error = %v, want wrapped failure", got)
+	}
+	if want := `boot stage "network" failed: "route rejected"`; !strings.Contains(got.Error(), want) {
+		t.Fatalf("annotated error = %q, want %q", got, want)
+	}
+}
+
+func TestAnnotateOneShotFailureFallsBackToChildError(t *testing.T) {
+	failure := errors.New("child exited")
+	loadFailure := errors.New("state unavailable")
+	for _, test := range []struct {
+		name        string
+		commandName string
+		load        func() (*boot.State, error)
+	}{
+		{
+			name:        "other command",
+			commandName: "nftables",
+			load: func() (*boot.State, error) {
+				t.Fatal("non-boot command loaded boot state")
+				return nil, nil
+			},
+		},
+		{
+			name:        "missing state",
+			commandName: string(hardening.ServiceBoot),
+			load: func() (*boot.State, error) {
+				return nil, loadFailure
+			},
+		},
+		{
+			name:        "no failed stage",
+			commandName: string(hardening.ServiceBoot),
+			load: func() (*boot.State, error) {
+				return &boot.State{Stages: []boot.Stage{{Name: boot.StageConfig, Status: boot.StatusOK}}}, nil
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := annotateOneShotFailure(test.commandName, failure, test.load); got != failure {
+				t.Fatalf("annotateOneShotFailure = %v, want original failure", got)
+			}
+		})
+	}
+}
+
 func TestBootDeadlineDoesNotEndSupervisionAndRequiredDeathFailsClosed(t *testing.T) {
 	harness := newLifecycleHarness()
 	parent, cancel := context.WithCancel(context.Background())

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -490,11 +490,15 @@ func TestStartupFailureDrainsStartedServices(t *testing.T) {
 
 func TestAnnotateOneShotFailureIncludesFixedBootStage(t *testing.T) {
 	failure := errors.New("boot child exited")
-	state := &boot.State{Stages: []boot.Stage{{
-		Name:   boot.StageNetwork,
-		Status: boot.StatusFailed,
-		Detail: "route rejected",
-	}}}
+	state := &boot.State{Stages: make([]boot.Stage, len(boot.InitialStages))}
+	for index, name := range boot.InitialStages {
+		state.Stages[index] = boot.Stage{Name: name, Status: boot.StatusOK}
+		if name == boot.StageNetwork {
+			state.Stages[index] = boot.Stage{
+				Name: boot.StageNetwork, Status: boot.StatusFailed, Detail: "route rejected",
+			}
+		}
+	}
 
 	got := annotateOneShotFailure(string(hardening.ServiceBoot), failure, func() (*boot.State, error) {
 		return state, nil

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -193,6 +193,14 @@ func (s *State) HasFailed() bool {
 // FailureSummary returns the first failed fixed boot stage as bounded,
 // log-safe text. It is diagnostic only and must not replace readiness checks.
 func (s *State) FailureSummary() (string, bool) {
+	if len(s.Stages) != len(InitialStages) {
+		return "", false
+	}
+	for index, name := range InitialStages {
+		if s.Stages[index].Name != name {
+			return "", false
+		}
+	}
 	for _, stage := range s.Stages {
 		if stage.Status != StatusFailed {
 			continue
@@ -211,13 +219,16 @@ func (s *State) FailureSummary() (string, bool) {
 }
 
 func boundedStateText(value string, limit int) string {
-	value = string([]rune(value))
 	if len(value) <= limit {
 		return value
 	}
-	end := limit
-	for end > 0 && !utf8.RuneStart(value[end]) {
-		end--
+	end := 0
+	for end < len(value) {
+		_, size := utf8.DecodeRuneInString(value[end:])
+		if end+size > limit {
+			break
+		}
+		end += size
 	}
 	return value[:end] + "..."
 }

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -5,8 +5,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
+	"unicode/utf8"
+)
+
+const (
+	failureStageLimit  = 64
+	failureDetailLimit = 512
 )
 
 type State struct {
@@ -181,6 +188,38 @@ func (s *State) HasFailed() bool {
 		}
 	}
 	return false
+}
+
+// FailureSummary returns the first failed fixed boot stage as bounded,
+// log-safe text. It is diagnostic only and must not replace readiness checks.
+func (s *State) FailureSummary() (string, bool) {
+	for _, stage := range s.Stages {
+		if stage.Status != StatusFailed {
+			continue
+		}
+		name := boundedStateText(stage.Name, failureStageLimit)
+		if name == "" {
+			return "", false
+		}
+		summary := "boot stage " + strconv.Quote(name) + " failed"
+		if detail := boundedStateText(stage.Detail, failureDetailLimit); detail != "" {
+			summary += ": " + strconv.Quote(detail)
+		}
+		return summary, true
+	}
+	return "", false
+}
+
+func boundedStateText(value string, limit int) string {
+	value = string([]rune(value))
+	if len(value) <= limit {
+		return value
+	}
+	end := limit
+	for end > 0 && !utf8.RuneStart(value[end]) {
+		end--
+	}
+	return value[:end] + "..."
 }
 
 // RecordStage loads the current state from disk, updates or appends a stage,

--- a/tinfoil/internal/boot/state_test.go
+++ b/tinfoil/internal/boot/state_test.go
@@ -51,11 +51,13 @@ func TestWriteStateAtomic(t *testing.T) {
 }
 
 func TestFailureSummaryReturnsFirstFailedStage(t *testing.T) {
-	state := &State{Stages: []Stage{
-		{Name: StageNetwork, Status: StatusOK},
-		{Name: StageCertificate, Status: StatusFailed, Detail: "issuer\nrejected request"},
-		{Name: StageContainers, Status: StatusFailed, Detail: "later failure"},
-	}}
+	state := fixedBootState()
+	state.Stages[fixedStageIndex(t, StageCertificate)] = Stage{
+		Name: StageCertificate, Status: StatusFailed, Detail: "issuer\nrejected request",
+	}
+	state.Stages[fixedStageIndex(t, StageContainers)] = Stage{
+		Name: StageContainers, Status: StatusFailed, Detail: "later failure",
+	}
 
 	got, ok := state.FailureSummary()
 	if !ok {
@@ -68,11 +70,12 @@ func TestFailureSummaryReturnsFirstFailedStage(t *testing.T) {
 }
 
 func TestFailureSummaryBoundsDetail(t *testing.T) {
-	state := &State{Stages: []Stage{{
+	state := fixedBootState()
+	state.Stages[fixedStageIndex(t, StageNetwork)] = Stage{
 		Name:   StageNetwork,
 		Status: StatusFailed,
 		Detail: strings.Repeat("x", failureDetailLimit+100),
-	}}}
+	}
 
 	got, ok := state.FailureSummary()
 	if !ok {
@@ -84,13 +87,83 @@ func TestFailureSummaryBoundsDetail(t *testing.T) {
 	}
 }
 
-func TestFailureSummaryRejectsMissingFailureIdentity(t *testing.T) {
-	for _, state := range []*State{
-		{Stages: []Stage{{Name: StageNetwork, Status: StatusOK}}},
-		{Stages: []Stage{{Status: StatusFailed, Detail: "no stage"}}},
-	} {
-		if got, ok := state.FailureSummary(); ok || got != "" {
-			t.Fatalf("FailureSummary = %q, %v; want empty, false", got, ok)
+func TestFailureSummaryRequiresExactInitialStages(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func([]Stage) []Stage
+	}{
+		{
+			name: "incomplete",
+			mutate: func(stages []Stage) []Stage {
+				return stages[:len(stages)-1]
+			},
+		},
+		{
+			name: "reordered",
+			mutate: func(stages []Stage) []Stage {
+				stages[0], stages[1] = stages[1], stages[0]
+				return stages
+			},
+		},
+		{
+			name: "unknown",
+			mutate: func(stages []Stage) []Stage {
+				stages[0].Name = "unknown-stage"
+				return stages
+			},
+		},
+		{
+			name: "extra",
+			mutate: func(stages []Stage) []Stage {
+				return append(stages, Stage{Name: "extra-stage", Status: StatusFailed})
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			state := fixedBootState()
+			state.Stages[0].Status = StatusFailed
+			state.Stages[0].Detail = "must not be trusted"
+			state.Stages = test.mutate(state.Stages)
+			if got, ok := state.FailureSummary(); ok || got != "" {
+				t.Fatalf("FailureSummary = %q, %v; want empty, false", got, ok)
+			}
+		})
+	}
+}
+
+func TestBoundedStateTextPreservesInvalidUTF8(t *testing.T) {
+	value := string([]byte{'a', 0xff, 'b', 'c'})
+	if got := boundedStateText(value, len(value)); got != value {
+		t.Fatalf("boundedStateText changed untruncated bytes: %q", []byte(got))
+	}
+	want := string([]byte{'a', 0xff, 'b'}) + "..."
+	if got := boundedStateText(value, 3); got != want {
+		t.Fatalf("boundedStateText = %q, want %q", []byte(got), []byte(want))
+	}
+}
+
+func TestBoundedStateTextDoesNotSplitValidUTF8(t *testing.T) {
+	if got, want := boundedStateText("ab€cd", 4), "ab..."; got != want {
+		t.Fatalf("boundedStateText = %q, want %q", got, want)
+	}
+}
+
+func fixedBootState() *State {
+	stages := make([]Stage, len(InitialStages))
+	for index, name := range InitialStages {
+		stages[index] = Stage{Name: name, Status: StatusOK}
+	}
+	return &State{Stages: stages}
+}
+
+func fixedStageIndex(t *testing.T, name string) int {
+	t.Helper()
+	for index, stage := range InitialStages {
+		if stage == name {
+			return index
 		}
 	}
+	t.Fatalf("fixed stage %q not found", name)
+	return -1
 }

--- a/tinfoil/internal/boot/state_test.go
+++ b/tinfoil/internal/boot/state_test.go
@@ -3,6 +3,7 @@ package boot
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -45,6 +46,51 @@ func TestWriteStateAtomic(t *testing.T) {
 	for _, e := range entries {
 		if e.Name() != "boot-state.json" {
 			t.Fatalf("leftover temp file %q in state dir", e.Name())
+		}
+	}
+}
+
+func TestFailureSummaryReturnsFirstFailedStage(t *testing.T) {
+	state := &State{Stages: []Stage{
+		{Name: StageNetwork, Status: StatusOK},
+		{Name: StageCertificate, Status: StatusFailed, Detail: "issuer\nrejected request"},
+		{Name: StageContainers, Status: StatusFailed, Detail: "later failure"},
+	}}
+
+	got, ok := state.FailureSummary()
+	if !ok {
+		t.Fatal("FailureSummary did not report a failed stage")
+	}
+	want := `boot stage "certificate" failed: "issuer\nrejected request"`
+	if got != want {
+		t.Fatalf("FailureSummary = %q, want %q", got, want)
+	}
+}
+
+func TestFailureSummaryBoundsDetail(t *testing.T) {
+	state := &State{Stages: []Stage{{
+		Name:   StageNetwork,
+		Status: StatusFailed,
+		Detail: strings.Repeat("x", failureDetailLimit+100),
+	}}}
+
+	got, ok := state.FailureSummary()
+	if !ok {
+		t.Fatal("FailureSummary did not report a failed stage")
+	}
+	want := `boot stage "network" failed: "` + strings.Repeat("x", failureDetailLimit) + `..."`
+	if got != want {
+		t.Fatalf("FailureSummary = %q, want %q", got, want)
+	}
+}
+
+func TestFailureSummaryRejectsMissingFailureIdentity(t *testing.T) {
+	for _, state := range []*State{
+		{Stages: []Stage{{Name: StageNetwork, Status: StatusOK}}},
+		{Stages: []Stage{{Status: StatusFailed, Detail: "no stage"}}},
+	} {
+		if got, ok := state.FailureSummary(); ok || got != "" {
+			t.Fatalf("FailureSummary = %q, %v; want empty, false", got, ok)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- report the first failed fixed `tinfoil-boot` stage when the one-shot exits nonzero
- reuse the existing atomic measured boot-state JSON contract; add no new runtime parser or status mechanism
- bound and quote stage/detail text before including it in PID1's fatal error
- retain the original child-exit error when state is missing, malformed, incomplete, or belongs to another one-shot

## Why

Box3 exact-artifact qualification reached resumed PID1 but only reported `tinfoil-boot ... exited with status 1`; the child log did not reach the serial console. The existing private boot-state file already records each fixed stage before exit, so PID1 can expose that bounded diagnostic without changing readiness or attestation decisions.

This summary is diagnostic only. Missing or malformed state never turns a failed child into success and never replaces the existing boot readiness checks.

## Validation

- `gofmt`
- `go build ./...`
- `go test ./...`
- `go test -race ./internal/boot ./cmd/init`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
PID1 now appends a bounded summary of the first failed fixed boot stage to the `tinfoil-boot` one-shot error. It reuses the existing measured boot-state JSON and does not change readiness or attestation behavior.

- **New Features**
  - `tinfoil/cmd/init`: wraps boot one-shot failures with `annotateOneShotFailure`, adding stage/detail from recorded state; falls back to the original child error when state is missing, malformed, unrelated, or has no failed stage.
  - `tinfoil/internal/boot`: adds `State.FailureSummary()` to report the first failed stage; bounds name (64) and detail (512), ensures UTF-8 safety, and quotes values.
  - Tests cover first-failed selection, fixed-stage layout enforcement, safe truncation (including UTF-8), and annotation/fallback behavior.

<sup>Written for commit 5410483effef1039f1e4df7e29e74507f1797367. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

