### PR TITLE
Add a fixed compile-time-gated debug image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Test
         run: cd tinfoil && go test ./...
 
+      - name: Test debug-tagged PID1
+        run: cd tinfoil && go test -tags=tinfoil_debug_image ./cmd/init
+
       - name: Test direct roothash contract
         run: ./scripts/test-roothash-artifacts.sh
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,7 @@ exports_files([
     "build/builder-work/output/artifacts/tinfoil-egress",
     "build/builder-work/output/artifacts/tinfoil-init",
     "build/builder-work/output/artifacts/tinfoil-shim",
+    "build/debug-work/output/artifacts/tinfoil-init",
     "build/rootfs-artifacts/nvattest/usr/bin/nvattest",
     "build/rootfs-artifacts/nvattest/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2",
 ])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,6 +23,7 @@ runtime_sources = use_extension("//image:runtime_sources.bzl", "runtime_sources"
 runtime_sources.from_lock(lock = "//image:runtime-sources.lock.json")
 use_repo(
     runtime_sources,
+    "runtime_source_debug_busybox",
     "runtime_source_docker_static",
     "runtime_source_libnvidia_cfg1",
     "runtime_source_libnvidia_compute",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -181,11 +181,22 @@
         "bzlTransitiveDigest": "mF2eV4slSMEbCIO+MjMBgMciOSkZb9UUI2fFj3BPwNA=",
         "usagesDigest": "ZhxnUxFkNDXMRlHkZ0sEOIsJVy8V8BOOqt1yt9cZEgI=",
         "recordedFileInputs": {
-          "@@//image/runtime-sources.lock.json": "b577d13cc0b5e0b433b758ae761594039cf0ffa20724a1c1387d8503ab3e3c36"
+          "@@//image/runtime-sources.lock.json": "376855455155da04e35a4b01e607ae2726044bdda6e29e3592c155cd0ae89789"
         },
         "recordedDirentsInputs": {},
         "envVariables": {},
         "generatedRepoSpecs": {
+          "runtime_source_debug_busybox": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "load(\"@rules_distroless//apt/private:deb_postfix.bzl\", \"deb_postfix\")\n\ndeb_postfix(\n    name = \"payload\",\n    srcs = glob([\"data.tar*\"]),\n    outs = [\"layer.tar.gz\"],\n    mergedusr = False,\n    visibility = [\"//visibility:public\"],\n)\n",
+              "sha256": "fd605342f62268753076aa7d9321ff098b36ba53e47434145a9aedc28fd141a4",
+              "type": ".deb",
+              "urls": [
+                "https://snapshot.ubuntu.com/ubuntu/20260721T000000Z/pool/main/b/busybox/busybox-static_1.37.0-7ubuntu1_amd64.deb"
+              ]
+            }
+          },
           "runtime_source_docker_static": {
             "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
             "attributes": {

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ MKOSI ?= sudo env PATH="$(TRUSTED_PATH)" mkosi
 BAZEL ?= bazel
 SHIPPING_KERNEL = kernel/out/tinfoil-custom.vmlinuz
 SHIPPING_INITRD = initrd.cpio.zst
-DEBUG_IMAGE = tinfoilcvm-debug
 
 NVATTEST_VERSION = 1.2.2.1780962352-1
 NVATTEST_DEBS = packages/nvattest_$(NVATTEST_VERSION)_amd64.deb \
@@ -51,7 +50,7 @@ test-roothash-artifacts:
 
 clean:
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm.*
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf $(DEBUG_IMAGE) $(DEBUG_IMAGE).*
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm-debug tinfoilcvm-debug.*
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf initrd
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf initrd.cpio.zst
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf build/stage build/artifacts
@@ -85,7 +84,7 @@ bazel-debug-layer: builder-debug-init
 	mkdir -p build/stage
 	install -m 0644 bazel-bin/image/bazel-debug-layer.tar build/stage/bazel-debug-layer.tar
 
-test-debug-image-contract: bazel-rootfs bazel-debug-layer
+test-debug-image-contract:
 	./scripts/test-debug-image-contract.sh \
 		build/stage/bazel-rootfs.tar \
 		build/stage/bazel-debug-layer.tar
@@ -134,6 +133,7 @@ update-runtime-locks:
 	BAZEL="$(BAZEL)" ./scripts/update-runtime-locks.sh
 
 shipping-image: bazel-rootfs additive-initrd
+	./scripts/test-debug-image-contract.sh build/stage/bazel-rootfs.tar
 	rm -f tinfoilcvm tinfoilcvm.raw tinfoilcvm.roothash tinfoilcvm.hash \
 		tinfoilcvm.vmlinuz tinfoilcvm.initrd
 	$(MKOSI) --force
@@ -150,22 +150,25 @@ shipping-image: bazel-rootfs additive-initrd
 	@echo "image hash: $$(cat tinfoilcvm.hash)"
 
 debug-image: bazel-rootfs bazel-debug-layer additive-initrd custom-kernel-artifacts
-	rm -f $(DEBUG_IMAGE) $(DEBUG_IMAGE).raw $(DEBUG_IMAGE).roothash \
-		$(DEBUG_IMAGE).hash $(DEBUG_IMAGE).vmlinuz $(DEBUG_IMAGE).initrd
-	$(MKOSI) --force --output=$(DEBUG_IMAGE) \
+	./scripts/test-debug-image-contract.sh \
+		build/stage/bazel-rootfs.tar \
+		build/stage/bazel-debug-layer.tar
+	rm -f tinfoilcvm-debug tinfoilcvm-debug.raw tinfoilcvm-debug.roothash \
+		tinfoilcvm-debug.hash tinfoilcvm-debug.vmlinuz tinfoilcvm-debug.initrd
+	$(MKOSI) --force --output=tinfoilcvm-debug \
 		--base-tree="$(CURDIR)/build/stage/bazel-debug-layer.tar"
-	sudo env PATH="$(TRUSTED_PATH)" chmod 0644 $(DEBUG_IMAGE).raw $(DEBUG_IMAGE).roothash
+	sudo env PATH="$(TRUSTED_PATH)" chmod 0644 tinfoilcvm-debug.raw tinfoilcvm-debug.roothash
 	sudo env PATH="$(TRUSTED_PATH)" chown "$$(id -u):$$(id -g)" \
-		$(DEBUG_IMAGE).raw $(DEBUG_IMAGE).roothash
-	install -m 0644 "$(SHIPPING_KERNEL)" $(DEBUG_IMAGE).vmlinuz
-	install -m 0644 "$(SHIPPING_INITRD)" $(DEBUG_IMAGE).initrd
-	cmp -s "$(SHIPPING_KERNEL)" $(DEBUG_IMAGE).vmlinuz
-	cmp -s "$(SHIPPING_INITRD)" $(DEBUG_IMAGE).initrd
-	test -s $(DEBUG_IMAGE).raw
-	test "$$(wc -c < $(DEBUG_IMAGE).roothash)" -eq 64
-	grep -Eq '^[a-f0-9]{64}$$' $(DEBUG_IMAGE).roothash
-	cp $(DEBUG_IMAGE).roothash $(DEBUG_IMAGE).hash
-	@echo "debug image hash: $$(cat $(DEBUG_IMAGE).hash)"
+		tinfoilcvm-debug.raw tinfoilcvm-debug.roothash
+	install -m 0644 "$(SHIPPING_KERNEL)" tinfoilcvm-debug.vmlinuz
+	install -m 0644 "$(SHIPPING_INITRD)" tinfoilcvm-debug.initrd
+	cmp -s "$(SHIPPING_KERNEL)" tinfoilcvm-debug.vmlinuz
+	cmp -s "$(SHIPPING_INITRD)" tinfoilcvm-debug.initrd
+	test -s tinfoilcvm-debug.raw
+	test "$$(wc -c < tinfoilcvm-debug.roothash)" -eq 64
+	grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm-debug.roothash
+	cp tinfoilcvm-debug.roothash tinfoilcvm-debug.hash
+	@echo "debug image hash: $$(cat tinfoilcvm-debug.hash)"
 
 rebuild: shipping-image
 

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,8 @@ debug-image: bazel-rootfs bazel-debug-layer additive-initrd custom-kernel-artifa
 	cmp -s "$(SHIPPING_KERNEL)" tinfoilcvm-debug.vmlinuz
 	cmp -s "$(SHIPPING_INITRD)" tinfoilcvm-debug.initrd
 	test -s tinfoilcvm-debug.raw
+	test -s tinfoilcvm-debug.vmlinuz
+	test -s tinfoilcvm-debug.initrd
 	test "$$(wc -c < tinfoilcvm-debug.roothash)" -eq 64
 	grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm-debug.roothash
 	cp tinfoilcvm-debug.roothash tinfoilcvm-debug.hash

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,12 @@ bazel-debug-layer: builder-debug-init
 	mkdir -p build/stage
 	install -m 0644 bazel-bin/image/bazel-debug-layer.tar build/stage/bazel-debug-layer.tar
 
+
 test-debug-image-contract:
+	@test -s build/stage/bazel-rootfs.tar -a -s build/stage/bazel-debug-layer.tar || { \
+		echo 'missing staged rootfs layers; run make bazel-rootfs bazel-debug-layer explicitly' >&2; \
+		exit 1; \
+	}
 	./scripts/test-debug-image-contract.sh \
 		build/stage/bazel-rootfs.tar \
 		build/stage/bazel-debug-layer.tar

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ MKOSI ?= sudo env PATH="$(TRUSTED_PATH)" mkosi
 BAZEL ?= bazel
 SHIPPING_KERNEL = kernel/out/tinfoil-custom.vmlinuz
 SHIPPING_INITRD = initrd.cpio.zst
+DEBUG_IMAGE = tinfoilcvm-debug
 
 NVATTEST_VERSION = 1.2.2.1780962352-1
 NVATTEST_DEBS = packages/nvattest_$(NVATTEST_VERSION)_amd64.deb \
@@ -14,6 +15,7 @@ NVATTEST_RUNTIME_OUTPUTS = build/rootfs-artifacts/nvattest/usr/bin/nvattest \
 
 .PHONY: all build rebuild shipping-image clean deepclean hash nvattest \
 	runtime-builder builder-initrd bazel-rootfs additive-initrd verify-additive-initrd \
+	builder-debug-init bazel-debug-layer debug-image test-debug-image-contract \
 	test-go-producer test-runtime-builder-contract test-additive-initrd reproducible-additive-initrd test-roothash-artifacts \
 	test-runtime-locks \
 	verify-runtime-sources update-runtime-locks \
@@ -49,6 +51,7 @@ test-roothash-artifacts:
 
 clean:
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm.*
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf $(DEBUG_IMAGE) $(DEBUG_IMAGE).*
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf initrd
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf initrd.cpio.zst
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf build/stage build/artifacts
@@ -63,6 +66,9 @@ runtime-builder:
 builder-initrd: runtime-builder
 	./scripts/run-runtime-builder.sh initrd
 
+builder-debug-init: runtime-builder
+	./scripts/run-runtime-builder.sh debug-init
+
 test-go-producer:
 	./scripts/test-go-producer.sh
 
@@ -73,6 +79,16 @@ bazel-rootfs: builder-initrd nvattest nvidia-module-artifacts
 	$(BAZEL) build --lockfile_mode=error //image:rootfs
 	mkdir -p build/stage
 	install -m 0644 bazel-bin/image/bazel-rootfs.tar build/stage/bazel-rootfs.tar
+
+bazel-debug-layer: builder-debug-init
+	$(BAZEL) build --lockfile_mode=error //image:debug-layer
+	mkdir -p build/stage
+	install -m 0644 bazel-bin/image/bazel-debug-layer.tar build/stage/bazel-debug-layer.tar
+
+test-debug-image-contract: bazel-rootfs bazel-debug-layer
+	./scripts/test-debug-image-contract.sh \
+		build/stage/bazel-rootfs.tar \
+		build/stage/bazel-debug-layer.tar
 
 custom-kernel-artifacts: runtime-builder
 	./scripts/run-runtime-builder.sh kernel
@@ -132,6 +148,24 @@ shipping-image: bazel-rootfs additive-initrd
 	grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm.roothash
 	cp tinfoilcvm.roothash tinfoilcvm.hash
 	@echo "image hash: $$(cat tinfoilcvm.hash)"
+
+debug-image: bazel-rootfs bazel-debug-layer additive-initrd custom-kernel-artifacts
+	rm -f $(DEBUG_IMAGE) $(DEBUG_IMAGE).raw $(DEBUG_IMAGE).roothash \
+		$(DEBUG_IMAGE).hash $(DEBUG_IMAGE).vmlinuz $(DEBUG_IMAGE).initrd
+	$(MKOSI) --force --output=$(DEBUG_IMAGE) \
+		--base-tree="$(CURDIR)/build/stage/bazel-debug-layer.tar"
+	sudo env PATH="$(TRUSTED_PATH)" chmod 0644 $(DEBUG_IMAGE).raw $(DEBUG_IMAGE).roothash
+	sudo env PATH="$(TRUSTED_PATH)" chown "$$(id -u):$$(id -g)" \
+		$(DEBUG_IMAGE).raw $(DEBUG_IMAGE).roothash
+	install -m 0644 "$(SHIPPING_KERNEL)" $(DEBUG_IMAGE).vmlinuz
+	install -m 0644 "$(SHIPPING_INITRD)" $(DEBUG_IMAGE).initrd
+	cmp -s "$(SHIPPING_KERNEL)" $(DEBUG_IMAGE).vmlinuz
+	cmp -s "$(SHIPPING_INITRD)" $(DEBUG_IMAGE).initrd
+	test -s $(DEBUG_IMAGE).raw
+	test "$$(wc -c < $(DEBUG_IMAGE).roothash)" -eq 64
+	grep -Eq '^[a-f0-9]{64}$$' $(DEBUG_IMAGE).roothash
+	cp $(DEBUG_IMAGE).roothash $(DEBUG_IMAGE).hash
+	@echo "debug image hash: $$(cat $(DEBUG_IMAGE).hash)"
 
 rebuild: shipping-image
 

--- a/builder/build-debug-init.sh
+++ b/builder/build-debug-init.sh
@@ -8,6 +8,13 @@ fi
 
 source_root=$1
 output_root=$2
+case "$source_root:$output_root" in
+    /*:/*) ;;
+    *)
+        echo "source and output roots must be absolute paths" >&2
+        exit 2
+        ;;
+esac
 artifact_dir="$output_root/artifacts"
 go_bin=/usr/lib/go-1.25/bin/go
 gcc_bin=/usr/bin/gcc

--- a/builder/build-debug-init.sh
+++ b/builder/build-debug-init.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 SOURCE_ROOT OUTPUT_ROOT" >&2
+    exit 2
+fi
+
+source_root=$1
+output_root=$2
+artifact_dir="$output_root/artifacts"
+go_bin=/usr/lib/go-1.25/bin/go
+gcc_bin=/usr/bin/gcc
+
+if [ ! -f "$source_root/tinfoil/go.mod" ]; then
+    echo "missing tinfoil source tree: $source_root/tinfoil" >&2
+    exit 1
+fi
+if [ "$("$go_bin" version | awk '{print $3}')" != go1.25.7 ]; then
+    echo "debug builder: non-canonical Go toolchain" >&2
+    exit 1
+fi
+if [ "$(dpkg-query -W -f='${Version}' gcc)" != 4:15.2.0-5ubuntu1 ] ||
+    [ "$(dpkg-query -W -f='${Version}' binutils)" != 2.46-3ubuntu2 ]; then
+    echo "debug builder: non-canonical external Go linker toolchain" >&2
+    exit 1
+fi
+
+umask 022
+export GOTOOLCHAIN=local
+export SOURCE_DATE_EPOCH=0
+
+rm -rf "$artifact_dir"
+mkdir -p "$artifact_dir"
+cd "$source_root/tinfoil"
+
+CC="$gcc_bin" CGO_ENABLED=1 "$go_bin" build \
+    -trimpath \
+    -buildvcs=false \
+    -mod=readonly \
+    -tags=tinfoil_debug_image \
+    -ldflags='-s -w -buildid= -linkmode=external -extld=/usr/bin/gcc -extldflags=-Wl,--build-id=none' \
+    -o "$artifact_dir/tinfoil-init" \
+    ./cmd/init
+chmod 0755 "$artifact_dir/tinfoil-init"
+touch -d @0 "$artifact_dir/tinfoil-init"
+printf 'debug builder: tinfoil-init sha256=%s modules=built-in\n' \
+    "$(sha256sum "$artifact_dir/tinfoil-init" | awk '{print $1}')"

--- a/docs/debug-image.md
+++ b/docs/debug-image.md
@@ -1,0 +1,17 @@
+# Fixed debug image
+
+`make debug-image` builds `tinfoilcvm-debug.*` with the exact pinned release
+kernel and additive initrd. The root filesystem intentionally differs: it
+adds one debug-only layer containing the pinned Ubuntu `busybox-static` payload
+and a `tinfoil_debug_image` build-tag replacement for `/usr/bin/tinfoil-init`.
+
+That PID1 launches one fixed interactive BusyBox `ash` child on `/dev/hvc0`
+before normal boot continues. There is no kernel command-line switch, path
+parser, fallback shell, or runtime activation mechanism. The release PID1 is
+built without the tag, and `shipping-image` never consumes the debug rootfs.
+
+The normal Bazel rootfs is not rebuilt or duplicated in that layer. The debug
+measurement is diagnostic and must never be promoted. Run
+`make test-debug-image-contract` to verify the shipping rootfs and release PID1
+remain shell-free and that the debug rootfs contains the exact pinned shell.
+IBT and NVIDIA qualification remain separate evidence-driven work.

--- a/image/BUILD.bazel
+++ b/image/BUILD.bazel
@@ -146,6 +146,20 @@ pkg_files(
 )
 
 pkg_files(
+    name = "debug-tinfoil-init",
+    srcs = ["//:build/debug-work/output/artifacts/tinfoil-init"],
+    attributes = pkg_attributes(mode = "0755", uid = 0, gid = 0),
+    prefix = "usr/bin",
+    strip_prefix = strip_prefix.files_only(),
+)
+
+pkg_mkdirs(
+    name = "debug-root-home",
+    dirs = ["root"],
+    attributes = pkg_attributes(mode = "0700", uid = 0, gid = 0),
+)
+
+pkg_files(
     name = "nvattest-binary",
     srcs = ["//:build/rootfs-artifacts/nvattest/usr/bin/nvattest"],
     attributes = pkg_attributes(mode = "0755", uid = 0, gid = 0),
@@ -247,5 +261,33 @@ pkg_tar(
     allow_duplicates_from_deps = True,
     extension = "tar",
     out = "bazel-rootfs.tar",
+    stamp = 0,
+)
+
+pkg_tar(
+    name = "debug-overlay",
+    srcs = [
+        ":debug-root-home",
+        ":debug-tinfoil-init",
+    ],
+    allow_duplicates_from_deps = False,
+    create_parents = True,
+    extension = "tar",
+    mtime = 0,
+    out = "debug-overlay.tar",
+    owner = "0.0",
+    portable_mtime = False,
+    stamp = 0,
+)
+
+pkg_tar(
+    name = "debug-layer",
+    deps = [
+        "@runtime_source_debug_busybox//:payload",
+        ":debug-overlay",
+    ],
+    allow_duplicates_from_deps = True,
+    extension = "tar",
+    out = "bazel-debug-layer.tar",
     stamp = 0,
 )

--- a/image/runtime-sources.lock.json
+++ b/image/runtime-sources.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "sources": [
     {
+      "id": "debug-busybox",
+      "kind": "deb",
+      "url": "https://snapshot.ubuntu.com/ubuntu/20260721T000000Z/pool/main/b/busybox/busybox-static_1.37.0-7ubuntu1_amd64.deb",
+      "sha256": "fd605342f62268753076aa7d9321ff098b36ba53e47434145a9aedc28fd141a4"
+    },
+    {
       "id": "docker-static",
       "kind": "tar",
       "url": "https://download.docker.com/linux/static/stable/x86_64/docker-29.5.3.tgz",

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -3,4 +3,5 @@ package(default_visibility = ["//visibility:public"])
 exports_files([
     "compare_runtime_package_lock.sh",
     "test-container-runtime-rootfs.sh",
+    "test-debug-image-contract.sh",
 ])

--- a/scripts/build-runtime-builder.sh
+++ b/scripts/build-runtime-builder.sh
@@ -9,6 +9,7 @@ recipe_sha256="$(
     cd "$repo_dir"
     sha256sum \
         builder/Dockerfile \
+        builder/build-debug-init.sh \
         builder/build-initrd.sh \
         scripts/runtime-builder-base-image.txt \
         scripts/runtime-builder-snapshot.txt | sha256sum | awk '{print $1}'

--- a/scripts/run-runtime-builder.sh
+++ b/scripts/run-runtime-builder.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 if [ "$#" -ne 1 ]; then
-    echo "usage: $0 {initrd|nvattest|kernel|nvidia}" >&2
+    echo "usage: $0 {debug-init|initrd|nvattest|kernel|nvidia}" >&2
     exit 2
 fi
 
@@ -18,6 +18,7 @@ recipe_sha256="$(
     cd "$repo_dir"
     sha256sum \
         builder/Dockerfile \
+        builder/build-debug-init.sh \
         builder/build-initrd.sh \
         scripts/runtime-builder-base-image.txt \
         scripts/runtime-builder-snapshot.txt | sha256sum | awk '{print $1}'
@@ -42,6 +43,20 @@ mkdir -p "$cache_root"
 repo_mount="type=bind,src=$repo_dir,dst=/workspace,readonly"
 
 case "$producer" in
+    debug-init)
+        output="${TINFOIL_DEBUG_BUILDER_OUTPUT:-$repo_dir/build/debug-work/output}"
+        mkdir -p "$output" "$cache_root/go-build" "$cache_root/go-mod"
+        docker run --rm \
+            --user "$host_uid:$host_gid" \
+            --mount "$repo_mount" \
+            --mount "type=bind,src=$output,dst=/output" \
+            --mount "type=bind,src=$cache_root/go-build,dst=/cache/go-build" \
+            --mount "type=bind,src=$cache_root/go-mod,dst=/cache/go-mod" \
+            --env GOCACHE=/cache/go-build \
+            --env GOMODCACHE=/cache/go-mod \
+            "$builder_image" \
+            /workspace/builder/build-debug-init.sh /workspace /output
+        ;;
     initrd)
         output="${TINFOIL_BUILDER_OUTPUT:-$repo_dir/build/builder-work/output}"
         mkdir -p "$output" "$cache_root/go-build" "$cache_root/go-mod"

--- a/scripts/test-debug-image-contract.sh
+++ b/scripts/test-debug-image-contract.sh
@@ -27,8 +27,10 @@ done
 
 mkdir "$scratch/release"
 tar -xf "$release_rootfs" -C "$scratch/release" usr/bin/tinfoil-init
-if [ ! -f "$scratch/release/usr/bin/tinfoil-init" ] || [ -L "$scratch/release/usr/bin/tinfoil-init" ]; then
-    echo 'shipping rootfs tinfoil-init is not a regular file' >&2
+if [ ! -f "$scratch/release/usr/bin/tinfoil-init" ] ||
+    [ -L "$scratch/release/usr/bin/tinfoil-init" ] ||
+    [ ! -x "$scratch/release/usr/bin/tinfoil-init" ]; then
+    echo 'shipping rootfs tinfoil-init is not a regular executable' >&2
     exit 1
 fi
 strings "$scratch/release/usr/bin/tinfoil-init" > "$scratch/release-strings"
@@ -54,8 +56,10 @@ mkdir "$scratch/debug"
 tar -xf "$debug_layer" -C "$scratch/debug" usr/bin/tinfoil-init
 tar -xf "$debug_layer" -C "$scratch/debug" ./usr/bin/busybox
 for artifact in usr/bin/tinfoil-init usr/bin/busybox; do
-    if [ ! -f "$scratch/debug/$artifact" ] || [ -L "$scratch/debug/$artifact" ]; then
-        echo "debug layer $artifact is not a regular file" >&2
+    if [ ! -f "$scratch/debug/$artifact" ] ||
+        [ -L "$scratch/debug/$artifact" ] ||
+        [ ! -x "$scratch/debug/$artifact" ]; then
+        echo "debug layer $artifact is not a regular executable" >&2
         exit 1
     fi
 done

--- a/scripts/test-debug-image-contract.sh
+++ b/scripts/test-debug-image-contract.sh
@@ -1,34 +1,52 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [ "$#" -ne 2 ]; then
-    echo "usage: $0 RELEASE_ROOTFS DEBUG_ROOTFS" >&2
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+    echo "usage: $0 RELEASE_ROOTFS [DEBUG_LAYER]" >&2
     exit 2
 fi
 
 release_rootfs=$1
-debug_layer=$2
 busybox_sha256=df12634c17fcdca839ae5dc47d7627b7558511f7645de7c99ccf097a0f28ed5b
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/cvmimage-debug-contract.XXXXXXXX")"
 trap 'rm -rf -- "$scratch"' EXIT
 
-for archive in "$release_rootfs" "$debug_layer"; do
-    test -s "$archive"
-done
+test -s "$release_rootfs"
 
 tar -tf "$release_rootfs" | sed 's#^\./##' > "$scratch/release-members"
-tar -tf "$debug_layer" | sed 's#^\./##' > "$scratch/debug-members"
-if grep -Fqx 'usr/bin/busybox' "$scratch/release-members"; then
-    echo 'shipping rootfs contains the debug shell' >&2
+shell_names=(sh bash dash ash zsh ksh mksh yash fish csh tcsh busybox toybox)
+shell_dirs=(bin sbin usr/bin usr/sbin usr/local/bin usr/local/sbin)
+for directory in "${shell_dirs[@]}"; do
+    for shell_name in "${shell_names[@]}"; do
+        if grep -Fqx "$directory/$shell_name" "$scratch/release-members"; then
+            echo "shipping rootfs contains executable shell path $directory/$shell_name" >&2
+            exit 1
+        fi
+    done
+done
+
+mkdir "$scratch/release"
+tar -xf "$release_rootfs" -C "$scratch/release" usr/bin/tinfoil-init
+strings "$scratch/release/usr/bin/tinfoil-init" > "$scratch/release-strings"
+if grep -Eq '/dev/hvc0|/usr/bin/busybox|debug console|debug image' "$scratch/release-strings"; then
+    echo 'release PID1 contains debug-console infrastructure' >&2
     exit 1
 fi
+
+if [ "$#" -eq 1 ]; then
+    echo 'shipping image contract tests passed'
+    exit 0
+fi
+
+debug_layer=$2
+test -s "$debug_layer"
+tar -tf "$debug_layer" | sed 's#^\./##' > "$scratch/debug-members"
 if [ "$(grep -Fxc 'usr/bin/busybox' "$scratch/debug-members")" -ne 1 ]; then
     echo 'debug rootfs must contain exactly one pinned BusyBox' >&2
     exit 1
 fi
 
-mkdir "$scratch/release" "$scratch/debug"
-tar -xf "$release_rootfs" -C "$scratch/release" usr/bin/tinfoil-init
+mkdir "$scratch/debug"
 tar -xf "$debug_layer" -C "$scratch/debug" usr/bin/tinfoil-init
 tar -xf "$debug_layer" -C "$scratch/debug" ./usr/bin/busybox
 printf '%s  %s\n' "$busybox_sha256" "$scratch/debug/usr/bin/busybox" | sha256sum -c --strict
@@ -36,13 +54,8 @@ if cmp -s "$scratch/release/usr/bin/tinfoil-init" "$scratch/debug/usr/bin/tinfoi
     echo 'debug PID1 is byte-identical to release PID1' >&2
     exit 1
 fi
-strings "$scratch/release/usr/bin/tinfoil-init" > "$scratch/release-strings"
 strings "$scratch/debug/usr/bin/tinfoil-init" > "$scratch/debug-strings"
-if grep -Eq '/dev/hvc0|/usr/bin/busybox|--tinfoil-debug-console' "$scratch/release-strings"; then
-    echo 'release PID1 contains debug-console infrastructure' >&2
-    exit 1
-fi
-for marker in /dev/hvc0 /usr/bin/busybox --tinfoil-debug-console; do
+for marker in /dev/hvc0 /usr/bin/busybox tinfoil-debug-console; do
     if ! grep -Fq -- "$marker" "$scratch/debug-strings"; then
         echo "debug PID1 is missing $marker" >&2
         exit 1

--- a/scripts/test-debug-image-contract.sh
+++ b/scripts/test-debug-image-contract.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: $0 RELEASE_ROOTFS DEBUG_ROOTFS" >&2
+    exit 2
+fi
+
+release_rootfs=$1
+debug_layer=$2
+busybox_sha256=df12634c17fcdca839ae5dc47d7627b7558511f7645de7c99ccf097a0f28ed5b
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/cvmimage-debug-contract.XXXXXXXX")"
+trap 'rm -rf -- "$scratch"' EXIT
+
+for archive in "$release_rootfs" "$debug_layer"; do
+    test -s "$archive"
+done
+
+tar -tf "$release_rootfs" | sed 's#^\./##' > "$scratch/release-members"
+tar -tf "$debug_layer" | sed 's#^\./##' > "$scratch/debug-members"
+if grep -Fqx 'usr/bin/busybox' "$scratch/release-members"; then
+    echo 'shipping rootfs contains the debug shell' >&2
+    exit 1
+fi
+if [ "$(grep -Fxc 'usr/bin/busybox' "$scratch/debug-members")" -ne 1 ]; then
+    echo 'debug rootfs must contain exactly one pinned BusyBox' >&2
+    exit 1
+fi
+
+mkdir "$scratch/release" "$scratch/debug"
+tar -xf "$release_rootfs" -C "$scratch/release" usr/bin/tinfoil-init
+tar -xf "$debug_layer" -C "$scratch/debug" usr/bin/tinfoil-init
+tar -xf "$debug_layer" -C "$scratch/debug" ./usr/bin/busybox
+printf '%s  %s\n' "$busybox_sha256" "$scratch/debug/usr/bin/busybox" | sha256sum -c --strict
+if cmp -s "$scratch/release/usr/bin/tinfoil-init" "$scratch/debug/usr/bin/tinfoil-init"; then
+    echo 'debug PID1 is byte-identical to release PID1' >&2
+    exit 1
+fi
+strings "$scratch/release/usr/bin/tinfoil-init" > "$scratch/release-strings"
+strings "$scratch/debug/usr/bin/tinfoil-init" > "$scratch/debug-strings"
+if grep -Eq '/dev/hvc0|/usr/bin/busybox|--tinfoil-debug-console' "$scratch/release-strings"; then
+    echo 'release PID1 contains debug-console infrastructure' >&2
+    exit 1
+fi
+for marker in /dev/hvc0 /usr/bin/busybox --tinfoil-debug-console; do
+    if ! grep -Fq -- "$marker" "$scratch/debug-strings"; then
+        echo "debug PID1 is missing $marker" >&2
+        exit 1
+    fi
+done
+
+echo 'debug image contract tests passed'

--- a/scripts/test-debug-image-contract.sh
+++ b/scripts/test-debug-image-contract.sh
@@ -27,6 +27,10 @@ done
 
 mkdir "$scratch/release"
 tar -xf "$release_rootfs" -C "$scratch/release" usr/bin/tinfoil-init
+if [ ! -f "$scratch/release/usr/bin/tinfoil-init" ] || [ -L "$scratch/release/usr/bin/tinfoil-init" ]; then
+    echo 'shipping rootfs tinfoil-init is not a regular file' >&2
+    exit 1
+fi
 strings "$scratch/release/usr/bin/tinfoil-init" > "$scratch/release-strings"
 if grep -Eq '/dev/hvc0|/usr/bin/busybox|debug console|debug image' "$scratch/release-strings"; then
     echo 'release PID1 contains debug-console infrastructure' >&2
@@ -49,6 +53,12 @@ fi
 mkdir "$scratch/debug"
 tar -xf "$debug_layer" -C "$scratch/debug" usr/bin/tinfoil-init
 tar -xf "$debug_layer" -C "$scratch/debug" ./usr/bin/busybox
+for artifact in usr/bin/tinfoil-init usr/bin/busybox; do
+    if [ ! -f "$scratch/debug/$artifact" ] || [ -L "$scratch/debug/$artifact" ]; then
+        echo "debug layer $artifact is not a regular file" >&2
+        exit 1
+    fi
+done
 printf '%s  %s\n' "$busybox_sha256" "$scratch/debug/usr/bin/busybox" | sha256sum -c --strict
 if cmp -s "$scratch/release/usr/bin/tinfoil-init" "$scratch/debug/usr/bin/tinfoil-init"; then
     echo 'debug PID1 is byte-identical to release PID1' >&2

--- a/scripts/test-runtime-builder-contract.sh
+++ b/scripts/test-runtime-builder-contract.sh
@@ -12,6 +12,7 @@ recipe_sha256="$(
     cd "$repo_dir"
     sha256sum \
         builder/Dockerfile \
+        builder/build-debug-init.sh \
         builder/build-initrd.sh \
         scripts/runtime-builder-base-image.txt \
         scripts/runtime-builder-snapshot.txt | sha256sum | awk '{print $1}'

--- a/tinfoil/cmd/init/debug_console_disabled.go
+++ b/tinfoil/cmd/init/debug_console_disabled.go
@@ -17,4 +17,4 @@ func startDebugConsole(context.Context, *supervisor.Manager) (*debugConsole, err
 
 func (*debugConsole) stop(time.Duration, time.Duration) error { return nil }
 
-func parkDebugFailure(error) {}
+func parkDebugFailure(context.Context, error) {}

--- a/tinfoil/cmd/init/debug_console_disabled.go
+++ b/tinfoil/cmd/init/debug_console_disabled.go
@@ -16,3 +16,5 @@ func startDebugConsole(context.Context, *supervisor.Manager) (*debugConsole, err
 }
 
 func (*debugConsole) stop(time.Duration, time.Duration) error { return nil }
+
+func parkDebugFailure(error) {}

--- a/tinfoil/cmd/init/debug_console_disabled.go
+++ b/tinfoil/cmd/init/debug_console_disabled.go
@@ -1,0 +1,9 @@
+//go:build !tinfoil_debug_image
+
+package main
+
+import "tinfoil/internal/pid1/supervisor"
+
+func dispatchDebugConsole([]string) (bool, error) { return false, nil }
+
+func startDebugConsole(*supervisor.Manager) error { return nil }

--- a/tinfoil/cmd/init/debug_console_disabled.go
+++ b/tinfoil/cmd/init/debug_console_disabled.go
@@ -2,8 +2,17 @@
 
 package main
 
-import "tinfoil/internal/pid1/supervisor"
+import (
+	"context"
+	"time"
 
-func dispatchDebugConsole([]string) (bool, error) { return false, nil }
+	"tinfoil/internal/pid1/supervisor"
+)
 
-func startDebugConsole(*supervisor.Manager) error { return nil }
+type debugConsole struct{}
+
+func startDebugConsole(context.Context, *supervisor.Manager) (*debugConsole, error) {
+	return &debugConsole{}, nil
+}
+
+func (*debugConsole) stop(time.Duration, time.Duration) error { return nil }

--- a/tinfoil/cmd/init/debug_console_enabled.go
+++ b/tinfoil/cmd/init/debug_console_enabled.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"tinfoil/internal/pid1/supervisor"
@@ -41,12 +39,9 @@ func (console *debugConsole) stop(termGrace, killGrace time.Duration) error {
 	return console.process.StopConsole(termGrace, killGrace)
 }
 
-func parkDebugFailure(err error) {
+func parkDebugFailure(ctx context.Context, err error) {
 	initLogf("debug image: lifecycle failed: %v; console remains available until shutdown", err)
-	shutdown := make(chan os.Signal, 1)
-	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
-	defer signal.Stop(shutdown)
-	<-shutdown
+	<-ctx.Done()
 }
 
 func debugConsoleCommand() supervisor.Command {

--- a/tinfoil/cmd/init/debug_console_enabled.go
+++ b/tinfoil/cmd/init/debug_console_enabled.go
@@ -3,73 +3,52 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
-	"syscall"
-
-	"golang.org/x/sys/unix"
+	"time"
 
 	"tinfoil/internal/pid1/supervisor"
 )
 
 const (
-	debugConsoleArg = "--tinfoil-debug-console"
 	debugConsoleTTY = "/dev/hvc0"
 	debugShellPath  = "/usr/bin/busybox"
 )
 
-func dispatchDebugConsole(args []string) (bool, error) {
-	if len(args) != 2 || args[1] != debugConsoleArg {
-		return false, nil
-	}
-	return true, execDebugConsole()
+type debugConsole struct {
+	process *supervisor.Process
 }
 
-func startDebugConsole(manager *supervisor.Manager) error {
+func startDebugConsole(_ context.Context, manager *supervisor.Manager) (*debugConsole, error) {
+	console, err := os.OpenFile(debugConsoleTTY, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", debugConsoleTTY, err)
+	}
+	defer console.Close()
+
 	initLogf("debug image: starting static shell on %s", debugConsoleTTY)
-	_, err := manager.Start(debugConsoleCommand())
-	return err
+	process, err := manager.StartConsole(debugConsoleCommand(), console)
+	if err != nil {
+		return nil, err
+	}
+	return &debugConsole{process: process}, nil
+}
+
+func (console *debugConsole) stop(termGrace, killGrace time.Duration) error {
+	return console.process.StopConsole(termGrace, killGrace)
 }
 
 func debugConsoleCommand() supervisor.Command {
-	return command("tinfoil-debug-console", selfExecPath, debugConsoleArg)
-}
-
-func execDebugConsole() error {
-	if err := unix.Setpgid(0, os.Getppid()); err != nil {
-		return fmt.Errorf("join PID1 process group: %w", err)
+	return supervisor.Command{
+		Name: "tinfoil-debug-console",
+		Path: debugShellPath,
+		Args: []string{"ash", "-i"},
+		Env: []string{
+			"HOME=/root",
+			"PATH=/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=linux",
+		},
+		Dir: "/",
 	}
-	if _, err := unix.Setsid(); err != nil {
-		return fmt.Errorf("create console session: %w", err)
-	}
-	console, err := unix.Open(debugConsoleTTY, unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
-	if err != nil {
-		return fmt.Errorf("open %s: %w", debugConsoleTTY, err)
-	}
-	defer unix.Close(console)
-	if err := unix.IoctlSetInt(console, unix.TIOCSCTTY, 0); err != nil {
-		return fmt.Errorf("acquire %s: %w", debugConsoleTTY, err)
-	}
-	if err := unix.IoctlSetPointerInt(console, unix.TIOCSPGRP, os.Getpid()); err != nil {
-		return fmt.Errorf("foreground %s: %w", debugConsoleTTY, err)
-	}
-	for descriptor := 0; descriptor <= 2; descriptor++ {
-		if err := unix.Dup3(console, descriptor, 0); err != nil {
-			return fmt.Errorf("attach %s to fd %d: %w", debugConsoleTTY, descriptor, err)
-		}
-	}
-	if console > 2 {
-		if err := unix.Close(console); err != nil {
-			return fmt.Errorf("close console descriptor: %w", err)
-		}
-		console = -1
-	}
-	if err := unix.Chdir("/"); err != nil {
-		return fmt.Errorf("chdir root: %w", err)
-	}
-	return syscall.Exec(debugShellPath, []string{"ash", "-i"}, []string{
-		"HOME=/root",
-		"PATH=/usr/sbin:/usr/bin:/sbin:/bin",
-		"TERM=linux",
-	})
 }

--- a/tinfoil/cmd/init/debug_console_enabled.go
+++ b/tinfoil/cmd/init/debug_console_enabled.go
@@ -6,6 +6,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"tinfoil/internal/pid1/supervisor"
@@ -37,6 +39,14 @@ func startDebugConsole(_ context.Context, manager *supervisor.Manager) (*debugCo
 
 func (console *debugConsole) stop(termGrace, killGrace time.Duration) error {
 	return console.process.StopConsole(termGrace, killGrace)
+}
+
+func parkDebugFailure(err error) {
+	initLogf("debug image: lifecycle failed: %v; console remains available until shutdown", err)
+	shutdown := make(chan os.Signal, 1)
+	signal.Notify(shutdown, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(shutdown)
+	<-shutdown
 }
 
 func debugConsoleCommand() supervisor.Command {

--- a/tinfoil/cmd/init/debug_console_enabled.go
+++ b/tinfoil/cmd/init/debug_console_enabled.go
@@ -1,0 +1,75 @@
+//go:build tinfoil_debug_image && linux && amd64
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	"tinfoil/internal/pid1/supervisor"
+)
+
+const (
+	debugConsoleArg = "--tinfoil-debug-console"
+	debugConsoleTTY = "/dev/hvc0"
+	debugShellPath  = "/usr/bin/busybox"
+)
+
+func dispatchDebugConsole(args []string) (bool, error) {
+	if len(args) != 2 || args[1] != debugConsoleArg {
+		return false, nil
+	}
+	return true, execDebugConsole()
+}
+
+func startDebugConsole(manager *supervisor.Manager) error {
+	initLogf("debug image: starting static shell on %s", debugConsoleTTY)
+	_, err := manager.Start(debugConsoleCommand())
+	return err
+}
+
+func debugConsoleCommand() supervisor.Command {
+	return command("tinfoil-debug-console", selfExecPath, debugConsoleArg)
+}
+
+func execDebugConsole() error {
+	if err := unix.Setpgid(0, os.Getppid()); err != nil {
+		return fmt.Errorf("join PID1 process group: %w", err)
+	}
+	if _, err := unix.Setsid(); err != nil {
+		return fmt.Errorf("create console session: %w", err)
+	}
+	console, err := unix.Open(debugConsoleTTY, unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", debugConsoleTTY, err)
+	}
+	defer unix.Close(console)
+	if err := unix.IoctlSetInt(console, unix.TIOCSCTTY, 0); err != nil {
+		return fmt.Errorf("acquire %s: %w", debugConsoleTTY, err)
+	}
+	if err := unix.IoctlSetPointerInt(console, unix.TIOCSPGRP, os.Getpid()); err != nil {
+		return fmt.Errorf("foreground %s: %w", debugConsoleTTY, err)
+	}
+	for descriptor := 0; descriptor <= 2; descriptor++ {
+		if err := unix.Dup3(console, descriptor, 0); err != nil {
+			return fmt.Errorf("attach %s to fd %d: %w", debugConsoleTTY, descriptor, err)
+		}
+	}
+	if console > 2 {
+		if err := unix.Close(console); err != nil {
+			return fmt.Errorf("close console descriptor: %w", err)
+		}
+		console = -1
+	}
+	if err := unix.Chdir("/"); err != nil {
+		return fmt.Errorf("chdir root: %w", err)
+	}
+	return syscall.Exec(debugShellPath, []string{"ash", "-i"}, []string{
+		"HOME=/root",
+		"PATH=/usr/sbin:/usr/bin:/sbin:/bin",
+		"TERM=linux",
+	})
+}

--- a/tinfoil/cmd/init/debug_console_enabled_test.go
+++ b/tinfoil/cmd/init/debug_console_enabled_test.go
@@ -7,23 +7,15 @@ import (
 	"testing"
 )
 
-func TestDebugConsoleCommandIsFixedSelfExec(t *testing.T) {
+func TestDebugConsoleCommandIsFixed(t *testing.T) {
 	command := debugConsoleCommand()
-	if command.Name != "tinfoil-debug-console" || command.Path != selfExecPath ||
-		!reflect.DeepEqual(command.Args, []string{debugConsoleArg}) || command.Dir != "/" {
+	if command.Name != "tinfoil-debug-console" || command.Path != debugShellPath ||
+		!reflect.DeepEqual(command.Args, []string{"ash", "-i"}) ||
+		!reflect.DeepEqual(command.Env, []string{
+			"HOME=/root",
+			"PATH=/usr/sbin:/usr/bin:/sbin:/bin",
+			"TERM=linux",
+		}) || command.Dir != "/" {
 		t.Fatalf("debug console command = %+v", command)
-	}
-}
-
-func TestDispatchDebugConsoleRejectsNonExactInvocation(t *testing.T) {
-	for _, args := range [][]string{
-		{"tinfoil-init"},
-		{"tinfoil-init", "--unknown"},
-		{"tinfoil-init", debugConsoleArg, "extra"},
-	} {
-		handled, err := dispatchDebugConsole(args)
-		if handled || err != nil {
-			t.Fatalf("dispatchDebugConsole(%q) = %v, %v; want false, nil", args, handled, err)
-		}
 	}
 }

--- a/tinfoil/cmd/init/debug_console_enabled_test.go
+++ b/tinfoil/cmd/init/debug_console_enabled_test.go
@@ -1,0 +1,29 @@
+//go:build tinfoil_debug_image && linux && amd64
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestDebugConsoleCommandIsFixedSelfExec(t *testing.T) {
+	command := debugConsoleCommand()
+	if command.Name != "tinfoil-debug-console" || command.Path != selfExecPath ||
+		!reflect.DeepEqual(command.Args, []string{debugConsoleArg}) || command.Dir != "/" {
+		t.Fatalf("debug console command = %+v", command)
+	}
+}
+
+func TestDispatchDebugConsoleRejectsNonExactInvocation(t *testing.T) {
+	for _, args := range [][]string{
+		{"tinfoil-init"},
+		{"tinfoil-init", "--unknown"},
+		{"tinfoil-init", debugConsoleArg, "extra"},
+	} {
+		handled, err := dispatchDebugConsole(args)
+		if handled || err != nil {
+			t.Fatalf("dispatchDebugConsole(%q) = %v, %v; want false, nil", args, handled, err)
+		}
+	}
+}

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -54,13 +54,6 @@ var consoleMu sync.Mutex
 
 func main() {
 	log.SetFlags(0)
-	if handled, err := dispatchDebugConsole(os.Args); handled {
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "tinfoil-init: debug console: %v\n", err)
-			os.Exit(127)
-		}
-		panic("debug console exec returned without an error")
-	}
 	if len(os.Args) > 1 && os.Args[1] == "--exec-service" {
 		if err := execService(os.Args[2:], hardening.ApplyService, syscall.Exec); err != nil {
 			fmt.Fprintf(os.Stderr, "tinfoil-init: exec-service: %v\n", err)
@@ -117,12 +110,16 @@ type lifecycleDeps struct {
 	kill        time.Duration
 }
 
-func run(parent context.Context) error {
+func run(parent context.Context) (result error) {
 	readiness := newReadiness(requiredServiceNames(), setReady)
 	manager := supervisor.NewManager(initLogf)
-	if err := startDebugConsole(manager); err != nil {
+	console, err := startDebugConsole(parent, manager)
+	if err != nil {
 		return fmt.Errorf("start debug console: %w", err)
 	}
+	defer func() {
+		result = errors.Join(result, console.stop(serviceTermGrace, serviceKillGrace))
+	}()
 	services := supervisor.New(parent, manager, supervisor.Config{Observe: readiness.Update})
 	deps := lifecycleDeps{
 		services: services,

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -54,6 +54,13 @@ var consoleMu sync.Mutex
 
 func main() {
 	log.SetFlags(0)
+	if handled, err := dispatchDebugConsole(os.Args); handled {
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "tinfoil-init: debug console: %v\n", err)
+			os.Exit(127)
+		}
+		panic("debug console exec returned without an error")
+	}
 	if len(os.Args) > 1 && os.Args[1] == "--exec-service" {
 		if err := execService(os.Args[2:], hardening.ApplyService, syscall.Exec); err != nil {
 			fmt.Fprintf(os.Stderr, "tinfoil-init: exec-service: %v\n", err)
@@ -113,6 +120,9 @@ type lifecycleDeps struct {
 func run(parent context.Context) error {
 	readiness := newReadiness(requiredServiceNames(), setReady)
 	manager := supervisor.NewManager(initLogf)
+	if err := startDebugConsole(manager); err != nil {
+		return fmt.Errorf("start debug console: %w", err)
+	}
 	services := supervisor.New(parent, manager, supervisor.Config{Observe: readiness.Update})
 	deps := lifecycleDeps{
 		services: services,

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -99,7 +99,7 @@ type lifecycleDeps struct {
 	oneShot      func(context.Context, supervisor.Command) error
 	nvidia       func(context.Context) error
 	lockModules  func() error
-	debugFailure func(error)
+	debugFailure func(context.Context, error)
 	setupFS      func(pidruntime.LogFunc) error
 	sysctls      func(pidruntime.LogFunc) error
 	ramdisk      func(pidruntime.LogFunc) error
@@ -170,7 +170,7 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	}()
 	defer func() {
 		if result != nil && deps.debugFailure != nil {
-			deps.debugFailure(result)
+			deps.debugFailure(parent, result)
 		}
 	}()
 

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -95,19 +95,20 @@ type serviceControl interface {
 }
 
 type lifecycleDeps struct {
-	services    serviceControl
-	oneShot     func(context.Context, supervisor.Command) error
-	nvidia      func(context.Context) error
-	lockModules func() error
-	setupFS     func(pidruntime.LogFunc) error
-	sysctls     func(pidruntime.LogFunc) error
-	ramdisk     func(pidruntime.LogFunc) error
-	limits      func() error
-	syslog      func(context.Context)
-	exists      func(string) (bool, error)
-	timeout     time.Duration
-	term        time.Duration
-	kill        time.Duration
+	services     serviceControl
+	oneShot      func(context.Context, supervisor.Command) error
+	nvidia       func(context.Context) error
+	lockModules  func() error
+	debugFailure func(error)
+	setupFS      func(pidruntime.LogFunc) error
+	sysctls      func(pidruntime.LogFunc) error
+	ramdisk      func(pidruntime.LogFunc) error
+	limits       func() error
+	syslog       func(context.Context)
+	exists       func(string) (bool, error)
+	timeout      time.Duration
+	term         time.Duration
+	kill         time.Duration
 }
 
 func run(parent context.Context) (result error) {
@@ -138,16 +139,17 @@ func run(parent context.Context) (result error) {
 				},
 			)
 		},
-		lockModules: hardening.LockKernelModules,
-		setupFS:     pidruntime.SetupFilesystems,
-		sysctls:     pidruntime.ApplySysctls,
-		ramdisk:     pidruntime.SetupRamdisk,
-		limits:      hardening.ApplyRuntimeLimits,
-		syslog:      startOptionalSyslogSink,
-		exists:      pathExists,
-		timeout:     bootTimeout,
-		term:        serviceTermGrace,
-		kill:        serviceKillGrace,
+		debugFailure: parkDebugFailure,
+		lockModules:  hardening.LockKernelModules,
+		setupFS:      pidruntime.SetupFilesystems,
+		sysctls:      pidruntime.ApplySysctls,
+		ramdisk:      pidruntime.SetupRamdisk,
+		limits:       hardening.ApplyRuntimeLimits,
+		syslog:       startOptionalSyslogSink,
+		exists:       pathExists,
+		timeout:      bootTimeout,
+		term:         serviceTermGrace,
+		kill:         serviceKillGrace,
 	}
 	return runLifecycle(parent, deps, readiness)
 }
@@ -164,6 +166,11 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 			result = drainErr
 		} else {
 			result = errors.Join(result, drainErr)
+		}
+	}()
+	defer func() {
+		if result != nil && deps.debugFailure != nil {
+			deps.debugFailure(result)
 		}
 	}()
 

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -83,15 +83,16 @@ func newLifecycleHarness() *lifecycleHarness {
 	harness.services.observe = harness.readiness.Update
 	noSetup := func(pidruntime.LogFunc) error { return nil }
 	harness.deps = lifecycleDeps{
-		services:    harness.services,
-		oneShot:     func(context.Context, supervisor.Command) error { return nil },
-		nvidia:      func(context.Context) error { return nil },
-		lockModules: func() error { return nil },
-		setupFS:     noSetup,
-		sysctls:     noSetup,
-		ramdisk:     noSetup,
-		limits:      func() error { return nil },
-		syslog:      func(context.Context) {},
+		services:     harness.services,
+		oneShot:      func(context.Context, supervisor.Command) error { return nil },
+		nvidia:       func(context.Context) error { return nil },
+		lockModules:  func() error { return nil },
+		debugFailure: func(error) {},
+		setupFS:      noSetup,
+		sysctls:      noSetup,
+		ramdisk:      noSetup,
+		limits:       func() error { return nil },
+		syslog:       func(context.Context) {},
 		exists: func(path string) (bool, error) {
 			return harness.existing[path], nil
 		},
@@ -467,6 +468,38 @@ func TestModuleLockFailureStopsBootBeforeServices(t *testing.T) {
 	}
 	if len(harness.services.started) != 0 {
 		t.Fatalf("services started despite module lock failure: %v", harness.services.started)
+	}
+}
+
+func TestLifecycleFailureParksBeforeServiceDrain(t *testing.T) {
+	harness := newLifecycleHarness()
+	setupErr := errors.New("filesystem setup failed")
+	harness.deps.setupFS = func(pidruntime.LogFunc) error { return setupErr }
+	parked := make(chan error, 1)
+	release := make(chan struct{})
+	harness.deps.debugFailure = func(err error) {
+		parked <- err
+		<-release
+	}
+	result := make(chan error, 1)
+	go func() {
+		result <- runLifecycle(context.Background(), harness.deps, harness.readiness)
+	}()
+
+	if err := receiveTest(t, parked); !errors.Is(err, setupErr) {
+		t.Fatalf("parked error = %v, want %v", err, setupErr)
+	}
+	select {
+	case groups := <-harness.services.drained:
+		t.Fatalf("services drained before debug failure release: %v", groups)
+	default:
+	}
+	close(release)
+	if groups := receiveTest(t, harness.services.drained); fmt.Sprint(groups) != fmt.Sprint(shutdownGroups()) {
+		t.Fatalf("drain groups = %v, want %v", groups, shutdownGroups())
+	}
+	if err := receiveTest(t, result); !errors.Is(err, setupErr) {
+		t.Fatalf("runLifecycle error = %v, want %v", err, setupErr)
 	}
 }
 

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -87,7 +87,7 @@ func newLifecycleHarness() *lifecycleHarness {
 		oneShot:      func(context.Context, supervisor.Command) error { return nil },
 		nvidia:       func(context.Context) error { return nil },
 		lockModules:  func() error { return nil },
-		debugFailure: func(error) {},
+		debugFailure: func(context.Context, error) {},
 		setupFS:      noSetup,
 		sysctls:      noSetup,
 		ramdisk:      noSetup,
@@ -477,7 +477,7 @@ func TestLifecycleFailureParksBeforeServiceDrain(t *testing.T) {
 	harness.deps.setupFS = func(pidruntime.LogFunc) error { return setupErr }
 	parked := make(chan error, 1)
 	release := make(chan struct{})
-	harness.deps.debugFailure = func(err error) {
+	harness.deps.debugFailure = func(_ context.Context, err error) {
 		parked <- err
 		<-release
 	}

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
@@ -1,0 +1,80 @@
+//go:build tinfoil_debug_image && linux && amd64
+
+package supervisor
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// StartConsole starts one debug-image child as a new session with console as
+// its controlling terminal. The manager remains the sole wait4 owner.
+func (m *Manager) StartConsole(command Command, console *os.File) (*Process, error) {
+	if command.Name == "" {
+		return nil, errors.New("child name is required")
+	}
+	if !filepath.IsAbs(command.Path) {
+		return nil, fmt.Errorf("child path must be absolute: %q", command.Path)
+	}
+	if console == nil {
+		return nil, errors.New("console is required")
+	}
+
+	reply := make(chan startResponse, 1)
+	m.ops <- func(children map[int]*Process) {
+		environment := command.Env
+		if environment == nil {
+			environment = os.Environ()
+		}
+		process, err := os.StartProcess(
+			command.Path,
+			append([]string{command.Path}, command.Args...),
+			&os.ProcAttr{
+				Dir:   command.Dir,
+				Env:   environment,
+				Files: []*os.File{console, console, console},
+				Sys: &syscall.SysProcAttr{
+					Setsid:  true,
+					Setctty: true,
+					Ctty:    0,
+				},
+			},
+		)
+		if err != nil {
+			reply <- startResponse{err: fmt.Errorf("start %s: %w", command.Name, err)}
+			return
+		}
+		child := osChild{process: process}
+		managed := &Process{child: child, done: make(chan struct{})}
+		children[process.Pid] = managed
+		reply <- startResponse{process: managed}
+	}
+	response := <-reply
+	return response.process, response.err
+}
+
+// StopConsole terminates the complete console process group with bounded
+// escalation, including background descendants left after the shell exits.
+func (p *Process) StopConsole(termGrace, killGrace time.Duration) error {
+	var errs []error
+	if err := p.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		errs = append(errs, err)
+	}
+	alive, waitErrs := waitProcessGroups([]*Process{p}, time.After(termGrace))
+	errs = append(errs, waitErrs...)
+	for _, process := range alive {
+		if err := process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			errs = append(errs, err)
+		}
+	}
+	alive, waitErrs = waitProcessGroups(alive, time.After(killGrace))
+	errs = append(errs, waitErrs...)
+	for _, process := range alive {
+		errs = append(errs, fmt.Errorf("debug console process group %d survived SIGKILL", process.PID()))
+	}
+	return errors.Join(errs...)
+}

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
@@ -48,13 +48,18 @@ func (m *Manager) StartConsole(command Command, console *os.File) (*Process, err
 			reply <- startResponse{err: fmt.Errorf("start %s: %w", command.Name, err)}
 			return
 		}
-		child := osChild{process: process}
-		managed := &Process{child: child, done: make(chan struct{})}
-		children[process.Pid] = managed
+		managed := newConsoleProcess(process, command.Name)
+		children[managed.PID()] = managed
 		reply <- startResponse{process: managed}
 	}
 	response := <-reply
 	return response.process, response.err
+}
+
+func newConsoleProcess(process *os.Process, name string) *Process {
+	pid := process.Pid
+	child := osChild{process: process, processID: pid}
+	return &Process{pid: pid, name: name, child: child, done: make(chan struct{})}
 }
 
 // StopConsole terminates the complete console process group with bounded

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
@@ -1,0 +1,23 @@
+//go:build tinfoil_debug_image && linux && amd64
+
+package supervisor
+
+import (
+	"os"
+	"testing"
+)
+
+func TestNewConsoleProcessCachesIdentity(t *testing.T) {
+	const (
+		pid  = 1234
+		name = "debug-console"
+	)
+	process := newConsoleProcess(&os.Process{Pid: pid}, name)
+	if process.PID() != pid || process.name != name {
+		t.Fatalf("process identity = (%d, %q), want (%d, %q)", process.PID(), process.name, pid, name)
+	}
+	child, ok := process.child.(osChild)
+	if !ok || child.processID != pid {
+		t.Fatalf("child process ID = %d, %v; want %d, true", child.processID, ok, pid)
+	}
+}


### PR DESCRIPTION
## Summary
- add a fixed debug-image target using the pinned release kernel and measured initrd
- compile a debug-tagged PID1 and stage one pinned static BusyBox shell on `/dev/hvc0`
- keep every debug path behind compile-time build tags and a separate additive rootfs layer
- prove the shipping rootfs and release PID1 remain shell-free and debug-marker-free
- run the debug shell as a supervised child so PID1 remains the sole `wait4` owner

The debug image is operational tooling only. Its measurement is intentionally different and must never be promoted as a shipping measurement. It does not add a generic kernel profile, compatibility kernel, runtime activation parser, or shell to the shipping rootfs.

## Dependency and merge order
This PR is stacked on #233 so it can be reviewed without the previous merge conflicts. Merge #233 first. After #233 lands, this branch will be rebased onto `jules/harden-tcb` using the already validated rehearsal, and the debug lifecycle-failure console persistence will be folded in before final merge.

## Validation
- `gofmt`
- `go build ./...`
- `go test ./...`
- debug-tagged PID1 tests
- focused race tests for PID1 and supervisor
- `go vet ./...`
- `make test-debug-image-contract`
- `make test-runtime-builder-contract`
- `git diff --check`
- exact-artifact Box3 boot-debug image readiness and deliberate boot-failure shell retention validated on the combined integration artifact