### PR TITLE
Preserve YAML format for NVIDIA CDI output

### DIFF
--- a/tinfoil/internal/nvidia/services.go
+++ b/tinfoil/internal/nvidia/services.go
@@ -210,7 +210,7 @@ func (s *Services) CreateCDITemporary() (string, error) {
 	if err := ensureDirectory(directory); err != nil {
 		return "", fmt.Errorf("prepare NVIDIA CDI directory: %w", err)
 	}
-	file, err := os.CreateTemp(directory, ".nvidia.yaml.*")
+	file, err := os.CreateTemp(directory, ".nvidia.*.yaml")
 	if err != nil {
 		return "", fmt.Errorf("create NVIDIA CDI temporary file: %w", err)
 	}

--- a/tinfoil/internal/nvidia/services_test.go
+++ b/tinfoil/internal/nvidia/services_test.go
@@ -345,6 +345,9 @@ func TestCreateAndPublishCDIAtomically(t *testing.T) {
 	if filepath.Dir(temporary) != filepath.Dir(services.paths.cdiSpec) {
 		t.Fatalf("temporary directory = %s", filepath.Dir(temporary))
 	}
+	if filepath.Ext(temporary) != ".yaml" || filepath.Base(temporary)[0] != '.' || temporary == services.paths.cdiSpec {
+		t.Fatalf("temporary path = %s, want hidden distinct YAML file", temporary)
+	}
 	if err := os.WriteFile(temporary, []byte("new\n"), 0600); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- give the same-directory CDI temporary file a final `.yaml` suffix
- assert that the temporary path stays hidden, distinct, and YAML-tagged
- preserve the existing regular-file validation, fsync, and atomic rename contract

NVIDIA Container Toolkit 1.19.1 chooses its output encoding from the destination suffix. The old `.nvidia.yaml.<random>` name does not end in `.yaml`, so `nvidia-ctk` writes a separate YAML sibling and leaves the file PID1 validates empty. The fixed `.nvidia.<random>.yaml` contract keeps generator and atomic publisher on the same file.

## Validation
- `gofmt`
- `go test ./internal/nvidia`
- `go test -race ./internal/nvidia`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- exact-artifact INF14 B300 boot with GPU attestation, nonempty CDI output, fresh NVIDIA workload, restart, and no temporary-file leftovers


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure CDI temporary files end with `.yaml` so `nvidia-ctk` writes YAML into the same file, preventing empty CDI outputs and keeping atomic publish behavior intact.

- **Bug Fixes**
  - Switched temp filename pattern to `.nvidia.*.yaml` in `CreateCDITemporary()` to preserve the `.yaml` suffix and avoid sibling output.
  - Added tests to assert the temp path is in the same directory, hidden, distinct, and ends with `.yaml`.

<sup>Written for commit d9b892eb64b3a27f34a20ddaac06496af8c2f020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

