### PR TITLE
Force clone3 fallback under service seccomp

### DIFF
--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64.go
@@ -55,9 +55,15 @@ func serviceSeccompFilters(denied []uint32, restrictNamespaceOps bool, domains [
 		{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.ENOSYS)},
 	}
 	for _, number := range denied {
+		errno := uint32(unix.EPERM)
+		if number == unix.SYS_CLONE3 {
+			// glibc falls back to clone(2) only when clone3 is unavailable.
+			// The clone filter below still rejects every namespace flag.
+			errno = uint32(unix.ENOSYS)
+		}
 		filters = append(filters,
 			unix.SockFilter{Code: unix.BPF_JMP | unix.BPF_JEQ | unix.BPF_K, Jf: 1, K: number},
-			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | uint32(unix.EPERM)},
+			unix.SockFilter{Code: unix.BPF_RET | unix.BPF_K, K: unix.SECCOMP_RET_ERRNO | errno},
 		)
 	}
 	if restrictNamespaceOps {

--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
@@ -124,6 +124,8 @@ func TestServiceDangerousSyscalls(t *testing.T) {
 			_, _, errno = unix.RawSyscall(unix.SYS_IO_URING_REGISTER, 0, 0, 0)
 		case "namespace-clone":
 			_, _, errno = unix.RawSyscall6(unix.SYS_CLONE, uintptr(unix.CLONE_NEWNS), 0, 0, 0, 0, 0)
+		case "clone3":
+			_, _, errno = unix.RawSyscall6(unix.SYS_CLONE3, 0, 0, 0, 0, 0, 0)
 		case "x32":
 			_, _, errno = unix.RawSyscall(uintptr(x32SyscallBit|unix.SYS_GETPID), 0, 0, 0)
 		default:
@@ -131,7 +133,7 @@ func TestServiceDangerousSyscalls(t *testing.T) {
 		}
 
 		want := syscall.EPERM
-		if operation == "x32" {
+		if operation == "clone3" || operation == "x32" {
 			want = syscall.ENOSYS
 		}
 		if errno != want {
@@ -151,6 +153,7 @@ func TestServiceDangerousSyscalls(t *testing.T) {
 		{name: "egress-cannot-io-uring-enter", service: ServiceEgress, operation: "io-uring-enter"},
 		{name: "status-cannot-io-uring-register", service: ServiceContainerStatus, operation: "io-uring-register"},
 		{name: "shim-cannot-mount", service: ServiceShim, operation: "mount"},
+		{name: "shim-forces-clone3-fallback", service: ServiceShim, operation: "clone3"},
 		{name: "egress-cannot-clone-namespace", service: ServiceEgress, operation: "namespace-clone"},
 		{name: "status-rejects-x32", service: ServiceContainerStatus, operation: "x32"},
 	}


### PR DESCRIPTION
## Summary
- return `ENOSYS` rather than `EPERM` for denied `clone3`
- let glibc fall back to legacy `clone(2)` for ordinary thread/process creation
- retain the existing argument filter that rejects every namespace-creating legacy clone flag

Exact-artifact Box3 boot showed that returning `EPERM` for `clone3` prevents glibc's compatibility fallback and breaks Docker/container startup even though ordinary non-namespace clone is allowed. This preserves the namespace boundary while exposing the kernel interface as unavailable.

## Validation
- `gofmt`
- focused `internal/pid1/hardening` tests
- focused race tests
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- exact-artifact Box3 shipping/debug boot and INF14 B300 workload qualification


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return ENOSYS for denied `clone3` in service seccomp so glibc falls back to `clone(2)`, restoring container startup while preserving namespace isolation. Keep rejecting all namespace-creating legacy `clone` flags; add a test asserting the `clone3` fallback.

<sup>Written for commit c65a74139dac97b07be5ac76b7a8a6545b76114b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

