### PR TITLE
Mount hardened configfs for TDX reports

### DIFF
--- a/tinfoil/internal/pid1/runtime/setup.go
+++ b/tinfoil/internal/pid1/runtime/setup.go
@@ -34,6 +34,24 @@ type sysctlSetting struct {
 	optional bool
 }
 
+type runtimeMount struct {
+	source string
+	target string
+	fstype string
+	flags  uintptr
+	data   string
+	fatal  bool
+}
+
+var runtimeMounts = []runtimeMount{
+	{"tmpfs", "/dev/shm", "tmpfs", syscall.MS_NOSUID | syscall.MS_NODEV, "mode=1777,size=512M", true},
+	{"devpts", "/dev/pts", "devpts", syscall.MS_NOSUID | syscall.MS_NOEXEC, "mode=0620,ptmxmode=0666,newinstance", true},
+	{"mqueue", "/dev/mqueue", "mqueue", syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC, "", false},
+	{"hugetlbfs", "/dev/hugepages", "hugetlbfs", syscall.MS_NOSUID | syscall.MS_NODEV, "mode=1770,gid=0", false},
+	{"configfs", "/sys/kernel/config", "configfs", syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC, "", true},
+	{"cgroup2", "/sys/fs/cgroup", "cgroup2", syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC, "", true},
+}
+
 // sysctlPolicy is compiled into the measured PID 1 binary. Keeping the exact
 // procfs paths here avoids shipping a configuration-language parser.
 var sysctlPolicy = []sysctlSetting{
@@ -66,27 +84,8 @@ func SetupFilesystems(log LogFunc) error {
 	if err := os.WriteFile("/proc/sys/kernel/hostname", []byte("tinfoil\n"), 0644); err != nil {
 		logf(log, "warning: setting hostname: %v", err)
 	}
-	mounts := []struct {
-		source string
-		target string
-		fstype string
-		flags  uintptr
-		data   string
-		fatal  bool
-	}{
-		{"tmpfs", "/dev/shm", "tmpfs", syscall.MS_NOSUID | syscall.MS_NODEV, "mode=1777,size=512M", true},
-		{"devpts", "/dev/pts", "devpts", syscall.MS_NOSUID | syscall.MS_NOEXEC, "mode=0620,ptmxmode=0666,newinstance", true},
-		{"mqueue", "/dev/mqueue", "mqueue", syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC, "", false},
-		{"hugetlbfs", "/dev/hugepages", "hugetlbfs", syscall.MS_NOSUID | syscall.MS_NODEV, "mode=1770,gid=0", false},
-		{"cgroup2", "/sys/fs/cgroup", "cgroup2", syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC, "", true},
-	}
-	for _, mount := range mounts {
-		if err := mountIfNeeded(mount.source, mount.target, mount.fstype, mount.flags, mount.data, log); err != nil {
-			if mount.fatal {
-				return err
-			}
-			logf(log, "optional mount skipped: %v", err)
-		}
+	if err := mountRuntimeFilesystems(runtimeMounts, mountIfNeeded, log); err != nil {
+		return err
 	}
 	if err := ensureSymlink("/dev/shm", "/run/shm"); err != nil {
 		logf(log, "warning: creating /run/shm compatibility symlink: %v", err)
@@ -100,6 +99,22 @@ func SetupFilesystems(log LogFunc) error {
 	} {
 		if err := ensureDir(dir.path, dir.mode); err != nil {
 			logf(log, "warning: creating runtime dir %s: %v", dir.path, err)
+		}
+	}
+	return nil
+}
+
+func mountRuntimeFilesystems(
+	mounts []runtimeMount,
+	mount func(string, string, string, uintptr, string, LogFunc) error,
+	log LogFunc,
+) error {
+	for _, entry := range mounts {
+		if err := mount(entry.source, entry.target, entry.fstype, entry.flags, entry.data, log); err != nil {
+			if entry.fatal {
+				return err
+			}
+			logf(log, "optional mount skipped: %v", err)
 		}
 	}
 	return nil

--- a/tinfoil/internal/pid1/runtime/setup_test.go
+++ b/tinfoil/internal/pid1/runtime/setup_test.go
@@ -1,8 +1,10 @@
 package runtime
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -57,6 +59,33 @@ func TestRamdiskSizeGB(t *testing.T) {
 	}
 	if _, _, err := ramdiskSizeGB(0); err == nil {
 		t.Fatal("ramdiskSizeGB(0) succeeded")
+	}
+}
+
+func TestRuntimeMountPolicyRequiresHardenedConfigFS(t *testing.T) {
+	wantFlags := uintptr(syscall.MS_NOSUID | syscall.MS_NODEV | syscall.MS_NOEXEC)
+	for _, mount := range runtimeMounts {
+		if mount.target != "/sys/kernel/config" {
+			continue
+		}
+		if mount.source != "configfs" || mount.fstype != "configfs" || mount.flags != wantFlags || mount.data != "" || !mount.fatal {
+			t.Fatalf("configfs mount = %+v", mount)
+		}
+		return
+	}
+	t.Fatal("configfs runtime mount is missing")
+}
+
+func TestRuntimeMountPolicyPropagatesConfigFSFailure(t *testing.T) {
+	want := errors.New("configfs unavailable")
+	err := mountRuntimeFilesystems(runtimeMounts, func(_, target, _ string, _ uintptr, _ string, _ LogFunc) error {
+		if target == "/sys/kernel/config" {
+			return want
+		}
+		return nil
+	}, nil)
+	if !errors.Is(err, want) {
+		t.Fatalf("mountRuntimeFilesystems error = %v, want %v", err, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- mount the pinned kernel's configfs at `/sys/kernel/config`
- require `nosuid,nodev,noexec` and fail PID1 setup closed if the mount is unavailable
- test the fixed mount contract and fatal failure propagation

The TDX attestation path requires `/sys/kernel/config/tsm/report`. The pinned kernel already has configfs and TSM reports built in, but PID1 did not mount configfs after systemd removal. Long-running isolated services continue to receive their restricted `/sys`; the measured boot service gets the fixed host mount it needs.

## Validation
- `gofmt`
- focused `internal/pid1/runtime` tests
- focused race tests
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
- exact-artifact Box3 TDX attestation and INF14 B300 boot with `/sys/kernel/config/tsm/report` present


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mount hardened `configfs` at `/sys/kernel/config` during PID1 setup to enable TDX attestation via `/sys/kernel/config/tsm/report`. The mount uses nosuid,nodev,noexec and fails closed if unavailable.

- **New Features**
  - Mount `configfs` at `/sys/kernel/config` with MS_NOSUID|MS_NODEV|MS_NOEXEC.
  - Treat the mount as fatal to ensure TDX attestation reliability.
  - Added tests that enforce the mount contract and verify failure propagation.

- **Refactors**
  - Introduced `runtimeMounts` and `mountRuntimeFilesystems` to centralize runtime mount policy and simplify `SetupFilesystems`.

<sup>Written for commit 72d2a2d5feefdd7b4de828f12c626df0d46d6309. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

