### PR TITLE
Add a fixed customer debug toolbox contract

### DIFF
--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/netip"
 	"os"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -241,7 +240,7 @@ func loadAndVerifyConfig(cmdline kernelCmdline) (*Config, error) {
 	if err := yaml.Unmarshal(configData, &config); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
-	if err := validateConfigShapeForMode(&config, cmdline.Debug); err != nil {
+	if err := validateConfigShape(&config, cmdline.Debug); err != nil {
 		return nil, err
 	}
 
@@ -380,22 +379,4 @@ func readDiskPayload(path string, maxBytes int64) ([]byte, error) {
 		return nil, fmt.Errorf("%s payload exceeds %d bytes", path, maxBytes)
 	}
 	return data, nil
-}
-
-// getCmdlineParam extracts a parameter value from /proc/cmdline
-func getCmdlineParam(param string) (string, error) {
-	data, err := os.ReadFile("/proc/cmdline")
-	if err != nil {
-		return "", fmt.Errorf("reading /proc/cmdline: %w", err)
-	}
-
-	prefix := param + "="
-
-	for part := range strings.FieldsSeq(string(data)) {
-		if value, found := strings.CutPrefix(part, prefix); found {
-			return value, nil
-		}
-	}
-
-	return "", fmt.Errorf("parameter %s not found in cmdline", param)
 }

--- a/tinfoil/cmd/boot/config.go
+++ b/tinfoil/cmd/boot/config.go
@@ -206,7 +206,7 @@ func ipv4Broadcast(prefix netip.Prefix) netip.Addr {
 }
 
 // loadAndVerifyConfig reads the config from disk and verifies its hash
-func loadAndVerifyConfig() (*Config, error) {
+func loadAndVerifyConfig(cmdline kernelCmdline) (*Config, error) {
 	configDiskPath, err := device.ConfigDisk()
 	if err != nil {
 		return nil, fmt.Errorf("finding config disk: %w", err)
@@ -218,7 +218,7 @@ func loadAndVerifyConfig() (*Config, error) {
 	}
 
 	// Verify hash against kernel cmdline
-	expectedHash, err := getCmdlineParam("tinfoil-config-hash")
+	expectedHash, err := cmdline.requiredConfigHash()
 	if err != nil {
 		return nil, fmt.Errorf("getting expected config hash: %w", err)
 	}
@@ -241,7 +241,7 @@ func loadAndVerifyConfig() (*Config, error) {
 	if err := yaml.Unmarshal(configData, &config); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
-	if err := validateConfigShape(&config); err != nil {
+	if err := validateConfigShapeForMode(&config, cmdline.Debug); err != nil {
 		return nil, err
 	}
 

--- a/tinfoil/cmd/boot/config_shape.go
+++ b/tinfoil/cmd/boot/config_shape.go
@@ -14,11 +14,7 @@ const (
 	maxEnvironmentNameBytes   = 256
 )
 
-func validateConfigShape(config *Config) error {
-	return validateConfigShapeForMode(config, false)
-}
-
-func validateConfigShapeForMode(config *Config, debug bool) error {
+func validateConfigShape(config *Config, debug bool) error {
 	if len(config.Containers) > maxConfigContainers {
 		return fmt.Errorf("containers exceeds limit %d", maxConfigContainers)
 	}
@@ -42,18 +38,14 @@ func validateConfigShapeForMode(config *Config, debug bool) error {
 			return fmt.Errorf("containers[%d].name %q duplicates containers[%d].name", index, config.Containers[index].Name, prior)
 		}
 		seenContainerNames[config.Containers[index].Name] = index
-		if err := validateContainerShapeForMode(index, &config.Containers[index], debug); err != nil {
+		if err := validateContainerShape(index, &config.Containers[index], debug); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateContainerShape(index int, container *Container) error {
-	return validateContainerShapeForMode(index, container, false)
-}
-
-func validateContainerShapeForMode(index int, container *Container, debug bool) error {
+func validateContainerShape(index int, container *Container, debug bool) error {
 	lists := []struct {
 		name  string
 		count int
@@ -78,7 +70,7 @@ func validateContainerShapeForMode(index int, container *Container, debug bool) 
 	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
 		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
 	}
-	if err := validateContainerInputPolicyForMode(index, container, debug); err != nil {
+	if err := validateContainerInputPolicy(index, container, debug); err != nil {
 		return err
 	}
 	for envIndex, item := range container.Env {

--- a/tinfoil/cmd/boot/config_shape.go
+++ b/tinfoil/cmd/boot/config_shape.go
@@ -15,6 +15,10 @@ const (
 )
 
 func validateConfigShape(config *Config) error {
+	return validateConfigShapeForMode(config, false)
+}
+
+func validateConfigShapeForMode(config *Config, debug bool) error {
 	if len(config.Containers) > maxConfigContainers {
 		return fmt.Errorf("containers exceeds limit %d", maxConfigContainers)
 	}
@@ -32,8 +36,13 @@ func validateConfigShape(config *Config) error {
 			return fmt.Errorf("networks.%s.allow exceeds limit %d", name, maxNetworkAllowEntries)
 		}
 	}
+	seenContainerNames := map[string]int{}
 	for index := range config.Containers {
-		if err := validateContainerShape(index, &config.Containers[index]); err != nil {
+		if prior, found := seenContainerNames[config.Containers[index].Name]; found {
+			return fmt.Errorf("containers[%d].name %q duplicates containers[%d].name", index, config.Containers[index].Name, prior)
+		}
+		seenContainerNames[config.Containers[index].Name] = index
+		if err := validateContainerShapeForMode(index, &config.Containers[index], debug); err != nil {
 			return err
 		}
 	}
@@ -41,6 +50,10 @@ func validateConfigShape(config *Config) error {
 }
 
 func validateContainerShape(index int, container *Container) error {
+	return validateContainerShapeForMode(index, container, false)
+}
+
+func validateContainerShapeForMode(index int, container *Container, debug bool) error {
 	lists := []struct {
 		name  string
 		count int
@@ -65,7 +78,7 @@ func validateContainerShape(index int, container *Container) error {
 	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
 		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
 	}
-	if err := validateContainerInputPolicy(index, container); err != nil {
+	if err := validateContainerInputPolicyForMode(index, container, debug); err != nil {
 		return err
 	}
 	for envIndex, item := range container.Env {

--- a/tinfoil/cmd/boot/config_shape_test.go
+++ b/tinfoil/cmd/boot/config_shape_test.go
@@ -33,7 +33,7 @@ func TestValidateConfigShapeEnforcesCollectionLimits(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			err := validateConfigShape(&test.config)
+			err := validateConfigShape(&test.config, false)
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("validateConfigShape error = %v, want %q", err, test.want)
 			}
@@ -48,8 +48,8 @@ func TestValidateConfigShapeRejectsDuplicateContainerNames(t *testing.T) {
 			{Name: "workload", Image: "example.invalid/b"},
 		},
 	}
-	if err := validateConfigShapeForMode(&config, false); err == nil || !strings.Contains(err.Error(), "duplicates") {
-		t.Fatalf("validateConfigShapeForMode error = %v, want duplicate-name rejection", err)
+	if err := validateConfigShape(&config, false); err == nil || !strings.Contains(err.Error(), "duplicates") {
+		t.Fatalf("validateConfigShape error = %v, want duplicate-name rejection", err)
 	}
 }
 
@@ -63,7 +63,7 @@ func TestValidateConfigShapeRejectsNestedOrAmbiguousEnv(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := Config{Containers: []Container{{Env: []interface{}{item}}}}
-			if err := validateConfigShape(&config); err == nil {
+			if err := validateConfigShape(&config, false); err == nil {
 				t.Fatalf("validateConfigShape accepted %s", name)
 			}
 		})

--- a/tinfoil/cmd/boot/config_shape_test.go
+++ b/tinfoil/cmd/boot/config_shape_test.go
@@ -41,6 +41,18 @@ func TestValidateConfigShapeEnforcesCollectionLimits(t *testing.T) {
 	}
 }
 
+func TestValidateConfigShapeRejectsDuplicateContainerNames(t *testing.T) {
+	config := Config{
+		Containers: []Container{
+			{Name: "workload", Image: "example.invalid/a"},
+			{Name: "workload", Image: "example.invalid/b"},
+		},
+	}
+	if err := validateConfigShapeForMode(&config, false); err == nil || !strings.Contains(err.Error(), "duplicates") {
+		t.Fatalf("validateConfigShapeForMode error = %v, want duplicate-name rejection", err)
+	}
+}
+
 func TestValidateConfigShapeRejectsNestedOrAmbiguousEnv(t *testing.T) {
 	for name, item := range map[string]interface{}{
 		"invalid name":  "BAD-NAME",

--- a/tinfoil/cmd/boot/container_input_policy.go
+++ b/tinfoil/cmd/boot/container_input_policy.go
@@ -39,11 +39,7 @@ func (c *Container) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-func validateContainerInputPolicy(index int, container *Container) error {
-	return validateContainerInputPolicyForMode(index, container, false)
-}
-
-func validateContainerInputPolicyForMode(index int, container *Container, debug bool) error {
+func validateContainerInputPolicy(index int, container *Container, debug bool) error {
 	fields := container.inputFields
 	if fields.privileged {
 		return fmt.Errorf("containers[%d].privileged is unsupported", index)
@@ -78,10 +74,8 @@ func validateContainerInputPolicyForMode(index int, container *Container, debug 
 }
 
 func canonicalizeContainerVolume(volume string, allowDebugDockerSocket bool) (string, error) {
-	if allowDebugDockerSocket {
-		if canonical, ok := canonicalizeDebugDockerSocketBind(volume); ok {
-			return canonical, nil
-		}
+	if allowDebugDockerSocket && volume == debugDockerSocketBind {
+		return volume, nil
 	}
 
 	source, _, found := strings.Cut(volume, ":")

--- a/tinfoil/cmd/boot/container_input_policy.go
+++ b/tinfoil/cmd/boot/container_input_policy.go
@@ -40,6 +40,10 @@ func (c *Container) UnmarshalYAML(node *yaml.Node) error {
 }
 
 func validateContainerInputPolicy(index int, container *Container) error {
+	return validateContainerInputPolicyForMode(index, container, false)
+}
+
+func validateContainerInputPolicyForMode(index int, container *Container, debug bool) error {
 	fields := container.inputFields
 	if fields.privileged {
 		return fmt.Errorf("containers[%d].privileged is unsupported", index)
@@ -60,9 +64,8 @@ func validateContainerInputPolicy(index int, container *Container) error {
 		return fmt.Errorf("containers[%d].ipc must be private or host", index)
 	}
 	for volumeIndex, volume := range container.Volumes {
-		source, _, found := strings.Cut(volume, ":")
-		if !found || !validNamedVolume(source) {
-			return fmt.Errorf("containers[%d].volumes[%d] must use a named volume source", index, volumeIndex)
+		if _, err := canonicalizeContainerVolume(volume, debug); err != nil {
+			return fmt.Errorf("containers[%d].volumes[%d] %w", index, volumeIndex, err)
 		}
 	}
 	for capabilityIndex, capability := range container.CapAdd {
@@ -71,6 +74,21 @@ func validateContainerInputPolicy(index int, container *Container) error {
 		}
 	}
 	return nil
+}
+
+func canonicalizeContainerVolume(volume string, debug bool) (string, error) {
+	if debug {
+		if canonical, ok := canonicalizeDebugDockerSocketBind(volume); ok {
+			return canonical, nil
+		}
+	}
+
+	source, _, found := strings.Cut(volume, ":")
+	if found && validNamedVolume(source) {
+		return volume, nil
+	}
+
+	return "", fmt.Errorf("must use a named volume source")
 }
 
 func allowedContainerCapability(capability string) bool {

--- a/tinfoil/cmd/boot/container_input_policy.go
+++ b/tinfoil/cmd/boot/container_input_policy.go
@@ -63,8 +63,9 @@ func validateContainerInputPolicyForMode(index int, container *Container, debug 
 	if container.IPC != "" && container.IPC != "private" && container.IPC != "host" {
 		return fmt.Errorf("containers[%d].ipc must be private or host", index)
 	}
+	allowDebugDockerSocket := reservedDebugRuntimeEnabled(container.Name, debug)
 	for volumeIndex, volume := range container.Volumes {
-		if _, err := canonicalizeContainerVolume(volume, debug); err != nil {
+		if _, err := canonicalizeContainerVolume(volume, allowDebugDockerSocket); err != nil {
 			return fmt.Errorf("containers[%d].volumes[%d] %w", index, volumeIndex, err)
 		}
 	}
@@ -76,8 +77,8 @@ func validateContainerInputPolicyForMode(index int, container *Container, debug 
 	return nil
 }
 
-func canonicalizeContainerVolume(volume string, debug bool) (string, error) {
-	if debug {
+func canonicalizeContainerVolume(volume string, allowDebugDockerSocket bool) (string, error) {
+	if allowDebugDockerSocket {
 		if canonical, ok := canonicalizeDebugDockerSocketBind(volume); ok {
 			return canonical, nil
 		}

--- a/tinfoil/cmd/boot/container_input_policy_test.go
+++ b/tinfoil/cmd/boot/container_input_policy_test.go
@@ -27,7 +27,7 @@ containers:
       - SYS_NICE
       - SYS_RESOURCE
 `)
-	if err := validateConfigShapeForMode(&config, false); err != nil {
+	if err := validateConfigShape(&config, false); err != nil {
 		t.Fatalf("validateConfigShape rejected known production inputs: %v", err)
 	}
 }
@@ -59,7 +59,7 @@ func TestContainerInputPolicyRejectsUnsupportedInputs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			config := decodePolicyConfig(t, "containers:\n  - name: workload\n    image: example.invalid/workload\n    "+test.body+"\n")
-			err := validateConfigShapeForMode(&config, false)
+			err := validateConfigShape(&config, false)
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("validateConfigShape error = %v, want %q", err, test.want)
 			}
@@ -93,15 +93,15 @@ func TestContainerInputPolicyDebugSocketPolicy(t *testing.T) {
 				containerName = "workload"
 			}
 			config := decodePolicyConfig(t, "containers:\n  - name: "+containerName+"\n    image: example.invalid/workload\n    "+test.body+"\n")
-			err := validateConfigShapeForMode(&config, test.debug)
+			err := validateConfigShape(&config, test.debug)
 			if test.want == "" {
 				if err != nil {
-					t.Fatalf("validateConfigShapeForMode rejected %s: %v", test.name, err)
+					t.Fatalf("validateConfigShape rejected %s: %v", test.name, err)
 				}
 				return
 			}
 			if err == nil || !strings.Contains(err.Error(), test.want) {
-				t.Fatalf("validateConfigShapeForMode error = %v, want %q", err, test.want)
+				t.Fatalf("validateConfigShape error = %v, want %q", err, test.want)
 			}
 		})
 	}
@@ -114,9 +114,9 @@ func TestContainerInputPolicyRejectsUserSuppliedSerialDevices(t *testing.T) {
 				name := fmt.Sprintf("debug=%t/container=%s/device=%s", debug, containerName, device)
 				t.Run(name, func(t *testing.T) {
 					config := decodePolicyConfig(t, "containers:\n  - name: "+containerName+"\n    image: example.invalid/workload\n    devices: ["+device+"]\n")
-					err := validateConfigShapeForMode(&config, debug)
+					err := validateConfigShape(&config, debug)
 					if err == nil || !strings.Contains(err.Error(), ".devices is unsupported") {
-						t.Fatalf("validateConfigShapeForMode error = %v, want device rejection", err)
+						t.Fatalf("validateConfigShape error = %v, want device rejection", err)
 					}
 				})
 			}
@@ -167,9 +167,9 @@ containers:
   - name: tinfoil-ssh-installer
     image: example.invalid/installer
 `)
-	err := validateConfigShapeForMode(&config, true)
+	err := validateConfigShape(&config, true)
 	if err == nil || !strings.Contains(err.Error(), `duplicates`) {
-		t.Fatalf("validateConfigShapeForMode error = %v, want duplicate-name rejection", err)
+		t.Fatalf("validateConfigShape error = %v, want duplicate-name rejection", err)
 	}
 }
 

--- a/tinfoil/cmd/boot/container_input_policy_test.go
+++ b/tinfoil/cmd/boot/container_input_policy_test.go
@@ -26,7 +26,7 @@ containers:
       - SYS_NICE
       - SYS_RESOURCE
 `)
-	if err := validateConfigShape(&config); err != nil {
+	if err := validateConfigShapeForMode(&config, false); err != nil {
 		t.Fatalf("validateConfigShape rejected known production inputs: %v", err)
 	}
 }
@@ -58,9 +58,42 @@ func TestContainerInputPolicyRejectsUnsupportedInputs(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			config := decodePolicyConfig(t, "containers:\n  - name: workload\n    image: example.invalid/workload\n    "+test.body+"\n")
-			err := validateConfigShape(&config)
+			err := validateConfigShapeForMode(&config, false)
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("validateConfigShape error = %v, want %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestContainerInputPolicyDebugSocketPolicy(t *testing.T) {
+	tests := []struct {
+		name  string
+		debug bool
+		body  string
+		want  string
+	}{
+		{name: "production rejects socket bind", body: "volumes: [/run/docker.sock:/var/run/docker.sock]", want: "named volume source"},
+		{name: "debug accepts exact socket bind", debug: true, body: "volumes: [/run/docker.sock:/var/run/docker.sock]"},
+		{name: "debug rejects rw socket bind alias", debug: true, body: "volumes: [/run/docker.sock:/var/run/docker.sock:rw]", want: "named volume source"},
+		{name: "debug rejects source alias", debug: true, body: "volumes: [/var/run/docker.sock:/var/run/docker.sock]", want: "named volume source"},
+		{name: "debug rejects target alias", debug: true, body: "volumes: [/run/docker.sock:/run/docker.sock]", want: "named volume source"},
+		{name: "debug rejects read-only socket bind", debug: true, body: "volumes: [/run/docker.sock:/var/run/docker.sock:ro]", want: "named volume source"},
+		{name: "debug rejects extra options", debug: true, body: "volumes: [/run/docker.sock:/var/run/docker.sock:rw,z]", want: "named volume source"},
+		{name: "debug rejects other host bind", debug: true, body: "volumes: [/tmp:/tmp]", want: "named volume source"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := decodePolicyConfig(t, "containers:\n  - name: workload\n    image: example.invalid/workload\n    "+test.body+"\n")
+			err := validateConfigShapeForMode(&config, test.debug)
+			if test.want == "" {
+				if err != nil {
+					t.Fatalf("validateConfigShapeForMode rejected %s: %v", test.name, err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("validateConfigShapeForMode error = %v, want %q", err, test.want)
 			}
 		})
 	}
@@ -98,6 +131,20 @@ func TestValidNamedVolume(t *testing.T) {
 		if validNamedVolume(name) {
 			t.Errorf("validNamedVolume(%q) = true", name)
 		}
+	}
+}
+
+func TestContainerInputPolicyRejectsDuplicateReservedName(t *testing.T) {
+	config := decodePolicyConfig(t, `
+containers:
+  - name: tinfoil-ssh-installer
+    image: example.invalid/installer
+  - name: tinfoil-ssh-installer
+    image: example.invalid/installer
+`)
+	err := validateConfigShapeForMode(&config, true)
+	if err == nil || !strings.Contains(err.Error(), `duplicates`) {
+		t.Fatalf("validateConfigShapeForMode error = %v, want duplicate-name rejection", err)
 	}
 }
 

--- a/tinfoil/cmd/boot/container_input_policy_test.go
+++ b/tinfoil/cmd/boot/container_input_policy_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -68,13 +69,16 @@ func TestContainerInputPolicyRejectsUnsupportedInputs(t *testing.T) {
 
 func TestContainerInputPolicyDebugSocketPolicy(t *testing.T) {
 	tests := []struct {
-		name  string
-		debug bool
-		body  string
-		want  string
+		name          string
+		containerName string
+		debug         bool
+		body          string
+		want          string
 	}{
 		{name: "production rejects socket bind", body: "volumes: [/run/docker.sock:/var/run/docker.sock]", want: "named volume source"},
-		{name: "debug accepts exact socket bind", debug: true, body: "volumes: [/run/docker.sock:/var/run/docker.sock]"},
+		{name: "generic debug rejects exact socket bind", debug: true, body: "volumes: [/run/docker.sock:/var/run/docker.sock]", want: "named volume source"},
+		{name: "reserved production rejects exact socket bind", containerName: reservedDebugContainerName, body: "volumes: [/run/docker.sock:/var/run/docker.sock]", want: "named volume source"},
+		{name: "reserved debug accepts exact socket bind", containerName: reservedDebugContainerName, debug: true, body: "volumes: [/run/docker.sock:/var/run/docker.sock]"},
 		{name: "debug rejects rw socket bind alias", debug: true, body: "volumes: [/run/docker.sock:/var/run/docker.sock:rw]", want: "named volume source"},
 		{name: "debug rejects source alias", debug: true, body: "volumes: [/var/run/docker.sock:/var/run/docker.sock]", want: "named volume source"},
 		{name: "debug rejects target alias", debug: true, body: "volumes: [/run/docker.sock:/run/docker.sock]", want: "named volume source"},
@@ -84,7 +88,11 @@ func TestContainerInputPolicyDebugSocketPolicy(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			config := decodePolicyConfig(t, "containers:\n  - name: workload\n    image: example.invalid/workload\n    "+test.body+"\n")
+			containerName := test.containerName
+			if containerName == "" {
+				containerName = "workload"
+			}
+			config := decodePolicyConfig(t, "containers:\n  - name: "+containerName+"\n    image: example.invalid/workload\n    "+test.body+"\n")
 			err := validateConfigShapeForMode(&config, test.debug)
 			if test.want == "" {
 				if err != nil {
@@ -96,6 +104,23 @@ func TestContainerInputPolicyDebugSocketPolicy(t *testing.T) {
 				t.Fatalf("validateConfigShapeForMode error = %v, want %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestContainerInputPolicyRejectsUserSuppliedSerialDevices(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		for _, containerName := range []string{"workload", reservedDebugContainerName} {
+			for _, device := range []string{"/dev/hvc0", "/dev/hvc1"} {
+				name := fmt.Sprintf("debug=%t/container=%s/device=%s", debug, containerName, device)
+				t.Run(name, func(t *testing.T) {
+					config := decodePolicyConfig(t, "containers:\n  - name: "+containerName+"\n    image: example.invalid/workload\n    devices: ["+device+"]\n")
+					err := validateConfigShapeForMode(&config, debug)
+					if err == nil || !strings.Contains(err.Error(), ".devices is unsupported") {
+						t.Fatalf("validateConfigShapeForMode error = %v, want device rejection", err)
+					}
+				})
+			}
+		}
 	}
 }
 

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -108,56 +108,10 @@ func networkCreateOptions(name string) dockernetwork.CreateOptions {
 	return opts
 }
 
-// launchContainers starts all containers from the config
-func launchContainers(ctx context.Context, config *Config, extConfig *shimconfig.ExternalConfig) error {
-	return launchContainersWithMode(ctx, config, extConfig, false)
-}
-
-func launchContainersWithMode(ctx context.Context, config *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
-	if len(config.Containers) == 0 {
-		log.Println("No containers to launch")
-		return nil
-	}
-
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		return fmt.Errorf("creating docker client: %w", err)
-	}
-	defer cli.Close()
-
-	if err := setupContainerNetwork(ctx, cli, config, debug); err != nil {
-		return fmt.Errorf("creating container network: %w", err)
-	}
-
-	log.Printf("Launching %d containers", len(config.Containers))
-	var errors []string
-	for _, c := range config.Containers {
-		log.Printf("Pulling image %s (%s)", c.Name, c.Image)
-		if err := pullImage(cli, c.Image); err != nil {
-			log.Printf("Error pulling image for %s: %v", c.Name, err)
-			errors = append(errors, fmt.Sprintf("%s: pulling image: %v", c.Name, err))
-			continue
-		}
-		if err := createAndStartContainerWithMode(cli, c, config, extConfig, debug); err != nil {
-			log.Printf("Error starting container %s: %v", c.Name, err)
-			errors = append(errors, fmt.Sprintf("%s: %v", c.Name, err))
-		}
-	}
-
-	if len(errors) > 0 {
-		return fmt.Errorf("failed to start %d container(s): %s", len(errors), strings.Join(errors, "; "))
-	}
-	return nil
-}
-
 // launchContainersAndWaitHealthy launches all containers in parallel with
 // health checking. Each container is tracked as a substage of "containers"
 // with per-phase sub-substages (pull, start, healthy).
-func launchContainersAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig) error {
-	return launchContainersAndWaitHealthyWithMode(ctx, tracker, config, extConfig, false)
-}
-
-func launchContainersAndWaitHealthyWithMode(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
+func launchContainersAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
 	if len(config.Containers) == 0 {
 		log.Println("No containers to launch")
 		tracker.Record(boot.StageContainers, boot.StatusSkipped, 0, "no containers")
@@ -266,7 +220,7 @@ func runContainer(
 
 	// Create + start
 	startPhase := time.Now()
-	if err := createAndStartContainerWithMode(cli, c, cfg, extConfig, debug); err != nil {
+	if err := createAndStartContainer(cli, c, cfg, extConfig, debug); err != nil {
 		detail := fmt.Sprintf("starting: %v", err)
 		record("start", boot.StatusFailed, time.Since(startPhase), detail)
 		finish(boot.StatusFailed, detail)
@@ -375,7 +329,7 @@ func attachOrder(c Container, cfg *Config) (first string, rest []string) {
 	return first, rest
 }
 
-func createAndStartContainerWithMode(cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
+func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
 	containerConfig, hostConfig, networkingConfig, rest, err := buildContainerCreateSpec(c, cfg, extConfig, debug)
 	if err != nil {
 		return err
@@ -406,12 +360,6 @@ func createAndStartContainerWithMode(cli *client.Client, c Container, cfg *Confi
 func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, debug bool) (*container.Config, *container.HostConfig, *dockernetwork.NetworkingConfig, []string, error) {
 	if c.Image == "" {
 		return nil, nil, nil, nil, fmt.Errorf("no image specified for container %s", c.Name)
-	}
-	if cfg == nil {
-		cfg = &Config{}
-	}
-	if extConfig == nil {
-		extConfig = &shimconfig.ExternalConfig{}
 	}
 
 	// Build environment variables
@@ -490,18 +438,10 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 		hostConfig.Resources.NanoCPUs = int64(c.CPUs * 1e9)
 	}
 
-	if len(c.Devices) != 0 {
-		return nil, nil, nil, nil, fmt.Errorf("container %q devices are unsupported", c.Name)
-	}
-
 	// Volume mounts
 	reservedDebugRuntime := reservedDebugRuntimeEnabled(c.Name, debug)
 	for _, vol := range c.Volumes {
-		canonical, err := canonicalizeContainerVolume(vol, reservedDebugRuntime)
-		if err != nil {
-			return nil, nil, nil, nil, fmt.Errorf("container %q volume %q %w", c.Name, vol, err)
-		}
-		hostConfig.Binds = append(hostConfig.Binds, canonical)
+		hostConfig.Binds = append(hostConfig.Binds, vol)
 	}
 
 	if reservedDebugRuntime {

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -30,7 +30,7 @@ const (
 	defaultPidsLimit   int64 = 65536
 )
 
-func setupContainerNetwork(ctx context.Context, cli *client.Client, cfg *Config) error {
+func setupContainerNetwork(ctx context.Context, cli *client.Client, cfg *Config, debug bool) error {
 	for name := range cfg.Networks {
 		if err := ensureNetwork(cli, name); err != nil {
 			return err
@@ -41,7 +41,7 @@ func setupContainerNetwork(ctx context.Context, cli *client.Client, cfg *Config)
 			return err
 		}
 	}
-	return setupContainerNetworkFirewall(ctx, cfg)
+	return setupContainerNetworkFirewall(ctx, cfg, debug)
 }
 
 func ensureNetwork(cli *client.Client, name string) error {
@@ -124,7 +124,7 @@ func launchContainersWithMode(ctx context.Context, config *Config, extConfig *sh
 	}
 	defer cli.Close()
 
-	if err := setupContainerNetwork(ctx, cli, config); err != nil {
+	if err := setupContainerNetwork(ctx, cli, config, debug); err != nil {
 		return fmt.Errorf("creating container network: %w", err)
 	}
 
@@ -169,7 +169,7 @@ func launchContainersAndWaitHealthyWithMode(ctx context.Context, tracker *boot.T
 	}
 	defer cli.Close()
 
-	if err := setupContainerNetwork(ctx, cli, config); err != nil {
+	if err := setupContainerNetwork(ctx, cli, config, debug); err != nil {
 		return fmt.Errorf("creating container network: %w", err)
 	}
 

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	healthPollInterval       = 5 * time.Second
-	defaultPidsLimit   int64 = 65536
+	healthPollInterval         = 5 * time.Second
+	defaultPidsLimit     int64 = 65536
+	openEgressGwPriority       = 100
 )
 
 func setupContainerNetwork(ctx context.Context, cli *client.Client, cfg *Config, debug bool) error {
@@ -374,11 +375,6 @@ func attachOrder(c Container, cfg *Config) (first string, rest []string) {
 	return first, rest
 }
 
-// createAndStartContainer creates and starts a container (image must already be pulled).
-func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig) error {
-	return createAndStartContainerWithMode(cli, c, cfg, extConfig, false)
-}
-
 func createAndStartContainerWithMode(cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
 	containerConfig, hostConfig, networkingConfig, rest, err := buildContainerCreateSpec(c, cfg, extConfig, debug)
 	if err != nil {
@@ -393,11 +389,7 @@ func createAndStartContainerWithMode(cli *client.Client, c Container, cfg *Confi
 	}
 
 	for _, n := range rest {
-		gwPriority := 0
-		if cfg.Networks[n] != nil && cfg.Networks[n].Egress != "closed" {
-			gwPriority = 100
-		}
-		ep := endpointSettings(n, gwPriority)
+		ep := endpointSettings(n, gatewayPriorityForNetwork(cfg, n))
 		if err := cli.NetworkConnect(context.Background(), n, resp.ID, ep); err != nil {
 			return fmt.Errorf("connecting container %s to %s: %w", c.Name, n, err)
 		}
@@ -417,9 +409,6 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 	}
 	if cfg == nil {
 		cfg = &Config{}
-	}
-	if cfg.Networks == nil {
-		cfg.Networks = map[string]*NetworkSpec{}
 	}
 	if extConfig == nil {
 		extConfig = &shimconfig.ExternalConfig{}
@@ -501,23 +490,21 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 		hostConfig.Resources.NanoCPUs = int64(c.CPUs * 1e9)
 	}
 
-	// Devices
-	for _, dev := range c.Devices {
-		hostConfig.Devices = append(hostConfig.Devices, container.DeviceMapping{
-			PathOnHost: dev, PathInContainer: dev, CgroupPermissions: "rwm",
-		})
+	if len(c.Devices) != 0 {
+		return nil, nil, nil, nil, fmt.Errorf("container %q devices are unsupported", c.Name)
 	}
 
 	// Volume mounts
+	reservedDebugRuntime := reservedDebugRuntimeEnabled(c.Name, debug)
 	for _, vol := range c.Volumes {
-		canonical, err := canonicalizeContainerVolume(vol, debug)
+		canonical, err := canonicalizeContainerVolume(vol, reservedDebugRuntime)
 		if err != nil {
 			return nil, nil, nil, nil, fmt.Errorf("container %q volume %q %w", c.Name, vol, err)
 		}
 		hostConfig.Binds = append(hostConfig.Binds, canonical)
 	}
 
-	if debug && c.Name == reservedDebugContainerName {
+	if reservedDebugRuntime {
 		applyReservedDebugRuntime(containerConfig, hostConfig)
 	}
 
@@ -528,23 +515,23 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 
 	// Pin the egress-capable network's GwPriority so Docker installs the
 	// default route through it; equal priorities are non-deterministic.
-	gwPriority := func(name string) int {
-		if cfg.Networks[name] != nil && cfg.Networks[name].Egress != "closed" {
-			return 100
-		}
-		return 0
-	}
-
 	var networkingConfig *dockernetwork.NetworkingConfig
 	if first != "" {
 		networkingConfig = &dockernetwork.NetworkingConfig{
 			EndpointsConfig: map[string]*dockernetwork.EndpointSettings{
-				first: endpointSettings(first, gwPriority(first)),
+				first: endpointSettings(first, gatewayPriorityForNetwork(cfg, first)),
 			},
 		}
 	}
 
 	return containerConfig, hostConfig, networkingConfig, rest, nil
+}
+
+func gatewayPriorityForNetwork(cfg *Config, name string) int {
+	if cfg != nil && cfg.Networks[name] != nil && cfg.Networks[name].Egress != "closed" {
+		return openEgressGwPriority
+	}
+	return 0
 }
 
 func applyReservedDebugRuntime(containerConfig *container.Config, hostConfig *container.HostConfig) {

--- a/tinfoil/cmd/boot/containers.go
+++ b/tinfoil/cmd/boot/containers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/docker/docker/api/types/image"
 	dockernetwork "github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
 	"github.com/docker/go-units"
 
 	"tinfoil/internal/boot"
@@ -108,6 +109,10 @@ func networkCreateOptions(name string) dockernetwork.CreateOptions {
 
 // launchContainers starts all containers from the config
 func launchContainers(ctx context.Context, config *Config, extConfig *shimconfig.ExternalConfig) error {
+	return launchContainersWithMode(ctx, config, extConfig, false)
+}
+
+func launchContainersWithMode(ctx context.Context, config *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
 	if len(config.Containers) == 0 {
 		log.Println("No containers to launch")
 		return nil
@@ -132,7 +137,7 @@ func launchContainers(ctx context.Context, config *Config, extConfig *shimconfig
 			errors = append(errors, fmt.Sprintf("%s: pulling image: %v", c.Name, err))
 			continue
 		}
-		if err := createAndStartContainer(cli, c, config, extConfig); err != nil {
+		if err := createAndStartContainerWithMode(cli, c, config, extConfig, debug); err != nil {
 			log.Printf("Error starting container %s: %v", c.Name, err)
 			errors = append(errors, fmt.Sprintf("%s: %v", c.Name, err))
 		}
@@ -148,6 +153,10 @@ func launchContainers(ctx context.Context, config *Config, extConfig *shimconfig
 // health checking. Each container is tracked as a substage of "containers"
 // with per-phase sub-substages (pull, start, healthy).
 func launchContainersAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig) error {
+	return launchContainersAndWaitHealthyWithMode(ctx, tracker, config, extConfig, false)
+}
+
+func launchContainersAndWaitHealthyWithMode(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
 	if len(config.Containers) == 0 {
 		log.Println("No containers to launch")
 		tracker.Record(boot.StageContainers, boot.StatusSkipped, 0, "no containers")
@@ -195,7 +204,7 @@ func launchContainersAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, 
 		wg.Add(1)
 		go func(i int, c Container) {
 			defer wg.Done()
-			errs[i] = runContainer(cli, c, config, extConfig, &substages, &mu, flush)
+			errs[i] = runContainer(cli, c, config, extConfig, &substages, &mu, flush, debug)
 		}(i, c)
 	}
 	wg.Wait()
@@ -226,6 +235,7 @@ func runContainer(
 	substages *[]boot.Stage,
 	mu *sync.Mutex,
 	flush func(),
+	debug bool,
 ) error {
 	cStart := time.Now()
 
@@ -255,7 +265,7 @@ func runContainer(
 
 	// Create + start
 	startPhase := time.Now()
-	if err := createAndStartContainer(cli, c, cfg, extConfig); err != nil {
+	if err := createAndStartContainerWithMode(cli, c, cfg, extConfig, debug); err != nil {
 		detail := fmt.Sprintf("starting: %v", err)
 		record("start", boot.StatusFailed, time.Since(startPhase), detail)
 		finish(boot.StatusFailed, detail)
@@ -366,8 +376,53 @@ func attachOrder(c Container, cfg *Config) (first string, rest []string) {
 
 // createAndStartContainer creates and starts a container (image must already be pulled).
 func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig) error {
+	return createAndStartContainerWithMode(cli, c, cfg, extConfig, false)
+}
+
+func createAndStartContainerWithMode(cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
+	containerConfig, hostConfig, networkingConfig, rest, err := buildContainerCreateSpec(c, cfg, extConfig, debug)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Creating container %s", c.Name)
+
+	resp, err := cli.ContainerCreate(context.Background(), containerConfig, hostConfig, networkingConfig, nil, c.Name)
+	if err != nil {
+		return fmt.Errorf("creating container: %w", err)
+	}
+
+	for _, n := range rest {
+		gwPriority := 0
+		if cfg.Networks[n] != nil && cfg.Networks[n].Egress != "closed" {
+			gwPriority = 100
+		}
+		ep := endpointSettings(n, gwPriority)
+		if err := cli.NetworkConnect(context.Background(), n, resp.ID, ep); err != nil {
+			return fmt.Errorf("connecting container %s to %s: %w", c.Name, n, err)
+		}
+	}
+
+	if err := cli.ContainerStart(context.Background(), resp.ID, container.StartOptions{}); err != nil {
+		return fmt.Errorf("starting container: %w", err)
+	}
+
+	log.Printf("Started container %s (%s)", c.Name, resp.ID[:12])
+	return nil
+}
+
+func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, debug bool) (*container.Config, *container.HostConfig, *dockernetwork.NetworkingConfig, []string, error) {
 	if c.Image == "" {
-		return fmt.Errorf("no image specified for container %s", c.Name)
+		return nil, nil, nil, nil, fmt.Errorf("no image specified for container %s", c.Name)
+	}
+	if cfg == nil {
+		cfg = &Config{}
+	}
+	if cfg.Networks == nil {
+		cfg.Networks = map[string]*NetworkSpec{}
+	}
+	if extConfig == nil {
+		extConfig = &shimconfig.ExternalConfig{}
 	}
 
 	// Build environment variables
@@ -455,15 +510,21 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 
 	// Volume mounts
 	for _, vol := range c.Volumes {
-		hostConfig.Binds = append(hostConfig.Binds, vol)
+		canonical, err := canonicalizeContainerVolume(vol, debug)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("container %q volume %q %w", c.Name, vol, err)
+		}
+		hostConfig.Binds = append(hostConfig.Binds, canonical)
+	}
+
+	if debug && c.Name == reservedDebugContainerName {
+		applyReservedDebugRuntime(containerConfig, hostConfig)
 	}
 
 	// GPU configuration
 	if req := parseGPUs(c.GPUs); req != nil {
 		hostConfig.DeviceRequests = []container.DeviceRequest{*req}
 	}
-
-	log.Printf("Creating container %s", c.Name)
 
 	// Pin the egress-capable network's GwPriority so Docker installs the
 	// default route through it; equal priorities are non-deterministic.
@@ -483,24 +544,27 @@ func createAndStartContainer(cli *client.Client, c Container, cfg *Config, extCo
 		}
 	}
 
-	resp, err := cli.ContainerCreate(context.Background(), containerConfig, hostConfig, networkingConfig, nil, c.Name)
-	if err != nil {
-		return fmt.Errorf("creating container: %w", err)
-	}
+	return containerConfig, hostConfig, networkingConfig, rest, nil
+}
 
-	for _, n := range rest {
-		ep := endpointSettings(n, gwPriority(n))
-		if err := cli.NetworkConnect(context.Background(), n, resp.ID, ep); err != nil {
-			return fmt.Errorf("connecting container %s to %s: %w", c.Name, n, err)
-		}
+func applyReservedDebugRuntime(containerConfig *container.Config, hostConfig *container.HostConfig) {
+	hostConfig.NetworkMode = "bridge"
+	port := nat.Port(reservedDebugPort)
+	if containerConfig.ExposedPorts == nil {
+		containerConfig.ExposedPorts = nat.PortSet{}
 	}
-
-	if err := cli.ContainerStart(context.Background(), resp.ID, container.StartOptions{}); err != nil {
-		return fmt.Errorf("starting container: %w", err)
+	containerConfig.ExposedPorts[port] = struct{}{}
+	if hostConfig.PortBindings == nil {
+		hostConfig.PortBindings = nat.PortMap{}
 	}
-
-	log.Printf("Started container %s (%s)", c.Name, resp.ID[:12])
-	return nil
+	hostConfig.PortBindings[port] = []nat.PortBinding{{
+		HostPort: fmt.Sprintf("%d", reservedDebugHostPort),
+	}}
+	hostConfig.Devices = append(hostConfig.Devices, container.DeviceMapping{
+		PathOnHost:        reservedDebugSerialDevice,
+		PathInContainer:   reservedDebugSerialDevice,
+		CgroupPermissions: "rw",
+	})
 }
 
 func endpointSettings(name string, gwPriority int) *dockernetwork.EndpointSettings {

--- a/tinfoil/cmd/boot/containers_test.go
+++ b/tinfoil/cmd/boot/containers_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"slices"
 	"testing"
 	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/go-connections/nat"
 
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/containernet"
@@ -163,5 +167,79 @@ func TestEndpointSettingsPinsShimUpstreamIP(t *testing.T) {
 	}
 	if regular.GwPriority != 100 {
 		t.Errorf("GwPriority: got %d, want 100", regular.GwPriority)
+	}
+}
+
+func TestBuildContainerCreateSpec_DebugInstallerGetsFixedRuntime(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{}}
+	c := Container{
+		Name:    reservedDebugContainerName,
+		Image:   "example.invalid/installer",
+		Volumes: []string{debugDockerSocketBind},
+	}
+
+	containerConfig, hostConfig, networkingConfig, rest, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, true)
+	if err != nil {
+		t.Fatalf("buildContainerCreateSpec: %v", err)
+	}
+	if networkingConfig != nil {
+		t.Fatalf("expected no networking config, got %+v", networkingConfig)
+	}
+	if len(rest) != 0 {
+		t.Fatalf("expected no follow-on networks, got %v", rest)
+	}
+	if hostConfig.NetworkMode != container.NetworkMode("bridge") {
+		t.Fatalf("NetworkMode = %q, want bridge", hostConfig.NetworkMode)
+	}
+	if !hostConfig.ReadonlyRootfs {
+		t.Fatal("ReadonlyRootfs = false, want true default")
+	}
+	if len(hostConfig.CapDrop) != 1 || hostConfig.CapDrop[0] != "ALL" {
+		t.Fatalf("CapDrop = %v, want [ALL]", hostConfig.CapDrop)
+	}
+	if !slices.Contains(hostConfig.SecurityOpt, "no-new-privileges:true") {
+		t.Fatalf("SecurityOpt = %v, want no-new-privileges", hostConfig.SecurityOpt)
+	}
+	if !slices.Contains(hostConfig.Binds, debugDockerSocketBind) {
+		t.Fatalf("Binds = %v, want exact docker socket bind", hostConfig.Binds)
+	}
+
+	port := nat.Port(reservedDebugPort)
+	if _, ok := containerConfig.ExposedPorts[port]; !ok {
+		t.Fatalf("ExposedPorts = %v, want %s", containerConfig.ExposedPorts, port)
+	}
+	bindings := hostConfig.PortBindings[port]
+	if len(bindings) != 1 || bindings[0].HostPort != "2222" {
+		t.Fatalf("PortBindings[%s] = %v, want host port 2222", port, bindings)
+	}
+	if len(hostConfig.Devices) != 1 {
+		t.Fatalf("Devices = %v, want one synthesized serial mapping", hostConfig.Devices)
+	}
+	if got := hostConfig.Devices[0]; got.PathOnHost != reservedDebugSerialDevice || got.PathInContainer != reservedDebugSerialDevice || got.CgroupPermissions != "rw" {
+		t.Fatalf("Devices[0] = %+v, want exact /dev/hvc0 rw mapping", got)
+	}
+}
+
+func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{}}
+	c := Container{
+		Name:  reservedDebugContainerName,
+		Image: "example.invalid/installer",
+	}
+
+	containerConfig, hostConfig, _, _, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildContainerCreateSpec: %v", err)
+	}
+	if len(containerConfig.ExposedPorts) != 0 {
+		t.Fatalf("ExposedPorts = %v, want none in production", containerConfig.ExposedPorts)
+	}
+	if len(hostConfig.PortBindings) != 0 {
+		t.Fatalf("PortBindings = %v, want none in production", hostConfig.PortBindings)
+	}
+	for _, dev := range hostConfig.Devices {
+		if dev.PathOnHost == reservedDebugSerialDevice || dev.PathInContainer == reservedDebugSerialDevice {
+			t.Fatalf("Devices = %v, want no synthesized serial device in production", hostConfig.Devices)
+		}
 	}
 }

--- a/tinfoil/cmd/boot/containers_test.go
+++ b/tinfoil/cmd/boot/containers_test.go
@@ -1,10 +1,7 @@
 package main
 
 import (
-	"fmt"
 	"slices"
-	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -223,44 +220,6 @@ func TestBuildContainerCreateSpec_DebugInstallerGetsFixedRuntime(t *testing.T) {
 	}
 }
 
-func TestBuildContainerCreateSpec_NonReservedDebugContainerGetsNoDebugAuthority(t *testing.T) {
-	c := Container{
-		Name:    "workload",
-		Image:   "example.invalid/workload",
-		Volumes: []string{debugDockerSocketBind},
-	}
-
-	if _, _, _, _, err := buildContainerCreateSpec(c, &Config{}, &shimconfig.ExternalConfig{}, true); err == nil || !strings.Contains(err.Error(), "named volume source") {
-		t.Fatalf("buildContainerCreateSpec error = %v, want docker socket rejection", err)
-	}
-
-	c.Volumes = nil
-	containerConfig, hostConfig, _, _, err := buildContainerCreateSpec(c, &Config{}, &shimconfig.ExternalConfig{}, true)
-	if err != nil {
-		t.Fatalf("buildContainerCreateSpec: %v", err)
-	}
-	if len(containerConfig.ExposedPorts) != 0 || len(hostConfig.PortBindings) != 0 || len(hostConfig.Devices) != 0 {
-		t.Fatalf("non-reserved debug runtime escaped: exposed=%v bindings=%v devices=%v", containerConfig.ExposedPorts, hostConfig.PortBindings, hostConfig.Devices)
-	}
-}
-
-func TestBuildContainerCreateSpec_RejectsUserSuppliedSerialDevices(t *testing.T) {
-	for _, debug := range []bool{false, true} {
-		for _, containerName := range []string{"workload", reservedDebugContainerName} {
-			for _, device := range []string{"/dev/hvc0", "/dev/hvc1"} {
-				name := fmt.Sprintf("debug=%t/container=%s/device=%s", debug, containerName, device)
-				t.Run(name, func(t *testing.T) {
-					c := Container{Name: containerName, Image: "example.invalid/workload", Devices: []string{device}}
-					_, _, _, _, err := buildContainerCreateSpec(c, &Config{}, &shimconfig.ExternalConfig{}, debug)
-					if err == nil || !strings.Contains(err.Error(), "devices are unsupported") {
-						t.Fatalf("buildContainerCreateSpec error = %v, want device rejection", err)
-					}
-				})
-			}
-		}
-	}
-}
-
 func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testing.T) {
 	cfg := &Config{Networks: map[string]*NetworkSpec{}}
 	c := Container{
@@ -282,49 +241,5 @@ func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testi
 		if dev.PathOnHost == reservedDebugSerialDevice || dev.PathInContainer == reservedDebugSerialDevice {
 			t.Fatalf("Devices = %v, want no synthesized serial device in production", hostConfig.Devices)
 		}
-	}
-}
-
-func TestBuildContainerCreateSpec_ProductionInstallerRejectsDockerSocket(t *testing.T) {
-	c := Container{
-		Name:    reservedDebugContainerName,
-		Image:   "example.invalid/installer",
-		Volumes: []string{debugDockerSocketBind},
-	}
-
-	_, _, _, _, err := buildContainerCreateSpec(c, &Config{}, &shimconfig.ExternalConfig{}, false)
-	if err == nil || !strings.Contains(err.Error(), "named volume source") {
-		t.Fatalf("buildContainerCreateSpec error = %v, want docker socket rejection", err)
-	}
-}
-
-func TestBuildContainerCreateSpec_DoesNotMutateSharedConfig(t *testing.T) {
-	cfg := &Config{}
-	c := Container{Name: "workload", Image: "example.invalid/workload"}
-
-	const workers = 32
-	var waitGroup sync.WaitGroup
-	start := make(chan struct{})
-	errors := make(chan error, workers)
-	for range workers {
-		waitGroup.Add(1)
-		go func() {
-			defer waitGroup.Done()
-			<-start
-			_, _, _, _, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, false)
-			errors <- err
-		}()
-	}
-	close(start)
-	waitGroup.Wait()
-	close(errors)
-
-	for err := range errors {
-		if err != nil {
-			t.Fatalf("buildContainerCreateSpec: %v", err)
-		}
-	}
-	if cfg.Networks != nil {
-		t.Fatalf("buildContainerCreateSpec mutated cfg.Networks: %v", cfg.Networks)
 	}
 }

--- a/tinfoil/cmd/boot/containers_test.go
+++ b/tinfoil/cmd/boot/containers_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"slices"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -216,7 +219,45 @@ func TestBuildContainerCreateSpec_DebugInstallerGetsFixedRuntime(t *testing.T) {
 		t.Fatalf("Devices = %v, want one synthesized serial mapping", hostConfig.Devices)
 	}
 	if got := hostConfig.Devices[0]; got.PathOnHost != reservedDebugSerialDevice || got.PathInContainer != reservedDebugSerialDevice || got.CgroupPermissions != "rw" {
-		t.Fatalf("Devices[0] = %+v, want exact /dev/hvc0 rw mapping", got)
+		t.Fatalf("Devices[0] = %+v, want exact /dev/hvc1 rw mapping", got)
+	}
+}
+
+func TestBuildContainerCreateSpec_NonReservedDebugContainerGetsNoDebugAuthority(t *testing.T) {
+	c := Container{
+		Name:    "workload",
+		Image:   "example.invalid/workload",
+		Volumes: []string{debugDockerSocketBind},
+	}
+
+	if _, _, _, _, err := buildContainerCreateSpec(c, &Config{}, &shimconfig.ExternalConfig{}, true); err == nil || !strings.Contains(err.Error(), "named volume source") {
+		t.Fatalf("buildContainerCreateSpec error = %v, want docker socket rejection", err)
+	}
+
+	c.Volumes = nil
+	containerConfig, hostConfig, _, _, err := buildContainerCreateSpec(c, &Config{}, &shimconfig.ExternalConfig{}, true)
+	if err != nil {
+		t.Fatalf("buildContainerCreateSpec: %v", err)
+	}
+	if len(containerConfig.ExposedPorts) != 0 || len(hostConfig.PortBindings) != 0 || len(hostConfig.Devices) != 0 {
+		t.Fatalf("non-reserved debug runtime escaped: exposed=%v bindings=%v devices=%v", containerConfig.ExposedPorts, hostConfig.PortBindings, hostConfig.Devices)
+	}
+}
+
+func TestBuildContainerCreateSpec_RejectsUserSuppliedSerialDevices(t *testing.T) {
+	for _, debug := range []bool{false, true} {
+		for _, containerName := range []string{"workload", reservedDebugContainerName} {
+			for _, device := range []string{"/dev/hvc0", "/dev/hvc1"} {
+				name := fmt.Sprintf("debug=%t/container=%s/device=%s", debug, containerName, device)
+				t.Run(name, func(t *testing.T) {
+					c := Container{Name: containerName, Image: "example.invalid/workload", Devices: []string{device}}
+					_, _, _, _, err := buildContainerCreateSpec(c, &Config{}, &shimconfig.ExternalConfig{}, debug)
+					if err == nil || !strings.Contains(err.Error(), "devices are unsupported") {
+						t.Fatalf("buildContainerCreateSpec error = %v, want device rejection", err)
+					}
+				})
+			}
+		}
 	}
 }
 
@@ -241,5 +282,49 @@ func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testi
 		if dev.PathOnHost == reservedDebugSerialDevice || dev.PathInContainer == reservedDebugSerialDevice {
 			t.Fatalf("Devices = %v, want no synthesized serial device in production", hostConfig.Devices)
 		}
+	}
+}
+
+func TestBuildContainerCreateSpec_ProductionInstallerRejectsDockerSocket(t *testing.T) {
+	c := Container{
+		Name:    reservedDebugContainerName,
+		Image:   "example.invalid/installer",
+		Volumes: []string{debugDockerSocketBind},
+	}
+
+	_, _, _, _, err := buildContainerCreateSpec(c, &Config{}, &shimconfig.ExternalConfig{}, false)
+	if err == nil || !strings.Contains(err.Error(), "named volume source") {
+		t.Fatalf("buildContainerCreateSpec error = %v, want docker socket rejection", err)
+	}
+}
+
+func TestBuildContainerCreateSpec_DoesNotMutateSharedConfig(t *testing.T) {
+	cfg := &Config{}
+	c := Container{Name: "workload", Image: "example.invalid/workload"}
+
+	const workers = 32
+	var waitGroup sync.WaitGroup
+	start := make(chan struct{})
+	errors := make(chan error, workers)
+	for range workers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			_, _, _, _, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, false)
+			errors <- err
+		}()
+	}
+	close(start)
+	waitGroup.Wait()
+	close(errors)
+
+	for err := range errors {
+		if err != nil {
+			t.Fatalf("buildContainerCreateSpec: %v", err)
+		}
+	}
+	if cfg.Networks != nil {
+		t.Fatalf("buildContainerCreateSpec mutated cfg.Networks: %v", cfg.Networks)
 	}
 }

--- a/tinfoil/cmd/boot/debug_policy.go
+++ b/tinfoil/cmd/boot/debug_policy.go
@@ -15,7 +15,7 @@ const (
 	reservedDebugContainerName = "tinfoil-ssh-installer"
 	reservedDebugPort          = "2222/tcp"
 	reservedDebugHostPort      = 2222
-	reservedDebugSerialDevice  = "/dev/hvc0"
+	reservedDebugSerialDevice  = "/dev/hvc1"
 	debugDockerSocketBind      = "/run/docker.sock:/var/run/docker.sock"
 )
 
@@ -80,6 +80,10 @@ func canonicalizeDebugDockerSocketBind(volume string) (string, bool) {
 		return volume, true
 	}
 	return "", false
+}
+
+func reservedDebugRuntimeEnabled(containerName string, debug bool) bool {
+	return debug && containerName == reservedDebugContainerName
 }
 
 func hasReservedDebugContainer(config *Config) bool {

--- a/tinfoil/cmd/boot/debug_policy.go
+++ b/tinfoil/cmd/boot/debug_policy.go
@@ -29,15 +29,12 @@ func readKernelCmdline() (kernelCmdline, error) {
 	if err != nil {
 		return kernelCmdline{}, fmt.Errorf("reading %s: %w", kernelCmdlinePath, err)
 	}
-	return parseKernelCmdline(string(data))
+	return parseKernelCmdline(string(data)), nil
 }
 
-func parseKernelCmdline(cmdline string) (kernelCmdline, error) {
+func parseKernelCmdline(cmdline string) kernelCmdline {
 	var parsed kernelCmdline
-	debugSeen := false
-
 	configPrefix := tinfoilConfigHashParam + "="
-	debugPrefix := tinfoilDebugParam + "="
 
 	for _, field := range strings.Fields(cmdline) {
 		if value, found := strings.CutPrefix(field, configPrefix); found {
@@ -46,26 +43,12 @@ func parseKernelCmdline(cmdline string) (kernelCmdline, error) {
 			}
 			continue
 		}
-
-		if field == tinfoilDebugParam {
-			return kernelCmdline{}, fmt.Errorf("malformed kernel command-line parameter %s", tinfoilDebugParam)
+		if field == tinfoilDebugParam+"=on" {
+			parsed.Debug = true
 		}
-
-		value, found := strings.CutPrefix(field, debugPrefix)
-		if !found {
-			continue
-		}
-		if debugSeen {
-			return kernelCmdline{}, fmt.Errorf("duplicate kernel command-line parameter %s", tinfoilDebugParam)
-		}
-		debugSeen = true
-		if value != "on" {
-			return kernelCmdline{}, fmt.Errorf("invalid kernel command-line parameter %s=%q", tinfoilDebugParam, value)
-		}
-		parsed.Debug = true
 	}
 
-	return parsed, nil
+	return parsed
 }
 
 func (cmdline kernelCmdline) requiredConfigHash() (string, error) {
@@ -75,21 +58,11 @@ func (cmdline kernelCmdline) requiredConfigHash() (string, error) {
 	return cmdline.ConfigHash, nil
 }
 
-func canonicalizeDebugDockerSocketBind(volume string) (string, bool) {
-	if volume == debugDockerSocketBind {
-		return volume, true
-	}
-	return "", false
-}
-
 func reservedDebugRuntimeEnabled(containerName string, debug bool) bool {
 	return debug && containerName == reservedDebugContainerName
 }
 
 func hasReservedDebugContainer(config *Config) bool {
-	if config == nil {
-		return false
-	}
 	for _, container := range config.Containers {
 		if container.Name == reservedDebugContainerName {
 			return true

--- a/tinfoil/cmd/boot/debug_policy.go
+++ b/tinfoil/cmd/boot/debug_policy.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	kernelCmdlinePath = "/proc/cmdline"
+
+	tinfoilConfigHashParam = "tinfoil-config-hash"
+	tinfoilDebugParam      = "tinfoil-debug"
+
+	reservedDebugContainerName = "tinfoil-ssh-installer"
+	reservedDebugPort          = "2222/tcp"
+	reservedDebugHostPort      = 2222
+	reservedDebugSerialDevice  = "/dev/hvc0"
+	debugDockerSocketBind      = "/run/docker.sock:/var/run/docker.sock"
+)
+
+type kernelCmdline struct {
+	ConfigHash string
+	Debug      bool
+}
+
+func readKernelCmdline() (kernelCmdline, error) {
+	data, err := os.ReadFile(kernelCmdlinePath)
+	if err != nil {
+		return kernelCmdline{}, fmt.Errorf("reading %s: %w", kernelCmdlinePath, err)
+	}
+	return parseKernelCmdline(string(data))
+}
+
+func parseKernelCmdline(cmdline string) (kernelCmdline, error) {
+	var parsed kernelCmdline
+	debugSeen := false
+
+	configPrefix := tinfoilConfigHashParam + "="
+	debugPrefix := tinfoilDebugParam + "="
+
+	for _, field := range strings.Fields(cmdline) {
+		if value, found := strings.CutPrefix(field, configPrefix); found {
+			if parsed.ConfigHash == "" {
+				parsed.ConfigHash = value
+			}
+			continue
+		}
+
+		if field == tinfoilDebugParam {
+			return kernelCmdline{}, fmt.Errorf("malformed kernel command-line parameter %s", tinfoilDebugParam)
+		}
+
+		value, found := strings.CutPrefix(field, debugPrefix)
+		if !found {
+			continue
+		}
+		if debugSeen {
+			return kernelCmdline{}, fmt.Errorf("duplicate kernel command-line parameter %s", tinfoilDebugParam)
+		}
+		debugSeen = true
+		if value != "on" {
+			return kernelCmdline{}, fmt.Errorf("invalid kernel command-line parameter %s=%q", tinfoilDebugParam, value)
+		}
+		parsed.Debug = true
+	}
+
+	return parsed, nil
+}
+
+func (cmdline kernelCmdline) requiredConfigHash() (string, error) {
+	if cmdline.ConfigHash == "" {
+		return "", fmt.Errorf("parameter %s not found in cmdline", tinfoilConfigHashParam)
+	}
+	return cmdline.ConfigHash, nil
+}
+
+func canonicalizeDebugDockerSocketBind(volume string) (string, bool) {
+	if volume == debugDockerSocketBind {
+		return volume, true
+	}
+	return "", false
+}
+
+func hasReservedDebugContainer(config *Config) bool {
+	if config == nil {
+		return false
+	}
+	for _, container := range config.Containers {
+		if container.Name == reservedDebugContainerName {
+			return true
+		}
+	}
+	return false
+}

--- a/tinfoil/cmd/boot/debug_policy_test.go
+++ b/tinfoil/cmd/boot/debug_policy_test.go
@@ -1,17 +1,13 @@
 package main
 
-import (
-	"strings"
-	"testing"
-)
+import "testing"
 
 func TestParseKernelCmdline(t *testing.T) {
 	tests := []struct {
-		name       string
-		cmdline    string
-		wantHash   string
-		wantDebug  bool
-		wantErrSub string
+		name      string
+		cmdline   string
+		wantHash  string
+		wantDebug bool
 	}{
 		{
 			name:      "production by default",
@@ -26,39 +22,20 @@ func TestParseKernelCmdline(t *testing.T) {
 			wantDebug: true,
 		},
 		{
-			name:       "reject duplicate debug flag",
-			cmdline:    "tinfoil-debug=on tinfoil-debug=on",
-			wantErrSub: "duplicate kernel command-line parameter tinfoil-debug",
+			name:      "duplicate exact token remains debug",
+			cmdline:   "tinfoil-debug=on tinfoil-debug=on",
+			wantDebug: true,
 		},
 		{
-			name:       "reject bare debug flag",
-			cmdline:    "quiet tinfoil-debug root=/dev/vda",
-			wantErrSub: "malformed kernel command-line parameter tinfoil-debug",
-		},
-		{
-			name:       "reject other debug value",
-			cmdline:    "tinfoil-debug=off",
-			wantErrSub: `invalid kernel command-line parameter tinfoil-debug="off"`,
-		},
-		{
-			name:       "reject empty debug value",
-			cmdline:    "tinfoil-debug=",
-			wantErrSub: `invalid kernel command-line parameter tinfoil-debug=""`,
+			name:      "other forms remain production",
+			cmdline:   "tinfoil-debug tinfoil-debug=off tinfoil-debug=",
+			wantDebug: false,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got, err := parseKernelCmdline(test.cmdline)
-			if test.wantErrSub != "" {
-				if err == nil || !strings.Contains(err.Error(), test.wantErrSub) {
-					t.Fatalf("parseKernelCmdline error = %v, want %q", err, test.wantErrSub)
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("parseKernelCmdline: %v", err)
-			}
+			got := parseKernelCmdline(test.cmdline)
 			if got.ConfigHash != test.wantHash {
 				t.Fatalf("ConfigHash = %q, want %q", got.ConfigHash, test.wantHash)
 			}

--- a/tinfoil/cmd/boot/debug_policy_test.go
+++ b/tinfoil/cmd/boot/debug_policy_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseKernelCmdline(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmdline    string
+		wantHash   string
+		wantDebug  bool
+		wantErrSub string
+	}{
+		{
+			name:      "production by default",
+			cmdline:   "console=ttyS0 tinfoil-config-hash=abc root=/dev/vda",
+			wantHash:  "abc",
+			wantDebug: false,
+		},
+		{
+			name:      "debug on exact token",
+			cmdline:   "tinfoil-config-hash=abc tinfoil-debug=on quiet",
+			wantHash:  "abc",
+			wantDebug: true,
+		},
+		{
+			name:       "reject duplicate debug flag",
+			cmdline:    "tinfoil-debug=on tinfoil-debug=on",
+			wantErrSub: "duplicate kernel command-line parameter tinfoil-debug",
+		},
+		{
+			name:       "reject bare debug flag",
+			cmdline:    "quiet tinfoil-debug root=/dev/vda",
+			wantErrSub: "malformed kernel command-line parameter tinfoil-debug",
+		},
+		{
+			name:       "reject other debug value",
+			cmdline:    "tinfoil-debug=off",
+			wantErrSub: `invalid kernel command-line parameter tinfoil-debug="off"`,
+		},
+		{
+			name:       "reject empty debug value",
+			cmdline:    "tinfoil-debug=",
+			wantErrSub: `invalid kernel command-line parameter tinfoil-debug=""`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseKernelCmdline(test.cmdline)
+			if test.wantErrSub != "" {
+				if err == nil || !strings.Contains(err.Error(), test.wantErrSub) {
+					t.Fatalf("parseKernelCmdline error = %v, want %q", err, test.wantErrSub)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseKernelCmdline: %v", err)
+			}
+			if got.ConfigHash != test.wantHash {
+				t.Fatalf("ConfigHash = %q, want %q", got.ConfigHash, test.wantHash)
+			}
+			if got.Debug != test.wantDebug {
+				t.Fatalf("Debug = %t, want %t", got.Debug, test.wantDebug)
+			}
+		})
+	}
+}

--- a/tinfoil/cmd/boot/firewall.go
+++ b/tinfoil/cmd/boot/firewall.go
@@ -41,8 +41,8 @@ type egressPopulator interface {
 // transaction, then synchronously populates any allowlist sets.
 // Must be called after the bridge interfaces exist so iif/oif resolve
 // by index.
-func setupContainerNetworkFirewall(ctx context.Context, cfg *Config) error {
-	return setupContainerNetworkFirewallWith(ctx, cfg, runNft, func() (egressPopulator, error) {
+func setupContainerNetworkFirewall(ctx context.Context, cfg *Config, debug bool) error {
+	return setupContainerNetworkFirewallWith(ctx, cfg, debug, runNft, func() (egressPopulator, error) {
 		return egress.Load()
 	})
 }
@@ -50,6 +50,7 @@ func setupContainerNetworkFirewall(ctx context.Context, cfg *Config) error {
 func setupContainerNetworkFirewallWith(
 	ctx context.Context,
 	cfg *Config,
+	debug bool,
 	applyNft func(string) error,
 	loadEgress func() (egressPopulator, error),
 ) error {
@@ -65,6 +66,9 @@ func setupContainerNetworkFirewallWith(
 	}
 	if shimUpstreamSet(cfg) {
 		writeBridgeRules(&script, containernet.ShimNetName, &NetworkSpec{Egress: "closed"})
+	}
+	if debug && hasReservedDebugContainer(cfg) {
+		writeReservedDebugForwardRules(&script)
 	}
 	if err := applyNft(script.String()); err != nil {
 		return fmt.Errorf("installing container-network firewall rules: %w", err)
@@ -95,6 +99,11 @@ func setupContainerNetworkFirewallWith(
 		break
 	}
 	return nil
+}
+
+func writeReservedDebugForwardRules(script *strings.Builder) {
+	fmt.Fprintf(script, "add rule inet tinfoil forward oifname %q ct status dnat tcp dport %d accept\n", "docker0", reservedDebugHostPort)
+	fmt.Fprintf(script, "add rule inet tinfoil forward iifname %q ct state established,related accept\n", "docker0")
 }
 
 func writeBridgeRules(script *strings.Builder, bridge string, spec *NetworkSpec) {

--- a/tinfoil/cmd/boot/firewall_test.go
+++ b/tinfoil/cmd/boot/firewall_test.go
@@ -28,6 +28,7 @@ func TestFirewall_AllowlistPopulationFollowsNftOnce(t *testing.T) {
 	err := setupContainerNetworkFirewallWith(
 		context.Background(),
 		cfg,
+		false,
 		func(string) error {
 			events = append(events, "nft")
 			return nil
@@ -57,6 +58,7 @@ func TestFirewall_NoAllowlistSkipsPopulation(t *testing.T) {
 	err := setupContainerNetworkFirewallWith(
 		context.Background(),
 		cfg,
+		false,
 		func(string) error { return nil },
 		func() (egressPopulator, error) {
 			loaded = true
@@ -80,6 +82,7 @@ func TestFirewall_PopulationFailureAbortsSetup(t *testing.T) {
 	err := setupContainerNetworkFirewallWith(
 		context.Background(),
 		cfg,
+		false,
 		func(string) error { return nil },
 		func() (egressPopulator, error) {
 			return fakeEgressPopulator{populate: func(context.Context) error {
@@ -103,6 +106,7 @@ func TestFirewall_PopulationHasFixedBootDeadline(t *testing.T) {
 	err := setupContainerNetworkFirewallWith(
 		context.Background(),
 		cfg,
+		false,
 		func(string) error { return nil },
 		func() (egressPopulator, error) {
 			return fakeEgressPopulator{populate: func(ctx context.Context) error {
@@ -132,6 +136,7 @@ func TestFirewall_PopulationInheritsBootCancellation(t *testing.T) {
 	err := setupContainerNetworkFirewallWith(
 		ctx,
 		cfg,
+		false,
 		func(string) error { return nil },
 		func() (egressPopulator, error) {
 			return fakeEgressPopulator{populate: func(ctx context.Context) error {
@@ -154,6 +159,7 @@ func TestFirewall_PopulationHonorsEarlierBootDeadline(t *testing.T) {
 	err := setupContainerNetworkFirewallWith(
 		ctx,
 		cfg,
+		false,
 		func(string) error { return nil },
 		func() (egressPopulator, error) {
 			return fakeEgressPopulator{populate: func(ctx context.Context) error {
@@ -169,13 +175,16 @@ func TestFirewall_PopulationHonorsEarlierBootDeadline(t *testing.T) {
 
 // renderFirewallScript returns the nft script setupContainerNetworkFirewall
 // would commit, minus the runNft call.
-func renderFirewallScript(cfg *Config) string {
+func renderFirewallScript(cfg *Config, debug bool) string {
 	var s strings.Builder
 	for name, spec := range cfg.Networks {
 		writeBridgeRules(&s, name, spec)
 	}
 	if shimUpstreamSet(cfg) {
 		writeBridgeRules(&s, "shim-net", &NetworkSpec{Egress: "closed"})
+	}
+	if debug && hasReservedDebugContainer(cfg) {
+		writeReservedDebugForwardRules(&s)
 	}
 	return s.String()
 }
@@ -184,7 +193,7 @@ func TestFirewall_ClosedBridgeHasNoEgressRule(t *testing.T) {
 	cfg := &Config{Networks: map[string]*NetworkSpec{
 		"ipc-exec": {Egress: "closed"},
 	}}
-	script := renderFirewallScript(cfg)
+	script := renderFirewallScript(cfg, false)
 	if !strings.Contains(script, `iif "ipc-exec" oif "ipc-exec" accept`) {
 		t.Error("closed bridge should still allow intra-bridge traffic")
 	}
@@ -203,7 +212,7 @@ func TestFirewall_OpenBridgeEmitsPublicAccept(t *testing.T) {
 	cfg := &Config{Networks: map[string]*NetworkSpec{
 		"web": {Egress: "open"},
 	}}
-	script := renderFirewallScript(cfg)
+	script := renderFirewallScript(cfg, false)
 	if !strings.Contains(script, `iif "web" ip daddr != {`) {
 		t.Errorf("open bridge should accept public v4; got:\n%s", script)
 	}
@@ -216,7 +225,7 @@ func TestFirewall_OpenBridgeBlocksNonPublicIPv4Ranges(t *testing.T) {
 	cfg := &Config{Networks: map[string]*NetworkSpec{
 		"web": {Egress: "open"},
 	}}
-	script := renderFirewallScript(cfg)
+	script := renderFirewallScript(cfg, false)
 	for _, cidr := range []string{
 		"100.64.0.0/10",   // RFC 6598 shared address space.
 		"198.18.0.0/15",   // RFC 6890 benchmarking.
@@ -235,7 +244,7 @@ func TestFirewall_AllowlistEmitsSetAndAcceptRule(t *testing.T) {
 	cfg := &Config{Networks: map[string]*NetworkSpec{
 		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
 	}}
-	script := renderFirewallScript(cfg)
+	script := renderFirewallScript(cfg, false)
 	if !strings.Contains(script, `add set inet tinfoil allow-control`) {
 		t.Errorf("allowlist must declare its set; got:\n%s", script)
 	}
@@ -251,7 +260,7 @@ func TestFirewall_AllowlistDropsNonPublicBeforeAllowSet(t *testing.T) {
 	cfg := &Config{Networks: map[string]*NetworkSpec{
 		"control": {Egress: "allowlist", Allow: []string{"api.tinfoil.sh"}},
 	}}
-	script := renderFirewallScript(cfg)
+	script := renderFirewallScript(cfg, false)
 	dropRule := `iif "control" ip daddr {`
 	dropIdx := strings.Index(script, dropRule)
 	allowIdx := strings.Index(script, `iif "control" ip daddr @allow-control accept`)
@@ -275,12 +284,51 @@ func TestFirewall_ShimNetAlwaysClosed(t *testing.T) {
 			"web": {Egress: "open"},
 		},
 	}
-	script := renderFirewallScript(cfg)
+	script := renderFirewallScript(cfg, false)
 	if !strings.Contains(script, `iif "shim-net" oif "shim-net" accept`) {
 		t.Errorf("shim-net should emit intra-bridge accept; got:\n%s", script)
 	}
 	if strings.Contains(script, `iif "shim-net" ip daddr !`) {
 		t.Error("shim-net must not get an egress-open rule")
+	}
+}
+
+func TestFirewall_DebugInstallerAllowsOnlyPublishedSSHForward(t *testing.T) {
+	cfg := &Config{
+		Networks: map[string]*NetworkSpec{},
+		Containers: []Container{{
+			Name: reservedDebugContainerName,
+		}},
+	}
+	script := renderFirewallScript(cfg, true)
+	for _, rule := range []string{
+		`oifname "docker0" ct status dnat tcp dport 2222 accept`,
+		`iifname "docker0" ct state established,related accept`,
+	} {
+		if !strings.Contains(script, rule) {
+			t.Errorf("debug installer rule %q missing from:\n%s", rule, script)
+		}
+	}
+}
+
+func TestFirewall_ProductionAndGenericContainersKeepDockerBridgeClosed(t *testing.T) {
+	reserved := &Config{
+		Networks:   map[string]*NetworkSpec{},
+		Containers: []Container{{Name: reservedDebugContainerName}},
+	}
+	generic := &Config{
+		Networks:   map[string]*NetworkSpec{},
+		Containers: []Container{{Name: "workload"}},
+	}
+	for name, script := range map[string]string{
+		"production": renderFirewallScript(reserved, false),
+		"generic":    renderFirewallScript(generic, true),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if strings.Contains(script, `docker0`) {
+				t.Fatalf("unexpected docker0 forwarding rule:\n%s", script)
+			}
+		})
 	}
 }
 

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -49,7 +49,12 @@ func run(ctx context.Context) error {
 	// 1. Config
 	start := time.Now()
 	log.Println("Loading configuration")
-	config, err := loadAndVerifyConfig()
+	cmdline, err := readKernelCmdline()
+	if err != nil {
+		tracker.Record("config", boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("parsing kernel cmdline: %w", err)
+	}
+	config, err := loadAndVerifyConfig(cmdline)
 	if err != nil {
 		tracker.Record("config", boot.StatusFailed, time.Since(start), err.Error())
 		return err
@@ -169,7 +174,7 @@ func run(ctx context.Context) error {
 
 	// 11. Containers + health checks
 	log.Println("Launching containers")
-	if err := launchContainersAndWaitHealthy(ctx, tracker, config, externalConfig); err != nil {
+	if err := launchContainersAndWaitHealthyWithMode(ctx, tracker, config, externalConfig, cmdline.Debug); err != nil {
 		return err
 	}
 

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -174,7 +174,7 @@ func run(ctx context.Context) error {
 
 	// 11. Containers + health checks
 	log.Println("Launching containers")
-	if err := launchContainersAndWaitHealthyWithMode(ctx, tracker, config, externalConfig, cmdline.Debug); err != nil {
+	if err := launchContainersAndWaitHealthy(ctx, tracker, config, externalConfig, cmdline.Debug); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary
- accept the exact `tinfoil-debug=on` kernel-command-line authority and reject absent, duplicate, or malformed values
- permit the Docker socket only for the reserved `tinfoil-ssh-installer` container in debug mode
- synthesize only the fixed bridge publication for toolbox TCP 2222 and the `/dev/hvc1` mapping
- allow nft forwarding only for DNAT traffic to toolbox port 2222 and its established replies
- keep shipping configurations and every generic container under the strict privilege-input policy

This is the customer-facing debug mode, not the compile-time boot-debug image. Debug mode changes the measured configuration, so normal attestation and secret delivery fail as intended. The toolbox remains bridge-mode and receives no host network, host PID namespace, host root bind, or broad capabilities; its one elevated authority is the exact Docker socket bind needed to inspect, exec, restart, pull, and run customer containers.

## Dependency and merge order
1. Merge #231 first.
2. Merge this PR.
3. Merge tinfoild #143 before the CVM 0.11+ rollout; it stops treating toolbox port 2222 as a generic guest inbound port.

## Validation
- `gofmt`
- `go build ./...`
- `go test ./...`
- `go test -race ./cmd/boot`
- `go vet ./...`
- `git diff --check`
- Box3 exact-artifact end-to-end direct SSH, `tinctl debug-shell`, `docker ps/logs/exec/pull/run`, workload restart, fixed `/dev/hvc1` access, broker restart/adoption, network-failure fallback, and cleanup
- Earlier INF14 B300 qualification covered the bridge-mode toolbox, NVIDIA workload, restart, serial, and cleanup path; the new console-broker/`hvc1` path remains gated on the released control plane and a free GPU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a strict, customer-facing debug mode gated by the exact kernel flag tinfoil-debug=on, with a locked-down toolbox runtime and local-only SSH on 2222. Only the reserved `tinfoil-ssh-installer` in debug gets the exact Docker socket bind; all other containers keep the strict input policy and the Docker bridge stays closed.

- **New Features**
  - Kernel cmdline: require `tinfoil-config-hash`; set debug only on exact `tinfoil-debug=on` (other forms are ignored).
  - Input policy: allow only `/run/docker.sock:/var/run/docker.sock` for `tinfoil-ssh-installer` in debug; reject aliases/extra options and all other host binds; reject user-supplied serial devices and duplicate container names.
  - Fixed debug runtime: force bridge mode, publish host TCP 2222 → container 2222, and synthesize `/dev/hvc1` rw; no host network/PID/privileged grants.
  - Firewall: when debug and the reserved container exists, allow only DNAT to 2222 on `docker0` and established replies; otherwise the bridge stays closed.
  - Debug plumbed through config validation, container launch, and firewall; removed legacy/duplicate paths to keep the exception minimal.

- **Migration**
  - Boot with `tinfoil-debug=on`.
  - Include a container named `tinfoil-ssh-installer` with volume `"/run/docker.sock:/var/run/docker.sock"`; SSH on host port 2222.
  - Debug changes the measured config; attestation and secret delivery will fail by design.

<sup>Written for commit a03aa44e5fab14e7d522d387e6aaa7a585d9d710. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

