### PR TITLE
Use a writable Fabric Manager log path

### DIFF
--- a/image/rootfs/usr/share/nvidia/nvswitch/fabricmanager.cfg
+++ b/image/rootfs/usr/share/nvidia/nvswitch/fabricmanager.cfg
@@ -15,7 +15,7 @@ LOG_LEVEL=4
 #	Possible Values:
 #       Full path/filename string (max length of 256). Logs will be redirected to console(stderr)
 #       if the specified log file can't be opened or the path is empty.
-LOG_FILE_NAME=/var/log/fabricmanager.log
+LOG_FILE_NAME=/run/nvidia-fabricmanager/fabricmanager.log
 
 #	Description: Append to an existing log file or overwrite the logs
 #	Possible Values:

--- a/scripts/test-fabric-manager-config.sh
+++ b/scripts/test-fabric-manager-config.sh
@@ -12,6 +12,11 @@ if [ "$(grep -Fxc 'DAEMONIZE=1' "$config")" -ne 1 ]; then
     echo "Fabric Manager must daemonize exactly once" >&2
     exit 1
 fi
+if [ "$(grep -Ec '^[[:space:]]*LOG_FILE_NAME[[:space:]]*=' "$config")" -ne 1 ] ||
+    [ "$(grep -Fxc 'LOG_FILE_NAME=/run/nvidia-fabricmanager/fabricmanager.log' "$config")" -ne 1 ]; then
+    echo "Fabric Manager must log to its writable runtime directory" >&2
+    exit 1
+fi
 if [ "$(grep -Ec '^[[:space:]]*FM_CMD_UNIX_SOCKET_PATH[[:space:]]*=' "$config")" -ne 1 ] ||
     [ "$(grep -Fxc 'FM_CMD_UNIX_SOCKET_PATH=/run/nvidia-fabricmanager/socket' "$config")" -ne 1 ]; then
     echo "Fabric Manager must use the fixed measured Unix socket" >&2


### PR DESCRIPTION
## Summary

- move the measured Fabric Manager log from absent, read-only `/var/log` into its prepared `/run/nvidia-fabricmanager` runtime directory
- pin that path in the focused Fabric Manager config contract test

## Failure mode

On the full eight-H200/NVSwitch INF12 path, `nv-fabricmanager` rejected `LOG_FILE_NAME=/var/log/fabricmanager.log` because the minimized measured root has no `/var/log`. The launcher returned status 0 despite printing the invalid-config error, so PID1 then waited for a PID file that could never appear and failed closed at GPU bootstrap.

## Validation

- `./scripts/test-fabric-manager-config.sh`
- `go build ./...`
- `go test ./...`
- `go test -race ./internal/nvidia`
- `go vet ./...`
- `git diff --check`
- rebuilt the compile-time debug image
- exact-artifact INF12 eight-H200 boot reached NVIDIA bootstrap ready
- Fabric Manager PID and Unix socket are live
- all four NVSwitches configured successfully
- `nvidia-smi topo -m` reports NV18 links across all eight H200s
- eight-GPU attestation passed
- customer debug toolbox is healthy and reachable on guest port 2222


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented Fabric Manager startup deadlock by using a writable log location when /var/log is absent. This unblocks GPU bootstrap on INF12 eight‑H200/NVSwitch systems.

- **Bug Fixes**
  - Set LOG_FILE_NAME to /run/nvidia-fabricmanager/fabricmanager.log in the Fabric Manager config.
  - Updated the config test to require the runtime log path.

<sup>Written for commit 4a04d3c811a82552f7257b20707d995078f7a608. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

