### PR TITLE
Remove the global PID1 boot deadline

### DIFF
--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -70,8 +70,8 @@ func runPID1() {
 		initLogf("warning: running with pid %d, expected pid 1", os.Getpid())
 	}
 
-	// This is the lifetime context. The boot deadline is deliberately created
-	// inside run and can never end post-boot supervision.
+	// This signal-notified context owns both startup and supervision. Narrow
+	// readiness checks apply their own operation-specific timeouts.
 	parent, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	err := run(parent)

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	bootTimeout          = 5 * time.Minute
 	containerdReadyLimit = 30 * time.Second
 	dockerReadyLimit     = 60 * time.Second
 	shimReadyLimit       = 30 * time.Second
@@ -106,7 +105,6 @@ type lifecycleDeps struct {
 	limits       func() error
 	syslog       func(context.Context)
 	exists       func(string) (bool, error)
-	timeout      time.Duration
 	term         time.Duration
 	kill         time.Duration
 }
@@ -147,7 +145,6 @@ func run(parent context.Context) (result error) {
 		limits:       hardening.ApplyRuntimeLimits,
 		syslog:       startOptionalSyslogSink,
 		exists:       pathExists,
-		timeout:      bootTimeout,
 		term:         serviceTermGrace,
 		kill:         serviceKillGrace,
 	}
@@ -155,8 +152,7 @@ func run(parent context.Context) (result error) {
 }
 
 func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readinessState) (result error) {
-	bootCtx, cancelBoot := context.WithTimeout(parent, deps.timeout)
-	defer cancelBoot()
+	bootCtx := parent
 	runtimeCtx, cancelRuntime := context.WithCancel(parent)
 	defer func() {
 		readiness.FailClosed()
@@ -254,7 +250,6 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 		return fmt.Errorf("publishing readiness: %w", err)
 	}
 	initLogf("boot complete")
-	cancelBoot()
 	<-parent.Done()
 	initLogf("shutdown requested")
 	return nil

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -96,7 +96,6 @@ func newLifecycleHarness() *lifecycleHarness {
 		exists: func(path string) (bool, error) {
 			return harness.existing[path], nil
 		},
-		timeout: time.Hour,
 	}
 	return harness
 }
@@ -616,7 +615,7 @@ func TestAnnotateOneShotFailureFallsBackToChildError(t *testing.T) {
 	}
 }
 
-func TestBootDeadlineDoesNotEndSupervisionAndRequiredDeathFailsClosed(t *testing.T) {
+func TestRequiredServiceDeathFailsClosedDuringSupervision(t *testing.T) {
 	harness := newLifecycleHarness()
 	parent, cancel := context.WithCancel(context.Background())
 	result := make(chan error, 1)
@@ -627,11 +626,9 @@ func TestBootDeadlineDoesNotEndSupervisionAndRequiredDeathFailsClosed(t *testing
 	if ready := receiveTest(t, harness.ready); !ready {
 		t.Fatal("lifecycle did not become ready")
 	}
-	// runLifecycle cancels its boot context immediately after publishing
-	// readiness. The signal-only parent must remain the sole lifetime gate.
 	select {
 	case err := <-result:
-		t.Fatalf("boot context ended supervision: %v", err)
+		t.Fatalf("lifecycle ended before shutdown: %v", err)
 	default:
 	}
 	harness.services.state(dockerName, false)


### PR DESCRIPTION
## Summary

- remove the global PID1 startup timeout
- keep the signal-driven lifetime context and ordered bounded shutdown
- retain narrow readiness bounds for NVIDIA devices, Fabric Manager, containerd, Docker, and the shim

## Rationale

The global five-minute timeout did not improve a specific diagnostic. On the full INF12 GLM 5.2 path it killed `tinfoil-boot` during an otherwise healthy image pull, even though the pinned workload contract allows up to 120 minutes for model startup.

Slow customer application startup is not a PID1 integrity failure. Failures with actionable ownership remain bounded at their narrow interfaces, such as Fabric Manager PID/socket readiness and daemon socket readiness.

## Validation

- `go build ./...`
- `go test ./...`
- `go test -race ./cmd/init`
- `go vet ./...`
- `git diff --check`
- reproduced the old failure on eight H200s: Fabric Manager, GPU attestation, certificate, model opening, and toolbox startup succeeded; the global deadline then interrupted the GLM image pull
- exact-artifact INF12 requalification without the global timeout is in progress

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the global PID1 boot deadline so init stays up until it receives SIGINT/SIGTERM, preventing shutdown during long image pulls while keeping readiness limits for critical services. Clarified that the signal-notified parent context owns both startup and supervision.

- **Bug Fixes**
  - Removed the 5-minute boot timeout and boot-scoped context (`bootTimeout`, `lifecycleDeps.timeout`, and boot cancellation); supervision now relies only on the signal-notified parent context.
  - Preserved bounded readiness for NVIDIA devices, Fabric Manager, `containerd`, `Docker`, and the shim; updated tests to drop the timeout field, rename the supervision test, and assert required service death fails closed during supervision.

<sup>Written for commit ed35638f9fc03288e52dfd983fa9810fea38fed5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

