### PR TITLE
Report container lifecycle through a fixed Docker client

### DIFF
--- a/tinfoil/cmd/container-status/docker_inspect.go
+++ b/tinfoil/cmd/container-status/docker_inspect.go
@@ -1,0 +1,175 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+const (
+	dockerSocketPath          = "/var/run/docker.sock"
+	dockerAPIVersion          = "v1.44"
+	maxContainerReferenceSize = 255
+	maxInspectResponseSize    = 1 << 20
+	dockerDialTimeout         = time.Second
+	dockerInspectTimeout      = 3 * time.Second
+	containerStateCreated     = "created"
+	containerStateDead        = "dead"
+	containerStateExited      = "exited"
+	containerStateRestarting  = "restarting"
+)
+
+var errContainerNotFound = errors.New("container not found")
+
+type dockerInspectClient struct {
+	client *http.Client
+}
+
+type containerInspect struct {
+	Base   *containerInspectBase
+	Config *containerConfig
+}
+
+type containerInspectBase struct {
+	ID           string
+	Name         string
+	RestartCount int
+	State        *containerState
+	HostConfig   *containerHostConfig
+}
+
+type containerConfig struct {
+	Image string `json:"Image"`
+}
+
+type containerHostConfig struct {
+	RestartPolicy containerRestartPolicy `json:"RestartPolicy"`
+}
+
+type containerRestartPolicy struct {
+	Name              string `json:"Name"`
+	MaximumRetryCount int    `json:"MaximumRetryCount"`
+}
+
+type containerState struct {
+	Status     string                `json:"Status"`
+	OOMKilled  bool                  `json:"OOMKilled"`
+	ExitCode   int                   `json:"ExitCode"`
+	Error      string                `json:"Error"`
+	StartedAt  string                `json:"StartedAt"`
+	FinishedAt string                `json:"FinishedAt"`
+	Health     *containerHealthState `json:"Health"`
+}
+
+type containerHealthState struct {
+	Status        string                   `json:"Status"`
+	FailingStreak int                      `json:"FailingStreak"`
+	Log           []*containerHealthResult `json:"Log"`
+}
+
+type containerHealthResult struct {
+	Start    time.Time `json:"Start"`
+	End      time.Time `json:"End"`
+	ExitCode int       `json:"ExitCode"`
+}
+
+type dockerInspectResponse struct {
+	ID           string               `json:"Id"`
+	Name         string               `json:"Name"`
+	RestartCount int                  `json:"RestartCount"`
+	State        *containerState      `json:"State"`
+	HostConfig   *containerHostConfig `json:"HostConfig"`
+	Config       *containerConfig     `json:"Config"`
+}
+
+func newDockerInspectClient(socketPath string) *dockerInspectClient {
+	dialer := &net.Dialer{Timeout: dockerDialTimeout}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "unix", socketPath)
+		},
+		DisableCompression:     true,
+		MaxIdleConns:           1,
+		MaxIdleConnsPerHost:    1,
+		MaxConnsPerHost:        1,
+		IdleConnTimeout:        2 * dockerInspectTimeout,
+		ResponseHeaderTimeout:  dockerInspectTimeout,
+		MaxResponseHeaderBytes: 16 << 10,
+	}
+	return &dockerInspectClient{client: &http.Client{
+		Transport: transport,
+		Timeout:   dockerInspectTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}}
+}
+
+func (c *dockerInspectClient) CloseIdleConnections() {
+	c.client.CloseIdleConnections()
+}
+
+func (c *dockerInspectClient) ContainerInspect(ctx context.Context, name string) (containerInspect, error) {
+	if name == "" || len(name) > maxContainerReferenceSize {
+		return containerInspect{}, fmt.Errorf("invalid container reference length %d", len(name))
+	}
+	requestURL := "http://docker/" + dockerAPIVersion + "/containers/" + url.PathEscape(name) + "/json"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
+	if err != nil {
+		return containerInspect{}, fmt.Errorf("creating inspect request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return containerInspect{}, fmt.Errorf("requesting inspect: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return containerInspect{}, errContainerNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return containerInspect{}, fmt.Errorf("inspect returned HTTP status %d", resp.StatusCode)
+	}
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return containerInspect{}, fmt.Errorf("inspect returned non-JSON content type %q", resp.Header.Get("Content-Type"))
+	}
+	if contentLength := resp.Header.Get("Content-Length"); contentLength != "" {
+		length, err := strconv.ParseInt(contentLength, 10, 64)
+		if err != nil || length < 0 || length > maxInspectResponseSize {
+			return containerInspect{}, fmt.Errorf("inspect response has invalid content length %q", contentLength)
+		}
+	}
+
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxInspectResponseSize+1))
+	if err != nil {
+		return containerInspect{}, fmt.Errorf("reading inspect response: %w", err)
+	}
+	if len(data) > maxInspectResponseSize {
+		return containerInspect{}, fmt.Errorf("inspect response exceeds %d bytes", maxInspectResponseSize)
+	}
+	var wire dockerInspectResponse
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return containerInspect{}, fmt.Errorf("decoding inspect response: %w", err)
+	}
+	return containerInspect{
+		Base: &containerInspectBase{
+			ID:           wire.ID,
+			Name:         wire.Name,
+			RestartCount: wire.RestartCount,
+			State:        wire.State,
+			HostConfig:   wire.HostConfig,
+		},
+		Config: wire.Config,
+	}, nil
+}

--- a/tinfoil/cmd/container-status/docker_inspect.go
+++ b/tinfoil/cmd/container-status/docker_inspect.go
@@ -24,7 +24,10 @@ const (
 	containerStateCreated     = "created"
 	containerStateDead        = "dead"
 	containerStateExited      = "exited"
+	containerStatePaused      = "paused"
+	containerStateRemoving    = "removing"
 	containerStateRestarting  = "restarting"
+	containerStateRunning     = "running"
 )
 
 var errContainerNotFound = errors.New("container not found")
@@ -162,6 +165,9 @@ func (c *dockerInspectClient) ContainerInspect(ctx context.Context, name string)
 	if err := json.Unmarshal(data, &wire); err != nil {
 		return containerInspect{}, fmt.Errorf("decoding inspect response: %w", err)
 	}
+	if err := validateDockerInspectResponse(wire); err != nil {
+		return containerInspect{}, err
+	}
 	return containerInspect{
 		Base: &containerInspectBase{
 			ID:           wire.ID,
@@ -172,4 +178,42 @@ func (c *dockerInspectClient) ContainerInspect(ctx context.Context, name string)
 		},
 		Config: wire.Config,
 	}, nil
+}
+
+func validateDockerInspectResponse(wire dockerInspectResponse) error {
+	if !validContainerID(wire.ID) {
+		return fmt.Errorf("inspect response has invalid container ID")
+	}
+	if wire.RestartCount < 0 {
+		return fmt.Errorf("inspect response has negative restart count")
+	}
+	if wire.State == nil {
+		return fmt.Errorf("inspect response is missing state")
+	}
+	if !validDockerStateStatus(wire.State.Status) {
+		return fmt.Errorf("inspect response has invalid state status %q", wire.State.Status)
+	}
+	if wire.State.ExitCode < 0 || wire.State.ExitCode > 255 {
+		return fmt.Errorf("inspect response has invalid exit code %d", wire.State.ExitCode)
+	}
+	if wire.State.StartedAt != "" {
+		if _, err := time.Parse(time.RFC3339Nano, wire.State.StartedAt); err != nil {
+			return fmt.Errorf("inspect response has invalid started_at")
+		}
+	}
+	if wire.State.FinishedAt != "" {
+		if _, err := time.Parse(time.RFC3339Nano, wire.State.FinishedAt); err != nil {
+			return fmt.Errorf("inspect response has invalid finished_at")
+		}
+	}
+	return nil
+}
+
+func validDockerStateStatus(status string) bool {
+	switch status {
+	case containerStateCreated, containerStateRunning, containerStatePaused, containerStateRestarting, containerStateRemoving, containerStateExited, containerStateDead:
+		return true
+	default:
+		return false
+	}
 }

--- a/tinfoil/cmd/container-status/docker_inspect_test.go
+++ b/tinfoil/cmd/container-status/docker_inspect_test.go
@@ -107,7 +107,7 @@ func TestDockerInspectClientEscapesContainerName(t *testing.T) {
 			t.Errorf("request URI = %q", r.RequestURI)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{}`)
+		fmt.Fprintf(w, `{"Id":%q,"State":{"Status":"running","ExitCode":0}}`, strings.Repeat("b", 64))
 	}))
 	client := newDockerInspectClient(socketPath)
 	t.Cleanup(client.CloseIdleConnections)
@@ -136,7 +136,6 @@ func TestDockerInspectClientRejectsUnexpectedResponses(t *testing.T) {
 	}{
 		{name: "error status", status: http.StatusInternalServerError, contentType: "application/json", body: `{"message":"sensitive"}`, want: "HTTP status 500"},
 		{name: "redirect", status: http.StatusTemporaryRedirect, contentType: "application/json", body: `{}`, want: "HTTP status 307"},
-		{name: "missing content type", status: http.StatusOK, body: `{}`, want: "non-JSON content type"},
 		{name: "text content type", status: http.StatusOK, contentType: "text/plain", body: `{}`, want: "non-JSON content type"},
 		{name: "malformed JSON", status: http.StatusOK, contentType: "application/json", body: `{`, want: "decoding inspect response"},
 		{name: "trailing JSON", status: http.StatusOK, contentType: "application/json", body: `{} {}`, want: "decoding inspect response"},
@@ -161,6 +160,38 @@ func TestDockerInspectClientRejectsUnexpectedResponses(t *testing.T) {
 			}
 			if strings.Contains(err.Error(), "sensitive") {
 				t.Fatalf("error exposed daemon response body: %v", err)
+			}
+		})
+	}
+}
+
+func TestDockerInspectClientRejectsMissingRequiredFields(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "missing container ID", body: `{"State":{"Status":"running","ExitCode":0}}`, want: "invalid container ID"},
+		{name: "short container ID", body: `{"Id":"abc","State":{"Status":"running","ExitCode":0}}`, want: "invalid container ID"},
+		{name: "negative restart count", body: fmt.Sprintf(`{"Id":%q,"RestartCount":-1,"State":{"Status":"running","ExitCode":0}}`, strings.Repeat("a", 64)), want: "negative restart count"},
+		{name: "missing state", body: fmt.Sprintf(`{"Id":%q}`, strings.Repeat("a", 64)), want: "missing state"},
+		{name: "missing state status", body: fmt.Sprintf(`{"Id":%q,"State":{"ExitCode":0}}`, strings.Repeat("a", 64)), want: "invalid state status"},
+		{name: "unknown state status", body: fmt.Sprintf(`{"Id":%q,"State":{"Status":"unknown","ExitCode":0}}`, strings.Repeat("a", 64)), want: "invalid state status"},
+		{name: "invalid exit code", body: fmt.Sprintf(`{"Id":%q,"State":{"Status":"exited","ExitCode":256}}`, strings.Repeat("a", 64)), want: "invalid exit code"},
+		{name: "invalid started time", body: fmt.Sprintf(`{"Id":%q,"State":{"Status":"running","ExitCode":0,"StartedAt":"invalid"}}`, strings.Repeat("a", 64)), want: "invalid started_at"},
+		{name: "invalid finished time", body: fmt.Sprintf(`{"Id":%q,"State":{"Status":"exited","ExitCode":0,"FinishedAt":"invalid"}}`, strings.Repeat("a", 64)), want: "invalid finished_at"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			socketPath := serveDockerSocket(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				fmt.Fprint(w, test.body)
+			}))
+			client := newDockerInspectClient(socketPath)
+			t.Cleanup(client.CloseIdleConnections)
+			_, err := client.ContainerInspect(context.Background(), "model")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want containing %q", err, test.want)
 			}
 		})
 	}

--- a/tinfoil/cmd/container-status/docker_inspect_test.go
+++ b/tinfoil/cmd/container-status/docker_inspect_test.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func serveDockerSocket(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	socketPath := filepath.Join(t.TempDir(), "docker.sock")
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("listening on Unix socket: %v", err)
+	}
+	server := &http.Server{Handler: handler}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := server.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Errorf("serving Unix socket: %v", err)
+		}
+	}()
+	t.Cleanup(func() {
+		if err := server.Close(); err != nil {
+			t.Errorf("closing test server: %v", err)
+		}
+		<-done
+	})
+	return socketPath
+}
+
+func TestDockerInspectClientFixedRequestAndResponse(t *testing.T) {
+	const containerName = "model.worker"
+	var requests atomic.Int32
+	socketPath := serveDockerSocket(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %q, want GET", r.Method)
+		}
+		if r.Host != "docker" {
+			t.Errorf("host = %q, want docker", r.Host)
+		}
+		if r.URL.RequestURI() != "/v1.44/containers/model.worker/json" {
+			t.Errorf("request URI = %q", r.URL.RequestURI())
+		}
+		if r.Header.Get("Accept") != "application/json" {
+			t.Errorf("Accept = %q", r.Header.Get("Accept"))
+		}
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		fmt.Fprint(w, `{
+  "Id":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "Name":"/model.worker",
+  "RestartCount":2,
+  "State":{
+    "Status":"running",
+    "OOMKilled":false,
+    "ExitCode":0,
+    "Error":"",
+    "StartedAt":"2026-07-24T01:02:03Z",
+    "FinishedAt":"0001-01-01T00:00:00Z",
+    "Health":{"Status":"healthy","FailingStreak":0,"Log":[{"Start":"2026-07-24T01:02:04Z","End":"2026-07-24T01:02:05Z","ExitCode":0,"Output":"ignored"}]}
+  },
+  "HostConfig":{"RestartPolicy":{"Name":"on-failure","MaximumRetryCount":4},"Privileged":true},
+  "Config":{"Image":"example/model@sha256:abc","Env":["IGNORED=1"]},
+  "Mounts":[{"Source":"ignored"}]
+}`)
+	}))
+	client := newDockerInspectClient(socketPath)
+	t.Cleanup(client.CloseIdleConnections)
+
+	inspect, err := client.ContainerInspect(context.Background(), containerName)
+	if err != nil {
+		t.Fatalf("ContainerInspect returned error: %v", err)
+	}
+	if requests.Load() != 1 {
+		t.Fatalf("request count = %d, want 1", requests.Load())
+	}
+	if inspect.Base == nil || inspect.Base.ID != strings.Repeat("a", 64) || inspect.Base.Name != "/model.worker" {
+		t.Fatalf("base inspect = %#v", inspect.Base)
+	}
+	if inspect.Base.RestartCount != 2 || inspect.Base.State == nil || inspect.Base.State.Status != "running" {
+		t.Fatalf("state inspect = %#v", inspect.Base)
+	}
+	if inspect.Base.HostConfig == nil || inspect.Base.HostConfig.RestartPolicy.Name != "on-failure" || inspect.Base.HostConfig.RestartPolicy.MaximumRetryCount != 4 {
+		t.Fatalf("host config = %#v", inspect.Base.HostConfig)
+	}
+	if inspect.Config == nil || inspect.Config.Image != "example/model@sha256:abc" {
+		t.Fatalf("config = %#v", inspect.Config)
+	}
+	if health := inspect.Base.State.Health; health == nil || len(health.Log) != 1 || health.Log[0].ExitCode != 0 {
+		t.Fatalf("health = %#v", health)
+	}
+}
+
+func TestDockerInspectClientEscapesContainerName(t *testing.T) {
+	socketPath := serveDockerSocket(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.RequestURI != "/v1.44/containers/name%2Fwith%20space/json" {
+			t.Errorf("request URI = %q", r.RequestURI)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{}`)
+	}))
+	client := newDockerInspectClient(socketPath)
+	t.Cleanup(client.CloseIdleConnections)
+	if _, err := client.ContainerInspect(context.Background(), "name/with space"); err != nil {
+		t.Fatalf("ContainerInspect returned error: %v", err)
+	}
+}
+
+func TestDockerInspectClientBoundsContainerReference(t *testing.T) {
+	client := newDockerInspectClient(filepath.Join(t.TempDir(), "unused.sock"))
+	t.Cleanup(client.CloseIdleConnections)
+	for _, name := range []string{"", strings.Repeat("a", maxContainerReferenceSize+1)} {
+		if _, err := client.ContainerInspect(context.Background(), name); err == nil || !strings.Contains(err.Error(), "invalid container reference length") {
+			t.Fatalf("reference length %d error = %v", len(name), err)
+		}
+	}
+}
+
+func TestDockerInspectClientRejectsUnexpectedResponses(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      int
+		contentType string
+		body        string
+		want        string
+	}{
+		{name: "error status", status: http.StatusInternalServerError, contentType: "application/json", body: `{"message":"sensitive"}`, want: "HTTP status 500"},
+		{name: "redirect", status: http.StatusTemporaryRedirect, contentType: "application/json", body: `{}`, want: "HTTP status 307"},
+		{name: "missing content type", status: http.StatusOK, body: `{}`, want: "non-JSON content type"},
+		{name: "text content type", status: http.StatusOK, contentType: "text/plain", body: `{}`, want: "non-JSON content type"},
+		{name: "malformed JSON", status: http.StatusOK, contentType: "application/json", body: `{`, want: "decoding inspect response"},
+		{name: "trailing JSON", status: http.StatusOK, contentType: "application/json", body: `{} {}`, want: "decoding inspect response"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			socketPath := serveDockerSocket(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if test.name == "redirect" {
+					w.Header().Set("Location", "http://ignored/version")
+				}
+				if test.contentType != "" {
+					w.Header().Set("Content-Type", test.contentType)
+				}
+				w.WriteHeader(test.status)
+				fmt.Fprint(w, test.body)
+			}))
+			client := newDockerInspectClient(socketPath)
+			t.Cleanup(client.CloseIdleConnections)
+			_, err := client.ContainerInspect(context.Background(), "model")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want containing %q", err, test.want)
+			}
+			if strings.Contains(err.Error(), "sensitive") {
+				t.Fatalf("error exposed daemon response body: %v", err)
+			}
+		})
+	}
+}
+
+func TestDockerInspectClientDistinguishesNotFound(t *testing.T) {
+	socketPath := serveDockerSocket(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "not JSON")
+	}))
+	client := newDockerInspectClient(socketPath)
+	t.Cleanup(client.CloseIdleConnections)
+	_, err := client.ContainerInspect(context.Background(), "missing")
+	if !errors.Is(err, errContainerNotFound) {
+		t.Fatalf("error = %v, want errContainerNotFound", err)
+	}
+}
+
+func TestDockerInspectClientBoundsResponse(t *testing.T) {
+	tests := []struct {
+		name          string
+		contentLength string
+		body          string
+		want          string
+	}{
+		{name: "declared too large", contentLength: fmt.Sprint(maxInspectResponseSize + 1), body: `{}`, want: "invalid content length"},
+		{name: "chunked too large", body: strings.Repeat(" ", maxInspectResponseSize+1), want: "exceeds"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			socketPath := serveDockerSocket(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if test.contentLength != "" {
+					w.Header().Set("Content-Length", test.contentLength)
+				}
+				if test.name == "chunked too large" {
+					w.Header().Set("Transfer-Encoding", "chunked")
+					w.(http.Flusher).Flush()
+				}
+				fmt.Fprint(w, test.body)
+			}))
+			client := newDockerInspectClient(socketPath)
+			t.Cleanup(client.CloseIdleConnections)
+			_, err := client.ContainerInspect(context.Background(), "model")
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDockerInspectClientHonorsContext(t *testing.T) {
+	socketPath := serveDockerSocket(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	client := newDockerInspectClient(socketPath)
+	t.Cleanup(client.CloseIdleConnections)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	_, err := client.ContainerInspect(ctx, "model")
+	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestDockerInspectClientFailsClosedWithoutSocket(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "missing.sock")
+	client := newDockerInspectClient(socketPath)
+	t.Cleanup(client.CloseIdleConnections)
+	_, err := client.ContainerInspect(context.Background(), "model")
+	if err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("error = %v, want missing socket", err)
+	}
+}

--- a/tinfoil/cmd/container-status/main.go
+++ b/tinfoil/cmd/container-status/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -22,7 +23,10 @@ import (
 )
 
 const (
-	pollInterval = 5 * time.Second
+	pollInterval            = 5 * time.Second
+	maxReportedRestartCount = 255
+	processOriginal         = "original"
+	processReplacement      = "replacement"
 )
 
 type declaredContainer struct {
@@ -46,19 +50,32 @@ type containersResponse struct {
 }
 
 type containerStatus struct {
-	Name          string           `json:"name"`
-	Image         string           `json:"image"`
-	Declared      bool             `json:"declared"`
-	Created       bool             `json:"created"`
-	Status        string           `json:"status,omitempty"`
-	RestartCount  int              `json:"restart_count"`
-	RestartPolicy string           `json:"restart_policy,omitempty"`
-	OOMKilled     bool             `json:"oom_killed"`
-	ExitCode      int              `json:"exit_code"`
-	Error         string           `json:"error,omitempty"`
-	StartedAt     string           `json:"started_at,omitempty"`
-	FinishedAt    string           `json:"finished_at,omitempty"`
-	Health        *containerHealth `json:"health,omitempty"`
+	Name                  string           `json:"name"`
+	Image                 string           `json:"image"`
+	Declared              bool             `json:"declared"`
+	Created               bool             `json:"created"`
+	ContainerID           string           `json:"container_id,omitempty"`
+	Process               string           `json:"process,omitempty"`
+	LifecycleComplete     bool             `json:"lifecycle_complete"`
+	Status                string           `json:"status,omitempty"`
+	RestartCount          int              `json:"restart_count"`
+	RestartCountTruncated bool             `json:"restart_count_truncated"`
+	RestartPolicy         string           `json:"restart_policy,omitempty"`
+	LatestOutcome         *processOutcome  `json:"latest_outcome,omitempty"`
+	OOMKilled             bool             `json:"oom_killed"`
+	ExitCode              int              `json:"exit_code"`
+	Error                 string           `json:"error,omitempty"`
+	StartedAt             string           `json:"started_at,omitempty"`
+	FinishedAt            string           `json:"finished_at,omitempty"`
+	Health                *containerHealth `json:"health,omitempty"`
+}
+
+type processOutcome struct {
+	Process    string `json:"process"`
+	Status     string `json:"status"`
+	ExitCode   int    `json:"exit_code"`
+	OOMKilled  bool   `json:"oom_killed"`
+	FinishedAt string `json:"finished_at,omitempty"`
 }
 
 type containerHealth struct {
@@ -102,6 +119,7 @@ func publishAndLog(ctx context.Context, cli containerStatusClient) {
 }
 
 func publishContainerStatus(ctx context.Context, cli containerStatusClient, configPath, outputPath string) error {
+	previous, persistedValid := loadPreviousStatuses(outputPath)
 	declared, err := loadDeclaredContainers(configPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -110,7 +128,7 @@ func publishContainerStatus(ctx context.Context, cli containerStatusClient, conf
 		return fmt.Errorf("loading declared containers: %w", err)
 	}
 
-	states, inspectErr := inspectDeclaredContainers(ctx, cli, declared)
+	states, inspectErr := inspectDeclaredContainersWithPrevious(ctx, cli, declared, previous, persistedValid)
 	resp := containersResponse{
 		ObservedAt: time.Now().UTC(),
 		Containers: states,
@@ -143,6 +161,10 @@ func loadDeclaredContainers(path string) ([]declaredContainer, error) {
 }
 
 func inspectDeclaredContainers(ctx context.Context, cli containerStatusClient, declared []declaredContainer) ([]containerStatus, error) {
+	return inspectDeclaredContainersWithPrevious(ctx, cli, declared, nil, true)
+}
+
+func inspectDeclaredContainersWithPrevious(ctx context.Context, cli containerStatusClient, declared []declaredContainer, previous map[string]containerStatus, persistedValid bool) ([]containerStatus, error) {
 	states := make([]containerStatus, 0, len(declared))
 	for _, c := range declared {
 		if c.Name == "" {
@@ -163,7 +185,10 @@ func inspectDeclaredContainers(ctx context.Context, cli containerStatusClient, d
 			}
 			return states, fmt.Errorf("inspecting %s: %w", c.Name, err)
 		}
-		states = append(states, containerStatusFromInspect(c, inspect))
+		status := containerStatusFromInspect(c, inspect)
+		prior, found := previous[c.Name]
+		applyLifecycle(&status, inspect, prior, found, persistedValid)
+		states = append(states, status)
 	}
 	return states, nil
 }
@@ -183,6 +208,7 @@ func containerStatusFromInspect(declared declaredContainer, inspect container.In
 	if inspect.ContainerJSONBase == nil {
 		return status
 	}
+	status.ContainerID = inspect.ID
 
 	if inspect.Name != "" {
 		status.Name = strings.TrimPrefix(inspect.Name, "/")
@@ -193,7 +219,7 @@ func containerStatusFromInspect(declared declaredContainer, inspect container.In
 			status.RestartPolicy = fmt.Sprintf("%s:%d", status.RestartPolicy, inspect.HostConfig.RestartPolicy.MaximumRetryCount)
 		}
 	}
-	status.RestartCount = inspect.RestartCount
+	status.RestartCount, status.RestartCountTruncated, _ = boundedRestartCount(inspect.RestartCount)
 	if inspect.State == nil {
 		return status
 	}
@@ -207,6 +233,160 @@ func containerStatusFromInspect(declared declaredContainer, inspect container.In
 	status.Health = containerHealthFromDocker(inspect.State.Health)
 
 	return status
+}
+
+func applyLifecycle(status *containerStatus, inspect container.InspectResponse, prior containerStatus, found, persistedValid bool) {
+	restartCount, truncated, countValid := boundedRestartCount(inspect.RestartCount)
+	status.RestartCount = restartCount
+	status.RestartCountTruncated = truncated
+	status.Process = processForRestartCount(restartCount)
+	status.LifecycleComplete = persistedValid && countValid && !truncated && inspect.RestartCount == 0 && validContainerID(status.ContainerID)
+
+	if found && prior.Created && (!validPriorStatus(prior) || prior.ContainerID != status.ContainerID) {
+		status.LifecycleComplete = false
+	} else if found && prior.Created {
+		if prior.Process == processReplacement {
+			status.Process = processReplacement
+		}
+		sameStart := prior.StartedAt == status.StartedAt
+		if prior.StartedAt != "" && status.StartedAt != "" && !sameStart {
+			status.Process = processReplacement
+		}
+		initialStart := prior.StartedAt == "" && status.StartedAt != "" && prior.Status == string(container.StateCreated)
+		priorTerminal := terminalStatus(prior.Status) && prior.LatestOutcome != nil
+		transitionProven := false
+		switch {
+		case truncated || prior.RestartCountTruncated:
+		case restartCount == prior.RestartCount && (sameStart || initialStart):
+			transitionProven = true
+		case restartCount == prior.RestartCount && priorTerminal:
+			status.Process = processReplacement
+			transitionProven = true
+		case restartCount == prior.RestartCount+1 && terminalStatus(status.Status):
+			status.Process = processReplacement
+			transitionProven = true
+		case restartCount < prior.RestartCount && priorTerminal && !sameStart:
+			status.Process = processReplacement
+			transitionProven = true
+		}
+		status.LifecycleComplete = persistedValid && countValid && prior.LifecycleComplete && transitionProven
+		if transitionProven {
+			status.LatestOutcome = cloneOutcome(prior.LatestOutcome)
+		}
+	}
+
+	outcomeProcess := status.Process
+	priorReplacement := found && prior.Created && validPriorStatus(prior) && prior.ContainerID == status.ContainerID && prior.Process == processReplacement
+	if inspect.State != nil && inspect.State.Status == container.StateRestarting && inspect.RestartCount == 1 && !priorReplacement {
+		outcomeProcess = processOriginal
+	}
+	if outcome := outcomeFromInspect(inspect.State, outcomeProcess); outcome != nil {
+		status.LatestOutcome = outcome
+	}
+}
+
+func loadPreviousStatuses(path string) (map[string]containerStatus, bool) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, true
+	}
+	if err != nil {
+		return nil, false
+	}
+	var response containersResponse
+	if json.Unmarshal(data, &response) != nil || response.ObservedAt.IsZero() {
+		return nil, false
+	}
+	previous := make(map[string]containerStatus, len(response.Containers))
+	for _, status := range response.Containers {
+		if status.Name == "" {
+			return nil, false
+		}
+		if !status.Created && (status.ContainerID != "" || status.Process != "" || status.LifecycleComplete || status.LatestOutcome != nil) {
+			return nil, false
+		}
+		if status.Created && !validPriorStatus(status) {
+			return nil, false
+		}
+		if _, exists := previous[status.Name]; exists {
+			return nil, false
+		}
+		previous[status.Name] = status
+	}
+	return previous, true
+}
+
+func validPriorStatus(status containerStatus) bool {
+	if !validContainerID(status.ContainerID) || status.RestartCount < 0 || status.RestartCount > maxReportedRestartCount {
+		return false
+	}
+	if status.Process != processOriginal && status.Process != processReplacement {
+		return false
+	}
+	if status.RestartCount > 0 && status.Process != processReplacement {
+		return false
+	}
+	if status.StartedAt != "" {
+		if _, err := time.Parse(time.RFC3339Nano, status.StartedAt); err != nil {
+			return false
+		}
+	}
+	if status.LatestOutcome == nil {
+		return true
+	}
+	outcome := status.LatestOutcome
+	return terminalStatus(outcome.Status) && outcome.ExitCode >= 0 && outcome.ExitCode <= 255 &&
+		(outcome.Process == processOriginal || outcome.Process == processReplacement)
+}
+
+func validContainerID(containerID string) bool {
+	if len(containerID) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(containerID)
+	return err == nil
+}
+
+func outcomeFromInspect(state *container.State, process string) *processOutcome {
+	if state == nil || !terminalStatus(string(state.Status)) || state.ExitCode < 0 || state.ExitCode > 255 {
+		return nil
+	}
+	return &processOutcome{
+		Process:    process,
+		Status:     string(state.Status),
+		ExitCode:   state.ExitCode,
+		OOMKilled:  state.OOMKilled,
+		FinishedAt: state.FinishedAt,
+	}
+}
+
+func terminalStatus(status string) bool {
+	return status == string(container.StateExited) || status == string(container.StateDead) || status == string(container.StateRestarting)
+}
+
+func processForRestartCount(restartCount int) string {
+	if restartCount == 0 {
+		return processOriginal
+	}
+	return processReplacement
+}
+
+func boundedRestartCount(restartCount int) (int, bool, bool) {
+	if restartCount < 0 {
+		return 0, false, false
+	}
+	if restartCount > maxReportedRestartCount {
+		return maxReportedRestartCount, true, true
+	}
+	return restartCount, false, true
+}
+
+func cloneOutcome(outcome *processOutcome) *processOutcome {
+	if outcome == nil {
+		return nil
+	}
+	copy := *outcome
+	return &copy
 }
 
 func containerHealthFromDocker(health *container.Health) *containerHealth {

--- a/tinfoil/cmd/container-status/main.go
+++ b/tinfoil/cmd/container-status/main.go
@@ -14,9 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containerd/errdefs"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
 	"gopkg.in/yaml.v3"
 
 	"tinfoil/internal/boot"
@@ -40,7 +37,7 @@ type declaredConfig struct {
 }
 
 type containerStatusClient interface {
-	ContainerInspect(context.Context, string) (container.InspectResponse, error)
+	ContainerInspect(context.Context, string) (containerInspect, error)
 }
 
 type containersResponse struct {
@@ -91,11 +88,8 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		log.Fatalf("creating docker client: %v", err)
-	}
-	defer cli.Close()
+	cli := newDockerInspectClient(dockerSocketPath)
+	defer cli.CloseIdleConnections()
 
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
@@ -172,7 +166,7 @@ func inspectDeclaredContainersWithPrevious(ctx context.Context, cli containerSta
 		}
 		inspect, err := cli.ContainerInspect(ctx, c.Name)
 		if err != nil {
-			if errdefs.IsNotFound(err) {
+			if errors.Is(err, errContainerNotFound) {
 				states = append(states, containerStatus{
 					Name:          c.Name,
 					Image:         c.Image,
@@ -193,7 +187,7 @@ func inspectDeclaredContainersWithPrevious(ctx context.Context, cli containerSta
 	return states, nil
 }
 
-func containerStatusFromInspect(declared declaredContainer, inspect container.InspectResponse) containerStatus {
+func containerStatusFromInspect(declared declaredContainer, inspect containerInspect) containerStatus {
 	status := containerStatus{
 		Name:          declared.Name,
 		Image:         declared.Image,
@@ -205,42 +199,46 @@ func containerStatusFromInspect(declared declaredContainer, inspect container.In
 	if inspect.Config != nil && inspect.Config.Image != "" {
 		status.Image = inspect.Config.Image
 	}
-	if inspect.ContainerJSONBase == nil {
+	if inspect.Base == nil {
 		return status
 	}
-	status.ContainerID = inspect.ID
+	status.ContainerID = inspect.Base.ID
 
-	if inspect.Name != "" {
-		status.Name = strings.TrimPrefix(inspect.Name, "/")
+	if inspect.Base.Name != "" {
+		status.Name = strings.TrimPrefix(inspect.Base.Name, "/")
 	}
-	if inspect.HostConfig != nil && inspect.HostConfig.RestartPolicy.Name != "" {
-		status.RestartPolicy = string(inspect.HostConfig.RestartPolicy.Name)
-		if inspect.HostConfig.RestartPolicy.MaximumRetryCount > 0 {
-			status.RestartPolicy = fmt.Sprintf("%s:%d", status.RestartPolicy, inspect.HostConfig.RestartPolicy.MaximumRetryCount)
+	if inspect.Base.HostConfig != nil && inspect.Base.HostConfig.RestartPolicy.Name != "" {
+		status.RestartPolicy = inspect.Base.HostConfig.RestartPolicy.Name
+		if inspect.Base.HostConfig.RestartPolicy.MaximumRetryCount > 0 {
+			status.RestartPolicy = fmt.Sprintf("%s:%d", status.RestartPolicy, inspect.Base.HostConfig.RestartPolicy.MaximumRetryCount)
 		}
 	}
-	status.RestartCount, status.RestartCountTruncated, _ = boundedRestartCount(inspect.RestartCount)
-	if inspect.State == nil {
+	status.RestartCount, status.RestartCountTruncated, _ = boundedRestartCount(inspect.Base.RestartCount)
+	if inspect.Base.State == nil {
 		return status
 	}
 
-	status.Status = string(inspect.State.Status)
-	status.OOMKilled = inspect.State.OOMKilled
-	status.ExitCode = inspect.State.ExitCode
-	status.Error = inspect.State.Error
-	status.StartedAt = inspect.State.StartedAt
-	status.FinishedAt = inspect.State.FinishedAt
-	status.Health = containerHealthFromDocker(inspect.State.Health)
+	status.Status = inspect.Base.State.Status
+	status.OOMKilled = inspect.Base.State.OOMKilled
+	status.ExitCode = inspect.Base.State.ExitCode
+	status.Error = inspect.Base.State.Error
+	status.StartedAt = inspect.Base.State.StartedAt
+	status.FinishedAt = inspect.Base.State.FinishedAt
+	status.Health = containerHealthFromDocker(inspect.Base.State.Health)
 
 	return status
 }
 
-func applyLifecycle(status *containerStatus, inspect container.InspectResponse, prior containerStatus, found, persistedValid bool) {
-	restartCount, truncated, countValid := boundedRestartCount(inspect.RestartCount)
+func applyLifecycle(status *containerStatus, inspect containerInspect, prior containerStatus, found, persistedValid bool) {
+	if inspect.Base == nil {
+		status.LifecycleComplete = false
+		return
+	}
+	restartCount, truncated, countValid := boundedRestartCount(inspect.Base.RestartCount)
 	status.RestartCount = restartCount
 	status.RestartCountTruncated = truncated
 	status.Process = processForRestartCount(restartCount)
-	status.LifecycleComplete = persistedValid && countValid && !truncated && inspect.RestartCount == 0 && validContainerID(status.ContainerID)
+	status.LifecycleComplete = persistedValid && countValid && !truncated && inspect.Base.RestartCount == 0 && validContainerID(status.ContainerID)
 
 	if found && prior.Created && (!validPriorStatus(prior) || prior.ContainerID != status.ContainerID) {
 		status.LifecycleComplete = false
@@ -252,7 +250,7 @@ func applyLifecycle(status *containerStatus, inspect container.InspectResponse, 
 		if prior.StartedAt != "" && status.StartedAt != "" && !sameStart {
 			status.Process = processReplacement
 		}
-		initialStart := prior.StartedAt == "" && status.StartedAt != "" && prior.Status == string(container.StateCreated)
+		initialStart := prior.StartedAt == "" && status.StartedAt != "" && prior.Status == containerStateCreated
 		priorTerminal := terminalStatus(prior.Status) && prior.LatestOutcome != nil
 		transitionProven := false
 		switch {
@@ -277,10 +275,10 @@ func applyLifecycle(status *containerStatus, inspect container.InspectResponse, 
 
 	outcomeProcess := status.Process
 	priorReplacement := found && prior.Created && validPriorStatus(prior) && prior.ContainerID == status.ContainerID && prior.Process == processReplacement
-	if inspect.State != nil && inspect.State.Status == container.StateRestarting && inspect.RestartCount == 1 && !priorReplacement {
+	if inspect.Base.State != nil && inspect.Base.State.Status == containerStateRestarting && inspect.Base.RestartCount == 1 && !priorReplacement {
 		outcomeProcess = processOriginal
 	}
-	if outcome := outcomeFromInspect(inspect.State, outcomeProcess); outcome != nil {
+	if outcome := outcomeFromInspect(inspect.Base.State, outcomeProcess); outcome != nil {
 		status.LatestOutcome = outcome
 	}
 }
@@ -347,13 +345,13 @@ func validContainerID(containerID string) bool {
 	return err == nil
 }
 
-func outcomeFromInspect(state *container.State, process string) *processOutcome {
-	if state == nil || !terminalStatus(string(state.Status)) || state.ExitCode < 0 || state.ExitCode > 255 {
+func outcomeFromInspect(state *containerState, process string) *processOutcome {
+	if state == nil || !terminalStatus(state.Status) || state.ExitCode < 0 || state.ExitCode > 255 {
 		return nil
 	}
 	return &processOutcome{
 		Process:    process,
-		Status:     string(state.Status),
+		Status:     state.Status,
 		ExitCode:   state.ExitCode,
 		OOMKilled:  state.OOMKilled,
 		FinishedAt: state.FinishedAt,
@@ -361,7 +359,7 @@ func outcomeFromInspect(state *container.State, process string) *processOutcome 
 }
 
 func terminalStatus(status string) bool {
-	return status == string(container.StateExited) || status == string(container.StateDead) || status == string(container.StateRestarting)
+	return status == containerStateExited || status == containerStateDead || status == containerStateRestarting
 }
 
 func processForRestartCount(restartCount int) string {
@@ -389,12 +387,12 @@ func cloneOutcome(outcome *processOutcome) *processOutcome {
 	return &copy
 }
 
-func containerHealthFromDocker(health *container.Health) *containerHealth {
+func containerHealthFromDocker(health *containerHealthState) *containerHealth {
 	if health == nil {
 		return nil
 	}
 	out := &containerHealth{
-		Status:        string(health.Status),
+		Status:        health.Status,
 		FailingStreak: health.FailingStreak,
 	}
 	if len(health.Log) == 0 {

--- a/tinfoil/cmd/container-status/main.go
+++ b/tinfoil/cmd/container-status/main.go
@@ -230,7 +230,7 @@ func containerStatusFromInspect(declared declaredContainer, inspect containerIns
 }
 
 func applyLifecycle(status *containerStatus, inspect containerInspect, prior containerStatus, found, persistedValid bool) {
-	if inspect.Base == nil {
+	if inspect.Base == nil || inspect.Base.State == nil {
 		status.LifecycleComplete = false
 		return
 	}
@@ -240,7 +240,7 @@ func applyLifecycle(status *containerStatus, inspect containerInspect, prior con
 	status.Process = processForRestartCount(restartCount)
 	status.LifecycleComplete = persistedValid && countValid && !truncated && inspect.Base.RestartCount == 0 && validContainerID(status.ContainerID)
 
-	if found && prior.Created && (!validPriorStatus(prior) || prior.ContainerID != status.ContainerID) {
+	if found && (!prior.Created || !validPriorStatus(prior) || prior.ContainerID != status.ContainerID) {
 		status.LifecycleComplete = false
 	} else if found && prior.Created {
 		if prior.Process == processReplacement {
@@ -261,9 +261,6 @@ func applyLifecycle(status *containerStatus, inspect containerInspect, prior con
 			status.Process = processReplacement
 			transitionProven = true
 		case restartCount == prior.RestartCount+1 && terminalStatus(status.Status):
-			status.Process = processReplacement
-			transitionProven = true
-		case restartCount < prior.RestartCount && priorTerminal && !sameStart:
 			status.Process = processReplacement
 			transitionProven = true
 		}
@@ -292,7 +289,7 @@ func loadPreviousStatuses(path string) (map[string]containerStatus, bool) {
 		return nil, false
 	}
 	var response containersResponse
-	if json.Unmarshal(data, &response) != nil || response.ObservedAt.IsZero() {
+	if json.Unmarshal(data, &response) != nil || response.ObservedAt.IsZero() || response.Unavailable != "" {
 		return nil, false
 	}
 	previous := make(map[string]containerStatus, len(response.Containers))
@@ -316,6 +313,9 @@ func loadPreviousStatuses(path string) (map[string]containerStatus, bool) {
 
 func validPriorStatus(status containerStatus) bool {
 	if !validContainerID(status.ContainerID) || status.RestartCount < 0 || status.RestartCount > maxReportedRestartCount {
+		return false
+	}
+	if !validDockerStateStatus(status.Status) {
 		return false
 	}
 	if status.Process != processOriginal && status.Process != processReplacement {

--- a/tinfoil/cmd/container-status/main_test.go
+++ b/tinfoil/cmd/container-status/main_test.go
@@ -159,6 +159,57 @@ func TestContainerStatusFromInspect_UnhealthyHealthcheck(t *testing.T) {
 	}
 }
 
+func TestLifecycleFreshBaselineAndInvalidPersistence(t *testing.T) {
+	inspect := containerInspect{
+		Base: &containerInspectBase{
+			ID: strings.Repeat("0", 64),
+			State: &containerState{
+				Status:    containerStateRunning,
+				StartedAt: "2026-07-24T00:30:00Z",
+			},
+		},
+	}
+
+	fresh := lifecycleStatus(inspect, containerStatus{}, false, true)
+	if !fresh.LifecycleComplete || fresh.Process != processOriginal {
+		t.Fatalf("fresh lifecycle baseline = %#v", fresh)
+	}
+
+	invalid := lifecycleStatus(inspect, containerStatus{}, false, false)
+	if invalid.LifecycleComplete {
+		t.Fatalf("invalid persisted lifecycle = %#v", invalid)
+	}
+}
+
+func TestLifecycleMissingStateFailsClosed(t *testing.T) {
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{ID: strings.Repeat("1", 64)},
+	}, containerStatus{}, false, true)
+
+	if got.LifecycleComplete || got.Process != "" {
+		t.Fatalf("missing state lifecycle = %#v", got)
+	}
+}
+
+func TestLifecycleDisappearanceCannotResetContinuity(t *testing.T) {
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
+			ID: strings.Repeat("2", 64),
+			State: &containerState{
+				Status:    containerStateRunning,
+				StartedAt: "2026-07-24T00:45:00Z",
+			},
+		},
+	}, containerStatus{
+		Name:    "model",
+		Created: false,
+	}, true, true)
+
+	if got.LifecycleComplete {
+		t.Fatalf("recreated lifecycle = %#v", got)
+	}
+}
+
 func TestLifecycleManualRestartBetweenInspectsFailsClosed(t *testing.T) {
 	prior := containerStatus{
 		Name:              "model",
@@ -317,7 +368,40 @@ func TestLifecycleMissedCrashLoopFailsClosed(t *testing.T) {
 	}
 }
 
-func TestLifecycleIdentityChangeAndTruncationFailClosed(t *testing.T) {
+func TestLifecycleRestartCountDecreaseFailsClosed(t *testing.T) {
+	prior := containerStatus{
+		Name:              "model",
+		Created:           true,
+		ContainerID:       strings.Repeat("8", 64),
+		Process:           processReplacement,
+		LifecycleComplete: true,
+		Status:            containerStateExited,
+		RestartCount:      2,
+		StartedAt:         "2026-07-24T04:40:00Z",
+		LatestOutcome: &processOutcome{
+			Process:    processReplacement,
+			Status:     containerStateExited,
+			ExitCode:   1,
+			FinishedAt: "2026-07-24T04:41:00Z",
+		},
+	}
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
+			ID:           prior.ContainerID,
+			RestartCount: 1,
+			State: &containerState{
+				Status:    containerStateRunning,
+				StartedAt: "2026-07-24T04:42:00Z",
+			},
+		},
+	}, prior, true, true)
+
+	if got.LifecycleComplete || got.RestartCount != 1 {
+		t.Fatalf("decreased restart count lifecycle = %#v", got)
+	}
+}
+
+func TestLifecycleIdentityChangeFailsClosed(t *testing.T) {
 	prior := containerStatus{
 		Name:              "model",
 		Created:           true,
@@ -329,14 +413,38 @@ func TestLifecycleIdentityChangeAndTruncationFailClosed(t *testing.T) {
 	}
 	got := lifecycleStatus(containerInspect{
 		Base: &containerInspectBase{
-			ID:           strings.Repeat("f", 64),
+			ID:    strings.Repeat("f", 64),
+			State: &containerState{Status: containerStateRunning, StartedAt: "2026-07-24T05:01:00Z"},
+		},
+	}, prior, true, true)
+
+	if got.LifecycleComplete || got.RestartCountTruncated || got.RestartCount != 0 {
+		t.Fatalf("identity change lifecycle = %#v", got)
+	}
+}
+
+func TestLifecycleRestartCountTruncationFailsClosed(t *testing.T) {
+	containerID := strings.Repeat("6", 64)
+	prior := containerStatus{
+		Name:              "model",
+		Created:           true,
+		ContainerID:       containerID,
+		Process:           processReplacement,
+		LifecycleComplete: true,
+		Status:            containerStateRunning,
+		RestartCount:      maxReportedRestartCount,
+		StartedAt:         "2026-07-24T05:10:00Z",
+	}
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
+			ID:           containerID,
 			RestartCount: maxReportedRestartCount + 1,
-			State:        &containerState{Status: "running", StartedAt: "2026-07-24T05:01:00Z"},
+			State:        &containerState{Status: containerStateRunning, StartedAt: prior.StartedAt},
 		},
 	}, prior, true, true)
 
 	if got.LifecycleComplete || !got.RestartCountTruncated || got.RestartCount != maxReportedRestartCount {
-		t.Fatalf("identity/truncation lifecycle = %#v", got)
+		t.Fatalf("restart count truncation lifecycle = %#v", got)
 	}
 }
 
@@ -356,6 +464,40 @@ func TestLoadPreviousStatusesRejectsMalformedIdentity(t *testing.T) {
 	}
 	if previous, valid := loadPreviousStatuses(path); valid || previous != nil {
 		t.Fatalf("malformed previous status accepted: valid=%v previous=%#v", valid, previous)
+	}
+}
+
+func TestLoadPreviousStatusesRejectsInvalidState(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "container-status.json")
+	if err := os.WriteFile(path, []byte(`{
+  "observed_at": "2026-07-24T06:02:00Z",
+  "containers": [{
+    "name": "model",
+    "created": true,
+    "container_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "process": "original",
+    "status": "unknown",
+    "restart_count": 0
+  }]
+}`), 0o644); err != nil {
+		t.Fatalf("writing previous status: %v", err)
+	}
+	if previous, valid := loadPreviousStatuses(path); valid || previous != nil {
+		t.Fatalf("invalid state accepted: valid=%v previous=%#v", valid, previous)
+	}
+}
+
+func TestLoadPreviousStatusesRejectsUnavailableObservation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "container-status.json")
+	if err := os.WriteFile(path, []byte(`{
+  "observed_at": "2026-07-24T06:05:00Z",
+  "containers": [],
+  "unavailable": "inspecting model: temporary failure"
+}`), 0o644); err != nil {
+		t.Fatalf("writing previous status: %v", err)
+	}
+	if previous, valid := loadPreviousStatuses(path); valid || previous != nil {
+		t.Fatalf("unavailable previous status accepted: valid=%v previous=%#v", valid, previous)
 	}
 }
 

--- a/tinfoil/cmd/container-status/main_test.go
+++ b/tinfoil/cmd/container-status/main_test.go
@@ -19,6 +19,12 @@ type fakeContainerClient struct {
 	errs    map[string]error
 }
 
+func lifecycleStatus(inspect container.InspectResponse, prior containerStatus, found, persistedValid bool) containerStatus {
+	status := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, inspect)
+	applyLifecycle(&status, inspect, prior, found, persistedValid)
+	return status
+}
+
 func (f fakeContainerClient) ContainerInspect(_ context.Context, name string) (container.InspectResponse, error) {
 	if err := f.errs[name]; err != nil {
 		return container.InspectResponse{}, err
@@ -158,6 +164,210 @@ func TestContainerStatusFromInspect_UnhealthyHealthcheck(t *testing.T) {
 	}
 }
 
+func TestLifecycleManualRestartBetweenInspectsFailsClosed(t *testing.T) {
+	prior := containerStatus{
+		Name:              "model",
+		Created:           true,
+		ContainerID:       strings.Repeat("a", 64),
+		Process:           processOriginal,
+		LifecycleComplete: true,
+		Status:            string(container.StateRunning),
+		StartedAt:         "2026-07-24T01:00:00Z",
+	}
+	got := lifecycleStatus(container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:           prior.ContainerID,
+			RestartCount: 1,
+			State: &container.State{
+				Status:    container.StateRunning,
+				Running:   true,
+				StartedAt: "2026-07-24T01:01:00Z",
+			},
+		},
+	}, prior, true, true)
+
+	if got.Process != processReplacement || got.RestartCount != 1 || got.LifecycleComplete {
+		t.Fatalf("manual restart lifecycle = %#v", got)
+	}
+	if got.LatestOutcome != nil {
+		t.Fatalf("missed manual restart reported outcome %#v", got.LatestOutcome)
+	}
+}
+
+func TestLifecycleMissedSameCountTransitionFailsClosed(t *testing.T) {
+	prior := containerStatus{
+		Name:              "model",
+		Created:           true,
+		ContainerID:       strings.Repeat("b", 64),
+		Process:           processOriginal,
+		LifecycleComplete: true,
+		Status:            string(container.StateRunning),
+		StartedAt:         "2026-07-24T02:00:00Z",
+	}
+	got := lifecycleStatus(container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID: prior.ContainerID,
+			State: &container.State{
+				Status:    container.StateRunning,
+				Running:   true,
+				StartedAt: "2026-07-24T02:01:00Z",
+			},
+		},
+	}, prior, true, true)
+
+	if got.Process != processReplacement || got.RestartCount != 0 || got.LifecycleComplete {
+		t.Fatalf("missed same-count transition = %#v", got)
+	}
+}
+
+func TestLifecycleObservedCleanStopThenStartRemainsComplete(t *testing.T) {
+	containerID := strings.Repeat("c", 64)
+	running := containerStatus{
+		Name:              "model",
+		Created:           true,
+		ContainerID:       containerID,
+		Process:           processOriginal,
+		LifecycleComplete: true,
+		Status:            string(container.StateRunning),
+		StartedAt:         "2026-07-24T03:00:00Z",
+	}
+	stopped := lifecycleStatus(container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID: containerID,
+			State: &container.State{
+				Status:     container.StateExited,
+				ExitCode:   0,
+				StartedAt:  running.StartedAt,
+				FinishedAt: "2026-07-24T03:01:00Z",
+			},
+		},
+	}, running, true, true)
+	if !stopped.LifecycleComplete || stopped.LatestOutcome == nil || stopped.LatestOutcome.Process != processOriginal {
+		t.Fatalf("observed clean stop = %#v", stopped)
+	}
+
+	restarted := lifecycleStatus(container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID: containerID,
+			State: &container.State{
+				Status:    container.StateRunning,
+				Running:   true,
+				StartedAt: "2026-07-24T03:02:00Z",
+			},
+		},
+	}, stopped, true, true)
+	if restarted.Process != processReplacement || restarted.RestartCount != 0 || !restarted.LifecycleComplete {
+		t.Fatalf("observed clean start = %#v", restarted)
+	}
+	if restarted.LatestOutcome == nil || restarted.LatestOutcome.ExitCode != 0 {
+		t.Fatalf("clean start lost latest outcome: %#v", restarted.LatestOutcome)
+	}
+}
+
+func TestLifecycleRestartingInspectCapturesLatestOutcome(t *testing.T) {
+	prior := containerStatus{
+		Name:              "model",
+		Created:           true,
+		ContainerID:       strings.Repeat("d", 64),
+		Process:           processOriginal,
+		LifecycleComplete: true,
+		Status:            string(container.StateRunning),
+		StartedAt:         "2026-07-24T04:00:00Z",
+	}
+	got := lifecycleStatus(container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:           prior.ContainerID,
+			RestartCount: 1,
+			State: &container.State{
+				Status:     container.StateRestarting,
+				Restarting: true,
+				ExitCode:   9,
+				StartedAt:  prior.StartedAt,
+				FinishedAt: "2026-07-24T04:01:00Z",
+			},
+		},
+	}, prior, true, true)
+
+	if got.Process != processReplacement || !got.LifecycleComplete || got.LatestOutcome == nil {
+		t.Fatalf("restarting lifecycle = %#v", got)
+	}
+	if got.LatestOutcome.Process != processOriginal || got.LatestOutcome.ExitCode != 9 {
+		t.Fatalf("restarting outcome = %#v", got.LatestOutcome)
+	}
+}
+
+func TestLifecycleMissedCrashLoopFailsClosed(t *testing.T) {
+	prior := containerStatus{
+		Name:              "model",
+		Created:           true,
+		ContainerID:       strings.Repeat("7", 64),
+		Process:           processReplacement,
+		LifecycleComplete: true,
+		Status:            string(container.StateRestarting),
+		RestartCount:      1,
+		StartedAt:         "2026-07-24T04:30:00Z",
+		LatestOutcome: &processOutcome{
+			Process:    processOriginal,
+			Status:     string(container.StateRestarting),
+			ExitCode:   1,
+			FinishedAt: "2026-07-24T04:31:00Z",
+		},
+	}
+	got := lifecycleStatus(container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:           prior.ContainerID,
+			RestartCount: 2,
+			State:        &container.State{Status: container.StateRunning, Running: true, StartedAt: "2026-07-24T04:32:00Z"},
+		},
+	}, prior, true, true)
+
+	if got.LifecycleComplete || got.LatestOutcome != nil || got.RestartCount != 2 {
+		t.Fatalf("missed crash loop = %#v", got)
+	}
+}
+
+func TestLifecycleIdentityChangeAndTruncationFailClosed(t *testing.T) {
+	prior := containerStatus{
+		Name:              "model",
+		Created:           true,
+		ContainerID:       strings.Repeat("e", 64),
+		Process:           processOriginal,
+		LifecycleComplete: true,
+		Status:            string(container.StateRunning),
+		StartedAt:         "2026-07-24T05:00:00Z",
+	}
+	got := lifecycleStatus(container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:           strings.Repeat("f", 64),
+			RestartCount: maxReportedRestartCount + 1,
+			State:        &container.State{Status: container.StateRunning, Running: true, StartedAt: "2026-07-24T05:01:00Z"},
+		},
+	}, prior, true, true)
+
+	if got.LifecycleComplete || !got.RestartCountTruncated || got.RestartCount != maxReportedRestartCount {
+		t.Fatalf("identity/truncation lifecycle = %#v", got)
+	}
+}
+
+func TestLoadPreviousStatusesRejectsMalformedIdentity(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "container-status.json")
+	if err := os.WriteFile(path, []byte(`{
+  "observed_at": "2026-07-24T06:00:00Z",
+  "containers": [{
+    "name": "model",
+    "created": true,
+    "container_id": "invalid",
+    "process": "original",
+    "restart_count": 0
+  }]
+}`), 0o644); err != nil {
+		t.Fatalf("writing previous status: %v", err)
+	}
+	if previous, valid := loadPreviousStatuses(path); valid || previous != nil {
+		t.Fatalf("malformed previous status accepted: valid=%v previous=%#v", valid, previous)
+	}
+}
+
 func TestInspectDeclaredContainers_UnexpectedError(t *testing.T) {
 	boom := errors.New("docker unavailable")
 	states, err := inspectDeclaredContainers(context.Background(), fakeContainerClient{
@@ -187,8 +397,13 @@ func TestPublishContainerStatusWritesJSON(t *testing.T) {
 		inspect: map[string]container.InspectResponse{
 			"model": {
 				ContainerJSONBase: &container.ContainerJSONBase{
-					Name:  "/model",
-					State: &container.State{Status: "running", Running: true},
+					ID:   strings.Repeat("9", 64),
+					Name: "/model",
+					State: &container.State{
+						Status:    container.StateRunning,
+						Running:   true,
+						StartedAt: "2026-07-24T07:00:00Z",
+					},
 				},
 			},
 		},
@@ -207,6 +422,9 @@ func TestPublishContainerStatusWritesJSON(t *testing.T) {
 	}
 	if len(got.Containers) != 1 || got.Containers[0].Name != "model" || got.Containers[0].Status != "running" {
 		t.Fatalf("unexpected output: %#v", got)
+	}
+	if got.Containers[0].Process != processOriginal || !got.Containers[0].LifecycleComplete {
+		t.Fatalf("unexpected lifecycle output: %#v", got.Containers[0])
 	}
 	if got.ObservedAt.IsZero() {
 		t.Fatal("expected observed_at to be set")

--- a/tinfoil/cmd/container-status/main_test.go
+++ b/tinfoil/cmd/container-status/main_test.go
@@ -9,30 +9,27 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/containerd/errdefs"
-	"github.com/docker/docker/api/types/container"
 )
 
 type fakeContainerClient struct {
-	inspect map[string]container.InspectResponse
+	inspect map[string]containerInspect
 	errs    map[string]error
 }
 
-func lifecycleStatus(inspect container.InspectResponse, prior containerStatus, found, persistedValid bool) containerStatus {
+func lifecycleStatus(inspect containerInspect, prior containerStatus, found, persistedValid bool) containerStatus {
 	status := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, inspect)
 	applyLifecycle(&status, inspect, prior, found, persistedValid)
 	return status
 }
 
-func (f fakeContainerClient) ContainerInspect(_ context.Context, name string) (container.InspectResponse, error) {
+func (f fakeContainerClient) ContainerInspect(_ context.Context, name string) (containerInspect, error) {
 	if err := f.errs[name]; err != nil {
-		return container.InspectResponse{}, err
+		return containerInspect{}, err
 	}
 	if inspect, ok := f.inspect[name]; ok {
 		return inspect, nil
 	}
-	return container.InspectResponse{}, errdefs.ErrNotFound
+	return containerInspect{}, errContainerNotFound
 }
 
 func TestInspectDeclaredContainers_MissingContainer(t *testing.T) {
@@ -60,18 +57,17 @@ func TestInspectDeclaredContainers_MissingContainer(t *testing.T) {
 }
 
 func TestContainerStatusFromInspect_RunningContainer(t *testing.T) {
-	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "declared:latest", Restart: "unless-stopped"}, container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "declared:latest", Restart: "unless-stopped"}, containerInspect{
+		Base: &containerInspectBase{
 			Name:         "/model",
 			RestartCount: 2,
-			State: &container.State{
+			State: &containerState{
 				Status:    "running",
-				Running:   true,
 				StartedAt: "2026-01-02T03:04:05Z",
 			},
-			HostConfig: &container.HostConfig{RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped}},
+			HostConfig: &containerHostConfig{RestartPolicy: containerRestartPolicy{Name: "unless-stopped"}},
 		},
-		Config: &container.Config{Image: "actual:latest"},
+		Config: &containerConfig{Image: "actual:latest"},
 	})
 
 	if got.Name != "model" || got.Image != "actual:latest" {
@@ -89,17 +85,16 @@ func TestContainerStatusFromInspect_RunningContainer(t *testing.T) {
 }
 
 func TestContainerStatusFromInspect_RestartingContainer(t *testing.T) {
-	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, containerInspect{
+		Base: &containerInspectBase{
 			Name:         "/model",
 			RestartCount: 4,
-			State: &container.State{
-				Status:     "restarting",
-				Restarting: true,
-				ExitCode:   1,
-				Error:      "restart loop",
+			State: &containerState{
+				Status:   "restarting",
+				ExitCode: 1,
+				Error:    "restart loop",
 			},
-			HostConfig: &container.HostConfig{RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyOnFailure, MaximumRetryCount: 10}},
+			HostConfig: &containerHostConfig{RestartPolicy: containerRestartPolicy{Name: "on-failure", MaximumRetryCount: 10}},
 		},
 	})
 
@@ -115,9 +110,9 @@ func TestContainerStatusFromInspect_RestartingContainer(t *testing.T) {
 }
 
 func TestContainerStatusFromInspect_OOMKilledExitedContainer(t *testing.T) {
-	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
-			State: &container.State{
+	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, containerInspect{
+		Base: &containerInspectBase{
+			State: &containerState{
 				Status:     "exited",
 				OOMKilled:  true,
 				ExitCode:   137,
@@ -137,16 +132,16 @@ func TestContainerStatusFromInspect_OOMKilledExitedContainer(t *testing.T) {
 func TestContainerStatusFromInspect_UnhealthyHealthcheck(t *testing.T) {
 	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
 	end := start.Add(time.Second)
-	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
-			State: &container.State{
+	got := containerStatusFromInspect(declaredContainer{Name: "model", Image: "model:latest"}, containerInspect{
+		Base: &containerInspectBase{
+			State: &containerState{
 				Status: "running",
-				Health: &container.Health{
-					Status:        container.Unhealthy,
+				Health: &containerHealthState{
+					Status:        "unhealthy",
 					FailingStreak: 3,
-					Log: []*container.HealthcheckResult{
-						{Start: start.Add(-time.Minute), End: end.Add(-time.Minute), ExitCode: 0, Output: "old"},
-						{Start: start, End: end, ExitCode: 1, Output: "model still loading"},
+					Log: []*containerHealthResult{
+						{Start: start.Add(-time.Minute), End: end.Add(-time.Minute), ExitCode: 0},
+						{Start: start, End: end, ExitCode: 1},
 					},
 				},
 			},
@@ -156,7 +151,7 @@ func TestContainerStatusFromInspect_UnhealthyHealthcheck(t *testing.T) {
 	if got.Health == nil {
 		t.Fatal("expected health state")
 	}
-	if got.Health.Status != container.Unhealthy || got.Health.FailingStreak != 3 {
+	if got.Health.Status != "unhealthy" || got.Health.FailingStreak != 3 {
 		t.Fatalf("health status/streak = %q/%d", got.Health.Status, got.Health.FailingStreak)
 	}
 	if got.Health.LastCheckExitCode == nil || *got.Health.LastCheckExitCode != 1 {
@@ -171,16 +166,15 @@ func TestLifecycleManualRestartBetweenInspectsFailsClosed(t *testing.T) {
 		ContainerID:       strings.Repeat("a", 64),
 		Process:           processOriginal,
 		LifecycleComplete: true,
-		Status:            string(container.StateRunning),
+		Status:            "running",
 		StartedAt:         "2026-07-24T01:00:00Z",
 	}
-	got := lifecycleStatus(container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
 			ID:           prior.ContainerID,
 			RestartCount: 1,
-			State: &container.State{
-				Status:    container.StateRunning,
-				Running:   true,
+			State: &containerState{
+				Status:    "running",
 				StartedAt: "2026-07-24T01:01:00Z",
 			},
 		},
@@ -201,15 +195,14 @@ func TestLifecycleMissedSameCountTransitionFailsClosed(t *testing.T) {
 		ContainerID:       strings.Repeat("b", 64),
 		Process:           processOriginal,
 		LifecycleComplete: true,
-		Status:            string(container.StateRunning),
+		Status:            "running",
 		StartedAt:         "2026-07-24T02:00:00Z",
 	}
-	got := lifecycleStatus(container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
 			ID: prior.ContainerID,
-			State: &container.State{
-				Status:    container.StateRunning,
-				Running:   true,
+			State: &containerState{
+				Status:    "running",
 				StartedAt: "2026-07-24T02:01:00Z",
 			},
 		},
@@ -228,14 +221,14 @@ func TestLifecycleObservedCleanStopThenStartRemainsComplete(t *testing.T) {
 		ContainerID:       containerID,
 		Process:           processOriginal,
 		LifecycleComplete: true,
-		Status:            string(container.StateRunning),
+		Status:            "running",
 		StartedAt:         "2026-07-24T03:00:00Z",
 	}
-	stopped := lifecycleStatus(container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	stopped := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
 			ID: containerID,
-			State: &container.State{
-				Status:     container.StateExited,
+			State: &containerState{
+				Status:     "exited",
 				ExitCode:   0,
 				StartedAt:  running.StartedAt,
 				FinishedAt: "2026-07-24T03:01:00Z",
@@ -246,12 +239,11 @@ func TestLifecycleObservedCleanStopThenStartRemainsComplete(t *testing.T) {
 		t.Fatalf("observed clean stop = %#v", stopped)
 	}
 
-	restarted := lifecycleStatus(container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	restarted := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
 			ID: containerID,
-			State: &container.State{
-				Status:    container.StateRunning,
-				Running:   true,
+			State: &containerState{
+				Status:    "running",
 				StartedAt: "2026-07-24T03:02:00Z",
 			},
 		},
@@ -271,16 +263,15 @@ func TestLifecycleRestartingInspectCapturesLatestOutcome(t *testing.T) {
 		ContainerID:       strings.Repeat("d", 64),
 		Process:           processOriginal,
 		LifecycleComplete: true,
-		Status:            string(container.StateRunning),
+		Status:            "running",
 		StartedAt:         "2026-07-24T04:00:00Z",
 	}
-	got := lifecycleStatus(container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
 			ID:           prior.ContainerID,
 			RestartCount: 1,
-			State: &container.State{
-				Status:     container.StateRestarting,
-				Restarting: true,
+			State: &containerState{
+				Status:     "restarting",
 				ExitCode:   9,
 				StartedAt:  prior.StartedAt,
 				FinishedAt: "2026-07-24T04:01:00Z",
@@ -303,21 +294,21 @@ func TestLifecycleMissedCrashLoopFailsClosed(t *testing.T) {
 		ContainerID:       strings.Repeat("7", 64),
 		Process:           processReplacement,
 		LifecycleComplete: true,
-		Status:            string(container.StateRestarting),
+		Status:            "restarting",
 		RestartCount:      1,
 		StartedAt:         "2026-07-24T04:30:00Z",
 		LatestOutcome: &processOutcome{
 			Process:    processOriginal,
-			Status:     string(container.StateRestarting),
+			Status:     "restarting",
 			ExitCode:   1,
 			FinishedAt: "2026-07-24T04:31:00Z",
 		},
 	}
-	got := lifecycleStatus(container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
 			ID:           prior.ContainerID,
 			RestartCount: 2,
-			State:        &container.State{Status: container.StateRunning, Running: true, StartedAt: "2026-07-24T04:32:00Z"},
+			State:        &containerState{Status: "running", StartedAt: "2026-07-24T04:32:00Z"},
 		},
 	}, prior, true, true)
 
@@ -333,14 +324,14 @@ func TestLifecycleIdentityChangeAndTruncationFailClosed(t *testing.T) {
 		ContainerID:       strings.Repeat("e", 64),
 		Process:           processOriginal,
 		LifecycleComplete: true,
-		Status:            string(container.StateRunning),
+		Status:            "running",
 		StartedAt:         "2026-07-24T05:00:00Z",
 	}
-	got := lifecycleStatus(container.InspectResponse{
-		ContainerJSONBase: &container.ContainerJSONBase{
+	got := lifecycleStatus(containerInspect{
+		Base: &containerInspectBase{
 			ID:           strings.Repeat("f", 64),
 			RestartCount: maxReportedRestartCount + 1,
-			State:        &container.State{Status: container.StateRunning, Running: true, StartedAt: "2026-07-24T05:01:00Z"},
+			State:        &containerState{Status: "running", StartedAt: "2026-07-24T05:01:00Z"},
 		},
 	}, prior, true, true)
 
@@ -394,14 +385,13 @@ func TestPublishContainerStatusWritesJSON(t *testing.T) {
 	}
 
 	err := publishContainerStatus(context.Background(), fakeContainerClient{
-		inspect: map[string]container.InspectResponse{
+		inspect: map[string]containerInspect{
 			"model": {
-				ContainerJSONBase: &container.ContainerJSONBase{
+				Base: &containerInspectBase{
 					ID:   strings.Repeat("9", 64),
 					Name: "/model",
-					State: &container.State{
-						Status:    container.StateRunning,
-						Running:   true,
+					State: &containerState{
+						Status:    "running",
 						StartedAt: "2026-07-24T07:00:00Z",
 					},
 				},


### PR DESCRIPTION
## Summary

- report measured container lifecycle across the existing five-second status publisher without adding event subscriptions or wait goroutines
- persist fixed container identity, bounded restart count, original/replacement process identity, latest observed terminal outcome, and fail-closed lifecycle continuity
- replace the generic Docker SDK/API negotiation path with a fixed Docker API v1.44 inspect client over `/var/run/docker.sock`
- bound requests to 3 seconds, headers to 16 KiB, bodies to 1 MiB, and container references to 255 bytes; reject redirects, unexpected statuses/content types, and malformed responses

## Qualification

Exact-artifact Box3 qualification was completed on July 24, 2026 with debug integration `954062e`, containing restart-aware integration commit `d98cf01` and the fixed inspect client. The qualified artifacts were:

- raw image SHA-256 `de3c597601b87f872ce31a98b49b59b71062177bf9b4d49b8ca19a316b8fdf5d`
- dm-verity root `811abf319c8384e33345c2d498290948e3c8bbbaad7ff99888f8d4e0abea6a96`
- kernel SHA-256 `d105caa6c6e78ce8f67e67f5f4f06658d09e87fa2d55860160e97178a4dd482f`
- initrd SHA-256 `747d7cfab8fa87279233f5fb18da321338db3b0dd2f760c42e97b7809808cc99`

The CVM reached ready through CPU attestation, fixed networking, firewall, container pull/start/health, and shim stages. Status publication reported fixed 64-byte container IDs, process identity, bounded restart counts, lifecycle continuity, and latest terminal outcomes. A deliberate restart loop reached count 5 and failed `lifecycle_complete` closed when intermediate transitions could not be proven. Both deployments were removed without deployment, run-directory, or QEMU residue; Box3's original control binaries were restored byte-for-byte and the daemon remained active with an empty deployment list.

## Validation

- `gofmt` on all changed Go files
- `go build ./...`
- `go test ./...`
- `go test -race -count=25 ./cmd/container-status`
- `go vet ./...`
- `make test-go-producer`
- `bazel test --lockfile_mode=error //image:container-runtime-rootfs-contract-test`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Report container lifecycle in the 5-second status publisher and switch to a fixed Docker Inspect client over `/var/run/docker.sock`. Adds restart-aware process identity, strict I/O limits, and fail-closed lifecycle continuity when transitions can’t be proven.

- **New Features**
  - Publish `container_id` (64-hex), `process` (`original`/`replacement`), bounded `restart_count` (0–255) with `restart_count_truncated`, `latest_outcome` (status, exit_code, OOM), and `lifecycle_complete` that fails closed on identity changes, restart-count truncation, disappearance, or unproven transitions.
  - Use previous JSON output to prove continuity (identity, restart_count, started_at) and carry forward the last terminal outcome; treat `restarting` with `restart_count=1` as an original-process outcome; ignore continuity if the prior file is missing, malformed, or marked `unavailable`.

- **Refactors**
  - Replace SDK/API negotiation with a minimal HTTP Inspect client to Docker API v1.44 via `/var/run/docker.sock`; enforce 3s timeout, 16 KiB headers, 1 MiB bodies; reject redirects, non-JSON or unexpected statuses; honor context; close idle conns.
  - Add unit tests for client bounds/behavior and lifecycle continuity, including persistence validation and fail-closed paths.

<sup>Written for commit b2b9c3f137ebb4a6c29587173b03ae6c45811563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

