### PR TITLE
Own PID1 process cleanup through fixed cgroups

### DIFF
--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -61,15 +61,23 @@ func main() {
 		}
 		panic("syscall.Exec returned without an error")
 	}
+	if err := requirePID1(os.Getpid()); err != nil {
+		fmt.Fprintf(os.Stderr, "tinfoil-init: %v\n", err)
+		os.Exit(1)
+	}
 	runPID1()
+}
+
+func requirePID1(pid int) error {
+	if pid != 1 {
+		return fmt.Errorf("must run as pid 1, got pid %d", pid)
+	}
+	return nil
 }
 
 func runPID1() {
 	_ = os.Setenv("PATH", "/usr/sbin:/usr/bin:/sbin:/bin")
 	_ = os.Setenv(pid1Env, pid1EnvValue)
-	if os.Getpid() != 1 {
-		initLogf("warning: running with pid %d, expected pid 1", os.Getpid())
-	}
 
 	// This signal-notified context owns both startup and supervision. Narrow
 	// readiness checks apply their own operation-specific timeouts.

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -560,10 +560,13 @@ func runOneShot(ctx context.Context, manager *supervisor.Manager, cmd supervisor
 	select {
 	case <-process.Done():
 	case <-timer.C:
-		_ = process.Signal(syscall.SIGKILL)
-		_, _ = process.Wait(context.Background())
 	}
-	return fmt.Errorf("%s interrupted: %w", cmd.Name, waitErr)
+	cleanupErr := process.KillCgroup()
+	cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), grace)
+	cleanupErr = errors.Join(cleanupErr, process.WaitCgroupEmpty(cleanupCtx))
+	_, directWaitErr := process.Wait(cleanupCtx)
+	cancelCleanup()
+	return fmt.Errorf("%s interrupted: %w", cmd.Name, errors.Join(waitErr, cleanupErr, directWaitErr))
 }
 
 func annotateOneShotFailure(

--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -41,6 +41,7 @@ const (
 	egressName       = "tinfoil-egress"
 	containerdSocket = "/run/containerd/containerd.sock"
 	dockerSocket     = "/run/docker.sock"
+	dockerCgroupRoot = "/tinfoil-init/docker"
 	readyPath        = "/run/tinfoil-init.ready"
 	selfExecPath     = "/proc/self/exe"
 	pid1Env          = "TINFOIL_PID1"
@@ -204,12 +205,7 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	}); err != nil {
 		return err
 	}
-	if err := deps.services.Start(bootCtx, supervisor.Service{
-		Name: dockerName, Required: true, Restart: true,
-		Command: command(dockerName, "/usr/bin/dockerd",
-			"-H", "unix://"+dockerSocket, "--containerd="+containerdSocket),
-		Ready: endpointReady("unix", dockerSocket, dockerReadyLimit),
-	}); err != nil {
+	if err := deps.services.Start(bootCtx, dockerService()); err != nil {
 		return err
 	}
 	if err := deps.oneShot(bootCtx, hardenedCommand(
@@ -253,6 +249,18 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	<-parent.Done()
 	initLogf("shutdown requested")
 	return nil
+}
+
+func dockerService() supervisor.Service {
+	return supervisor.Service{
+		Name: dockerName, Required: true, Restart: true,
+		Command: command(dockerName, "/usr/bin/dockerd",
+			"-H", "unix://"+dockerSocket,
+			"--containerd="+containerdSocket,
+			"--exec-opt=native.cgroupdriver=cgroupfs",
+			"--cgroup-parent="+dockerCgroupRoot),
+		Ready: endpointReady("unix", dockerSocket, dockerReadyLimit),
+	}
 }
 
 type nvidiaBootstrapControl interface {

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -444,6 +444,14 @@ func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
 	}
 }
 
+func TestDockerUsesPID1OwnedCgroupParent(t *testing.T) {
+	dockerArgs := dockerService().Command.Args
+	if !slices.Contains(dockerArgs, "--exec-opt=native.cgroupdriver=cgroupfs") ||
+		!slices.Contains(dockerArgs, "--cgroup-parent="+dockerCgroupRoot) {
+		t.Fatalf("dockerd cgroup args = %v", dockerArgs)
+	}
+}
+
 func TestModuleLockFailureStopsBootBeforeServices(t *testing.T) {
 	harness := newLifecycleHarness()
 	lockErr := errors.New("module lock failed")

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -100,6 +100,22 @@ func newLifecycleHarness() *lifecycleHarness {
 	return harness
 }
 
+func TestRequirePID1AcceptsPID1(t *testing.T) {
+	if err := requirePID1(1); err != nil {
+		t.Fatalf("requirePID1(1) = %v", err)
+	}
+}
+
+func TestRequirePID1RejectsNonPID1(t *testing.T) {
+	err := requirePID1(42)
+	if err == nil {
+		t.Fatal("requirePID1(42) succeeded")
+	}
+	if got, want := err.Error(), "must run as pid 1, got pid 42"; got != want {
+		t.Fatalf("requirePID1(42) = %q, want %q", got, want)
+	}
+}
+
 type fakeNVIDIA struct {
 	mu         sync.Mutex
 	calls      []string

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
@@ -58,7 +58,7 @@ func (m *Manager) StartConsole(command Command, console *os.File) (*Process, err
 
 func newConsoleProcess(process *os.Process, name string) *Process {
 	pid := process.Pid
-	child := osChild{process: process, processID: pid}
+	child := &osChild{process: process, processID: pid}
 	return &Process{pid: pid, name: name, child: child, done: make(chan struct{})}
 }
 

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
@@ -16,7 +16,7 @@ func TestNewConsoleProcessCachesIdentity(t *testing.T) {
 	if process.PID() != pid || process.name != name {
 		t.Fatalf("process identity = (%d, %q), want (%d, %q)", process.PID(), process.name, pid, name)
 	}
-	child, ok := process.child.(osChild)
+	child, ok := process.child.(*osChild)
 	if !ok || child.processID != pid {
 		t.Fatalf("child process ID = %d, %v; want %d, true", child.processID, ok, pid)
 	}

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -3,6 +3,7 @@
 package supervisor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -13,6 +14,13 @@ import (
 	"sync"
 	"syscall"
 	"time"
+)
+
+const (
+	childCgroupRoot     = "/sys/fs/cgroup/tinfoil-init"
+	cgroupEventsLimit   = 4096
+	cgroupPollInterval  = 10 * time.Millisecond
+	initialCleanupGrace = 5 * time.Second
 )
 
 // Command describes a direct child of PID 1.
@@ -52,6 +60,9 @@ type backendProcess interface {
 	pid() int
 	signal(syscall.Signal) error
 	groupAlive() (bool, error)
+	cgroupPopulated() (bool, error)
+	killCgroup() error
+	removeCgroup() error
 	release() error
 }
 
@@ -91,7 +102,38 @@ func (p *Process) Signal(sig syscall.Signal) error {
 	return p.child.signal(sig)
 }
 
+// KillCgroup recursively kills every process in this child instance's cgroup.
+func (p *Process) KillCgroup() error { return p.child.killCgroup() }
+
+// WaitCgroupEmpty waits for cgroup.events to report populated 0, then removes
+// the per-child cgroup directory.
+func (p *Process) WaitCgroupEmpty(ctx context.Context) error {
+	for {
+		populated, err := p.cgroupPopulated()
+		if err != nil {
+			return err
+		}
+		if !populated {
+			return p.removeCgroup()
+		}
+		timer := time.NewTimer(cgroupPollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
 func (p *Process) groupAlive() (bool, error) { return p.child.groupAlive() }
+func (p *Process) cgroupPopulated() (bool, error) {
+	return p.child.cgroupPopulated()
+}
+func (p *Process) killCgroup() error   { return p.child.killCgroup() }
+func (p *Process) removeCgroup() error { return p.child.removeCgroup() }
 
 type startResponse struct {
 	process *Process
@@ -113,7 +155,7 @@ type Manager struct {
 func NewManager(log func(string, ...any)) *Manager {
 	sigchld := make(chan os.Signal, 1)
 	signal.Notify(sigchld, syscall.SIGCHLD)
-	manager := newManager(osBackend{}, sigchld, log)
+	manager := newManager(&osBackend{cgroupRoot: childCgroupRoot}, sigchld, log)
 	return manager
 }
 
@@ -189,6 +231,14 @@ func (m *Manager) reapChildren(children map[int]*Process) {
 		if err := process.child.release(); err != nil {
 			m.logf("releasing child pid=%d: %v", pid, err)
 		}
+		populated, err := process.cgroupPopulated()
+		if err != nil {
+			m.logf("reading child cgroup pid=%d: %v", pid, err)
+		} else if !populated {
+			if err := process.removeCgroup(); err != nil {
+				m.logf("removing child cgroup pid=%d: %v", pid, err)
+			}
+		}
 	}
 }
 
@@ -198,26 +248,74 @@ func (m *Manager) logf(format string, args ...any) {
 	}
 }
 
-type osBackend struct{}
+type osBackend struct {
+	cgroupRoot string
+	nextCgroup uint64
+}
 
-func (osBackend) start(command Command) (backendProcess, error) {
+func (b *osBackend) start(command Command) (backendProcess, error) {
 	env := command.Env
 	if env == nil {
 		env = os.Environ()
 	}
+	cgroup, cgroupFD, err := b.createCgroup()
+	if err != nil {
+		return nil, fmt.Errorf("prepare cgroup for %s: %w", command.Name, err)
+	}
+	defer cgroupFD.Close()
 	process, err := os.StartProcess(command.Path, append([]string{command.Path}, command.Args...), &os.ProcAttr{
 		Dir:   command.Dir,
 		Env:   env,
 		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
-		Sys:   &syscall.SysProcAttr{Setpgid: true},
+		Sys: &syscall.SysProcAttr{
+			Setpgid:     true,
+			UseCgroupFD: true,
+			CgroupFD:    int(cgroupFD.Fd()),
+		},
 	})
 	if err != nil {
+		_ = os.Remove(cgroup.path)
 		return nil, fmt.Errorf("start %s: %w", command.Name, err)
 	}
-	return osChild{process: process, processID: process.Pid}, nil
+	return &osChild{process: process, processID: process.Pid, cgroup: cgroup}, nil
 }
 
-func (osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
+func (b *osBackend) createCgroup() (*processCgroup, *os.File, error) {
+	if err := os.Mkdir(b.cgroupRoot, 0700); err != nil && !errors.Is(err, os.ErrExist) {
+		return nil, nil, err
+	}
+	for {
+		b.nextCgroup++
+		path := filepath.Join(b.cgroupRoot, fmt.Sprintf("child-%016x", b.nextCgroup))
+		if err := os.Mkdir(path, 0700); errors.Is(err, os.ErrExist) {
+			continue
+		} else if err != nil {
+			return nil, nil, err
+		}
+		cgroup := &processCgroup{path: path}
+		if _, err := cgroup.populated(); err != nil {
+			_ = os.Remove(path)
+			return nil, nil, err
+		}
+		killFile, err := os.OpenFile(filepath.Join(path, "cgroup.kill"), os.O_WRONLY, 0)
+		if err != nil {
+			_ = os.Remove(path)
+			return nil, nil, err
+		}
+		if err := killFile.Close(); err != nil {
+			_ = os.Remove(path)
+			return nil, nil, err
+		}
+		fd, err := os.Open(path)
+		if err != nil {
+			_ = os.Remove(path)
+			return nil, nil, err
+		}
+		return cgroup, fd, nil
+	}
+}
+
+func (*osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
 	var status syscall.WaitStatus
 	pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
 	return pid, status, err
@@ -226,17 +324,18 @@ func (osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
 type osChild struct {
 	process   *os.Process
 	processID int
+	cgroup    *processCgroup
 }
 
-func (p osChild) pid() int { return p.processID }
-func (p osChild) signal(sig syscall.Signal) error {
+func (p *osChild) pid() int { return p.processID }
+func (p *osChild) signal(sig syscall.Signal) error {
 	err := syscall.Kill(-p.processID, sig)
 	if errors.Is(err, syscall.ESRCH) {
 		return os.ErrProcessDone
 	}
 	return err
 }
-func (p osChild) groupAlive() (bool, error) {
+func (p *osChild) groupAlive() (bool, error) {
 	err := syscall.Kill(-p.processID, 0)
 	if errors.Is(err, syscall.ESRCH) {
 		return false, nil
@@ -246,7 +345,64 @@ func (p osChild) groupAlive() (bool, error) {
 	}
 	return err == nil, err
 }
-func (p osChild) release() error { return p.process.Release() }
+func (p *osChild) cgroupPopulated() (bool, error) { return p.cgroup.populated() }
+func (p *osChild) killCgroup() error              { return p.cgroup.kill() }
+func (p *osChild) removeCgroup() error            { return p.cgroup.remove() }
+func (p *osChild) release() error                 { return p.process.Release() }
+
+type processCgroup struct {
+	path string
+}
+
+func (c *processCgroup) populated() (bool, error) {
+	data, err := os.ReadFile(filepath.Join(c.path, "cgroup.events"))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if len(data) > cgroupEventsLimit {
+		return false, fmt.Errorf("cgroup.events exceeds %d bytes", cgroupEventsLimit)
+	}
+	for len(data) > 0 {
+		end := bytes.IndexByte(data, '\n')
+		if end < 0 {
+			return false, errors.New("cgroup.events has unterminated line")
+		}
+		line := data[:end]
+		data = data[end+1:]
+		switch {
+		case bytes.Equal(line, []byte("populated 0")):
+			return false, nil
+		case bytes.Equal(line, []byte("populated 1")):
+			return true, nil
+		case bytes.HasPrefix(line, []byte("populated ")):
+			return false, fmt.Errorf("invalid cgroup.events populated line %q", line)
+		}
+	}
+	return false, errors.New("cgroup.events lacks populated state")
+}
+
+func (c *processCgroup) kill() error {
+	file, err := os.OpenFile(filepath.Join(c.path, "cgroup.kill"), os.O_WRONLY, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	_, writeErr := file.WriteString("1")
+	return errors.Join(writeErr, file.Close())
+}
+
+func (c *processCgroup) remove() error {
+	err := os.Remove(c.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
 
 // State reports whether a managed service is ready. A required service is
 // marked unready before restart delay begins, allowing callers to fail closed.
@@ -388,9 +544,7 @@ func (s *Supervisor) startLocked(record *serviceRecord) (*Process, error) {
 
 func (s *Supervisor) stopInitial(record *serviceRecord, process *Process) error {
 	var errs []error
-	if err := process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		errs = append(errs, err)
-	}
+	errs = append(errs, s.killCgroups([]*Process{process}, initialCleanupGrace))
 	if _, err := process.Wait(context.Background()); err != nil {
 		errs = append(errs, err)
 	}
@@ -432,8 +586,8 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 		if record.process == process {
 			record.process = nil
 		}
-		alive, aliveErr := process.groupAlive()
-		if aliveErr == nil && !alive {
+		populated, populatedErr := process.cgroupPopulated()
+		if populatedErr == nil && !populated && process.removeCgroup() == nil {
 			delete(record.groups, process)
 		}
 		draining := s.draining
@@ -472,19 +626,22 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 			}
 			if readyErr := s.ready(s.context, record, next); readyErr != nil {
 				s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: readyErr})
-				_ = next.Signal(syscall.SIGKILL)
+				cleanupErr := s.killCgroups([]*Process{next}, initialCleanupGrace)
 				_, _ = next.Wait(context.Background())
 				s.mu.Lock()
 				if record.process == next {
 					record.process = nil
 				}
-				if alive, err := next.groupAlive(); err == nil && !alive {
+				if populated, err := next.cgroupPopulated(); err == nil && !populated && next.removeCgroup() == nil {
 					delete(record.groups, next)
 				}
 				if s.clock.Now().Sub(record.started) >= s.stable {
 					record.delay = s.base
 				}
 				s.mu.Unlock()
+				if cleanupErr != nil {
+					s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: cleanupErr})
+				}
 				continue
 			}
 			s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Ready: true})
@@ -508,7 +665,7 @@ func (s *Supervisor) emit(state State) {
 }
 
 // Drain prevents new starts, then stops each dependency group with TERM and a
-// bounded wait before escalating remaining members to KILL.
+// bounded wait before recursively killing each remaining child cgroup.
 func (s *Supervisor) Drain(groups [][]string, termGrace, killGrace time.Duration) error {
 	s.mu.Lock()
 	s.draining = true
@@ -565,21 +722,64 @@ func (s *Supervisor) drainGroup(names []string, termGrace, killGrace time.Durati
 		}
 		alive = append(alive, process)
 	}
-	alive, waitErrs := waitProcessGroups(alive, s.clock.After(termGrace))
+	_, waitErrs := waitProcessGroups(alive, s.clock.After(termGrace))
 	errs = append(errs, waitErrs...)
-	killed := alive[:0]
-	for _, process := range alive {
-		if err := process.Signal(syscall.SIGKILL); errors.Is(err, os.ErrProcessDone) {
+	errs = append(errs, s.killCgroups(processes, killGrace))
+	return errors.Join(errs...)
+}
+
+func (s *Supervisor) killCgroups(processes []*Process, grace time.Duration) error {
+	pending := make(map[*Process]bool, len(processes))
+	var errs []error
+	for _, process := range processes {
+		populated, err := process.cgroupPopulated()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("pid %d cgroup state: %w", process.PID(), err))
 			continue
-		} else if err != nil {
-			errs = append(errs, err)
 		}
-		killed = append(killed, process)
+		if !populated {
+			if err := process.removeCgroup(); err != nil {
+				errs = append(errs, fmt.Errorf("remove pid %d cgroup: %w", process.PID(), err))
+			}
+			continue
+		}
+		if err := process.killCgroup(); err != nil {
+			errs = append(errs, fmt.Errorf("kill pid %d cgroup: %w", process.PID(), err))
+		}
+		pending[process] = true
 	}
-	alive, waitErrs = waitProcessGroups(killed, s.clock.After(killGrace))
-	errs = append(errs, waitErrs...)
-	for _, process := range alive {
-		errs = append(errs, fmt.Errorf("pid %d did not exit after SIGKILL", process.PID()))
+	if len(pending) == 0 {
+		return errors.Join(errs...)
+	}
+
+	timeout := s.clock.After(grace)
+	for len(pending) > 0 {
+		for process := range pending {
+			populated, err := process.cgroupPopulated()
+			if err != nil {
+				errs = append(errs, fmt.Errorf("pid %d cgroup state after kill: %w", process.PID(), err))
+				delete(pending, process)
+				continue
+			}
+			if populated {
+				continue
+			}
+			if err := process.removeCgroup(); err != nil {
+				errs = append(errs, fmt.Errorf("remove pid %d cgroup: %w", process.PID(), err))
+			}
+			delete(pending, process)
+		}
+		if len(pending) == 0 {
+			break
+		}
+		select {
+		case <-timeout:
+			for process := range pending {
+				errs = append(errs, fmt.Errorf("pid %d cgroup remained populated after cgroup.kill", process.PID()))
+			}
+			return errors.Join(errs...)
+		case <-s.clock.After(cgroupPollInterval):
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -346,10 +346,23 @@ func (p *osChild) groupAlive() (bool, error) {
 	}
 	return err == nil, err
 }
-func (p *osChild) cgroupPopulated() (bool, error) { return p.cgroup.populated() }
-func (p *osChild) killCgroup() error              { return p.cgroup.kill() }
+func (p *osChild) cgroupPopulated() (bool, error) {
+	if p.cgroup == nil {
+		return false, nil
+	}
+	return p.cgroup.populated()
+}
+func (p *osChild) killCgroup() error {
+	if p.cgroup == nil {
+		return nil
+	}
+	return p.cgroup.kill()
+}
 func (p *osChild) release() error {
 	err := p.process.Release()
+	if p.cgroup == nil {
+		return err
+	}
 	populated, stateErr := p.cgroup.populated()
 	if stateErr != nil || populated {
 		return errors.Join(err, stateErr)

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -364,8 +364,11 @@ func (p *osChild) release() error {
 		return err
 	}
 	populated, stateErr := p.cgroup.populated()
-	if stateErr != nil || populated {
+	if stateErr != nil {
 		return errors.Join(err, stateErr)
+	}
+	if populated {
+		return errors.Join(err, fmt.Errorf("cgroup %s remained populated during release", p.cgroup.path))
 	}
 	return errors.Join(err, p.cgroup.remove())
 }
@@ -376,9 +379,6 @@ type processCgroup struct {
 
 func (c *processCgroup) populated() (bool, error) {
 	data, err := os.ReadFile(filepath.Join(c.path, "cgroup.events"))
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
 	if err != nil {
 		return false, err
 	}
@@ -402,11 +402,7 @@ func (c *processCgroup) populated() (bool, error) {
 }
 
 func (c *processCgroup) kill() error {
-	err := os.WriteFile(filepath.Join(c.path, "cgroup.kill"), []byte("1"), 0)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return err
+	return os.WriteFile(filepath.Join(c.path, "cgroup.kill"), []byte("1"), 0)
 }
 
 func (c *processCgroup) remove() error {
@@ -555,14 +551,31 @@ func (s *Supervisor) startLocked(record *serviceRecord) (*Process, error) {
 }
 
 func (s *Supervisor) stopInitial(record *serviceRecord, process *Process) error {
-	var errs []error
-	errs = append(errs, s.killCgroups([]*Process{process}, initialCleanupGrace))
-	if _, err := process.Wait(context.Background()); err != nil {
-		errs = append(errs, err)
-	}
+	cleanupErr := s.stopFailedProcess(process)
 	s.mu.Lock()
 	s.retireLocked(record)
 	s.mu.Unlock()
+	return cleanupErr
+}
+
+func (s *Supervisor) stopFailedProcess(process *Process) error {
+	var errs []error
+	errs = append(errs, s.killCgroups([]*Process{process}, initialCleanupGrace))
+	select {
+	case <-process.Done():
+	default:
+		if err := process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			errs = append(errs, fmt.Errorf("kill pid %d process group: %w", process.PID(), err))
+		}
+	}
+	select {
+	case <-process.Done():
+		if _, err := process.Wait(context.Background()); err != nil {
+			errs = append(errs, err)
+		}
+	case <-s.clock.After(initialCleanupGrace):
+		errs = append(errs, fmt.Errorf("pid %d did not exit after readiness cleanup", process.PID()))
+	}
 	return errors.Join(errs...)
 }
 
@@ -638,8 +651,7 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 			}
 			if readyErr := s.ready(s.context, record, next); readyErr != nil {
 				s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: readyErr})
-				cleanupErr := s.killCgroups([]*Process{next}, initialCleanupGrace)
-				_, _ = next.Wait(context.Background())
+				cleanupErr := s.stopFailedProcess(next)
 				s.mu.Lock()
 				if record.process == next {
 					record.process = nil
@@ -780,6 +792,7 @@ func (s *Supervisor) killCgroups(processes []*Process, grace time.Duration) erro
 		}
 		if err := process.killCgroup(); err != nil {
 			errs = append(errs, fmt.Errorf("kill pid %d cgroup: %w", process.PID(), err))
+			continue
 		}
 		pending[process] = true
 	}

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -62,13 +62,14 @@ type backendProcess interface {
 	groupAlive() (bool, error)
 	cgroupPopulated() (bool, error)
 	killCgroup() error
-	removeCgroup() error
 	release() error
 }
 
 type processBackend interface {
 	start(Command) (backendProcess, error)
 	waitNoHang() (int, syscall.WaitStatus, error)
+	cgroupPopulated() (bool, error)
+	killCgroup() error
 }
 
 // Process is a child whose status is owned by Manager. Wait may be called by
@@ -105,8 +106,7 @@ func (p *Process) Signal(sig syscall.Signal) error {
 // KillCgroup recursively kills every process in this child instance's cgroup.
 func (p *Process) KillCgroup() error { return p.child.killCgroup() }
 
-// WaitCgroupEmpty waits for cgroup.events to report populated 0, then removes
-// the per-child cgroup directory.
+// WaitCgroupEmpty waits for cgroup.events to report populated 0.
 func (p *Process) WaitCgroupEmpty(ctx context.Context) error {
 	for {
 		populated, err := p.cgroupPopulated()
@@ -114,7 +114,7 @@ func (p *Process) WaitCgroupEmpty(ctx context.Context) error {
 			return err
 		}
 		if !populated {
-			return p.removeCgroup()
+			return nil
 		}
 		timer := time.NewTimer(cgroupPollInterval)
 		select {
@@ -132,8 +132,7 @@ func (p *Process) groupAlive() (bool, error) { return p.child.groupAlive() }
 func (p *Process) cgroupPopulated() (bool, error) {
 	return p.child.cgroupPopulated()
 }
-func (p *Process) killCgroup() error   { return p.child.killCgroup() }
-func (p *Process) removeCgroup() error { return p.child.removeCgroup() }
+func (p *Process) killCgroup() error { return p.child.killCgroup() }
 
 type startResponse struct {
 	process *Process
@@ -231,14 +230,6 @@ func (m *Manager) reapChildren(children map[int]*Process) {
 		if err := process.child.release(); err != nil {
 			m.logf("releasing child pid=%d: %v", pid, err)
 		}
-		populated, err := process.cgroupPopulated()
-		if err != nil {
-			m.logf("reading child cgroup pid=%d: %v", pid, err)
-		} else if !populated {
-			if err := process.removeCgroup(); err != nil {
-				m.logf("removing child cgroup pid=%d: %v", pid, err)
-			}
-		}
 	}
 }
 
@@ -247,6 +238,9 @@ func (m *Manager) logf(format string, args ...any) {
 		m.log(format, args...)
 	}
 }
+
+func (m *Manager) cgroupPopulated() (bool, error) { return m.backend.cgroupPopulated() }
+func (m *Manager) killCgroup() error              { return m.backend.killCgroup() }
 
 type osBackend struct {
 	cgroupRoot string
@@ -298,11 +292,10 @@ func (b *osBackend) createCgroup() (*processCgroup, *os.File, error) {
 			return nil, nil, err
 		}
 		killFile, err := os.OpenFile(filepath.Join(path, "cgroup.kill"), os.O_WRONLY, 0)
-		if err != nil {
-			_ = os.Remove(path)
-			return nil, nil, err
+		if err == nil {
+			err = killFile.Close()
 		}
-		if err := killFile.Close(); err != nil {
+		if err != nil {
 			_ = os.Remove(path)
 			return nil, nil, err
 		}
@@ -319,6 +312,14 @@ func (*osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
 	var status syscall.WaitStatus
 	pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
 	return pid, status, err
+}
+
+func (b *osBackend) cgroupPopulated() (bool, error) {
+	return (&processCgroup{path: b.cgroupRoot}).populated()
+}
+
+func (b *osBackend) killCgroup() error {
+	return (&processCgroup{path: b.cgroupRoot}).kill()
 }
 
 type osChild struct {
@@ -347,8 +348,14 @@ func (p *osChild) groupAlive() (bool, error) {
 }
 func (p *osChild) cgroupPopulated() (bool, error) { return p.cgroup.populated() }
 func (p *osChild) killCgroup() error              { return p.cgroup.kill() }
-func (p *osChild) removeCgroup() error            { return p.cgroup.remove() }
-func (p *osChild) release() error                 { return p.process.Release() }
+func (p *osChild) release() error {
+	err := p.process.Release()
+	populated, stateErr := p.cgroup.populated()
+	if stateErr != nil || populated {
+		return errors.Join(err, stateErr)
+	}
+	return errors.Join(err, p.cgroup.remove())
+}
 
 type processCgroup struct {
 	path string
@@ -365,13 +372,10 @@ func (c *processCgroup) populated() (bool, error) {
 	if len(data) > cgroupEventsLimit {
 		return false, fmt.Errorf("cgroup.events exceeds %d bytes", cgroupEventsLimit)
 	}
-	for len(data) > 0 {
-		end := bytes.IndexByte(data, '\n')
-		if end < 0 {
-			return false, errors.New("cgroup.events has unterminated line")
-		}
-		line := data[:end]
-		data = data[end+1:]
+	if len(data) == 0 || data[len(data)-1] != '\n' {
+		return false, errors.New("cgroup.events has unterminated line")
+	}
+	for _, line := range bytes.Split(data[:len(data)-1], []byte{'\n'}) {
 		switch {
 		case bytes.Equal(line, []byte("populated 0")):
 			return false, nil
@@ -385,23 +389,18 @@ func (c *processCgroup) populated() (bool, error) {
 }
 
 func (c *processCgroup) kill() error {
-	file, err := os.OpenFile(filepath.Join(c.path, "cgroup.kill"), os.O_WRONLY, 0)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	_, writeErr := file.WriteString("1")
-	return errors.Join(writeErr, file.Close())
-}
-
-func (c *processCgroup) remove() error {
-	err := os.Remove(c.path)
+	err := os.WriteFile(filepath.Join(c.path, "cgroup.kill"), []byte("1"), 0)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	return err
+}
+
+func (c *processCgroup) remove() error {
+	if err := os.Remove(c.path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
 }
 
 // State reports whether a managed service is ready. A required service is
@@ -587,7 +586,7 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 			record.process = nil
 		}
 		populated, populatedErr := process.cgroupPopulated()
-		if populatedErr == nil && !populated && process.removeCgroup() == nil {
+		if populatedErr == nil && !populated {
 			delete(record.groups, process)
 		}
 		draining := s.draining
@@ -632,7 +631,7 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 				if record.process == next {
 					record.process = nil
 				}
-				if populated, err := next.cgroupPopulated(); err == nil && !populated && next.removeCgroup() == nil {
+				if populated, err := next.cgroupPopulated(); err == nil && !populated {
 					delete(record.groups, next)
 				}
 				if s.clock.Now().Sub(record.started) >= s.stable {
@@ -690,7 +689,33 @@ func (s *Supervisor) Drain(groups [][]string, termGrace, killGrace time.Duration
 	s.mu.Unlock()
 	sort.Strings(remaining)
 	errs = append(errs, s.drainGroup(remaining, termGrace, killGrace))
+	errs = append(errs, s.killOwnedRoot(killGrace))
 	return errors.Join(errs...)
+}
+
+func (s *Supervisor) killOwnedRoot(grace time.Duration) error {
+	populated, err := s.manager.cgroupPopulated()
+	if err != nil || !populated {
+		return err
+	}
+	if err := s.manager.killCgroup(); err != nil {
+		return fmt.Errorf("kill PID1 child cgroup: %w", err)
+	}
+	timeout := s.clock.After(grace)
+	for {
+		populated, err := s.manager.cgroupPopulated()
+		if err != nil {
+			return fmt.Errorf("PID1 child cgroup state after kill: %w", err)
+		}
+		if !populated {
+			return nil
+		}
+		select {
+		case <-timeout:
+			return errors.New("PID1 child cgroup remained populated after cgroup.kill")
+		case <-s.clock.After(cgroupPollInterval):
+		}
+	}
 }
 
 func (s *Supervisor) drainGroup(names []string, termGrace, killGrace time.Duration) error {
@@ -738,9 +763,6 @@ func (s *Supervisor) killCgroups(processes []*Process, grace time.Duration) erro
 			continue
 		}
 		if !populated {
-			if err := process.removeCgroup(); err != nil {
-				errs = append(errs, fmt.Errorf("remove pid %d cgroup: %w", process.PID(), err))
-			}
 			continue
 		}
 		if err := process.killCgroup(); err != nil {
@@ -763,9 +785,6 @@ func (s *Supervisor) killCgroups(processes []*Process, grace time.Duration) erro
 			}
 			if populated {
 				continue
-			}
-			if err := process.removeCgroup(); err != nil {
-				errs = append(errs, fmt.Errorf("remove pid %d cgroup: %w", process.PID(), err))
 			}
 			delete(pending, process)
 		}

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -31,7 +31,8 @@ type fakeBackend struct {
 	exitOnTERM     map[string]bool
 	groupSurvives  map[string]bool
 	cgroupSurvives map[string]bool
-	orphanPIDs     map[string][]int
+	removeErr      map[string]error
+	externalCgroup bool
 }
 
 type fakeProcess struct {
@@ -49,7 +50,8 @@ func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
 		nextPID: 100, children: map[int]*fakeProcess{}, sigchld: sigchld,
 		started: make(chan int, 32), signaled: make(chan string, 32),
 		exitOnTERM: map[string]bool{}, groupSurvives: map[string]bool{},
-		cgroupSurvives: map[string]bool{}, orphanPIDs: map[string][]int{},
+		cgroupSurvives: map[string]bool{},
+		removeErr:      map[string]error{},
 	}
 }
 
@@ -85,6 +87,28 @@ func (b *fakeBackend) waitNoHang() (int, syscall.WaitStatus, error) {
 	return wait.pid, wait.status, nil
 }
 
+func (b *fakeBackend) cgroupPopulated() (bool, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.externalCgroup {
+		return true, nil
+	}
+	for _, child := range b.children {
+		if child.cgroupRunning {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (b *fakeBackend) killCgroup() error {
+	b.signaled <- "root:cgroup.kill"
+	b.mu.Lock()
+	b.externalCgroup = false
+	b.mu.Unlock()
+	return nil
+}
+
 func (b *fakeBackend) exit(pid int, status syscall.WaitStatus) {
 	b.mu.Lock()
 	if child := b.children[pid]; child != nil {
@@ -104,7 +128,7 @@ func (b *fakeBackend) exit(pid int, status syscall.WaitStatus) {
 func (p *fakeProcess) pid() int { return p.id }
 func (p *fakeProcess) release() error {
 	p.id = -1
-	return nil
+	return p.backend.removeErr[p.name]
 }
 func (p *fakeProcess) signal(signal syscall.Signal) error {
 	p.backend.signaled <- fmt.Sprintf("%s:%s", p.name, signal)
@@ -143,19 +167,12 @@ func (p *fakeProcess) killCgroup() error {
 	exited := p.exited
 	p.groupRunning = false
 	p.cgroupRunning = false
-	orphans := append([]int(nil), p.backend.orphanPIDs[p.name]...)
-	p.backend.orphanPIDs[p.name] = nil
 	p.backend.mu.Unlock()
 	if !exited {
 		p.backend.exit(p.pgid, syscall.WaitStatus(uint32(syscall.SIGKILL)&0x7f))
 	}
-	for _, pid := range orphans {
-		p.backend.exit(pid, syscall.WaitStatus(uint32(syscall.SIGKILL)&0x7f))
-	}
 	return nil
 }
-
-func (p *fakeProcess) removeCgroup() error { return nil }
 
 func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
@@ -447,6 +464,7 @@ func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
 	backend.exitOnTERM["shim"] = true
 	backend.exitOnTERM["dockerd"] = true
 	backend.exitOnTERM["containerd"] = true
+	backend.externalCgroup = true
 	manager := newManager(backend, sigchld, nil)
 	clock := newFakeClock()
 	supervisor := New(context.Background(), manager, Config{Clock: clock})
@@ -475,12 +493,13 @@ func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
 	got = append(got, receive(t, backend.signaled))
 	got = append(got, receive(t, backend.signaled))
 	got = append(got, receive(t, backend.signaled))
+	got = append(got, receive(t, backend.signaled))
 	if err := receive(t, result); err != nil {
 		t.Fatal(err)
 	}
 	want := []string{
 		"egress:terminated", "shim:terminated", "egress:cgroup.kill",
-		"dockerd:terminated", "containerd:terminated",
+		"dockerd:terminated", "containerd:terminated", "root:cgroup.kill",
 	}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Fatalf("signals = %v, want %v", got, want)
@@ -492,11 +511,12 @@ func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
 	}
 }
 
-func TestDrainKillsSurvivingCgroupAfterDirectChildExit(t *testing.T) {
+func TestDrainKillsSetsidDescendantAfterDirectChildExit(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
 	backend.exitOnTERM["service"] = true
-	backend.groupSurvives["service"] = true
+	backend.cgroupSurvives["service"] = true
+	backend.removeErr["service"] = syscall.ENOTEMPTY
 	manager := newManager(backend, sigchld, nil)
 	clock := newFakeClock()
 	supervisor := New(context.Background(), manager, Config{Clock: clock})
@@ -528,83 +548,30 @@ func TestDrainKillsSurvivingCgroupAfterDirectChildExit(t *testing.T) {
 }
 
 func TestProcessCgroupReadsFixedPopulatedEvent(t *testing.T) {
-	for _, test := range []struct {
-		name      string
-		events    string
-		populated bool
-		wantErr   bool
-	}{
-		{name: "empty", events: "populated 0\nfrozen 0\n"},
-		{name: "populated", events: "populated 1\nfrozen 0\n", populated: true},
-		{name: "invalid value", events: "populated 2\n", wantErr: true},
-		{name: "missing", events: "frozen 0\n", wantErr: true},
-		{name: "unterminated", events: "populated 0", wantErr: true},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			directory := t.TempDir()
-			if err := os.WriteFile(filepath.Join(directory, "cgroup.events"), []byte(test.events), 0600); err != nil {
-				t.Fatal(err)
-			}
-			populated, err := (&processCgroup{path: directory}).populated()
-			if (err != nil) != test.wantErr {
-				t.Fatalf("populated error = %v, wantErr %v", err, test.wantErr)
-			}
-			if populated != test.populated {
-				t.Fatalf("populated = %v, want %v", populated, test.populated)
-			}
-		})
+	directory := t.TempDir()
+	events := filepath.Join(directory, "cgroup.events")
+	cgroup := &processCgroup{path: directory}
+	for contents, want := range map[string]bool{"populated 0\n": false, "populated 1\n": true} {
+		if err := os.WriteFile(events, []byte(contents), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if got, err := cgroup.populated(); err != nil || got != want {
+			t.Fatalf("events %q: populated=%v error=%v", contents, got, err)
+		}
+	}
+	if err := os.WriteFile(events, []byte("populated 2\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cgroup.populated(); err == nil {
+		t.Fatal("invalid populated value succeeded")
 	}
 }
 
-func TestDrainKillsSetsidDescendantOutsideStableProcessGroup(t *testing.T) {
+func TestDrainKillsOrphanedDescendant(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
-	backend.exitOnTERM["service"] = true
 	backend.cgroupSurvives["service"] = true
 	manager := newManager(backend, sigchld, nil)
-	supervisor := New(context.Background(), manager, Config{Clock: newFakeClock()})
-	if err := supervisor.Start(context.Background(), Service{
-		Name: "service", Command: Command{Name: "service", Path: "/service"},
-	}); err != nil {
-		t.Fatal(err)
-	}
-	pid := receive(t, backend.started)
-
-	result := make(chan error, 1)
-	go func() {
-		result <- supervisor.Drain([][]string{{"service"}}, time.Second, 2*time.Second)
-	}()
-	if got := receive(t, backend.signaled); got != "service:terminated" {
-		t.Fatalf("TERM signal = %q", got)
-	}
-	backend.mu.Lock()
-	process := backend.children[pid]
-	groupRunning := process.groupRunning
-	cgroupRunning := process.cgroupRunning
-	backend.mu.Unlock()
-	if groupRunning || !cgroupRunning {
-		t.Fatalf("after setsid escape: groupRunning=%v cgroupRunning=%v", groupRunning, cgroupRunning)
-	}
-	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
-		t.Fatalf("final cleanup = %q", got)
-	}
-	if err := receive(t, result); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestDrainKillsAndReapsOrphanedDescendant(t *testing.T) {
-	sigchld := make(chan os.Signal, 8)
-	backend := newFakeBackend(sigchld)
-	backend.cgroupSurvives["service"] = true
-	backend.orphanPIDs["service"] = []int{777}
-	var logsMu sync.Mutex
-	var logs []string
-	manager := newManager(backend, sigchld, func(format string, args ...any) {
-		logsMu.Lock()
-		logs = append(logs, fmt.Sprintf(format, args...))
-		logsMu.Unlock()
-	})
 	supervisor := New(context.Background(), manager, Config{Clock: newFakeClock()})
 	if err := supervisor.Start(context.Background(), Service{
 		Name: "service", Command: Command{Name: "service", Path: "/service"},
@@ -627,18 +594,4 @@ func TestDrainKillsAndReapsOrphanedDescendant(t *testing.T) {
 	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
 		t.Fatalf("orphan cleanup = %q", got)
 	}
-
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
-		logsMu.Lock()
-		got := strings.Join(logs, "\n")
-		logsMu.Unlock()
-		if strings.Contains(got, "reaped adopted child pid=777") {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	logsMu.Lock()
-	defer logsMu.Unlock()
-	t.Fatalf("orphan was not reaped by manager:\n%s", strings.Join(logs, "\n"))
 }

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -567,6 +567,20 @@ func TestProcessCgroupReadsFixedPopulatedEvent(t *testing.T) {
 	}
 }
 
+func TestOSChildWithoutCgroupIsExplicitlyUnpopulated(t *testing.T) {
+	child := &osChild{}
+	populated, err := child.cgroupPopulated()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if populated {
+		t.Fatal("child without cgroup reported populated")
+	}
+	if err := child.killCgroup(); err != nil {
+		t.Fatalf("killCgroup() = %v", err)
+	}
+}
+
 func TestDrainKillsOrphanedDescendant(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -31,6 +31,7 @@ type fakeBackend struct {
 	exitOnTERM     map[string]bool
 	groupSurvives  map[string]bool
 	cgroupSurvives map[string]bool
+	killCgroupErr  map[string]error
 	removeErr      map[string]error
 	externalCgroup bool
 }
@@ -51,6 +52,7 @@ func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
 		started: make(chan int, 32), signaled: make(chan string, 32),
 		exitOnTERM: map[string]bool{}, groupSurvives: map[string]bool{},
 		cgroupSurvives: map[string]bool{},
+		killCgroupErr:  map[string]error{},
 		removeErr:      map[string]error{},
 	}
 }
@@ -164,6 +166,10 @@ func (p *fakeProcess) cgroupPopulated() (bool, error) {
 func (p *fakeProcess) killCgroup() error {
 	p.backend.signaled <- fmt.Sprintf("%s:cgroup.kill", p.name)
 	p.backend.mu.Lock()
+	if err := p.backend.killCgroupErr[p.name]; err != nil {
+		p.backend.mu.Unlock()
+		return err
+	}
 	exited := p.exited
 	p.groupRunning = false
 	p.cgroupRunning = false
@@ -318,6 +324,29 @@ func TestInitialReadinessFailureKillsCgroupWaitsAndPermitsRetry(t *testing.T) {
 		t.Fatalf("retry start: %v", err)
 	}
 	_ = receive(t, backend.started)
+}
+
+func TestInitialReadinessFailureFallsBackWhenCgroupKillFails(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	backend.killCgroupErr["service"] = errors.New("cgroup kill denied")
+	manager := newManager(backend, sigchld, nil)
+	supervisor := New(context.Background(), manager, Config{})
+	service := Service{
+		Name: "service", Command: Command{Name: "service", Path: "/service"},
+		Ready: func(context.Context) error { return errors.New("not ready") },
+	}
+
+	err := supervisor.Start(context.Background(), service)
+	if err == nil || !strings.Contains(err.Error(), "cgroup kill denied") {
+		t.Fatalf("Start() = %v, want cgroup cleanup error", err)
+	}
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("cleanup signal = %q, want service:cgroup.kill", got)
+	}
+	if got := receive(t, backend.signaled); got != "service:killed" {
+		t.Fatalf("fallback signal = %q, want service:killed", got)
+	}
 }
 
 func TestRestartMaximumIsNeverBelowBase(t *testing.T) {
@@ -564,6 +593,31 @@ func TestProcessCgroupReadsFixedPopulatedEvent(t *testing.T) {
 	}
 	if _, err := cgroup.populated(); err == nil {
 		t.Fatal("invalid populated value succeeded")
+	}
+}
+
+func TestProcessCgroupMissingControlsFailClosed(t *testing.T) {
+	cgroup := &processCgroup{path: filepath.Join(t.TempDir(), "missing")}
+	if _, err := cgroup.populated(); err == nil {
+		t.Fatal("missing cgroup.events succeeded")
+	}
+	if err := cgroup.kill(); err == nil {
+		t.Fatal("missing cgroup.kill succeeded")
+	}
+}
+
+func TestOSChildReleaseRejectsPopulatedCgroup(t *testing.T) {
+	directory := t.TempDir()
+	if err := os.WriteFile(filepath.Join(directory, "cgroup.events"), []byte("populated 1\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	process, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatal(err)
+	}
+	child := &osChild{process: process, processID: os.Getpid(), cgroup: &processCgroup{path: directory}}
+	if err := child.release(); err == nil {
+		t.Fatal("populated cgroup release succeeded")
 	}
 }
 

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"syscall"
@@ -18,26 +19,29 @@ type fakeWait struct {
 }
 
 type fakeBackend struct {
-	mu            sync.Mutex
-	nextPID       int
-	waits         []fakeWait
-	children      map[int]*fakeProcess
-	sigchld       chan os.Signal
-	started       chan int
-	signaled      chan string
-	startErrs     []error
-	beforeStart   func()
-	exitOnTERM    map[string]bool
-	groupSurvives map[string]bool
+	mu             sync.Mutex
+	nextPID        int
+	waits          []fakeWait
+	children       map[int]*fakeProcess
+	sigchld        chan os.Signal
+	started        chan int
+	signaled       chan string
+	startErrs      []error
+	beforeStart    func()
+	exitOnTERM     map[string]bool
+	groupSurvives  map[string]bool
+	cgroupSurvives map[string]bool
+	orphanPIDs     map[string][]int
 }
 
 type fakeProcess struct {
-	backend      *fakeBackend
-	id           int
-	pgid         int
-	name         string
-	exited       bool
-	groupRunning bool
+	backend       *fakeBackend
+	id            int
+	pgid          int
+	name          string
+	exited        bool
+	groupRunning  bool
+	cgroupRunning bool
 }
 
 func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
@@ -45,6 +49,7 @@ func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
 		nextPID: 100, children: map[int]*fakeProcess{}, sigchld: sigchld,
 		started: make(chan int, 32), signaled: make(chan string, 32),
 		exitOnTERM: map[string]bool{}, groupSurvives: map[string]bool{},
+		cgroupSurvives: map[string]bool{}, orphanPIDs: map[string][]int{},
 	}
 }
 
@@ -60,7 +65,10 @@ func (b *fakeBackend) start(command Command) (backendProcess, error) {
 		return nil, err
 	}
 	b.nextPID++
-	child := &fakeProcess{backend: b, id: b.nextPID, pgid: b.nextPID, name: command.Name, groupRunning: true}
+	child := &fakeProcess{
+		backend: b, id: b.nextPID, pgid: b.nextPID, name: command.Name,
+		groupRunning: true, cgroupRunning: true,
+	}
 	b.children[child.id] = child
 	b.started <- child.id
 	return child, nil
@@ -83,6 +91,9 @@ func (b *fakeBackend) exit(pid int, status syscall.WaitStatus) {
 		child.exited = true
 		if !b.groupSurvives[child.name] {
 			child.groupRunning = false
+		}
+		if !b.groupSurvives[child.name] && !b.cgroupSurvives[child.name] {
+			child.cgroupRunning = false
 		}
 	}
 	b.waits = append(b.waits, fakeWait{pid: pid, status: status})
@@ -119,6 +130,32 @@ func (p *fakeProcess) groupAlive() (bool, error) {
 	defer p.backend.mu.Unlock()
 	return p.groupRunning, nil
 }
+
+func (p *fakeProcess) cgroupPopulated() (bool, error) {
+	p.backend.mu.Lock()
+	defer p.backend.mu.Unlock()
+	return p.cgroupRunning, nil
+}
+
+func (p *fakeProcess) killCgroup() error {
+	p.backend.signaled <- fmt.Sprintf("%s:cgroup.kill", p.name)
+	p.backend.mu.Lock()
+	exited := p.exited
+	p.groupRunning = false
+	p.cgroupRunning = false
+	orphans := append([]int(nil), p.backend.orphanPIDs[p.name]...)
+	p.backend.orphanPIDs[p.name] = nil
+	p.backend.mu.Unlock()
+	if !exited {
+		p.backend.exit(p.pgid, syscall.WaitStatus(uint32(syscall.SIGKILL)&0x7f))
+	}
+	for _, pid := range orphans {
+		p.backend.exit(pid, syscall.WaitStatus(uint32(syscall.SIGKILL)&0x7f))
+	}
+	return nil
+}
+
+func (p *fakeProcess) removeCgroup() error { return nil }
 
 func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
@@ -216,7 +253,7 @@ func TestInitialStartFailureRetiresRegistrationAndPermitsRetry(t *testing.T) {
 	_ = receive(t, backend.started)
 }
 
-func TestInitialReadinessFailureKillsGroupWaitsAndPermitsRetry(t *testing.T) {
+func TestInitialReadinessFailureKillsCgroupWaitsAndPermitsRetry(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
 	backend.groupSurvives["service"] = true
@@ -243,8 +280,8 @@ func TestInitialReadinessFailureKillsGroupWaitsAndPermitsRetry(t *testing.T) {
 	if err := supervisor.Start(context.Background(), service); err == nil {
 		t.Fatal("readiness failure was ignored")
 	}
-	if got := receive(t, backend.signaled); got != "service:killed" {
-		t.Fatalf("cleanup signal = %q, want service:killed", got)
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("cleanup signal = %q, want service:cgroup.kill", got)
 	}
 	if failedRecord == nil {
 		t.Fatal("failed readiness record was not captured")
@@ -442,7 +479,7 @@ func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []string{
-		"egress:terminated", "shim:terminated", "egress:killed",
+		"egress:terminated", "shim:terminated", "egress:cgroup.kill",
 		"dockerd:terminated", "containerd:terminated",
 	}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
@@ -455,7 +492,7 @@ func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
 	}
 }
 
-func TestDrainKillsSurvivingGroupAfterDirectChildExit(t *testing.T) {
+func TestDrainKillsSurvivingCgroupAfterDirectChildExit(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
 	backend.exitOnTERM["service"] = true
@@ -482,10 +519,126 @@ func TestDrainKillsSurvivingGroupAfterDirectChildExit(t *testing.T) {
 	}
 	receive(t, process.Done())
 	clock.fire(t, time.Second)
-	if got := receive(t, backend.signaled); got != "service:killed" {
-		t.Fatalf("KILL signal = %q", got)
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("cgroup kill = %q", got)
 	}
 	if err := receive(t, result); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestProcessCgroupReadsFixedPopulatedEvent(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		events    string
+		populated bool
+		wantErr   bool
+	}{
+		{name: "empty", events: "populated 0\nfrozen 0\n"},
+		{name: "populated", events: "populated 1\nfrozen 0\n", populated: true},
+		{name: "invalid value", events: "populated 2\n", wantErr: true},
+		{name: "missing", events: "frozen 0\n", wantErr: true},
+		{name: "unterminated", events: "populated 0", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			if err := os.WriteFile(filepath.Join(directory, "cgroup.events"), []byte(test.events), 0600); err != nil {
+				t.Fatal(err)
+			}
+			populated, err := (&processCgroup{path: directory}).populated()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("populated error = %v, wantErr %v", err, test.wantErr)
+			}
+			if populated != test.populated {
+				t.Fatalf("populated = %v, want %v", populated, test.populated)
+			}
+		})
+	}
+}
+
+func TestDrainKillsSetsidDescendantOutsideStableProcessGroup(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	backend.exitOnTERM["service"] = true
+	backend.cgroupSurvives["service"] = true
+	manager := newManager(backend, sigchld, nil)
+	supervisor := New(context.Background(), manager, Config{Clock: newFakeClock()})
+	if err := supervisor.Start(context.Background(), Service{
+		Name: "service", Command: Command{Name: "service", Path: "/service"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pid := receive(t, backend.started)
+
+	result := make(chan error, 1)
+	go func() {
+		result <- supervisor.Drain([][]string{{"service"}}, time.Second, 2*time.Second)
+	}()
+	if got := receive(t, backend.signaled); got != "service:terminated" {
+		t.Fatalf("TERM signal = %q", got)
+	}
+	backend.mu.Lock()
+	process := backend.children[pid]
+	groupRunning := process.groupRunning
+	cgroupRunning := process.cgroupRunning
+	backend.mu.Unlock()
+	if groupRunning || !cgroupRunning {
+		t.Fatalf("after setsid escape: groupRunning=%v cgroupRunning=%v", groupRunning, cgroupRunning)
+	}
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("final cleanup = %q", got)
+	}
+	if err := receive(t, result); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDrainKillsAndReapsOrphanedDescendant(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	backend.cgroupSurvives["service"] = true
+	backend.orphanPIDs["service"] = []int{777}
+	var logsMu sync.Mutex
+	var logs []string
+	manager := newManager(backend, sigchld, func(format string, args ...any) {
+		logsMu.Lock()
+		logs = append(logs, fmt.Sprintf(format, args...))
+		logsMu.Unlock()
+	})
+	supervisor := New(context.Background(), manager, Config{Clock: newFakeClock()})
+	if err := supervisor.Start(context.Background(), Service{
+		Name: "service", Command: Command{Name: "service", Path: "/service"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pid := receive(t, backend.started)
+	supervisor.mu.Lock()
+	process := supervisor.services["service"].process
+	supervisor.mu.Unlock()
+	backend.exit(pid, 0)
+	receive(t, process.Done())
+
+	if err := supervisor.Drain([][]string{{"service"}}, time.Second, 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := receive(t, backend.signaled); got != "service:terminated" {
+		t.Fatalf("TERM signal = %q", got)
+	}
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("orphan cleanup = %q", got)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		logsMu.Lock()
+		got := strings.Join(logs, "\n")
+		logsMu.Unlock()
+		if strings.Contains(got, "reaped adopted child pid=777") {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	logsMu.Lock()
+	defer logsMu.Unlock()
+	t.Fatalf("orphan was not reaped by manager:\n%s", strings.Join(logs, "\n"))
 }


### PR DESCRIPTION
## Summary
- own production child cleanup through a fixed cgroup v2 subtree
- place Docker and customer container tasks beneath PID1's owned cgroup root
- recursively kill and verify the complete owned subtree during shutdown
- require production `tinfoil-init` to execute as PID 1 while retaining the fixed service re-exec path
- keep the compile-time debug console process-group-only

## Fixed contracts
- no systemd cgroup manager or generic cgroup discovery
- bounded parsing of `cgroup.events`
- `cgroup.kill` and populated-state verification fail shutdown closed
- Docker cgroup parent is fixed at `/tinfoil-init/docker`
- no global boot deadline is reintroduced

## Validation
- `gofmt`
- `go build ./...`
- `go test ./...`
- `go test -race ./cmd/init ./internal/pid1/supervisor`
- `go vet ./...`
- `make test-go-producer`
- `bazel test //image:all`
- `git diff --check`

The cgroup cleanup portion previously passed exact-artifact Box3 qualification with stubborn `setsid` descendants under Docker. This consolidated replay is based on the merged `jules/harden-tcb` tip through #242.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Own all `tinfoil-init` children under a fixed cgroup v2 subtree and cleanly kill the entire tree on shutdown to prevent strays. Enforce PID 1 and contain Docker under `/tinfoil-init/docker`; cleanup now fails closed on cgroup errors.

- **New Features**
  - PID1-owned cgroup root at `/sys/fs/cgroup/tinfoil-init`; each child runs in its own cgroup via `UseCgroupFD`.
  - Drain sends TERM, then uses per-child `cgroup.kill`, waits for `cgroup.events` to be unpopulated, and finally kills the PID1-owned root; errors if any cgroup remains populated or controls are missing.
  - `dockerd` starts with `--exec-opt=native.cgroupdriver=cgroupfs` and `--cgroup-parent=/tinfoil-init/docker`.
  - One-shot commands use the same cgroup cleanup and verification, with SIGKILL fallback if `cgroup.kill` fails.

- **Migration**
  - `tinfoil-init` must run as PID 1; it exits if not.
  - Docker tasks are contained under `/tinfoil-init/docker`; no systemd cgroup manager is used.
  - The compile-time debug console stays process-group-only.

<sup>Written for commit 3590471ce7b01ecb112303fd05c848e0bf1ea78c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

