### PR TITLE
Reduce the fixed measured runtime surface

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,12 @@ jobs:
       - name: Test locked runtime inputs
         run: make test-runtime-locks
 
+      - name: Test measured runtime libcap payload
+        run: make test-runtime-libcap-contract
+
+      - name: Test measured runtime debconf payload
+        run: make test-runtime-debconf-contract
+
       - name: Test nvattest artifact safety
         run: make test-nvattest-artifacts
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ NVATTEST_RUNTIME_OUTPUTS = build/rootfs-artifacts/nvattest/usr/bin/nvattest \
 	runtime-builder builder-initrd bazel-rootfs additive-initrd verify-additive-initrd \
 	builder-debug-init bazel-debug-layer debug-image test-debug-image-contract \
 	test-go-producer test-runtime-builder-contract test-additive-initrd reproducible-additive-initrd test-roothash-artifacts \
-	test-runtime-locks \
+	test-runtime-locks test-runtime-libcap-contract test-runtime-debconf-contract \
 	verify-runtime-sources update-runtime-locks \
 	test-nvattest-artifacts reproducible-nvattest custom-kernel-artifacts \
 	nvidia-module-artifacts test-nvidia-module-producer reproducible-nvidia-modules \
@@ -130,6 +130,12 @@ test-runtime-locks:
 		//image:runtime-package-lock-test
 	$(BAZEL) --output_base=/tmp/cvmimage-bazel-runtime-lock-graph \
 		mod deps --lockfile_mode=error >/dev/null
+
+test-runtime-libcap-contract:
+	$(BAZEL) test --lockfile_mode=error //image:runtime-libcap-contract-test
+
+test-runtime-debconf-contract:
+	$(BAZEL) test --lockfile_mode=error //image:runtime-debconf-contract-test
 
 verify-runtime-sources:
 	BAZEL="$(BAZEL)" ./scripts/update-runtime-locks.sh --check

--- a/docs/fixed-rootfs-policy.md
+++ b/docs/fixed-rootfs-policy.md
@@ -11,9 +11,10 @@ identical to the fixed resolver contract used by `tinfoil-boot`.
 
 The measured daemon policy includes these mode `0644` files:
 
-- `/etc/containerd/config.toml` disables unused containerd service families and
-  places mutable daemon state below the private ramdisk. This measured file is
-  the canonical policy owner and is installed only by the additive rootfs.
+- `/etc/containerd/config.toml` disables containerd families outside the Docker
+  runtime path, including CRI/sandbox, transfer/image-verifier, tracing,
+  restart-monitor, and unused snapshotter plugins. It places mutable daemon
+  state below the private ramdisk and is installed only by the additive rootfs.
 - `/etc/docker/daemon.json` disables inter-container communication and the
   userland proxy, uses Docker's nftables backend, enables no-new-privileges and
   the containerd snapshotter, and registers only the pinned NVIDIA runtime by

--- a/docs/runtime-locks.md
+++ b/docs/runtime-locks.md
@@ -7,8 +7,12 @@ contents, or claim to authenticate a builder.
 the dated `20260721T000000Z` snapshot and exact requested package versions.
 `rules_distroless` resolves the complete dependency closure into
 `image/runtime-packages.lock.json`, including each package URL and SHA-256.
-`@ubuntu_runtime//:packages` exposes every complete normalized package payload
-layer for later additive assembly.
+Each `@ubuntu_runtime//PACKAGE:data` target exposes one complete normalized
+package payload. `_RUNTIME_PACKAGE_LAYERS` in `image/BUILD.bazel` is the fixed
+measured-rootfs assembly selection; it uses those complete data layers without
+path filtering or archive repacking. `debconf` and `libcap2-bin` remain in the
+canonical lock as dependency provenance, but their administrative payloads are
+intentionally absent from `_RUNTIME_PACKAGE_LAYERS` and the measured rootfs.
 
 `image/runtime-sources.lock.json` contains ordinary URL and SHA-256 locks for
 Docker and NVIDIA archives that cannot be represented by the Ubuntu apt

--- a/image/BUILD.bazel
+++ b/image/BUILD.bazel
@@ -39,8 +39,14 @@ sh_test(
 sh_test(
     name = "container-runtime-rootfs-contract-test",
     srcs = ["//scripts:test-container-runtime-rootfs.sh"],
-    args = ["$(location :docker-static-rootfs-layer)"],
-    data = [":docker-static-rootfs-layer"],
+    args = [
+        "$(location :container-runtime-contract-rootfs-layer)",
+        "$(location rootfs/etc/containerd/config.toml)",
+    ],
+    data = [
+        ":container-runtime-contract-rootfs-layer",
+        "rootfs/etc/containerd/config.toml",
+    ],
 )
 
 filegroup(
@@ -126,6 +132,20 @@ pkg_tar(
     extension = "tar",
     mtime = 0,
     out = "docker-static-rootfs-layer.tar",
+    owner = "0.0",
+    portable_mtime = False,
+    stamp = 0,
+)
+
+pkg_tar(
+    name = "container-runtime-contract-rootfs-layer",
+    srcs = [
+        ":docker-static-payload",
+        ":repository-rootfs-0644",
+    ],
+    extension = "tar",
+    mtime = 0,
+    out = "container-runtime-contract-rootfs-layer.tar",
     owner = "0.0",
     portable_mtime = False,
     stamp = 0,

--- a/image/BUILD.bazel
+++ b/image/BUILD.bazel
@@ -12,10 +12,11 @@ load(
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 # Only package data archives enter the measured rootfs; Debian maintainer
-# scripts and control archives are neither included nor executed.
+# scripts and control archives are neither included nor executed. Debconf and
+# libcap2-bin stay pinned in the canonical lock as dependency provenance, but
+# their administrative payloads are not needed by the fixed runtime.
 _RUNTIME_PACKAGE_LAYERS = [
     "@ubuntu_runtime//ca-certificates:data",
-    "@ubuntu_runtime//debconf:data",
     "@ubuntu_runtime//gcc-16-base:data",
     "@ubuntu_runtime//iproute2:data",
     "@ubuntu_runtime//libbpf1:data",
@@ -104,6 +105,22 @@ sh_test(
     ],
     data = [
         ":runtime-packages.lock.json",
+    ] + _RUNTIME_PACKAGE_LAYERS,
+)
+
+sh_test(
+    name = "runtime-debconf-contract-test",
+    srcs = ["//scripts:test-runtime-debconf-contract.sh"],
+    args = [
+        "$(location :runtime-packages.lock.json)",
+        "$(location @ubuntu_runtime//debconf:data)",
+    ] + [
+        "$(location %s)" % layer
+        for layer in _RUNTIME_PACKAGE_LAYERS
+    ],
+    data = [
+        ":runtime-packages.lock.json",
+        "@ubuntu_runtime//debconf:data",
     ] + _RUNTIME_PACKAGE_LAYERS,
 )
 

--- a/image/BUILD.bazel
+++ b/image/BUILD.bazel
@@ -11,6 +11,52 @@ load(
 )
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
+# Only package data archives enter the measured rootfs; Debian maintainer
+# scripts and control archives are neither included nor executed.
+_RUNTIME_PACKAGE_LAYERS = [
+    "@ubuntu_runtime//ca-certificates:data",
+    "@ubuntu_runtime//debconf:data",
+    "@ubuntu_runtime//gcc-16-base:data",
+    "@ubuntu_runtime//iproute2:data",
+    "@ubuntu_runtime//libbpf1:data",
+    "@ubuntu_runtime//libbsd0:data",
+    "@ubuntu_runtime//libc-bin:data",
+    "@ubuntu_runtime//libc-gconv-modules-extra:data",
+    "@ubuntu_runtime//libc6:data",
+    "@ubuntu_runtime//libcap2:data",
+    "@ubuntu_runtime//libcom-err2:data",
+    "@ubuntu_runtime//libdb5.3t64:data",
+    "@ubuntu_runtime//libedit2:data",
+    "@ubuntu_runtime//libelf1t64:data",
+    "@ubuntu_runtime//libgcc-s1:data",
+    "@ubuntu_runtime//libgmp10:data",
+    "@ubuntu_runtime//libgssapi-krb5-2:data",
+    "@ubuntu_runtime//libjansson4:data",
+    "@ubuntu_runtime//libk5crypto3:data",
+    "@ubuntu_runtime//libkeyutils1:data",
+    "@ubuntu_runtime//libkrb5-3:data",
+    "@ubuntu_runtime//libkrb5support0:data",
+    "@ubuntu_runtime//libmd0:data",
+    "@ubuntu_runtime//libmnl0:data",
+    "@ubuntu_runtime//libnftables1:data",
+    "@ubuntu_runtime//libnftnl11:data",
+    "@ubuntu_runtime//libpcre2-8-0:data",
+    "@ubuntu_runtime//libseccomp2:data",
+    "@ubuntu_runtime//libselinux1:data",
+    "@ubuntu_runtime//libssl3t64:data",
+    "@ubuntu_runtime//libstdc++6:data",
+    "@ubuntu_runtime//libtinfo6:data",
+    "@ubuntu_runtime//libtirpc-common:data",
+    "@ubuntu_runtime//libtirpc3t64:data",
+    "@ubuntu_runtime//libxml2-16:data",
+    "@ubuntu_runtime//libxtables12:data",
+    "@ubuntu_runtime//libzstd1:data",
+    "@ubuntu_runtime//nftables:data",
+    "@ubuntu_runtime//openssl-provider-legacy:data",
+    "@ubuntu_runtime//openssl:data",
+    "@ubuntu_runtime//zlib1g:data",
+]
+
 cacerts(
     name = "ubuntu-runtime-cacerts",
     mode = "0644",
@@ -49,9 +95,21 @@ sh_test(
     ],
 )
 
+sh_test(
+    name = "runtime-libcap-contract-test",
+    srcs = ["//scripts:test-runtime-libcap-contract.sh"],
+    args = ["$(location :runtime-packages.lock.json)"] + [
+        "$(location %s)" % layer
+        for layer in _RUNTIME_PACKAGE_LAYERS
+    ],
+    data = [
+        ":runtime-packages.lock.json",
+    ] + _RUNTIME_PACKAGE_LAYERS,
+)
+
 filegroup(
     name = "runtime-package-layers",
-    srcs = ["@ubuntu_runtime//:packages"],
+    srcs = _RUNTIME_PACKAGE_LAYERS,
 )
 
 filegroup(

--- a/image/rootfs/etc/containerd/config.toml
+++ b/image/rootfs/etc/containerd/config.toml
@@ -7,6 +7,8 @@ disabled_plugins = [
     "io.containerd.grpc.v1.cri",
     "io.containerd.grpc.v1.sandbox-controllers",
     "io.containerd.grpc.v1.sandboxes",
+    "io.containerd.grpc.v1.transfer",
+    "io.containerd.image-verifier.v1.bindir",
     "io.containerd.internal.v1.opt",
     "io.containerd.internal.v1.tracing",
     "io.containerd.monitor.container.v1.restart",
@@ -20,6 +22,7 @@ disabled_plugins = [
     "io.containerd.snapshotter.v1.erofs",
     "io.containerd.snapshotter.v1.zfs",
     "io.containerd.tracing.processor.v1.otlp",
+    "io.containerd.transfer.v1.local",
 ]
 
 root = "/mnt/ramdisk/private/containerd/root"

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -4,5 +4,6 @@ exports_files([
     "compare_runtime_package_lock.sh",
     "test-container-runtime-rootfs.sh",
     "test-debug-image-contract.sh",
+    "test-runtime-debconf-contract.sh",
     "test-runtime-libcap-contract.sh",
 ])

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -4,4 +4,5 @@ exports_files([
     "compare_runtime_package_lock.sh",
     "test-container-runtime-rootfs.sh",
     "test-debug-image-contract.sh",
+    "test-runtime-libcap-contract.sh",
 ])

--- a/scripts/test-container-runtime-rootfs.sh
+++ b/scripts/test-container-runtime-rootfs.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-    echo "usage: $0 /path/to/docker-static-rootfs-layer.tar" >&2
+if [[ $# -ne 2 ]]; then
+    echo "usage: $0 /path/to/container-runtime-rootfs-layer.tar /path/to/containerd-config.toml" >&2
     exit 2
 fi
 
 archive="$1"
+containerd_config="$2"
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 
@@ -46,3 +47,35 @@ for executable in "${forbidden[@]}"; do
         exit 1
     fi
 done
+
+config_path="etc/containerd/config.toml"
+if [[ "$(grep -Fxc "$config_path" "$members")" -ne 1 ]]; then
+    echo "$config_path must appear exactly once in the packaged rootfs layer" >&2
+    exit 1
+fi
+config_metadata="$(tar --numeric-owner -tvf "$archive" "$config_path" | awk '{print $1, $2}')"
+if [[ "$config_metadata" != "-rw-r--r-- 0/0" ]]; then
+    echo "$config_path metadata must be mode 0644 and owner 0:0" >&2
+    exit 1
+fi
+tar -xf "$archive" -C "$scratch" "$config_path"
+if [[ ! -f "$scratch/$config_path" || -L "$scratch/$config_path" ]]; then
+    echo "$config_path must be a regular file" >&2
+    exit 1
+fi
+if ! cmp -s "$containerd_config" "$scratch/$config_path"; then
+    echo "$config_path differs from the measured source configuration" >&2
+    exit 1
+fi
+
+expected_config_digest="b2f8b797ab9c0f0b520c8a1e7ac022fe0b607e08562c70fa49ff5888d6c5485d"
+actual_config_digest="$(sha256sum "$scratch/$config_path" | cut -d' ' -f1)"
+if [[ "$actual_config_digest" != "$expected_config_digest" ]]; then
+    echo "$config_path digest mismatch" >&2
+    exit 1
+fi
+
+if grep -Eq '^opt/containerd/image-verifier(/|$)' "$members"; then
+    echo "external containerd image verifiers must not be packaged" >&2
+    exit 1
+fi

--- a/scripts/test-containerd-config.sh
+++ b/scripts/test-containerd-config.sh
@@ -45,7 +45,7 @@ if [[ "$actual_version" != "$expected_version" ]]; then
     exit 1
 fi
 
-expected_config_digest="d6ca942be2c014cd726da80c336d4b5cd49728f0ec98043821d09156ef4e831f"
+expected_config_digest="b2f8b797ab9c0f0b520c8a1e7ac022fe0b607e08562c70fa49ff5888d6c5485d"
 actual_config_sha256="$(sha256sum "$config" | cut -d' ' -f1)"
 if [[ "$actual_config_sha256" != "$expected_config_digest" ]]; then
     echo "containerd config digest mismatch" >&2
@@ -125,6 +125,8 @@ io.containerd.differ.v1.erofs
 io.containerd.grpc.v1.cri
 io.containerd.grpc.v1.sandbox-controllers
 io.containerd.grpc.v1.sandboxes
+io.containerd.grpc.v1.transfer
+io.containerd.image-verifier.v1.bindir
 io.containerd.internal.v1.opt
 io.containerd.internal.v1.tracing
 io.containerd.monitor.container.v1.restart
@@ -138,6 +140,7 @@ io.containerd.snapshotter.v1.devmapper
 io.containerd.snapshotter.v1.erofs
 io.containerd.snapshotter.v1.zfs
 io.containerd.tracing.processor.v1.otlp
+io.containerd.transfer.v1.local
 EOF
 comm -23 "$scratch/expected-full" "$scratch/expected-disabled" >"$scratch/expected-policy"
 

--- a/scripts/test-runtime-debconf-contract.sh
+++ b/scripts/test-runtime-debconf-contract.sh
@@ -13,8 +13,22 @@ shift 2
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 
-grep -Fq '"key": "debconf_1.5.92_amd64"' "$lock"
-grep -Fq '"sha256": "025984be5dc70b32e02c8a668fdcceba674173bbda4a3e7ff93fac800dcdd122"' "$lock"
+python3 - "$lock" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as lock_file:
+    packages = json.load(lock_file)["packages"]
+
+matches = [
+    package
+    for package in packages
+    if package.get("key") == "debconf_1.5.92_amd64"
+    and package.get("sha256") == "025984be5dc70b32e02c8a668fdcceba674173bbda4a3e7ff93fac800dcdd122"
+]
+if len(matches) != 1:
+    raise SystemExit("locked debconf key and SHA-256 must identify exactly one package record")
+PY
 
 debconf_members="$scratch/debconf-members"
 tar -tzf "$debconf_archive" | sed 's#^\./##' >"$debconf_members"
@@ -56,12 +70,17 @@ for archive in "$@"; do
     tar -tzf "$archive" | sed 's#^\./##' >>"$runtime_members"
 done
 
-for path in "${debconf_paths[@]}"; do
-    if grep -Fqx "$path" "$runtime_members"; then
-        echo "$path must not be present in the measured runtime package layers" >&2
-        exit 1
-    fi
-done
+debconf_payload_members="$scratch/debconf-payload-members"
+runtime_payload_members="$scratch/runtime-payload-members"
+find "$scratch/debconf" \( -type f -o -type l \) -printf '%P\n' | LC_ALL=C sort -u >"$debconf_payload_members"
+LC_ALL=C sort -u "$runtime_members" >"$runtime_payload_members"
+overlap="$scratch/debconf-runtime-overlap"
+comm -12 "$debconf_payload_members" "$runtime_payload_members" >"$overlap"
+if [[ -s "$overlap" ]]; then
+    echo "locked debconf payload members must not enter the measured runtime package layers:" >&2
+    cat "$overlap" >&2
+    exit 1
+fi
 
 required=(
     usr/bin/ip

--- a/scripts/test-runtime-debconf-contract.sh
+++ b/scripts/test-runtime-debconf-contract.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+    echo "usage: $0 /path/to/runtime-packages.lock.json /path/to/debconf-layer.tar.gz PACKAGE_LAYER..." >&2
+    exit 2
+fi
+
+lock="$1"
+debconf_archive="$2"
+shift 2
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+grep -Fq '"key": "debconf_1.5.92_amd64"' "$lock"
+grep -Fq '"sha256": "025984be5dc70b32e02c8a668fdcceba674173bbda4a3e7ff93fac800dcdd122"' "$lock"
+
+debconf_members="$scratch/debconf-members"
+tar -tzf "$debconf_archive" | sed 's#^\./##' >"$debconf_members"
+
+debconf_paths=(
+    etc/apt/apt.conf.d/70debconf
+    etc/debconf.conf
+    usr/bin/debconf
+    usr/sbin/dpkg-preconfigure
+    usr/sbin/dpkg-reconfigure
+    usr/share/debconf/frontend
+    usr/share/perl5/Debconf/Config.pm
+)
+for path in "${debconf_paths[@]}"; do
+    if [[ "$(grep -Fxc "$path" "$debconf_members")" -ne 1 ]]; then
+        echo "$path must appear exactly once in the locked debconf payload" >&2
+        exit 1
+    fi
+done
+
+mkdir "$scratch/debconf"
+tar -xzf "$debconf_archive" -C "$scratch/debconf"
+
+regular_files="$(find "$scratch/debconf" -type f | wc -l)"
+symlinks="$(find "$scratch/debconf" -type l | wc -l)"
+uncompressed_bytes="$(find "$scratch/debconf" -type f -printf '%s\n' | awk '{sum += $1} END {print sum + 0}')"
+if [[ "$regular_files" -ne 134 || "$symlinks" -ne 1 || "$uncompressed_bytes" -ne 255330 ]]; then
+    echo "locked debconf payload changed: expected 134 regular files, 1 symlink, and 255330 uncompressed file bytes; got $regular_files, $symlinks, and $uncompressed_bytes" >&2
+    exit 1
+fi
+
+runtime_members="$scratch/runtime-members"
+: >"$runtime_members"
+for archive in "$@"; do
+    if cmp -s "$debconf_archive" "$archive"; then
+        echo "the locked debconf payload archive must not enter the measured runtime package layers" >&2
+        exit 1
+    fi
+    tar -tzf "$archive" | sed 's#^\./##' >>"$runtime_members"
+done
+
+for path in "${debconf_paths[@]}"; do
+    if grep -Fqx "$path" "$runtime_members"; then
+        echo "$path must not be present in the measured runtime package layers" >&2
+        exit 1
+    fi
+done
+
+required=(
+    usr/bin/ip
+    usr/lib/x86_64-linux-gnu/libcap.so.2.75
+)
+for path in "${required[@]}"; do
+    if [[ "$(grep -Fxc "$path" "$runtime_members")" -ne 1 ]]; then
+        echo "$path must appear exactly once in the measured runtime package layers" >&2
+        exit 1
+    fi
+done

--- a/scripts/test-runtime-libcap-contract.sh
+++ b/scripts/test-runtime-libcap-contract.sh
@@ -12,8 +12,22 @@ shift
 scratch="$(mktemp -d)"
 trap 'rm -rf "$scratch"' EXIT
 
-grep -Fq '"key": "libcap2-bin_1-2.75-10ubuntu2_amd64"' "$lock"
-grep -Fq '"sha256": "d92a8f9affbd2277d191e65978ba2a194d00d00a04f52ee9d1bca2a2ba26697d"' "$lock"
+python3 - "$lock" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as lock_file:
+    packages = json.load(lock_file)["packages"]
+
+matches = [
+    package
+    for package in packages
+    if package.get("key") == "libcap2-bin_1-2.75-10ubuntu2_amd64"
+    and package.get("sha256") == "d92a8f9affbd2277d191e65978ba2a194d00d00a04f52ee9d1bca2a2ba26697d"
+]
+if len(matches) != 1:
+    raise SystemExit("locked libcap2-bin key and SHA-256 must identify exactly one package record")
+PY
 
 members="$scratch/members"
 : >"$members"

--- a/scripts/test-runtime-libcap-contract.sh
+++ b/scripts/test-runtime-libcap-contract.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "usage: $0 /path/to/runtime-packages.lock.json PACKAGE_LAYER..." >&2
+    exit 2
+fi
+
+lock="$1"
+shift
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+grep -Fq '"key": "libcap2-bin_1-2.75-10ubuntu2_amd64"' "$lock"
+grep -Fq '"sha256": "d92a8f9affbd2277d191e65978ba2a194d00d00a04f52ee9d1bca2a2ba26697d"' "$lock"
+
+members="$scratch/members"
+: >"$members"
+for archive in "$@"; do
+    tar -tzf "$archive" | sed 's#^\./##' >>"$members"
+done
+
+forbidden=(
+    usr/sbin/capsh
+    usr/sbin/getcap
+    usr/sbin/getpcaps
+    usr/sbin/setcap
+    usr/share/doc/libcap2-bin/README.Debian
+    usr/share/doc/libcap2-bin/changelog.Debian.gz
+    usr/share/doc/libcap2-bin/copyright
+    usr/share/lintian/overrides/libcap2-bin
+    usr/share/man/man1/capsh.1.gz
+    usr/share/man/man8/getcap.8.gz
+    usr/share/man/man8/getpcaps.8.gz
+    usr/share/man/man8/setcap.8.gz
+)
+for path in "${forbidden[@]}"; do
+    if grep -Fqx "$path" "$members"; then
+        echo "$path must not be present in the measured runtime package layers" >&2
+        exit 1
+    fi
+done
+
+required=(
+    usr/bin/ip
+    usr/lib/x86_64-linux-gnu/libcap.so.2
+    usr/lib/x86_64-linux-gnu/libcap.so.2.75
+    usr/sbin/ip
+)
+for path in "${required[@]}"; do
+    if [[ "$(grep -Fxc "$path" "$members")" -ne 1 ]]; then
+        echo "$path must appear exactly once in the measured runtime package layers" >&2
+        exit 1
+    fi
+done
+
+ip_archive=""
+libcap_archive=""
+for archive in "$@"; do
+    archive_members="$scratch/archive-members"
+    tar -tzf "$archive" | sed 's#^\./##' >"$archive_members"
+    if grep -Fqx 'usr/bin/ip' "$archive_members"; then
+        ip_archive="$archive"
+    fi
+    if grep -Fqx 'usr/lib/x86_64-linux-gnu/libcap.so.2.75' "$archive_members"; then
+        libcap_archive="$archive"
+    fi
+done
+
+if [[ -z "$ip_archive" || -z "$libcap_archive" ]]; then
+    echo "required iproute2 or libcap2 package layer was not selected" >&2
+    exit 1
+fi
+
+tar -xzf "$ip_archive" -C "$scratch" ./usr/bin/ip ./usr/sbin/ip
+tar -xzf "$libcap_archive" -C "$scratch" \
+    ./usr/lib/x86_64-linux-gnu/libcap.so.2 \
+    ./usr/lib/x86_64-linux-gnu/libcap.so.2.75
+
+if [[ ! -f "$scratch/usr/bin/ip" || -L "$scratch/usr/bin/ip" || ! -x "$scratch/usr/bin/ip" ]]; then
+    echo "usr/bin/ip must be an executable regular file" >&2
+    exit 1
+fi
+if [[ "$(readlink "$scratch/usr/sbin/ip")" != "../bin/ip" ]]; then
+    echo "usr/sbin/ip must remain the fixed ../bin/ip symlink" >&2
+    exit 1
+fi
+if [[ "$(readlink "$scratch/usr/lib/x86_64-linux-gnu/libcap.so.2")" != "libcap.so.2.75" ]]; then
+    echo "libcap.so.2 must remain the fixed libcap.so.2.75 symlink" >&2
+    exit 1
+fi
+if ! readelf -dW "$scratch/usr/bin/ip" | grep -Fq 'Shared library: [libcap.so.2]'; then
+    echo "usr/bin/ip must retain its libcap.so.2 dependency" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

- disable the unused containerd transfer service and local/streaming transfer plugins in the fixed measured config
- replace the aggregate Ubuntu runtime package input with an explicit data-layer allowlist
- keep `libcap2-bin` and `debconf` pinned in the canonical dependency lock for provenance while excluding their administrative payloads from the measured rootfs
- add package, rootfs, config, and live containerd plugin-policy contracts for each reduction

This deliberately excludes/rejects local candidates L05 and L09. It does not change entropy policy, Fabric Manager packaging, runtime source repositories, module locks, or source acquisition. Package pruning selects existing locked data layers directly; it does not unpack/repack package archives or introduce a generic filtering mechanism.

## Validation

- `bash -n` on all changed contract scripts
- live pinned containerd v2.2.4 config/runtime plugin test
- `bazel test --lockfile_mode=error //image:container-runtime-rootfs-contract-test //image:runtime-libcap-contract-test //image:runtime-debconf-contract-test`
- `make test-runtime-locks`
- `make verify-runtime-sources`
- `go build ./...`
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `bazel build --lockfile_mode=error //image:rootfs` using existing staged runtime artifacts
- `./scripts/test-debug-image-contract.sh bazel-bin/image/bazel-rootfs.tar`
- `git diff --check`

The fresh pre-push fetch confirmed `origin/jules/harden-tcb` remained at `c0ece7e`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink the fixed measured runtime by disabling non-Docker `containerd` plugins (including transfer and image-verifier paths) and packaging only explicit Debian data layers. Keep `libcap2-bin` and `debconf` pinned for provenance while excluding their admin payloads from the measured rootfs.

- **Refactors**
  - Add an explicit `_RUNTIME_PACKAGE_LAYERS` allowlist; only data archives enter the measured rootfs.
  - Introduce `container-runtime-contract-rootfs-layer` and route the rootfs test to it.

- **New Features**
  - Add contract tests to enforce package policy: exclude `libcap2-bin` tools and the `debconf` payload; ensure required `iproute2`/`libcap` artifacts and linkages exist; verify pinned lock keys and SHA-256 for both.
  - Strengthen rootfs/config tests to validate `etc/containerd/config.toml` content, digest, and metadata and to enforce plugin policy (disable transfer and image-verifier families; no external image verifiers).

<sup>Written for commit b7490923de9984b98067175d5699579a070244ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

