### PR TITLE
Use fixed nvattest producer outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean:
 
 deepclean:
 	$(MKOSI) clean
-	sudo env PATH="$(TRUSTED_PATH)" rm -f packages/nvattest_*.deb packages/libnvat_*.deb
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf "$(NVATTEST_RUNTIME_OUTPUT)"
 
 runtime-builder:
 	./scripts/build-runtime-builder.sh
@@ -177,17 +177,17 @@ rebuild: shipping-image
 
 build: shipping-image
 
-# Reuse an existing worktree-local nvattest build. Rebuild only when either
-# runtime output is absent or regeneration is requested explicitly.
+# Normal image builds consume only the two fixed producer outputs. Building
+# nvattest is an explicit operation because it is expensive and release-only.
 nvattest:
-	@if [ ! -x "$(NVATTEST_RUNTIME_BINARY)" ] || [ ! -f "$(NVATTEST_RUNTIME_LIBRARY)" ]; then \
-	    ./scripts/build-runtime-builder.sh; \
-	    ./scripts/run-runtime-builder.sh nvattest; \
-	else \
-	    echo "Reusing existing nvattest runtime artifacts"; \
-	fi
-	test -x "$(NVATTEST_RUNTIME_BINARY)"
-	test -f "$(NVATTEST_RUNTIME_LIBRARY)"
+	@test -x "$(NVATTEST_RUNTIME_BINARY)" || { \
+		echo "missing nvattest runtime binary; run 'make regenerate-nvattest'" >&2; \
+		exit 1; \
+	}
+	@test -f "$(NVATTEST_RUNTIME_LIBRARY)" || { \
+		echo "missing libnvat runtime library; run 'make regenerate-nvattest'" >&2; \
+		exit 1; \
+	}
 
 regenerate-nvattest:
 	rm -rf "$(NVATTEST_RUNTIME_OUTPUT)"

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ BAZEL ?= bazel
 SHIPPING_KERNEL = kernel/out/tinfoil-custom.vmlinuz
 SHIPPING_INITRD = initrd.cpio.zst
 
-NVATTEST_RUNTIME_OUTPUT = build/rootfs-artifacts/nvattest
+override NVATTEST_RUNTIME_OUTPUT := build/rootfs-artifacts/nvattest
 NVATTEST_RUNTIME_BINARY = $(NVATTEST_RUNTIME_OUTPUT)/usr/bin/nvattest
 NVATTEST_RUNTIME_LIBRARY = $(NVATTEST_RUNTIME_OUTPUT)/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2
 
@@ -55,7 +55,7 @@ clean:
 
 deepclean:
 	$(MKOSI) clean
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf build/rootfs-artifacts/nvattest
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf "$(NVATTEST_RUNTIME_OUTPUT)"
 
 runtime-builder:
 	./scripts/build-runtime-builder.sh

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ clean:
 
 deepclean:
 	$(MKOSI) clean
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf "$(NVATTEST_RUNTIME_OUTPUT)"
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf build/rootfs-artifacts/nvattest
 
 runtime-builder:
 	./scripts/build-runtime-builder.sh

--- a/build-nvattest.sh
+++ b/build-nvattest.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Builds nvattest + libnvat debs for mkosi and exports the two named runtime
-# artifacts needed by the additive rootfs. Always runs inside the shared pinned
-# runtime builder selected by the Makefile.
+# Builds the two named nvattest runtime artifacts used by the additive rootfs.
+# Always runs inside the shared pinned runtime builder selected by the Makefile.
 # The cuda-ubuntu2604 repo now ships nvattest, but its libnvat links
 # libxml2.so.2 while Ubuntu resolute ships only libxml2.so.16 (libxml2 2.14
 # bumped the SONAME). So we keep building from source against system libxml2-16.
@@ -40,25 +39,18 @@ readonly JSON_URL=https://github.com/nlohmann/json/releases/download/v3.12.0/jso
 readonly JSON_SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa
 readonly REGORUS_LOCK_SHA256=847ed5732480d7b4bdb65ed932c0413f6966c5bdc5a62e272be9a48bf103cd3b
 
-readonly PKG_VERSION=1.2.2.1780962352-1
 readonly SO_VERSION=1.2.2
-readonly ARCH=amd64
 
-DEB_OUT_DIR="${repo_dir}/packages"
 RUNTIME_OUT_DIR="${repo_dir}/build/rootfs-artifacts/nvattest"
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --deb-output)
-            DEB_OUT_DIR=${2:?missing value for --deb-output}
-            shift 2
-            ;;
         --runtime-output)
             RUNTIME_OUT_DIR=${2:?missing value for --runtime-output}
             shift 2
             ;;
         *)
-            echo "usage: $0 [--deb-output DIR] [--runtime-output DIR]" >&2
+            echo "usage: $0 [--runtime-output DIR]" >&2
             exit 2
             ;;
     esac
@@ -75,7 +67,6 @@ trap cleanup EXIT
 
 rm -rf -- "${WORK}"
 mkdir -p "${WORK}"
-mkdir -p "${DEB_OUT_DIR}"
 
 export SOURCE_DATE_EPOCH=0
 export TZ=UTC
@@ -139,51 +130,6 @@ nvattest_install_runtime_artifacts \
     "${INSTALL}" "${RUNTIME_OUT_DIR}" "${SO_VERSION}" \
     "${HOST_UID}" "${HOST_GID}" "${SOURCE_DATE_EPOCH}"
 
-make_deb() {
-    local stage=$1 pkg=$2 section=$3 deps=$4 desc=$5
-    local size; size=$(du -sk "${stage}/usr" | awk '{print $1}')
-    cat > "${stage}/DEBIAN/control" <<EOF
-Package: ${pkg}
-Source: libnvat
-Version: ${PKG_VERSION}
-Architecture: ${ARCH}
-Maintainer: tinfoil <noreply@tinfoil.sh>
-Installed-Size: ${size}
-Depends: ${deps}
-Section: ${section}
-Priority: optional
-Description: ${desc}
- Built from ${UPSTREAM_URL}@${UPSTREAM_TAG}.
-EOF
-    dpkg-deb --root-owner-group --build "${stage}" \
-        "${DEB_OUT_DIR}/${pkg}_${PKG_VERSION}_${ARCH}.deb"
-}
-
-libnvat="${WORK}/deb-libnvat"
-mkdir -p "${libnvat}/DEBIAN" "${libnvat}/usr/lib/x86_64-linux-gnu"
-cp -a "${INSTALL}"/usr/lib/x86_64-linux-gnu/libnvat.so{,.1,.${SO_VERSION}} \
-    "${libnvat}/usr/lib/x86_64-linux-gnu/"
-make_deb "${libnvat}" libnvat libs \
-    "libc6 (>= 2.34), libgcc-s1 (>= 3.0), libstdc++6 (>= 13), libxml2-16 (>= 2.14)" \
-    "Runtime libraries for NVIDIA attestation SDK (built from source)"
-
-nvattest="${WORK}/deb-nvattest"
-mkdir -p "${nvattest}/DEBIAN" "${nvattest}/usr/bin"
-cp -a "${INSTALL}/usr/bin/nvattest" "${nvattest}/usr/bin/"
-make_deb "${nvattest}" nvattest devel \
-    "libnvat (= ${PKG_VERSION}), libc6 (>= 2.34), libgcc-s1 (>= 3.0), libstdc++6 (>= 13)" \
-    "NVIDIA Attestation SDK CLI (built from source)"
-
-for package in \
-    "${DEB_OUT_DIR}/libnvat_${PKG_VERSION}_${ARCH}.deb" \
-    "${DEB_OUT_DIR}/nvattest_${PKG_VERSION}_${ARCH}.deb"; do
-    if [ "$(id -u)" -eq 0 ]; then
-        chown "${HOST_UID}:${HOST_GID}" "${package}"
-    fi
-    touch -d "@${SOURCE_DATE_EPOCH}" "${package}"
-done
-
 sha256sum \
     "${RUNTIME_OUT_DIR}/usr/bin/nvattest" \
     "${RUNTIME_OUT_DIR}/usr/lib/x86_64-linux-gnu/libnvat.so.${SO_VERSION}"
-ls -la "${DEB_OUT_DIR}"/{libnvat,nvattest}_*.deb

--- a/docs/runtime-builder.md
+++ b/docs/runtime-builder.md
@@ -20,9 +20,10 @@ trees, caches, logs, and installed tools are discarded. Rootfs construction
 may consume only the named producer outputs mounted from explicit output
 directories.
 
-Normal rootfs and image builds reuse the two worktree-local nvattest runtime
-outputs when both already exist. Their reproducible epoch-zero timestamps are
-not Make targets and therefore do not trigger unnecessary source rebuilds.
+Normal rootfs and image builds never compile nvattest. They require the two
+fixed worktree-local runtime outputs and fail with an instruction to run `make
+regenerate-nvattest` when either is absent. The trusted builder publishes those
+files directly; there is no second output-authentication or cache-lock layer.
 
 The standard producer interface is:
 
@@ -40,8 +41,9 @@ make regenerate-nvattest
 ```
 
 The release workflow calls `make release-image`, which first regenerates
-nvattest on the fresh release worker and then builds the shipping image.
-`make reproducible-nvattest` remains available for independent qualification.
+nvattest from pinned inputs on the fresh release worker and then builds the
+shipping image. `make reproducible-nvattest` remains a release-qualification
+tool and is not part of routine PR CI.
 
 Initrd, nvattest, and kernel producers use ordinary unprivileged containers.
 NVIDIA alone receives `CAP_SYS_ADMIN` with confined host-device access for its

--- a/scripts/reproduce-nvattest.sh
+++ b/scripts/reproduce-nvattest.sh
@@ -9,9 +9,8 @@ trap 'rm -rf -- "$temporary"' EXIT
 
 build_one() {
     local name=$1
-    mkdir -p "$temporary/$name/packages" "$temporary/$name/runtime"
-    TINFOIL_NVATTEST_DEB_OUTPUT="$temporary/$name/packages" \
-        TINFOIL_NVATTEST_RUNTIME_OUTPUT="$temporary/$name/runtime" \
+    mkdir -p "$temporary/$name/runtime"
+    TINFOIL_NVATTEST_RUNTIME_OUTPUT="$temporary/$name/runtime" \
         TINFOIL_RUNTIME_BUILDER_CACHE="$temporary/$name/cache" \
         "$repo_dir/scripts/run-runtime-builder.sh" nvattest
 }

--- a/scripts/run-runtime-builder.sh
+++ b/scripts/run-runtime-builder.sh
@@ -72,14 +72,12 @@ case "$producer" in
             /usr/local/bin/build-initrd /workspace /output
         ;;
     nvattest)
-        deb_output="${TINFOIL_NVATTEST_DEB_OUTPUT:-$repo_dir/packages}"
         runtime_output="${TINFOIL_NVATTEST_RUNTIME_OUTPUT:-$repo_dir/build/rootfs-artifacts/nvattest}"
         nvattest_home="$cache_root/nvattest-home"
-        mkdir -p "$deb_output" "$runtime_output" "$nvattest_home"
+        mkdir -p "$runtime_output" "$nvattest_home"
         docker run --rm \
             --user "$host_uid:$host_gid" \
             --mount "$repo_mount" \
-            --mount "type=bind,src=$deb_output,dst=/output/debs" \
             --mount "type=bind,src=$runtime_output,dst=/output/runtime" \
             --mount "type=bind,src=$nvattest_home,dst=/builder-home" \
             --env HOME=/builder-home \
@@ -88,7 +86,6 @@ case "$producer" in
             --env "HOST_GID=$host_gid" \
             "$builder_image" \
             /workspace/build-nvattest.sh \
-                --deb-output /output/debs \
                 --runtime-output /output/runtime
         ;;
     kernel)


### PR DESCRIPTION
## Summary

- make ordinary image builds require the two fixed worktree-local nvattest runtime outputs instead of compiling on a cache miss
- keep regeneration explicit and release-only
- remove unused nvattest/libnvat Debian package production and its output plumbing
- retain pinned source inputs, producer-side runtime validation, and release-only reproducibility checks

## Threat model

The disposable runtime builder is trusted. Re-authenticating its own outputs through a second content-addressed cache does not establish provenance or strengthen measurement promotion. Any changed runtime bytes change the final image measurement; only a qualified measurement is promoted.

External source and dependency hashes remain pinned. This PR only removes redundant authentication and unused packaging of builder-produced outputs.

## Validation

- `bash -n build-nvattest.sh scripts/run-runtime-builder.sh scripts/reproduce-nvattest.sh scripts/nvattest-artifacts.sh scripts/test-nvattest-artifacts.sh`
- `shellcheck build-nvattest.sh scripts/run-runtime-builder.sh scripts/reproduce-nvattest.sh`
- `make test-nvattest-artifacts`
- verified `make nvattest` accepts both fixed files
- verified `make nvattest` fails with an explicit regeneration instruction when the output is absent
- `git diff --check`

The expensive source rebuild remains behind `make regenerate-nvattest` and was intentionally not added to routine PR validation.

Supersedes closed #253 while preserving that branch as historical reference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch normal image builds to use fixed worktree-local `nvattest` runtime artifacts; rebuilding from source is now explicit and release-only. Pins the output path contract and removes unused `nvattest`/`libnvat` Debian packaging and redundant output authentication.

- **Refactors**
  - `make nvattest` now only checks for the `nvattest` binary and `libnvat.so`; if missing, it fails and instructs to run `make regenerate-nvattest`.
  - Source rebuild is gated behind `make regenerate-nvattest` and used by the release workflow.
  - Hard-pin `NVATTEST_RUNTIME_OUTPUT` to `build/rootfs-artifacts/nvattest`; deep-clean removes that directory.
  - Dropped `.deb` plumbing and mounts in builder/repro scripts; docs updated to reflect no second cache/auth layer. Pinned inputs and release-only reproducibility checks remain.

<sup>Written for commit b723c7d8c16ae09818d0ca9740948a347c8126d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

