### PR TITLE
Use a fixed NVIDIA module Bazel package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,12 @@ tinfoil/shim
 /build/
 /kernel/build/
 /kernel/out/
+!/kernel/out/
+/kernel/out/*
+!/kernel/out/rootfs-artifacts/
+/kernel/out/rootfs-artifacts/*
+!/kernel/out/rootfs-artifacts/nvidia-modules/
+/kernel/out/rootfs-artifacts/nvidia-modules/*
+!/kernel/out/rootfs-artifacts/nvidia-modules/BUILD.bazel
 /bazel-*
 /evidence/

--- a/docs/nvidia-module-producer.md
+++ b/docs/nvidia-module-producer.md
@@ -22,9 +22,9 @@ exposing host devices to the container.
 By default, the modules are written beneath
 `kernel/out/rootfs-artifacts/nvidia-modules`. A later rootfs assembly step is
 responsible for installing them at `/usr/lib/tinfoil/kernel-modules`.
-The producer also writes a deterministic Bazel package in that output directory
-from the same `kernel/nvidia-modules.txt` contract, so rootfs assembly cannot
-drift onto an independent hard-coded module list.
+The checked-in Bazel package in that output directory exposes the fixed
+`//kernel/out/rootfs-artifacts/nvidia-modules:modules` filegroup consumed by
+rootfs assembly. The producer writes only the three module files.
 Downloaded source packages are retained in `kernel/build/nvidia-packages` and
 are verified against the pinned hashes before every build.
 

--- a/kernel/build-nvidia-open-local.sh
+++ b/kernel/build-nvidia-open-local.sh
@@ -124,35 +124,6 @@ validate_nvidia_modules() {
     done
 }
 
-write_bazel_module_package() {
-    local destination=$1
-    local module temporary
-
-    for module in "${required_modules[@]}"; do
-        if [[ ! "$module" =~ ^[a-z0-9-]+\.ko$ ]]; then
-            echo "invalid NVIDIA module contract entry: $module" >&2
-            return 1
-        fi
-    done
-
-    temporary="$(mktemp "$destination/.BUILD.bazel.XXXXXXXX")"
-
-    if ! {
-        printf '%s\n' 'package(default_visibility = ["//visibility:public"])' ''
-        printf '%s\n' 'filegroup(' '    name = "modules",' '    srcs = ['
-        for module in "${required_modules[@]}"; do
-            printf '        "%s",\n' "$module"
-        done
-        printf '%s\n' '    ],' ')'
-    } > "$temporary"; then
-        rm -f -- "$temporary"
-        return 1
-    fi
-    chmod 0644 "$temporary"
-    touch -d @0 "$temporary"
-    mv -f -- "$temporary" "$destination/BUILD.bazel"
-}
-
 main() {
     check_toolchain
 
@@ -208,13 +179,11 @@ chmod 0755 "$nvidia_source_dir/pahole.sh"
 
     validate_nvidia_modules "$kernel_source_dir" "$scratch/built-modules" "$kernel_release"
 
-    rm -rf "$output_dir"
     install -d -m 0755 "$output_dir"
     for module in "${required_modules[@]}"; do
         install -m 0644 "$scratch/built-modules/$module" "$output_dir/$module"
         touch -d @0 "$output_dir/$module"
     done
-    write_bazel_module_package "$output_dir"
     if [ "$(id -u)" -eq 0 ]; then
         chown -R "$host_uid:$host_gid" "$output_dir"
     fi

--- a/kernel/out/rootfs-artifacts/nvidia-modules/BUILD.bazel
+++ b/kernel/out/rootfs-artifacts/nvidia-modules/BUILD.bazel
@@ -1,0 +1,10 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "modules",
+    srcs = [
+        "nvidia.ko",
+        "nvidia-uvm.ko",
+        "nvidia-modeset.ko",
+    ],
+)

--- a/scripts/reproduce-nvidia-modules.sh
+++ b/scripts/reproduce-nvidia-modules.sh
@@ -30,7 +30,5 @@ while IFS= read -r module; do
     cmp "$reproduction_dir/first/nvidia-modules/$module" \
         "$reproduction_dir/second/nvidia-modules/$module"
 done < "$repo_dir/kernel/nvidia-modules.txt"
-cmp "$reproduction_dir/first/nvidia-modules/BUILD.bazel" \
-    "$reproduction_dir/second/nvidia-modules/BUILD.bazel"
 
 echo "NVIDIA modules are byte-identical across isolated builds"

--- a/scripts/test-nvidia-module-producer.sh
+++ b/scripts/test-nvidia-module-producer.sh
@@ -62,25 +62,6 @@ grep -Fq 'removing NVIDIA package with checksum mismatch' "$scratch/failure.log"
 
 validate_nvidia_modules "$source_dir" "$module_dir" "$release"
 
-bazel_package="$scratch/bazel-package"
-mkdir -p "$bazel_package"
-printf 'incomplete\n' > "$bazel_package/BUILD.bazel"
-write_bazel_module_package "$bazel_package"
-cat > "$scratch/expected-BUILD.bazel" <<'EOF'
-package(default_visibility = ["//visibility:public"])
-
-filegroup(
-    name = "modules",
-    srcs = [
-        "nvidia.ko",
-        "nvidia-uvm.ko",
-        "nvidia-modeset.ko",
-    ],
-)
-EOF
-cmp "$scratch/expected-BUILD.bazel" "$bazel_package/BUILD.bazel"
-test -z "$(find "$bazel_package" -maxdepth 1 -name '.BUILD.bazel.*' -print -quit)"
-
 for module in "${required_modules[@]}"; do
     mv "$module_dir/$module" "$module_dir/$module.missing"
     expect_failure "missing $module" validate_nvidia_modules "$source_dir" "$module_dir" "$release"


### PR DESCRIPTION
## Summary
- check in the fixed Bazel filegroup for the three measured NVIDIA modules
- remove runtime BUILD-file generation and generator-only tests
- preserve `//kernel/out/rootfs-artifacts/nvidia-modules:modules`

## Validation
- focused NVIDIA producer tests
- shell syntax checks
- Bazel package and consumer queries/builds
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch to a checked-in Bazel package for NVIDIA kernel modules. Removes runtime `BUILD.bazel` generation and keeps `//kernel/out/rootfs-artifacts/nvidia-modules:modules` stable for rootfs assembly.

- **Refactors**
  - Add fixed `BUILD.bazel` under `kernel/out/rootfs-artifacts/nvidia-modules` listing the three modules.
  - Remove generator logic and related tests from `build-nvidia-open-local.sh` and scripts.
  - Update `.gitignore` to allow committing the Bazel file while ignoring other outputs.
  - Refresh docs and reproduction script to reflect the fixed package.

- **Migration**
  - No action needed. Continue using `//kernel/out/rootfs-artifacts/nvidia-modules:modules`.

<sup>Written for commit 499e06152082950a92e3fbd8b90b11fc2f038893. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

