### PR TITLE
Resolve the runtime package lock once

### DIFF
--- a/docs/runtime-locks.md
+++ b/docs/runtime-locks.md
@@ -28,7 +28,8 @@ module declarations instead of a resolver-generated apt lock.
 `.bazelversion` pins Bazel 8.7.0 and `MODULE.bazel.lock` pins the Bzlmod graph.
 Run `make test-runtime-locks` for the package-lock comparison and locked module
 graph. Run `make verify-runtime-sources` to regenerate the Ubuntu package lock
-twice and compare it with the checked-in file. Run `make update-runtime-locks`
-only when intentionally rotating the package manifest. Regenerate
+once with the upstream `rules_distroless` resolver and compare it with the
+checked-in file. Run `make update-runtime-locks` only when intentionally
+rotating the package manifest. Regenerate
 `MODULE.bazel.lock` from the real workspace with
 `bazel mod deps --lockfile_mode=update` when module dependencies change.

--- a/scripts/update-runtime-locks.sh
+++ b/scripts/update-runtime-locks.sh
@@ -26,11 +26,10 @@ cleanup() {
 }
 trap cleanup EXIT
 
-resolve_once() {
-    local name=$1
-    local workspace="$scratch/$name/workspace"
-    local output_base="$scratch/$name/output-base"
-    local generated="$scratch/$name/generated"
+resolve_runtime_lock() {
+    local workspace="$scratch/workspace"
+    local output_base="$scratch/output-base"
+    local generated="$scratch/generated"
 
     mkdir -p "$workspace/image" "$generated"
     cp "$repo_dir/image/runtime-packages.yaml" "$workspace/image/"
@@ -70,18 +69,15 @@ EOF
     )
 }
 
-resolve_once first
-resolve_once second
-cmp "$scratch/first/generated/runtime-packages.lock.json" \
-    "$scratch/second/generated/runtime-packages.lock.json"
+resolve_runtime_lock
 (cd "$repo_dir" && "$bazel_bin" mod deps --lockfile_mode=error >/dev/null)
 
 if [ "$check_only" -eq 1 ]; then
-    cmp "$scratch/first/generated/runtime-packages.lock.json" \
+    cmp "$scratch/generated/runtime-packages.lock.json" \
         "$repo_dir/image/runtime-packages.lock.json"
 else
     replacement="$(mktemp "$repo_dir/image/.runtime-packages.lock.json.XXXXXXXX")"
-    install -m 0644 "$scratch/first/generated/runtime-packages.lock.json" "$replacement"
+    install -m 0644 "$scratch/generated/runtime-packages.lock.json" "$replacement"
     mv -f -- "$replacement" "$repo_dir/image/runtime-packages.lock.json"
     replacement=
 fi


### PR DESCRIPTION
## Summary
- run the upstream `rules_distroless` package resolver once
- compare that result directly with the checked-in lock
- preserve module-lock validation and atomic lock updates

Repeated isolated build comparison is deferred to later release qualification rather than routine lock maintenance.

## Validation
- dedicated runtime-lock behavior tests
- `bazel test --lockfile_mode=error //image:runtime-package-lock-test`
- `scripts/update-runtime-locks.sh --check`
- shell syntax and `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve the runtime package lock once using the upstream `rules_distroless` resolver and compare it directly to the checked-in lock. Keeps module lock validation and atomic updates while simplifying maintenance.

- **Refactors**
  - Consolidated resolver into a single `resolve_runtime_lock` step; removed the second run.
  - Validate `MODULE.bazel.lock` with `bazel mod deps --lockfile_mode=error`.
  - Preserve atomic lock updates; updated docs and `scripts/update-runtime-locks.sh`.

<sup>Written for commit 1c00df1da636a15e9dab8e98e81957ef12e5ac4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

