### PR TITLE
Build PID1 CGO with the pinned Bazel builder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Build
         run: cd tinfoil && go build ./...
 
+      - name: Build Bazel Go commands
+        run: bazel build //tinfoil/cmd/init:tinfoil-init //tinfoil/cmd/initrd:tinfoil-initrd
+
       - name: Test
         run: cd tinfoil && go test ./...
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,11 +15,20 @@ go_sdk.download(version = "1.25.7")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.module(
+    path = "github.com/NVIDIA/go-nvml",
+    sum = "h1:OLX8Jq3dONuPOQPC7rndB6+iDmDakw0XTYgzMxObkEw=",
+    version = "v0.13.0-1",
+)
+go_deps.module(
     path = "golang.org/x/sys",
     sum = "h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=",
     version = "v0.45.0",
 )
-use_repo(go_deps, "org_golang_x_sys")
+use_repo(
+    go_deps,
+    "com_github_nvidia_go_nvml",
+    "org_golang_x_sys",
+)
 
 bazel_lib_toolchains = use_extension("@bazel_lib//lib:extensions.bzl", "toolchains")
 use_repo(bazel_lib_toolchains, "zstd_toolchains")

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NVATTEST_RUNTIME_BINARY = $(NVATTEST_RUNTIME_OUTPUT)/usr/bin/nvattest
 NVATTEST_RUNTIME_LIBRARY = $(NVATTEST_RUNTIME_OUTPUT)/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2
 
 .PHONY: all build rebuild shipping-image release-image clean deepclean hash nvattest regenerate-nvattest \
-	runtime-builder builder-initrd bazel-rootfs additive-initrd \
+	runtime-builder builder-bazel-pid1 builder-initrd bazel-rootfs additive-initrd \
 	builder-debug-init bazel-debug-layer debug-image test-debug-image-contract \
 	test-additive-initrd reproducible-additive-initrd test-roothash-artifacts \
 	test-runtime-locks \
@@ -59,6 +59,9 @@ deepclean:
 
 runtime-builder:
 	./scripts/build-runtime-builder.sh
+
+builder-bazel-pid1: runtime-builder
+	./scripts/run-runtime-builder.sh bazel-pid1
 
 builder-initrd: runtime-builder
 	./scripts/run-runtime-builder.sh initrd

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -76,6 +76,21 @@ RUN set -eux; \
     apt-get clean; \
     rm -rf /var/lib/apt/lists/*
 
+RUN set -eux; \
+    test "$(dpkg-query -W -f='${Version}' gcc)" = 4:15.2.0-5ubuntu1; \
+    test "$(dpkg-query -W -f='${Version}' gcc-15)" = 15.2.0-16ubuntu1; \
+    test "$(dpkg-query -W -f='${Version}' binutils)" = 2.46-3ubuntu2; \
+    test "$(dpkg-query -W -f='${Version}' libc6-dev)" = 2.43-2ubuntu2; \
+    curl -fsSL --retry 3 \
+        https://github.com/bazelbuild/bazel/releases/download/8.7.0/bazel-8.7.0-linux-x86_64 \
+        -o /tmp/bazel; \
+    printf '%s  %s\n' \
+        d7606e679b78067c811096fb3d6cf135225b528835ca396e3a4dddf957859544 \
+        /tmp/bazel | sha256sum -c --strict -; \
+    install -m 0755 /tmp/bazel /usr/local/bin/bazel; \
+    rm -f /tmp/bazel; \
+    test "$(bazel --version)" = 'bazel 8.7.0'
+
 COPY build-initrd.sh /usr/local/bin/build-initrd
 
 WORKDIR /workspace

--- a/docs/runtime-builder.md
+++ b/docs/runtime-builder.md
@@ -20,6 +20,14 @@ trees, caches, logs, and installed tools are discarded. Rootfs construction
 may consume only the named producer outputs mounted from explicit output
 directories.
 
+Bazel builds the shipping PID1 target with upstream `rules_go` CGO support.
+The Bazel invocation runs inside this same pinned builder and explicitly selects
+`/usr/bin/gcc`; Bazel's native C toolchain discovery therefore sees the fixed
+GCC 15.2, binutils 2.46, and glibc 2.43 development environment rather than the
+developer host. No project-defined C rule or third-party C toolchain framework
+is involved. The production artifact cutover remains a separate
+measurement-changing change.
+
 Normal rootfs and image builds never compile nvattest. They require the two
 fixed worktree-local runtime outputs and fail with an instruction to run `make
 regenerate-nvattest` when either is absent. The trusted builder publishes those
@@ -29,6 +37,7 @@ The standard producer interface is:
 
 ```sh
 ./scripts/build-runtime-builder.sh
+./scripts/run-runtime-builder.sh bazel-pid1
 ./scripts/run-runtime-builder.sh initrd
 ./scripts/run-runtime-builder.sh kernel
 ./scripts/run-runtime-builder.sh nvidia

--- a/scripts/run-runtime-builder.sh
+++ b/scripts/run-runtime-builder.sh
@@ -2,7 +2,7 @@
 set -Eeuo pipefail
 
 if [ "$#" -ne 1 ]; then
-    echo "usage: $0 {debug-init|initrd|nvattest|kernel|nvidia}" >&2
+    echo "usage: $0 {bazel-pid1|debug-init|initrd|nvattest|kernel|nvidia}" >&2
     exit 2
 fi
 
@@ -43,6 +43,21 @@ mkdir -p "$cache_root"
 repo_mount="type=bind,src=$repo_dir,dst=/workspace,readonly"
 
 case "$producer" in
+    bazel-pid1)
+        mkdir -p "$cache_root/bazel"
+        docker run --rm \
+            --user "$host_uid:$host_gid" \
+            --mount "$repo_mount" \
+            --mount "type=bind,src=$cache_root/bazel,dst=/cache/bazel" \
+            "$builder_image" \
+            bazel \
+                --output_user_root=/cache/bazel \
+                build \
+                --lockfile_mode=error \
+                --repo_env=CC=/usr/bin/gcc \
+                --symlink_prefix=/tmp/cvmimage-bazel- \
+                //tinfoil/cmd/init:tinfoil-init
+        ;;
     debug-init)
         output="${TINFOIL_DEBUG_BUILDER_OUTPUT:-$repo_dir/build/debug-work/output}"
         mkdir -p "$output" "$cache_root/go-build" "$cache_root/go-mod"

--- a/tinfoil/cmd/init/BUILD.bazel
+++ b/tinfoil/cmd/init/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "init_lib",
+    srcs = [
+        "debug_console_disabled.go",
+        "main.go",
+    ],
+    importpath = "tinfoil/cmd/init",
+    visibility = [":__pkg__"],
+    deps = [
+        "//tinfoil/internal/boot",
+        "//tinfoil/internal/nvidia",
+        "//tinfoil/internal/pid1/hardening",
+        "//tinfoil/internal/pid1/runtime",
+        "//tinfoil/internal/pid1/supervisor",
+        "@org_golang_x_sys//unix",
+    ],
+)
+
+go_binary(
+    name = "tinfoil-init",
+    embed = [":init_lib"],
+    gc_linkopts = [
+        "-s",
+        "-w",
+    ],
+    pure = "off",
+    visibility = ["//visibility:public"],
+)

--- a/tinfoil/internal/nvidia/BUILD.bazel
+++ b/tinfoil/internal/nvidia/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "nvidia",
+    srcs = [
+        "bootstrap_status.go",
+        "devices.go",
+        "modules.go",
+        "services.go",
+    ],
+    importpath = "tinfoil/internal/nvidia",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_nvidia_go_nvml//pkg/nvml",
+        "@org_golang_x_sys//unix",
+    ],
+)

--- a/tinfoil/internal/pid1/hardening/BUILD.bazel
+++ b/tinfoil/internal/pid1/hardening/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "hardening",
+    srcs = [
+        "filesystems_linux.go",
+        "hardening.go",
+        "module_lock.go",
+        "seccomp_linux_amd64.go",
+    ],
+    importpath = "tinfoil/internal/pid1/hardening",
+    visibility = ["//tinfoil:__subpackages__"],
+    deps = ["@org_golang_x_sys//unix"],
+)

--- a/tinfoil/internal/pid1/runtime/BUILD.bazel
+++ b/tinfoil/internal/pid1/runtime/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "runtime",
+    srcs = ["setup.go"],
+    importpath = "tinfoil/internal/pid1/runtime",
+    visibility = ["//tinfoil:__subpackages__"],
+    deps = [
+        "//tinfoil/internal/boot",
+        "@org_golang_x_sys//unix",
+    ],
+)

--- a/tinfoil/internal/pid1/supervisor/BUILD.bazel
+++ b/tinfoil/internal/pid1/supervisor/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "supervisor",
+    srcs = ["supervisor.go"],
+    importpath = "tinfoil/internal/pid1/supervisor",
+    visibility = ["//tinfoil:__subpackages__"],
+)


### PR DESCRIPTION
## Summary

- add ordinary upstream `rules_go` targets for the shipping PID1 and its small internal dependency closure
- build the real `go-nvml` CGO dependency through Bazel's native C toolchain discovery inside the existing pinned disposable builder
- pin and verify Bazel 8.7.0, GCC 15.2, binutils 2.46, and glibc 2.43 development inputs without adding a third-party C toolchain framework or project-defined Bazel rules
- add a lightweight host-CI Bazel build for graph compatibility while keeping the exact production toolchain boundary in the pinned builder

## Scope

This PR establishes and validates the CGO build target only. It does not replace the currently shipped PID1 artifact, so it does not change the image measurement. Production cutover remains a separate reviewable PR.

## Validation

- `make builder-bazel-pid1`
- `bazel build //tinfoil/cmd/init:tinfoil-init //tinfoil/internal/nvidia:nvidia`
- `bazel test //tinfoil/cmd/initrd:initrd_test //tinfoil/internal/boot:boot_test //tinfoil/internal/devicemapper:devicemapper_test`
- `go build ./...`
- `go test ./...`
- `go test -race ./cmd/init ./internal/nvidia ./internal/pid1/...`
- `go vet ./...`
- shell syntax checks
- `git diff --check`

The first CGO build in a fresh Bazel cache completed in 43 seconds; the cached rebuild completed in 3.2 seconds.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds PID1 (`tinfoil-init`) with Bazel CGO inside the pinned runtime builder, verifying a fixed toolchain (Bazel 8.7.0, GCC 15.2, binutils 2.46, glibc 2.43). Adds upstream `@rules_go` targets and CI builds; no change to the shipped artifact yet.

- **New Features**
  - Add Bazel `@rules_go` targets for PID1 and its deps; build CGO for `github.com/NVIDIA/go-nvml` via native C toolchain discovery with `CC=/usr/bin/gcc`.
  - Pin and verify Bazel 8.7.0 (sha256), GCC 15.2, binutils 2.46, and glibc 2.43 in the builder; no third-party C toolchain rules.
  - Add `make builder-bazel-pid1` and `scripts/run-runtime-builder.sh bazel-pid1`; CI now builds `//tinfoil/cmd/init:tinfoil-init` and `//tinfoil/cmd/initrd:tinfoil-initrd`.

<sup>Written for commit 1ffb1db03deca4abd1968ec815a1be548481f7ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

