### PR TITLE
Reduce Make to a public interface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,9 @@ jobs:
           test "$(bazel --version)" = "bazel 8.7.0"
 
       - name: Build image
-        run: make release-image
+        run: |
+          make regenerate-nvattest
+          make shipping-image
 
       - name: Check release artifacts
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,14 +41,5 @@ jobs:
           sudo install -m 0755 "$archive" /usr/local/bin/bazel
           test "$(bazel --version)" = "bazel 8.7.0"
 
-      - name: Build
-        run: cd tinfoil && go build ./...
-
       - name: Test
-        run: cd tinfoil && go test ./...
-
-      - name: Test debug-tagged PID1
-        run: cd tinfoil && go test -tags=tinfoil_debug_image ./cmd/init
-
-      - name: Test fixed measured initrd
-        run: make test-bazel-initrd
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,89 +1,34 @@
-all: build
-
 TRUSTED_PATH := /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 MKOSI ?= sudo env PATH="$(TRUSTED_PATH)" mkosi
 BAZEL ?= bazel
-SHIPPING_KERNEL = kernel/out/tinfoil-custom.vmlinuz
-SHIPPING_INITRD = bazel-bin/image/initrd/initrd.cpio.zst
+BUILDER_IMAGE := cvmimage-runtime-builder
+SHIPPING_KERNEL := kernel/out/tinfoil-custom.vmlinuz
+SHIPPING_INITRD := bazel-bin/image/initrd/initrd.cpio.zst
+NVATTEST_OUTPUT := build/rootfs-artifacts/nvattest
+NVATTEST_BINARY := $(NVATTEST_OUTPUT)/usr/bin/nvattest
+NVATTEST_LIBRARY := $(NVATTEST_OUTPUT)/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2
 
-override NVATTEST_RUNTIME_OUTPUT := build/rootfs-artifacts/nvattest
-NVATTEST_RUNTIME_BINARY = $(NVATTEST_RUNTIME_OUTPUT)/usr/bin/nvattest
-NVATTEST_RUNTIME_LIBRARY = $(NVATTEST_RUNTIME_OUTPUT)/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2
+.PHONY: rootfs shipping-image debug-image test regenerate-nvattest clean
 
-.PHONY: all build rebuild shipping-image release-image clean deepclean hash nvattest regenerate-nvattest \
-	runtime-builder builder-runtime-go bazel-initrd bazel-rootfs \
-	builder-debug-init bazel-debug-layer debug-image \
-	test-bazel-initrd update-runtime-locks \
-	custom-kernel-artifacts \
-	nvidia-module-artifacts
-
-# tinfoilcvm.hash is the compatibility copy written by `shipping-image`; mkosi's
-# direct roothash split artifact is the source contract.
-hash:
-	@if [ ! -f tinfoilcvm.roothash ]; then \
-	    echo "missing authoritative tinfoilcvm.roothash" >&2; \
-	    exit 1; \
-	fi; \
-	if [ "$$(wc -c < tinfoilcvm.roothash)" -ne 64 ] || ! grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm.roothash; then \
-	    echo "invalid roothash artifact tinfoilcvm.roothash" >&2; \
-	    exit 1; \
-	fi; \
-	if [ -f tinfoilcvm.hash ]; then \
-	    if [ "$$(wc -c < tinfoilcvm.hash)" -ne 64 ] || ! grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm.hash; then \
-	        echo "invalid compatibility artifact tinfoilcvm.hash" >&2; \
-	        exit 1; \
-	    fi; \
-	    if ! cmp -s tinfoilcvm.roothash tinfoilcvm.hash; then \
-	        echo "tinfoilcvm.hash differs from authoritative tinfoilcvm.roothash" >&2; \
-	        exit 1; \
-	    fi; \
-	fi; \
-	cat tinfoilcvm.roothash
-
-clean:
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm.*
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm-debug tinfoilcvm-debug.*
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf build/stage build/artifacts
-
-deepclean:
-	$(MKOSI) clean
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf "$(NVATTEST_RUNTIME_OUTPUT)"
-
-runtime-builder:
-	docker build --pull --file builder/Dockerfile --tag cvmimage-runtime-builder builder
-
-builder-runtime-go: runtime-builder
+rootfs:
+	docker build --pull --file builder/Dockerfile --tag $(BUILDER_IMAGE) builder
 	./builder/run.sh runtime-go
-
-builder-debug-init: runtime-builder
-	./builder/run.sh debug-init
-
-bazel-rootfs: builder-runtime-go nvattest nvidia-module-artifacts
+	@test -x "$(NVATTEST_BINARY)" || { \
+		echo "missing nvattest runtime binary; run 'make regenerate-nvattest'" >&2; \
+		exit 1; \
+	}
+	@test -f "$(NVATTEST_LIBRARY)" || { \
+		echo "missing libnvat runtime library; run 'make regenerate-nvattest'" >&2; \
+		exit 1; \
+	}
+	./builder/run.sh kernel
+	./builder/run.sh nvidia
 	$(BAZEL) build --lockfile_mode=error //image:rootfs
 	mkdir -p build/stage
 	install -m 0644 bazel-bin/image/bazel-rootfs.tar build/stage/bazel-rootfs.tar
 
-bazel-debug-layer: builder-debug-init
-	$(BAZEL) build --lockfile_mode=error //image:debug-layer
-	mkdir -p build/stage
-	install -m 0644 bazel-bin/image/bazel-debug-layer.tar build/stage/bazel-debug-layer.tar
-
-custom-kernel-artifacts: runtime-builder
-	./builder/run.sh kernel
-
-nvidia-module-artifacts: custom-kernel-artifacts
-	./builder/run.sh nvidia
-
-bazel-initrd:
+shipping-image: rootfs
 	$(BAZEL) build -c opt --lockfile_mode=error //image/initrd:initrd
-
-test-bazel-initrd: bazel-initrd
-	$(BAZEL) test -c opt --lockfile_mode=error //image/initrd:writer_test
-
-update-runtime-locks:
-	$(BAZEL) run @ubuntu_runtime//:lock
-
-shipping-image: bazel-rootfs bazel-initrd
 	rm -f tinfoilcvm tinfoilcvm.raw tinfoilcvm.roothash tinfoilcvm.hash \
 		tinfoilcvm.vmlinuz tinfoilcvm.initrd
 	$(MKOSI) --force
@@ -99,7 +44,12 @@ shipping-image: bazel-rootfs bazel-initrd
 	cp tinfoilcvm.roothash tinfoilcvm.hash
 	@echo "image hash: $$(cat tinfoilcvm.hash)"
 
-debug-image: bazel-rootfs bazel-debug-layer bazel-initrd custom-kernel-artifacts
+debug-image: rootfs
+	./builder/run.sh debug-init
+	$(BAZEL) build --lockfile_mode=error //image:debug-layer
+	mkdir -p build/stage
+	install -m 0644 bazel-bin/image/bazel-debug-layer.tar build/stage/bazel-debug-layer.tar
+	$(BAZEL) build -c opt --lockfile_mode=error //image/initrd:initrd
 	rm -f tinfoilcvm-debug tinfoilcvm-debug.raw tinfoilcvm-debug.roothash \
 		tinfoilcvm-debug.hash tinfoilcvm-debug.vmlinuz tinfoilcvm-debug.initrd
 	$(MKOSI) --force --output=tinfoilcvm-debug \
@@ -109,8 +59,6 @@ debug-image: bazel-rootfs bazel-debug-layer bazel-initrd custom-kernel-artifacts
 		tinfoilcvm-debug.raw tinfoilcvm-debug.roothash
 	install -m 0644 "$(SHIPPING_KERNEL)" tinfoilcvm-debug.vmlinuz
 	install -m 0644 "$(SHIPPING_INITRD)" tinfoilcvm-debug.initrd
-	cmp -s "$(SHIPPING_KERNEL)" tinfoilcvm-debug.vmlinuz
-	cmp -s "$(SHIPPING_INITRD)" tinfoilcvm-debug.initrd
 	test -s tinfoilcvm-debug.raw
 	test -s tinfoilcvm-debug.vmlinuz
 	test -s tinfoilcvm-debug.initrd
@@ -119,29 +67,22 @@ debug-image: bazel-rootfs bazel-debug-layer bazel-initrd custom-kernel-artifacts
 	cp tinfoilcvm-debug.roothash tinfoilcvm-debug.hash
 	@echo "debug image hash: $$(cat tinfoilcvm-debug.hash)"
 
-release-image:
-	$(MAKE) regenerate-nvattest
-	$(MAKE) shipping-image
-
-rebuild: shipping-image
-
-build: shipping-image
-
-# Normal image builds consume only the two fixed producer outputs. Building
-# nvattest is an explicit operation because it is expensive and release-only.
-nvattest:
-	@test -x "$(NVATTEST_RUNTIME_BINARY)" || { \
-		echo "missing nvattest runtime binary; run 'make regenerate-nvattest'" >&2; \
-		exit 1; \
-	}
-	@test -f "$(NVATTEST_RUNTIME_LIBRARY)" || { \
-		echo "missing libnvat runtime library; run 'make regenerate-nvattest'" >&2; \
-		exit 1; \
-	}
+test:
+	cd tinfoil && go test ./...
+	cd tinfoil && go test -race ./cmd/init ./internal/boot/...
+	cd tinfoil && go test -tags=tinfoil_debug_image ./cmd/init
+	cd tinfoil && go vet ./...
+	$(BAZEL) test -c opt --lockfile_mode=error //tinfoil/... //image/initrd:writer_test
+	$(BAZEL) build -c opt --lockfile_mode=error //image/initrd:initrd
 
 regenerate-nvattest:
-	rm -rf "$(NVATTEST_RUNTIME_OUTPUT)"
-	$(MAKE) runtime-builder
+	docker build --pull --file builder/Dockerfile --tag $(BUILDER_IMAGE) builder
+	rm -rf "$(NVATTEST_OUTPUT)"
 	./builder/run.sh nvattest
-	test -x "$(NVATTEST_RUNTIME_BINARY)"
-	test -f "$(NVATTEST_RUNTIME_LIBRARY)"
+	test -x "$(NVATTEST_BINARY)"
+	test -f "$(NVATTEST_LIBRARY)"
+
+clean:
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm.*
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm-debug tinfoilcvm-debug.*
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf build/stage build/artifacts


### PR DESCRIPTION
## Summary

Reduce Make to a human-facing interface without adding any build machinery.

The Makefile now exposes only six operations:

- `make rootfs`
- `make shipping-image`
- `make debug-image`
- `make test`
- `make regenerate-nvattest`
- `make clean`

This removes the internal alias/prerequisite graph, misleading Bazel-prefixed names, synthetic hash/deep-clean helpers, and the release alias. Each remaining recipe shows the owner transition directly: pinned builder, then Bazel, then mkosi where applicable.

No helper, parser, rule, wrapper, or comparison mechanism is added. `compare-runtime-artifact-builds` is intentionally not introduced here because the reproduction wrappers were removed in #264 and recreating that operation would make this PR additive rather than a Make cleanup. Full repeated-build qualification remains outside routine PR CI.

CI now calls `make test`. Release CI spells out the two deliberate operations—`make regenerate-nvattest` followed by `make shipping-image`—instead of hiding them behind `release-image`.

## Size

- Makefile: 145 changed lines, reduced to 90 total lines
- Whole PR: 60 additions, 129 deletions
- New files: none

## Validation

- `make test`
- dry-run expansion of all six public targets
- retained shell entrypoint syntax checks
- stale Make target reference audit
- `git diff --check`

## Stack order

This PR is based on #264 because it simplifies the builder interface established there.

1. #263
2. #264
3. this PR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduced the Makefile to a small, public interface and removed hidden build machinery. CI calls `make test`; release runs `make regenerate-nvattest` then `make shipping-image`.

- **Refactors**
  - Exposes six targets: `rootfs`, `shipping-image`, `debug-image`, `test`, `regenerate-nvattest`, `clean`.
  - `rootfs` runs trusted producers (`runtime-go`, `kernel`, `nvidia`) and requires `nvattest` artifacts; instructs `make regenerate-nvattest` if missing.
  - `test` runs Go unit/race/debug-tag tests, `go vet`, Bazel `//tinfoil/...` and initrd writer tests; also builds the initrd.
  - Removes internal alias graph, Bazel-prefixed targets, `hash`/deep-clean helpers, `update-runtime-locks`, `build`/`rebuild`, and `release-image`.

<sup>Written for commit 71930883c559022b6f7d64dcc1b48cea74ab7163. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

