### PR TITLE
Move nvattest producer beside its lockfile

### DIFF
--- a/builder/nvattest/build.sh
+++ b/builder/nvattest/build.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Builds the two named nvattest runtime artifacts used by the additive rootfs.
-# Always runs inside the shared pinned runtime builder selected by the Makefile.
+# Always runs inside the shared pinned runtime builder.
 # The cuda-ubuntu2604 repo now ships nvattest, but its libnvat links
 # libxml2.so.2 while Ubuntu resolute ships only libxml2.so.16 (libxml2 2.14
 # bumped the SONAME). So we keep building from source against system libxml2-16.
 
 set -Eeuo pipefail
 
-repo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 readonly UPSTREAM_URL=https://github.com/NVIDIA/attestation-sdk.git
 readonly UPSTREAM_TAG=2026.06.09

--- a/builder/run.sh
+++ b/builder/run.sh
@@ -59,7 +59,7 @@ case "$producer" in
             --env "HOST_UID=$host_uid" \
             --env "HOST_GID=$host_gid" \
             "$builder_image" \
-            /workspace/build-nvattest.sh --runtime-output /output/runtime
+            /workspace/builder/nvattest/build.sh --runtime-output /output/runtime
         ;;
     kernel)
         build_root="$repo_dir/kernel/build"


### PR DESCRIPTION
## Summary

Move the nvattest source producer from the repository root to `builder/nvattest/build.sh`, beside its required `regorus.Cargo.lock` input.

The only behavioral references changed are:

- repository-root calculation now walks up from `builder/nvattest/`
- `builder/run.sh` invokes the new fixed path
- the header no longer claims Make selects the builder

The build commands, pinned inputs, output paths, and published runtime artifacts are unchanged.

## Validation

- `bash -n builder/run.sh builder/nvattest/build.sh`
- verified the committed Regorus lock SHA-256 against the producer constant
- built the cached pinned runtime builder
- invoked `/workspace/builder/nvattest/build.sh` inside that builder and verified its fixed usage/error contract
- `git diff --check`

The expensive nvattest source regeneration is intentionally not duplicated for this path-only move.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the `nvattest` source producer next to its `regorus.Cargo.lock` at `builder/nvattest/build.sh` to keep inputs together. Build behavior and outputs are unchanged.

- **Refactors**
  - Compute repo root by walking up from `builder/nvattest/`.
  - Update `builder/run.sh` to invoke `/workspace/builder/nvattest/build.sh`.
  - Remove the header note about Make selecting the builder.

<sup>Written for commit 747eeaf58c77be076eebbf910374e065734a4ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/267?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

