### PR TITLE
Fix nvattest bind-mounted output publication

### DIFF
--- a/builder/nvattest/build.sh
+++ b/builder/nvattest/build.sh
@@ -125,7 +125,7 @@ DESTDIR="${INSTALL}" cmake --install "${BUILD}/nv-attestation-sdk-build"
     "${INSTALL}/usr/bin/nvattest" \
     "${INSTALL}/usr/lib/x86_64-linux-gnu/libnvat.so.${SO_VERSION}"
 
-rm -rf -- "${RUNTIME_OUT_DIR}"
+rm -rf -- "${RUNTIME_OUT_DIR}/usr"
 install -d -m 0755 \
     "${RUNTIME_OUT_DIR}/usr/bin" \
     "${RUNTIME_OUT_DIR}/usr/lib/x86_64-linux-gnu"


### PR DESCRIPTION
## Summary
- keep the bind-mounted runtime output directory intact
- replace only its fixed `usr` payload during explicit nvattest regeneration
- preserve fail-closed publication without attempting to remove the mount point

## Validation
- `bash -n builder/nvattest/build.sh`
- `make regenerate-nvattest`
- `make -j2 shipping-image debug-image`
- `git diff --check`

The full shipping and debug image build completed successfully after this fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the bind-mounted nvattest runtime output directory during publication by deleting only its `usr` subtree on regeneration. This avoids removing the mount point and maintains fail-closed behavior.

<sup>Written for commit c9fd25c3598d3fbf10901384848775bd5119ee1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/271?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

