### PR TITLE
Expose boot stages before boot completes

### DIFF
--- a/tinfoil/cmd/init/main.go
+++ b/tinfoil/cmd/init/main.go
@@ -212,6 +212,13 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	}); err != nil {
 		return err
 	}
+	if err := deps.services.Start(bootCtx, supervisor.Service{
+		Name: shimName, Required: true, Restart: true,
+		Command: hardenedCommand(hardening.ServiceShim, boot.ShimBinary),
+		Ready:   endpointReady("tcp", "127.0.0.1:443", shimReadyLimit),
+	}); err != nil {
+		return err
+	}
 	if err := deps.oneShot(bootCtx, hardenedCommand(
 		hardening.ServiceBoot, boot.BootBinary,
 	)); err != nil {
@@ -227,13 +234,6 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 		}); err != nil {
 			return err
 		}
-	}
-	if err := deps.services.Start(bootCtx, supervisor.Service{
-		Name: shimName, Required: true, Restart: true,
-		Command: hardenedCommand(hardening.ServiceShim, boot.ShimBinary),
-		Ready:   endpointReady("tcp", "127.0.0.1:443", shimReadyLimit),
-	}); err != nil {
-		return err
 	}
 	if exists, err := deps.exists(boot.EgressConfigPath); err != nil {
 		return err

--- a/tinfoil/cmd/init/main_test.go
+++ b/tinfoil/cmd/init/main_test.go
@@ -439,7 +439,10 @@ func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
 	lock := slices.Index(events, "module-lock")
 	nftables := slices.Index(events, "nftables")
 	containerd := slices.Index(events, containerdName)
-	if loopback < 0 || bootstrap != loopback+1 || lock != bootstrap+1 || nftables != lock+1 || containerd <= nftables {
+	docker := slices.Index(events, dockerName)
+	shim := slices.Index(events, shimName)
+	boot := slices.Index(events, string(hardening.ServiceBoot))
+	if loopback < 0 || bootstrap != loopback+1 || lock != bootstrap+1 || nftables != lock+1 || containerd <= nftables || docker <= containerd || shim <= docker || boot <= shim {
 		t.Fatalf("startup events = %v", events)
 	}
 }


### PR DESCRIPTION
## Summary
- start the existing minimal shim handler before running the boot one-shot
- expose fixed boot-stage state while containers and final shim readiness are still pending
- keep all non-stage endpoints fail-closed until boot artifacts are ready

## Validation
- `go test ./cmd/init`
- `go test -race ./cmd/init ./internal/boot`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `make -j2 shipping-image debug-image`
- Box3 SEV-SNP shipping launch with real attestation
- observed `status=started` with ten resolved stages while `containers` and `shim` remained pending
- workload and `/.well-known/tinfoil-containers` remained healthy after readiness
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start the minimal shim before running the boot one‑shot to expose boot-stage status while boot continues. All non-stage endpoints remain closed until boot artifacts are ready.

- New Features
  - Start shim early to publish boot-stage state; containers and final shim readiness still wait for boot completion.
  - Keep non-stage endpoints fail-closed until artifacts are present.

- Refactors
  - Enforce new startup order: loopback → bootstrap → module-lock → nftables → containerd → docker → shim → boot (updated test to assert this).

<sup>Written for commit fe71cfb2374d8cde1216c123dd0291979694a761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

