### PR TITLE
Track observed container restarts

### DIFF
--- a/tinfoil/cmd/container-status/main.go
+++ b/tinfoil/cmd/container-status/main.go
@@ -47,6 +47,7 @@ type containersResponse struct {
 
 type containerStatus struct {
 	Name          string           `json:"name"`
+	ContainerID   string           `json:"container_id,omitempty"`
 	Image         string           `json:"image"`
 	Declared      bool             `json:"declared"`
 	Created       bool             `json:"created"`
@@ -110,7 +111,15 @@ func publishContainerStatus(ctx context.Context, cli containerStatusClient, conf
 		return fmt.Errorf("loading declared containers: %w", err)
 	}
 
+	previous, err := loadPreviousContainerStatus(outputPath)
+	if err != nil {
+		return fmt.Errorf("loading previous status: %w", err)
+	}
 	states, inspectErr := inspectDeclaredContainers(ctx, cli, declared)
+	if inspectErr != nil {
+		states = preservePreviousContainerStatuses(declared, previous, states)
+	}
+	mergeContainerLifecycles(previous, states)
 	resp := containersResponse{
 		ObservedAt: time.Now().UTC(),
 		Containers: states,
@@ -128,6 +137,61 @@ func publishContainerStatus(ctx context.Context, cli containerStatusClient, conf
 		return fmt.Errorf("writing status: %w", err)
 	}
 	return inspectErr
+}
+
+func preservePreviousContainerStatuses(declared []declaredContainer, previous, current []containerStatus) []containerStatus {
+	previousByName := make(map[string]containerStatus, len(previous))
+	for _, status := range previous {
+		previousByName[status.Name] = status
+	}
+	currentByName := make(map[string]containerStatus, len(current))
+	for _, status := range current {
+		currentByName[status.Name] = status
+	}
+	preserved := make([]containerStatus, 0, len(declared))
+	for _, container := range declared {
+		if status, ok := currentByName[container.Name]; ok {
+			preserved = append(preserved, status)
+		} else if status, ok := previousByName[container.Name]; ok {
+			preserved = append(preserved, status)
+		}
+	}
+	return preserved
+}
+
+func loadPreviousContainerStatus(path string) ([]containerStatus, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var response containersResponse
+	if err := json.Unmarshal(data, &response); err != nil {
+		return nil, err
+	}
+	return response.Containers, nil
+}
+
+func mergeContainerLifecycles(previous, current []containerStatus) {
+	byName := make(map[string]containerStatus, len(previous))
+	for _, status := range previous {
+		byName[status.Name] = status
+	}
+	for i := range current {
+		prior, ok := byName[current[i].Name]
+		if !ok || !prior.Created || !current[i].Created {
+			continue
+		}
+		observedReplacement := prior.ContainerID != "" && current[i].ContainerID != "" && prior.ContainerID != current[i].ContainerID
+		observedRestart := prior.StartedAt != "" && current[i].StartedAt != "" && prior.StartedAt != current[i].StartedAt
+		if observedReplacement || observedRestart {
+			current[i].RestartCount = max(current[i].RestartCount, prior.RestartCount+1)
+		} else {
+			current[i].RestartCount = max(current[i].RestartCount, prior.RestartCount)
+		}
+	}
 }
 
 func loadDeclaredContainers(path string) ([]declaredContainer, error) {
@@ -171,6 +235,7 @@ func inspectDeclaredContainers(ctx context.Context, cli containerStatusClient, d
 func containerStatusFromInspect(declared declaredContainer, inspect container.InspectResponse) containerStatus {
 	status := containerStatus{
 		Name:          declared.Name,
+		ContainerID:   inspect.ID,
 		Image:         declared.Image,
 		Declared:      true,
 		Created:       true,

--- a/tinfoil/cmd/container-status/main_test.go
+++ b/tinfoil/cmd/container-status/main_test.go
@@ -212,3 +212,75 @@ func TestPublishContainerStatusWritesJSON(t *testing.T) {
 		t.Fatal("expected observed_at to be set")
 	}
 }
+
+func TestPublishContainerStatusCountsManualRestart(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yml")
+	outputPath := filepath.Join(dir, "container-status.json")
+	if err := os.WriteFile(configPath, []byte("containers:\n  - name: model\n    image: model:latest\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	client := fakeContainerClient{inspect: map[string]container.InspectResponse{
+		"model": {
+			ContainerJSONBase: &container.ContainerJSONBase{
+				ID:    "container-id",
+				State: &container.State{Status: "running", StartedAt: "2026-07-25T01:00:00Z"},
+			},
+		},
+	}}
+	if err := publishContainerStatus(context.Background(), client, configPath, outputPath); err != nil {
+		t.Fatal(err)
+	}
+	client.inspect["model"].State.StartedAt = "2026-07-25T01:01:00Z"
+	client.inspect["model"].State.FinishedAt = "2026-07-25T01:00:59Z"
+	if err := publishContainerStatus(context.Background(), client, configPath, outputPath); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got containersResponse
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Containers) != 1 || got.Containers[0].ContainerID != "container-id" || got.Containers[0].RestartCount != 1 {
+		t.Fatalf("unexpected lifecycle status: %#v", got.Containers)
+	}
+}
+
+func TestMergeContainerLifecyclesCountsReplacement(t *testing.T) {
+	current := []containerStatus{{
+		Name:        "model",
+		ContainerID: "replacement-id",
+		Created:     true,
+		StartedAt:   "2026-07-25T01:00:00Z",
+	}}
+	mergeContainerLifecycles([]containerStatus{{
+		Name:         "model",
+		ContainerID:  "original-id",
+		Created:      true,
+		RestartCount: 2,
+		StartedAt:    current[0].StartedAt,
+	}}, current)
+	if current[0].RestartCount != 3 {
+		t.Fatalf("restart_count = %d, want 3", current[0].RestartCount)
+	}
+}
+
+func TestPreservePreviousContainerStatusesAfterInspectFailure(t *testing.T) {
+	declared := []declaredContainer{{Name: "first"}, {Name: "second"}}
+	previous := []containerStatus{
+		{Name: "first", ContainerID: "first-old", Created: true},
+		{Name: "second", ContainerID: "second-old", Created: true, RestartCount: 4},
+	}
+	current := []containerStatus{{Name: "first", ContainerID: "first-new", Created: true}}
+
+	got := preservePreviousContainerStatuses(declared, previous, current)
+	if len(got) != 2 {
+		t.Fatalf("statuses = %#v", got)
+	}
+	if got[0].ContainerID != "first-new" || got[1].ContainerID != "second-old" || got[1].RestartCount != 4 {
+		t.Fatalf("statuses = %#v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- expose the current Docker container ID in the fixed status response
- retain the previous atomic status snapshot across polls
- count manual restarts and same-name replacements when identity or `started_at` changes
- preserve Docker's native automatic restart count when it is higher

## Validation
- `go test ./cmd/container-status`
- `go test -race ./cmd/container-status`
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- `make -j2 shipping-image debug-image`
- Box3 SEV-SNP debug launch with toolbox SSH, Docker pull/run/exec, serial console, and endpoint checks
- manual `docker restart` changed published `restart_count` from 0 to 1 while the container returned to `running`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds restart observability to `container-status`. Tracks manual restarts and same-name replacements across polls, publishes `container_id`, and falls back to the last snapshot on inspect failures while keeping Docker’s restart count when higher.

- **New Features**
  - Adds `container_id` to the status JSON.
  - Loads the prior status snapshot and merges lifecycle data across polls; increments `restart_count` when `started_at` or `container_id` changes, using the max of observed and Docker-reported counts.
  - Preserves previous statuses if Docker inspect fails; adds tests for manual restarts, replacements, and failure fallback.

<sup>Written for commit 1b90e6a43ae20988bb1880864e2ecf41bc2a6f99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

