### PR TITLE
Stage Bazel outputs before parallel image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,12 @@ MKOSI ?= sudo env PATH="$(TRUSTED_PATH)" mkosi
 BAZEL ?= bazel
 BUILDER_IMAGE := cvmimage-runtime-builder
 SHIPPING_KERNEL := kernel/out/tinfoil-custom.vmlinuz
-SHIPPING_INITRD := bazel-bin/image/initrd/initrd.cpio.zst
+SHIPPING_INITRD := build/stage/initrd.cpio.zst
 NVATTEST_OUTPUT := build/rootfs-artifacts/nvattest
 NVATTEST_BINARY := $(NVATTEST_OUTPUT)/usr/bin/nvattest
 NVATTEST_LIBRARY := $(NVATTEST_OUTPUT)/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2
 
-.PHONY: rootfs shipping-image debug-image test regenerate-nvattest clean
+.PHONY: rootfs initrd debug-layer shipping-image debug-image test regenerate-nvattest clean
 
 rootfs:
 	docker build --pull --file builder/Dockerfile --tag $(BUILDER_IMAGE) builder
@@ -25,10 +25,20 @@ rootfs:
 	./builder/run.sh nvidia
 	$(BAZEL) build --lockfile_mode=error //image:rootfs
 	mkdir -p build/stage
-	install -m 0644 bazel-bin/image/bazel-rootfs.tar build/stage/bazel-rootfs.tar
+	install -m 0644 "$$($(BAZEL) info bazel-bin)/image/bazel-rootfs.tar" build/stage/bazel-rootfs.tar
 
-shipping-image: rootfs
+initrd: rootfs
 	$(BAZEL) build -c opt --lockfile_mode=error //image/initrd:initrd
+	mkdir -p build/stage
+	install -m 0644 "$$($(BAZEL) info -c opt bazel-bin)/image/initrd/initrd.cpio.zst" "$(SHIPPING_INITRD)"
+
+debug-layer: rootfs
+	./builder/run.sh debug-init
+	$(BAZEL) build --lockfile_mode=error //image:debug-layer
+	mkdir -p build/stage
+	install -m 0644 "$$($(BAZEL) info bazel-bin)/image/bazel-debug-layer.tar" build/stage/bazel-debug-layer.tar
+
+shipping-image: initrd
 	rm -f tinfoilcvm tinfoilcvm.raw tinfoilcvm.roothash tinfoilcvm.hash \
 		tinfoilcvm.vmlinuz tinfoilcvm.initrd
 	$(MKOSI) --force
@@ -44,12 +54,7 @@ shipping-image: rootfs
 	cp tinfoilcvm.roothash tinfoilcvm.hash
 	@echo "image hash: $$(cat tinfoilcvm.hash)"
 
-debug-image: rootfs
-	./builder/run.sh debug-init
-	$(BAZEL) build --lockfile_mode=error //image:debug-layer
-	mkdir -p build/stage
-	install -m 0644 bazel-bin/image/bazel-debug-layer.tar build/stage/bazel-debug-layer.tar
-	$(BAZEL) build -c opt --lockfile_mode=error //image/initrd:initrd
+debug-image: initrd debug-layer
 	rm -f tinfoilcvm-debug tinfoilcvm-debug.raw tinfoilcvm-debug.roothash \
 		tinfoilcvm-debug.hash tinfoilcvm-debug.vmlinuz tinfoilcvm-debug.initrd
 	$(MKOSI) --force --output=tinfoilcvm-debug \


### PR DESCRIPTION
## Summary
- give shared rootfs, initrd, and debug-layer producers explicit Make ownership
- copy Bazel outputs from their configuration-specific output directories into stable staging paths
- let shipping and debug mkosi finalizers run in parallel without racing the mutable `bazel-bin` symlink

## Validation
- `make -n -j2 shipping-image debug-image`
- reproduced the previous race as `install: No such file or directory` for `bazel-bin/image/initrd/initrd.cpio.zst`
- `make -j2 shipping-image debug-image` completes after the fix
- byte-for-byte `cmp` matches for shipping/debug raw disks, hashes, kernels, initrds, Bazel rootfs, nvattest artifacts, and all three NVIDIA modules
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stage Bazel outputs into stable `build/stage` paths and split Make targets so shipping and debug images can build in parallel without racing the `bazel-bin` symlink. Fixes intermittent “install: No such file or directory” when running `make -j`.

- **Bug Fixes**
  - Copy `image/bazel-rootfs.tar`, `image/initrd/initrd.cpio.zst`, and `image/bazel-debug-layer.tar` from config-specific `bazel-bin` into `build/stage`.
  - Resolve outputs via `$(BAZEL) info bazel-bin` and `$(BAZEL) info -c opt bazel-bin` instead of hardcoded `bazel-bin`.
  - Add `initrd` and `debug-layer` targets; `shipping-image` depends on `initrd`, `debug-image` depends on `initrd` + `debug-layer`.
  - Set `SHIPPING_INITRD` to `build/stage/initrd.cpio.zst`.

<sup>Written for commit 9188945dc87155ca4abde61a02d8b1b266886e5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

