### PR TITLE
Build Go runtime and initrd artifacts with Nix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,47 @@ on:
 permissions: {}
 
 jobs:
+  nix-go-initrd:
+    name: Nix Go and initrd
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends nix-bin nix-setup-systemd
+          sudo install -d -m 0755 /etc/nix
+          printf 'sandbox = true\nbuild-users-group = nixbld\n' |
+            sudo tee /etc/nix/nix.conf >/dev/null
+          sudo install -d -o root -g nixbld -m 1775 /nix/store
+          sudo usermod -aG nix-users "$USER"
+          sudo systemctl restart nix-daemon.service
+          nix-build --version
+
+      - name: Build and compare Nix outputs
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo --preserve-env=HOME -u "$USER" -g nix-users \
+            env NIX_REMOTE=daemon bash -Eeuo pipefail <<'NIX_BUILD'
+            set -Eeuo pipefail
+            targets=(runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd)
+            for target in "${targets[@]}"; do
+              nix-build --no-out-link -A "$target"
+            done
+            for target in "${targets[@]}"; do
+              nix-build --no-out-link --check -A "$target"
+            done
+          NIX_BUILD
+
   test:
     name: Build and Test
     runs-on: ubuntu-latest

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,24 @@
+{
+  system ? builtins.currentSystem,
+}:
+
+assert system == "x86_64-linux";
+
+let
+  nixpkgsLock = builtins.fromJSON (builtins.readFile ./nixpkgs.lock.json);
+  nixpkgs = builtins.fetchTarball {
+    inherit (nixpkgsLock) url sha256;
+  };
+  pkgs = import nixpkgs { inherit system; };
+  go = import ./nix/go.nix { inherit pkgs; };
+  initrd = import ./nix/initrd.nix {
+    inherit pkgs;
+    inherit (go) upstreamGo;
+    tinfoilInitrd = go.packages."tinfoil-initrd";
+  };
+in
+go.packages
+// {
+  "fixed-cpio-writer" = initrd.writer;
+  initrd = initrd.archive;
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -9,6 +9,36 @@ This is a declarative, pinned build graph. It is not a claim that Bazel builds
 the complete image, that every action is hermetic, or that Bazel itself proves
 full-image reproducibility.
 
+## Nix Go and initrd producer
+
+The next release builds the five CGO runtime commands, compile-time debug PID1,
+pure-Go initrd command, fixed CPIO writer, and compressed initrd through the
+top-level `default.nix`. This boundary uses one checksum-pinned Nixpkgs source
+and Nixpkgs' `buildGoModule` implementation with the checksum-pinned upstream
+Go toolchain. It does not invoke Docker, Bazel, Make, or mkosi.
+
+Build the runtime commands or initrd with `nix-build`:
+
+```sh
+nix-build --option sandbox true -A runtime-go
+nix-build --option sandbox true -A debug-init
+nix-build --option sandbox true -A initrd
+```
+
+The CGO outputs retain the measured Ubuntu runtime ABI: they request
+`/lib64/ld-linux-x86-64.so.2`, have no effective runtime search path, and are
+required by Nix to contain no store references. The initrd command is static.
+The fixed writer runs its existing unit tests while it builds and emits
+`initrd.cpio.zst` directly from that command and pinned Zstandard. The
+`debug-init` derivation enables only the `tinfoil_debug_image` build tag. The
+existing Go test job runs the tag-specific PID1 tests before these artifacts
+are accepted.
+
+This PR establishes the producer boundary but does not switch the current
+rootfs or shipping-image consumers. That cutover belongs with Nix ownership of
+the additive rootfs, so no intermediate adapter or duplicated staging protocol
+is introduced here.
+
 ## Graph
 
 ```mermaid

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -1,0 +1,113 @@
+{ pkgs }:
+
+let
+  commonEnv.GOTOOLCHAIN = "local";
+
+  upstreamGo = pkgs.stdenvNoCC.mkDerivation {
+    pname = "go";
+    version = "1.25.7";
+
+    src = pkgs.fetchurl {
+      url = "https://go.dev/dl/go1.25.7.linux-amd64.tar.gz";
+      hash = "sha256-EubWoZEJGuJ9wx9u/GMOOjuLpAm681c9lVsZb98IYAU=";
+    };
+
+    sourceRoot = "go";
+    dontBuild = true;
+    dontFixup = true;
+
+    installPhase = ''
+      runHook preInstall
+      cp -a . "$out"
+      runHook postInstall
+    '';
+
+    passthru = {
+      GOOS = "linux";
+      GOARCH = "amd64";
+      CGO_ENABLED = 1;
+    };
+  };
+
+  buildGoModule = pkgs.callPackage (pkgs.path + "/pkgs/build-support/go/module.nix") {
+    go = upstreamGo;
+  };
+
+  common = {
+    version = "0";
+    src = pkgs.lib.cleanSource ../tinfoil;
+    vendorHash = "sha256-gQi1zu60GGk89+RWnafiZ1Wqu0DR5N2uX1UbYTjqRHM=";
+    ldflags = [
+      "-s"
+      "-w"
+    ];
+    allowedReferences = [ ];
+    doCheck = false;
+  };
+
+  buildCgoCommand =
+    attributes:
+    buildGoModule (
+      common
+      // {
+        env = {
+          CGO_ENABLED = "1";
+          NIX_DONT_SET_RPATH = "1";
+        } // commonEnv;
+        # go-nvml leaves NVML symbols unresolved until the measured NVIDIA
+        # library is available in the guest. BIND_NOW resolves them before
+        # main and makes CPU-only boot fail with a symbol lookup error.
+        hardeningDisable = [ "bindnow" ];
+        ldflags = common.ldflags ++ [
+          "-linkmode=external"
+          "-extldflags=-Wl,--build-id=none,--dynamic-linker=/lib64/ld-linux-x86-64.so.2"
+        ];
+      }
+      // attributes
+    );
+
+  runtime = buildCgoCommand {
+    pname = "tinfoil-runtime";
+    subPackages = [
+      "cmd/boot"
+      "cmd/container-status"
+      "cmd/egress"
+      "cmd/init"
+      "cmd/shim"
+    ];
+    postInstall = ''
+      for command in boot container-status egress init shim; do
+        mv "$out/bin/$command" "$out/bin/tinfoil-$command"
+      done
+    '';
+  };
+
+  debugInit = buildCgoCommand {
+    pname = "tinfoil-debug-init";
+    subPackages = [ "cmd/init" ];
+    tags = [ "tinfoil_debug_image" ];
+    postInstall = ''
+      mv "$out/bin/init" "$out/bin/tinfoil-init"
+    '';
+  };
+
+  initrd = buildGoModule (
+    common
+    // {
+      pname = "tinfoil-initrd";
+      subPackages = [ "cmd/initrd" ];
+      env = commonEnv // { CGO_ENABLED = "0"; };
+      postInstall = ''
+        mv "$out/bin/initrd" "$out/bin/tinfoil-initrd"
+      '';
+    }
+  );
+in
+{
+  inherit upstreamGo;
+  packages = {
+    "debug-init" = debugInit;
+    "runtime-go" = runtime;
+    "tinfoil-initrd" = initrd;
+  };
+}

--- a/nix/initrd.nix
+++ b/nix/initrd.nix
@@ -1,0 +1,46 @@
+{
+  pkgs,
+  upstreamGo,
+  tinfoilInitrd,
+}:
+
+let
+  writer = pkgs.stdenvNoCC.mkDerivation {
+    pname = "fixed-cpio-writer";
+    version = "0";
+    src = pkgs.lib.cleanSource ../image/initrd;
+    nativeBuildInputs = [ upstreamGo ];
+    allowedReferences = [ ];
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+      export GOCACHE="$TMPDIR/go-cache"
+      export GOTOOLCHAIN=local
+      GO111MODULE=off CGO_ENABLED=0 go test writer.go writer_test.go
+      GO111MODULE=off CGO_ENABLED=0 go build \
+        -trimpath \
+        -buildvcs=false \
+        -ldflags='-s -w -buildid=' \
+        -o write-fixed-cpio \
+        writer.go
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      install -D -m 0755 write-fixed-cpio "$out/bin/write-fixed-cpio"
+      runHook postInstall
+    '';
+  };
+
+  archive = pkgs.runCommand "initrd.cpio.zst" { allowedReferences = [ ]; } ''
+    ${writer}/bin/write-fixed-cpio \
+      ${tinfoilInitrd}/bin/tinfoil-initrd \
+      ${pkgs.zstd}/bin/zstd \
+      "$out"
+  '';
+in
+{
+  inherit writer archive;
+}

--- a/nixpkgs.lock.json
+++ b/nixpkgs.lock.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs/archive/597283ad8aa0b331c788e97c4c262d58877074ef.tar.gz",
+  "sha256": "sha256-J+Bx1Z6Oeoj2FgnBhRMKyUhhtDoOpTgXYaVLZpDjW4A="
+}


### PR DESCRIPTION
## Summary

- add a stable `default.nix` entry with one checksum-pinned Nixpkgs source
- build the five CGO runtime commands, debug-tagged PID1, and pure-Go initrd with standard Nixpkgs `buildGoModule`
- build the existing fixed Go CPIO writer and emit `initrd.cpio.zst` directly
- add a sandboxed Ubuntu `nix-bin` CI job

This establishes a real Nix-owned producer boundary. It does not wrap Docker or Bazel and does not cut over the shipping image yet.

## Design

- official checksum-pinned upstream Go 1.25.7 archive
- ordinary Nixpkgs Go module helper, with no custom Go/CGO rule
- fixed Ubuntu FHS interpreter for CGO outputs
- no effective RPATH and no `/nix/store` references in runtime outputs
- stable Nix files rather than flakes
- no compatibility requirement with previous artifact bytes; this is a new release measurement

## Validation

- two sandboxed Box3 builds matched for all five exposed targets
- `go build ./...`
- `go test ./...`
- focused race tests
- debug-tagged PID1 and supervisor tests
- writer tests
- `go vet ./...`
- `git diff --check`

An independent clean INF14 build is running; its hashes will be added to the PR once complete.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build Go runtime and initrd with Nix to create a stable, pinned producer boundary for the next release. Produces five CGO runtime commands, a debug-tagged PID1, a static `tinfoil-initrd`, and a compressed `initrd.cpio.zst`.

- **New Features**
  - Added `default.nix` pinned via `nixpkgs.lock.json`; uses upstream Go 1.25.7 with `buildGoModule`.
  - Exposes Nix attrs: `runtime-go`, `debug-init`, `tinfoil-initrd`, `fixed-cpio-writer`, `initrd`.
  - `fixed-cpio-writer` runs unit tests; `initrd` uses it to emit `initrd.cpio.zst`.
  - CGO outputs use `/lib64/ld-linux-x86-64.so.2`, have no RPATH, and contain no `/nix/store` refs; `tinfoil-initrd` is static.
  - CI: sandboxed Ubuntu job installs `nix-bin`, builds all targets, and verifies with `--check`.
  - Docs: adds `nix-build` usage and clarifies this is only the producer boundary (no consumer cutover).

<sup>Written for commit ba0577a242adfce2ac09480501c0644337552ef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

