### PR TITLE
Build the pinned kernel with Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -16,9 +16,11 @@ let
     inherit (go) upstreamGo;
     tinfoilInitrd = go.packages."tinfoil-initrd";
   };
+  kernel = import ./nix/kernel.nix { inherit pkgs; };
 in
 go.packages
 // {
   "fixed-cpio-writer" = initrd.writer;
   initrd = initrd.archive;
+  "kernel-artifacts" = kernel.artifacts;
 }

--- a/nix/kernel.nix
+++ b/nix/kernel.nix
@@ -1,0 +1,138 @@
+{ pkgs }:
+
+let
+  inherit (pkgs) lib;
+
+  version = "7.0.0";
+  release = "7.0.0-28-generic";
+  buildTimestamp = "Tue Jan  1 00:00:00 UTC 1980";
+
+  sourceDeb = pkgs.fetchurl {
+    url = "https://snapshot.ubuntu.com/ubuntu/20260721T000000Z/pool/main/l/linux/linux-source-7.0.0_7.0.0-28.28_all.deb";
+    hash = "sha256-3VmUsZmhywax8za7CGxcI6klj9z9y7fcyNOvqaXZLhM=";
+  };
+
+  source =
+    pkgs.runCommand "linux-source-7.0.0-28.28"
+      {
+        nativeBuildInputs = [
+          pkgs.dpkg
+          pkgs.gnutar
+          pkgs.xz
+        ];
+      }
+      ''
+        mkdir unpack "$out"
+        dpkg-deb -x ${sourceDeb} unpack
+        source_tarball=$(find unpack/usr/src/linux-source-${version} \
+          -maxdepth 1 -type f -name 'linux-source-*.tar.*' -print -quit)
+        test -n "$source_tarball"
+        tar -xf "$source_tarball" \
+          --strip-components=1 -C "$out"
+      '';
+
+  configFile = pkgs.stdenv.mkDerivation {
+    pname = "tinfoil-linux-config";
+    inherit version;
+    src = source;
+    nativeBuildInputs = [
+      pkgs.bash
+      pkgs.bison
+      pkgs.flex
+      pkgs.gawk
+      pkgs.gnumake
+      pkgs.pahole
+      pkgs.pkg-config
+    ];
+    dontConfigure = true;
+    buildPhase = ''
+      runHook preBuild
+      install -Dm0644 ${../kernel/tinfoil-cvm-7.0.defconfig} \
+        arch/x86/configs/tinfoil_cvm_defconfig
+      make KERNELVERSION=${version} tinfoil_cvm_defconfig
+      scripts/kconfig/merge_config.sh -m \
+        .config ${../kernel/config.d/10-tinfoil-cvm-policy.config}
+      make KERNELVERSION=${version} olddefconfig
+      ${pkgs.bash}/bin/bash ${../kernel/check-config.sh} \
+        .config ${../kernel/config.d/10-tinfoil-cvm-policy.config}
+      runHook postBuild
+    '';
+    installPhase = ''
+      runHook preInstall
+      install -Dm0644 .config "$out"
+      runHook postInstall
+    '';
+  };
+
+  uncheckedKernel = pkgs.linuxManualConfig {
+    pname = "tinfoil-linux";
+    inherit version;
+    src = source;
+    configfile = configFile;
+    config = {
+      CONFIG_MODULES = "y";
+      CONFIG_RUST = "n";
+    };
+    modDirVersion = release;
+    kernelPatches = [
+      {
+        name = "disable-build-id";
+        patch = ./patches/kernel-disable-build-id.patch;
+      }
+    ];
+    extraMakeFlags = [
+      "KBUILD_BUILD_USER=tinfoil"
+      "KBUILD_BUILD_HOST=tinfoil-builder"
+      "KERNELVERSION=${version}"
+    ];
+  };
+
+  kernel = uncheckedKernel.overrideAttrs (old: {
+    buildFlags =
+      builtins.filter (flag: !(lib.hasPrefix "KBUILD_BUILD_VERSION=" flag)) (old.buildFlags or [ ])
+      ++ [
+        "KBUILD_BUILD_VERSION=1"
+      ];
+    preBuild = (old.preBuild or "") + ''
+      export KBUILD_BUILD_TIMESTAMP='${buildTimestamp}'
+      export KCFLAGS="''${KCFLAGS:-} -ffile-prefix-map=$buildRoot=/build -fmacro-prefix-map=$buildRoot=/build -fdebug-prefix-map=$buildRoot=/build"
+      export KAFLAGS="''${KAFLAGS:-} -Wa,--debug-prefix-map=$buildRoot=/build"
+    '';
+    postInstall = (old.postInstall or "") + ''
+      find "$dev/lib/modules/${release}/build" -type f -name '*.cmd' \
+        -exec sed -i "s|$buildRoot|/build|g" {} +
+    '';
+    postConfigure = (old.postConfigure or "") + ''
+      ${pkgs.bash}/bin/bash ${../kernel/check-config.sh} \
+        "$buildRoot/.config" ${../kernel/config.d/10-tinfoil-cvm-policy.config}
+    '';
+  });
+
+  artifacts =
+    pkgs.runCommand "tinfoil-kernel-${release}-artifacts"
+      {
+        nativeBuildInputs = [ pkgs.coreutils ];
+      }
+      ''
+        mkdir "$out"
+        install -m0644 ${kernel}/bzImage "$out/tinfoil-custom.vmlinuz"
+        install -m0644 ${kernel.dev}/lib/modules/${release}/build/.config "$out/config"
+        install -m0644 ${kernel.dev}/lib/modules/${release}/build/Module.symvers "$out/Module.symvers"
+        install -m0644 ${kernel.modules}/lib/modules/${release}/modules.builtin "$out/modules.builtin"
+        printf '%s\n' '${release}' > "$out/kernel.release"
+        (cd "$out" && sha256sum \
+          tinfoil-custom.vmlinuz config Module.symvers modules.builtin kernel.release \
+          > checksums.sha256)
+      '';
+in
+{
+  config = configFile;
+  inherit
+    source
+    kernel
+    artifacts
+    release
+    version
+    ;
+  kernelPackages = pkgs.linuxPackagesFor kernel;
+}

--- a/nix/patches/kernel-disable-build-id.patch
+++ b/nix/patches/kernel-disable-build-id.patch
@@ -1,0 +1,12 @@
+--- a/Makefile
++++ b/Makefile
+@@ -1158,2 +1158,2 @@
+-KBUILD_LDFLAGS_MODULE += --build-id=sha1
+-LDFLAGS_vmlinux += --build-id=sha1
++KBUILD_LDFLAGS_MODULE += --build-id=none
++LDFLAGS_vmlinux += --build-id=none
+--- a/arch/x86/entry/vdso/common/Makefile.include
++++ b/arch/x86/entry/vdso/common/Makefile.include
+@@ -64 +64 @@
+-VDSO_LDFLAGS := -shared --hash-style=both --build-id=sha1 --no-undefined \
++VDSO_LDFLAGS := -shared --hash-style=both --build-id=none --no-undefined \


### PR DESCRIPTION
## Summary
- build the pinned Ubuntu 7.0 source with Nixpkgs `linuxManualConfig`
- reuse the existing fixed defconfig and policy check
- export only the kernel, config, symbol versions, built-in module list, and release
- normalize the kernel identity and build paths needed for reproducibility

## Review boundary
This is stacked on #275 and contains only the kernel producer. NVIDIA modules are a separate dependent PR.

## Validation
- sandboxed Nix build completed on Box3
- kernel identity is fixed to `tinfoil@tinfoil-builder`, build number `1`, and the fixed timestamp
- output kernel SHA-256: `ef81a9916efd8e0b8ccc4066447f34c301939e01bbbcc51d4e4bd44aa0e3ddcd`
- full forced kernel-output rebuild passed before the final identity cleanup
- an A/B experiment removing the build-ID and build-path normalization failed Nix's determinism check, confirming these controls are necessary rather than decorative
- `git diff --check`

Merge #275 before this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build the pinned Ubuntu 7.0 kernel with Nix and produce deterministic artifacts for downstream modules. Exposes a reproducible kernel builder via `kernel-artifacts`.

- **New Features**
  - Uses Nixpkgs `linuxManualConfig` with the existing defconfig and policy check.
  - Fixes build identity and paths for determinism: sets a fixed timestamp and build version, pins user/host, maps build paths, and removes ELF build-ids via `kernel-disable-build-id.patch`.
  - Exports `tinfoil-custom.vmlinuz`, `config`, `Module.symvers`, `modules.builtin`, `kernel.release` (plus `checksums.sha256`).
  - Pins Ubuntu source to `7.0.0-28-generic` from Ubuntu snapshots; wires `default.nix` to expose `kernel-artifacts`.

<sup>Written for commit 9914e989b53e5b3516271a8c2bb05bece2dea3d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

