### PR TITLE
Build fixed NVIDIA modules with Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,10 +17,12 @@ let
     tinfoilInitrd = go.packages."tinfoil-initrd";
   };
   kernel = import ./nix/kernel.nix { inherit pkgs; };
+  nvidia = import ./nix/nvidia-modules.nix { inherit pkgs kernel; };
 in
 go.packages
 // {
   "fixed-cpio-writer" = initrd.writer;
   initrd = initrd.archive;
   "kernel-artifacts" = kernel.artifacts;
+  "nvidia-modules" = nvidia.modules;
 }

--- a/nix/nvidia-modules.nix
+++ b/nix/nvidia-modules.nix
@@ -1,0 +1,134 @@
+{ pkgs, kernel }:
+
+let
+  inherit (pkgs) lib;
+  inherit (kernel) kernelPackages release;
+  version = "595.71.05";
+
+  _versionCheck =
+    assert kernelPackages.nvidiaPackages.production.version == version;
+    true;
+  nvidiaOpen = kernelPackages.nvidiaPackages.production.open.overrideAttrs (old: {
+    env = (old.env or { }) // {
+      CONFIG_X86_KERNEL_IBT = "";
+      KBUILD_BUILD_TIMESTAMP = "Tue Jan  1 00:00:00 UTC 1980";
+      NV_EXCLUDE_KERNEL_MODULES = "nvidia-drm nvidia-peermem";
+      NV_BUILD_HOST = "tinfoil-builder";
+      NV_BUILD_USER = "tinfoil";
+    };
+    makeFlags = builtins.filter (flag: !(lib.hasPrefix "KBUILD_BUILD_TIMESTAMP=" flag)) (
+      old.makeFlags or [ ]
+    );
+  });
+
+  modules =
+    assert _versionCheck;
+    pkgs.runCommand "tinfoil-nvidia-open-${version}-${release}"
+      {
+        nativeBuildInputs = [
+          pkgs.binutils
+          pkgs.coreutils
+          pkgs.diffutils
+          pkgs.findutils
+          pkgs.gawk
+          pkgs.gnugrep
+          pkgs.kmod
+        ];
+      }
+      ''
+        source_root=${nvidiaOpen}/lib/modules/${release}
+        mapfile -t built_modules < <(find "$source_root" -type f -name '*.ko' -printf '%f\n' | sort)
+        expected_modules=(nvidia-modeset.ko nvidia-uvm.ko nvidia.ko)
+
+        if ! diff -u \
+          <(printf '%s\n' "''${expected_modules[@]}") \
+          <(printf '%s\n' "''${built_modules[@]}"); then
+          echo "NVIDIA build produced an unexpected module set" >&2
+          exit 1
+        fi
+
+        mkdir "$out"
+        for module in "''${expected_modules[@]}"; do
+          source=$(find "$source_root" -type f -name "$module" -print -quit)
+          test -n "$source"
+          install -m0644 "$source" "$out/$module"
+        done
+
+        expected_vermagic='${release} SMP preempt mod_unload modversions '
+        : > kernel-crcs
+        awk '{ print $2, tolower($1) }' ${kernel.artifacts}/Module.symvers \
+          | sort -u > kernel-crcs
+        : > selected-crcs
+        for module in "$out"/*.ko; do
+          for section in __kcrctab __kcrctab_gpl; do
+            section_index=$(readelf -SW "$module" \
+              | sed -n "s/^ *\[ *\([0-9][0-9]*\)\] $section .*/\1/p")
+            test -n "$section_index" || continue
+            section_file=$(mktemp)
+            objcopy --dump-section "$section=$section_file" "$module" /dev/null
+            while read -r offset symbol; do
+              crc=$(od -An -tx4 -N4 -j "$((16#$offset))" "$section_file" \
+                | tr -d '[:space:]')
+              printf '%s 0x%s\n' "''${symbol#__crc_}" "$crc"
+            done < <(readelf -sW "$module" \
+              | awk -v section_index="$section_index" \
+                '$7 == section_index && $8 ~ /^__crc_/ { print $2, $8 }')
+            rm -f "$section_file"
+          done
+        done | sort -u > selected-crcs
+
+        {
+          printf 'version=%s\n' '${version}'
+          printf 'release=%s\n' '${release}'
+          printf 'vermagic=%s\n' "$expected_vermagic"
+        } > "$out/validation.txt"
+
+        for module in "''${expected_modules[@]}"; do
+          module_path="$out/$module"
+          actual_version=$(modinfo -F version "$module_path")
+          actual_vermagic=$(modinfo -F vermagic "$module_path")
+          case "$module" in
+            nvidia.ko) expected_depends= ;;
+            *) expected_depends='nvidia' ;;
+          esac
+          actual_depends=$(modinfo -F depends "$module_path")
+
+          test "$actual_version" = '${version}'
+          test "$actual_vermagic" = "$expected_vermagic"
+          test "$actual_depends" = "$expected_depends"
+
+          kernel_imports=0
+          selected_imports=0
+          while read -r imported_crc symbol; do
+            imported_crc=$(printf '%s' "$imported_crc" | tr '[:upper:]' '[:lower:]')
+            kernel_crc=$(awk -v symbol="$symbol" '$1 == symbol { print $2 }' kernel-crcs)
+            if test -n "$kernel_crc"; then
+              test "$imported_crc" = "$kernel_crc"
+              kernel_imports=$((kernel_imports + 1))
+            else
+              selected_crc=$(awk -v symbol="$symbol" '$1 == symbol { print $2 }' selected-crcs)
+              if test -n "$selected_crc"; then
+                if test "$imported_crc" != "$selected_crc"; then
+                  echo "$module imports $symbol with CRC $imported_crc, selected module exports $selected_crc" >&2
+                  exit 1
+                fi
+                selected_imports=$((selected_imports + 1))
+              else
+                echo "$module imports unprovided symbol $symbol" >&2
+                exit 1
+              fi
+            fi
+          done < <(modprobe --dump-modversions "$module_path")
+
+          printf '%s kernel_imports=%s selected_module_imports=%s depends=%s\n' \
+            "$module" "$kernel_imports" "$selected_imports" "$actual_depends" \
+            >> "$out/validation.txt"
+        done
+
+        (cd "$out" && sha256sum "''${expected_modules[@]}" > checksums.sha256)
+      '';
+in
+{
+  inherit nvidiaOpen modules;
+  inherit version;
+}


### PR DESCRIPTION
## Summary
- use the standard Nixpkgs open NVIDIA package for the pinned kernel
- build only `nvidia.ko`, `nvidia-uvm.ko`, and `nvidia-modeset.ko`
- validate version, vermagic, direct dependencies, kernel symbol CRCs, and inter-module CRCs
- fix the embedded producer identity to `tinfoil@tinfoil-builder`

## Review boundary
This is stacked on the Nix kernel PR and contains only the NVIDIA module producer.

## Validation
- sandboxed Nix build completed on Box3
- forced rebuild of the underlying NVIDIA derivation passed
- output is exactly three modules; no DRM or peer-memory module is present
- no Box3 hostname or host username remains in the modules
- module SHA-256 values:
  - `nvidia.ko`: `c36f421b0518f8c615729d0bc931bb6daccc0a1bc0c87e922db8c254bd3a179d`
  - `nvidia-uvm.ko`: `071f8ad5536471f5b36aa9fe1ed61cab023fc9357360d19f4e557d043f01672a`
  - `nvidia-modeset.ko`: `5db58f5a8ef06e6734c81ab26424dc1d9e5373d1e1d7382370ac717d32e83067`
- `git diff --check`

Merge order: #275, the Nix kernel PR, then this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build reproducible NVIDIA kernel modules with Nix for the pinned kernel using the open driver. Outputs only the required modules and validates compatibility with strict CRC checks.

- **New Features**
  - Uses `kernelPackages.nvidiaPackages.production.open` pinned to `595.71.05`; excludes `nvidia-drm` and `nvidia-peermem`.
  - Builds only `nvidia.ko`, `nvidia-uvm.ko`, and `nvidia-modeset.ko`; fails if anything else is produced.
  - Enforces deterministic builds: fixed `KBUILD_BUILD_TIMESTAMP`, `NV_BUILD_USER=tinfoil`, `NV_BUILD_HOST=tinfoil-builder`; strips timestamp flag from `makeFlags`.
  - Validates `version`, `vermagic`, and `depends`; checks kernel symbol CRCs and inter-module CRCs; writes `validation.txt` and `checksums.sha256`.
  - Exposes `nvidia-modules` in `default.nix` for downstream use.

<sup>Written for commit 8fdac051aa63d075be4b799ffc68d211e31282de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

