### PR TITLE
Build nvattest with Nix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+nix/patches/*.patch whitespace=-blank-at-eol,-blank-at-eof

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,12 @@ jobs:
           sudo --preserve-env=HOME -u "$USER" -g nix-users \
             env NIX_REMOTE=daemon bash -Eeuo pipefail <<'NIX_BUILD'
             set -Eeuo pipefail
-            targets=(runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd)
-            for target in "${targets[@]}"; do
+            build_targets=(runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd nvattest)
+            for target in "${build_targets[@]}"; do
               nix-build --no-out-link -A "$target"
             done
-            for target in "${targets[@]}"; do
+            reproducibility_targets=(runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd)
+            for target in "${reproducibility_targets[@]}"; do
               nix-build --no-out-link --check -A "$target"
             done
           NIX_BUILD

--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,7 @@ let
   };
   kernel = import ./nix/kernel.nix { inherit pkgs; };
   nvidia = import ./nix/nvidia-modules.nix { inherit pkgs kernel; };
+  nvattest = import ./nix/nvattest.nix { inherit pkgs; };
 in
 go.packages
 // {
@@ -25,4 +26,5 @@ go.packages
   initrd = initrd.archive;
   "kernel-artifacts" = kernel.artifacts;
   "nvidia-modules" = nvidia.modules;
+  inherit (nvattest) nvattest;
 }

--- a/nix/nvattest.nix
+++ b/nix/nvattest.nix
@@ -1,0 +1,169 @@
+{ pkgs }:
+
+let
+  regorusRevision = "c7bf460bc160c96e38048296e5708943d2e43909";
+
+  source = name: url: hash: pkgs.fetchzip {
+    inherit url hash;
+    name = "${name}-source";
+  };
+
+  attestationSdk = source "attestation-sdk"
+    "https://github.com/NVIDIA/attestation-sdk/archive/9d12801cea8a198ea0f29640dfaf8a4017c841c5.tar.gz"
+    "sha256-e41BjJV4C1tRqYtZ347AYzIjBiwtGEBOJ3FRWbWItsg=";
+  cli11 = source "cli11"
+    "https://github.com/CLIUtils/CLI11/archive/bfffd37e1f804ca4fae1caae106935791696b6a9.tar.gz"
+    "sha256-q5q6TgSex0xjdWFf/4e6dhrN0qWPDjIgWBpdkCTlLys=";
+  jwtCpp = source "jwt-cpp"
+    "https://github.com/Thalhammer/jwt-cpp/archive/e71e0c2d584baff06925bbb3aad683f677e4d498.tar.gz"
+    "sha256-neOCARLkeB1kCYGIkm5BKK+MWF1T830xRNzpdE0SSWM=";
+  fmtSource = source "fmt"
+    "https://github.com/fmtlib/fmt/archive/e69e5f977d458f2650bb346dadf2ad30c5320281.tar.gz"
+    "sha256-pEltGLAHLZ3xypD/Ur4dWPWJ9BGVXwqQyKcDWVmC3co=";
+  spdlogSource = source "spdlog"
+    "https://github.com/gabime/spdlog/archive/27cb4c76708608465c413f6d0e6b8d99a4d84302.tar.gz"
+    "sha256-F7khXbMilbh5b+eKnzcB0fPPWQqUHqAYPWJb83OnUKQ=";
+  jsonSource = source "json"
+    "https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz"
+    "sha256-tOInM4YYi/cbHCWP2R0jlFzlaTN0ZVgHFMWagz9Wnvk=";
+  opensslSource = source "openssl"
+    "https://github.com/openssl/openssl/releases/download/openssl-3.6.1/openssl-3.6.1.tar.gz"
+    "sha256-pj8ekUqkZPEnevY3i+42uF//cWyr1tgWSaSn0V+DjjU=";
+  xmlsecSource = source "xmlsec"
+    "https://github.com/lsh123/xmlsec/releases/download/xmlsec-1_2_39/xmlsec1-1.2.39.tar.gz"
+    "sha256-v4gbjei20nkgCLOUyOvEkx9vT3TcfaVfHQ7wbVQx56A=";
+  curlSource = source "curl"
+    "https://github.com/curl/curl/releases/download/curl-7_88_1/curl-7.88.1.tar.gz"
+    "sha256-A+ig2Cjyu4QE5gh9X5yvvHPjYMRT9jo45QmPAOBpgpA=";
+  regorusSource = pkgs.fetchzip {
+    url = "https://github.com/microsoft/regorus/archive/${regorusRevision}.tar.gz";
+    hash = "sha256-bb4rCGFItwXQB+JlIObzkVOfEi8y+PFR3xMufTwB94U=";
+  };
+
+  regorusFfi = pkgs.rustPlatform.buildRustPackage {
+    pname = "regorus-ffi";
+    version = "0.2.2";
+    src = regorusSource;
+    cargoRoot = "bindings/ffi";
+    buildAndTestSubdir = "bindings/ffi";
+    cargoLock.lockFile = ../builder/nvattest/regorus.Cargo.lock;
+    env.CARGO_INCREMENTAL = "0";
+    patches = [ ./patches/regorus-pinned-revision.patch ];
+    postPatch = ''
+      cp ${../builder/nvattest/regorus.Cargo.lock} bindings/ffi/Cargo.lock
+      substituteInPlace build.rs \
+        --replace-fail '@REGORUS_REVISION@' '${regorusRevision}'
+    '';
+    preBuild = ''
+      export NIX_BUILD_CORES=1
+      export RUSTFLAGS="--remap-path-prefix=$NIX_BUILD_TOP=/usr/src/regorus -C target-cpu=x86-64 -C codegen-units=1"
+    '';
+    buildFeatures = [ "regorus/semver" ];
+    doCheck = false;
+    installPhase = ''
+      runHook preInstall
+      install -Dm0644 target/x86_64-unknown-linux-gnu/release/libregorus_ffi.a \
+        "$out/lib/libregorus_ffi.a"
+      install -Dm0644 bindings/ffi/regorus.h "$out/include/regorus.h"
+      install -Dm0644 bindings/ffi/regorus.ffi.hpp "$out/include/regorus.ffi.hpp"
+      runHook postInstall
+    '';
+  };
+
+  nvattestBuilt = pkgs.stdenv.mkDerivation {
+    pname = "nvattest";
+    version = "1.2.2";
+    src = attestationSdk;
+    patches = [
+      ./patches/nvattest-pinned-sources.patch
+      ./patches/nvattest-ca-bundle.patch
+      ./patches/nvattest-explicit-runtime-links.patch
+    ];
+    postPatch = ''
+      substituteInPlace nv-attestation-sdk-cpp/CMakeLists.txt \
+        --replace-fail '@REGORUS_LIBRARY@' '${regorusFfi}/lib/libregorus_ffi.a' \
+        --replace-fail '@REGORUS_INCLUDE@' '${regorusFfi}/include' \
+        --replace-fail '@OPENSSL_SOURCE@' '${opensslSource}' \
+        --replace-fail '@OPENSSL_PATCH@' '${./patches/openssl-reproducible-buildinfo.patch}' \
+        --replace-fail '@PERL@' '${pkgs.perl}/bin/perl' \
+        --replace-fail '@XMLSEC_SOURCE@' '${xmlsecSource}' \
+        --replace-fail '@CURL_SOURCE@' '${curlSource}'
+    '';
+    nativeBuildInputs = [
+      pkgs.cmake
+      pkgs.perl
+      pkgs.pkg-config
+      pkgs.patchelf
+    ];
+    buildInputs = [
+      pkgs.libxml2
+      pkgs.zlib
+    ];
+    cmakeDir = "../nv-attestation-cli";
+    cmakeFlags = [
+      "-DBUILD_TESTING=OFF"
+      "-DBUILD_EXAMPLES=OFF"
+      "-DFETCHCONTENT_FULLY_DISCONNECTED=ON"
+      "-DFETCHCONTENT_SOURCE_DIR_CLI11=${cli11}"
+      "-DFETCHCONTENT_SOURCE_DIR_JSON=${jsonSource}"
+      "-DFETCHCONTENT_SOURCE_DIR_JWT-CPP=${jwtCpp}"
+      "-DFETCHCONTENT_SOURCE_DIR_FMT=${fmtSource}"
+      "-DFETCHCONTENT_SOURCE_DIR_SPDLOG=${spdlogSource}"
+      "-DCMAKE_INSTALL_PREFIX=/usr"
+      "-DCMAKE_INSTALL_BINDIR=bin"
+      "-DCMAKE_INSTALL_LIBDIR=lib"
+      "-DCMAKE_INSTALL_INCLUDEDIR=include"
+      "-DCMAKE_SKIP_RPATH=ON"
+      "-DCMAKE_EXE_LINKER_FLAGS=-Wl,--build-id=none"
+      "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--build-id=none"
+    ];
+    enableParallelBuilding = false;
+    dontPatchELF = true;
+    env.SOURCE_DATE_EPOCH = "0";
+    preConfigure = ''
+      prefixMap="-ffile-prefix-map=$NIX_BUILD_TOP=/usr/src/nvattest -fmacro-prefix-map=$NIX_BUILD_TOP=/usr/src/nvattest -fdebug-prefix-map=$NIX_BUILD_TOP=/usr/src/nvattest"
+      export CFLAGS="''${CFLAGS:-} $prefixMap -march=x86-64 -mtune=generic"
+      export CXXFLAGS="''${CXXFLAGS:-} $prefixMap -march=x86-64 -mtune=generic"
+      export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE:-} $prefixMap -march=x86-64 -mtune=generic"
+    '';
+    buildPhase = ''
+      runHook preBuild
+      cmake --build . --target xmlsec_external curl_external --parallel 1
+      finalLdflags=()
+      skipNext=false
+      for flag in $NIX_LDFLAGS; do
+        if $skipNext; then
+          skipNext=false
+          continue
+        fi
+        case "$flag" in
+          -rpath) skipNext=true ;;
+          -rpath=*) ;;
+          *) finalLdflags+=("$flag") ;;
+        esac
+      done
+      NIX_DONT_SET_RPATH=1 NIX_LDFLAGS="''${finalLdflags[*]}" \
+        cmake --build . --target nvattest --parallel 1
+      runHook postBuild
+    '';
+    installPhase = ''
+      runHook preInstall
+      install -Dm0755 nvattest "$out/usr/bin/nvattest"
+      install -Dm0644 nv-attestation-sdk-build/libnvat.so.1.2.2 \
+        "$out/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2"
+      strip --strip-unneeded \
+        "$out/usr/bin/nvattest" \
+        "$out/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2"
+      patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 \
+        --remove-rpath "$out/usr/bin/nvattest"
+      patchelf --remove-rpath \
+        "$out/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2"
+      runHook postInstall
+    '';
+    doCheck = false;
+  };
+in
+{
+  regorus-ffi = regorusFfi;
+  nvattest = nvattestBuilt;
+}

--- a/nix/patches/nvattest-ca-bundle.patch
+++ b/nix/patches/nvattest-ca-bundle.patch
@@ -1,0 +1,10 @@
+--- a/nv-attestation-sdk-cpp/CMakeLists.txt
++++ b/nv-attestation-sdk-cpp/CMakeLists.txt
+@@ -242,6 +242,7 @@
+     CONFIGURE_COMMAND <SOURCE_DIR>/configure
+       --prefix=${CURL_INSTALL_DIR}
+       --with-openssl=${OPENSSL_INSTALL_DIR}
++      --with-ca-bundle=/etc/ssl/certs/ca-certificates.crt
+       --without-libssh2
+       --without-nghttp2
+       --without-brotli

--- a/nix/patches/nvattest-explicit-runtime-links.patch
+++ b/nix/patches/nvattest-explicit-runtime-links.patch
@@ -1,0 +1,21 @@
+--- a/nv-attestation-cli/CMakeLists.txt
++++ b/nv-attestation-cli/CMakeLists.txt
+@@ -95,10 +95,18 @@
+     endif()
+ endif()
+ 
++find_package(LibXml2 REQUIRED)
++find_package(Threads REQUIRED)
++find_package(ZLIB REQUIRED)
++
+ target_link_libraries(nvattest PRIVATE
+     nvat::nvat
+     nlohmann_json::nlohmann_json
+     CLI11::CLI11
++    LibXml2::LibXml2
++    Threads::Threads
++    ZLIB::ZLIB
++    ${CMAKE_DL_LIBS}
+ )
+ 
+ # spdlog/fmt headers needed for compilation (nvat has them statically linked, no need to link again)

--- a/nix/patches/nvattest-pinned-sources.patch
+++ b/nix/patches/nvattest-pinned-sources.patch
@@ -1,0 +1,116 @@
+--- a/nv-attestation-sdk-cpp/CMakeLists.txt
++++ b/nv-attestation-sdk-cpp/CMakeLists.txt
+@@ -37,33 +37,10 @@
+ 
+ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+ 
+-FetchContent_Declare(
+-    Corrosion
+-    GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
+-    # Use a tag that has a fix for https://github.com/corrosion-rs/corrosion/issues/590
+-    GIT_TAG 6be991bb34c348dfb8344be22f3606288ea5c7fd
+-    EXCLUDE_FROM_ALL
+-)
+-FetchContent_MakeAvailable(Corrosion)
+-
+-FetchContent_Declare(
+-  regorus
+-  GIT_REPOSITORY https://github.com/microsoft/regorus.git
+-  GIT_TAG regorus-v0.4.0
++add_library(regorus_ffi STATIC IMPORTED GLOBAL)
++set_target_properties(regorus_ffi PROPERTIES
++  IMPORTED_LOCATION "@REGORUS_LIBRARY@"
+ )
+-FetchContent_MakeAvailable(regorus)
+-
+-corrosion_import_crate(
+-  MANIFEST_PATH "${regorus_SOURCE_DIR}/bindings/ffi/Cargo.toml"
+-  PROFILE "release"
+-  CRATES regorus-ffi
+-  FEATURES "regorus/semver"
+-  CRATE_TYPES "staticlib"
+-)
+-
+-if (ENABLE_SCCACHE)
+-  corrosion_set_env_vars(regorus_ffi "RUSTC_WRAPPER=${SCCACHE}")
+-endif()
+ 
+ set(JWT_DISABLE_PICOJSON ON CACHE BOOL "Disable picojson support in jwt-cpp")
+ set(JWT_BUILD_EXAMPLES OFF CACHE BOOL "Disable building jwt-cpp examples")
+@@ -179,16 +156,18 @@
+   set(_EP_CFLAGS "${CMAKE_C_FLAGS} -fPIC")
+ 
+   # Build OpenSSL statically — RHEL8 ships 1.1.1 but the code needs 3.x APIs
+-  set(OPENSSL_INSTALL_DIR "${CMAKE_BINARY_DIR}/openssl-install")
++  set(OPENSSL_STAGE_DIR "${CMAKE_BINARY_DIR}/openssl-stage")
++  set(OPENSSL_INSTALL_DIR "${OPENSSL_STAGE_DIR}/usr")
+ 
+   ExternalProject_Add(openssl_external
+-    URL https://github.com/openssl/openssl/releases/download/openssl-3.6.1/openssl-3.6.1.tar.gz
+-    URL_HASH SHA256=b1bfedcd5b289ff22aee87c9d600f515767ebf45f77168cb6d64f231f518a82e
++    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory "@OPENSSL_SOURCE@" <SOURCE_DIR>
++    COMMAND chmod -R u+w <SOURCE_DIR>
++    PATCH_COMMAND patch -d <SOURCE_DIR> -p1 -i "@OPENSSL_PATCH@"
+-    CONFIGURE_COMMAND <SOURCE_DIR>/Configure
++    CONFIGURE_COMMAND "@PERL@" <SOURCE_DIR>/Configure
+       "CC=${_EP_CC}"
+       "CFLAGS=${_EP_CFLAGS}"
+-      --prefix=${OPENSSL_INSTALL_DIR}
+-      --openssldir=${OPENSSL_INSTALL_DIR}
++      --prefix=/usr
++      --openssldir=/etc/ssl
+       --libdir=lib
+       no-shared
+       no-tests      # Skip ~100+ test binaries — not needed, saves link-time memory
+@@ -198,7 +177,10 @@
+       no-engine     # Disable deprecated ENGINE API — unused with static linking
+       no-dtls       # Disable DTLS — SDK uses TLS only, not UDP-based DTLS
+     BUILD_COMMAND make -j${CMAKE_BUILD_PARALLEL_LEVEL}
+-    INSTALL_COMMAND make install_sw install_ssldirs
++    INSTALL_COMMAND make DESTDIR=${OPENSSL_STAGE_DIR} install_sw
++    COMMAND sed -i "s|prefix=/usr|prefix=${OPENSSL_INSTALL_DIR}|" ${OPENSSL_INSTALL_DIR}/lib/pkgconfig/libcrypto.pc
++    COMMAND sed -i "s|prefix=/usr|prefix=${OPENSSL_INSTALL_DIR}|" ${OPENSSL_INSTALL_DIR}/lib/pkgconfig/libssl.pc
++    COMMAND sed -i "s|prefix=/usr|prefix=${OPENSSL_INSTALL_DIR}|" ${OPENSSL_INSTALL_DIR}/lib/pkgconfig/openssl.pc
+     BUILD_IN_SOURCE 1
+   )
+ 
+@@ -224,8 +206,8 @@
+ 
+   ExternalProject_Add(xmlsec_external
+     DEPENDS openssl_external
+-    URL https://github.com/lsh123/xmlsec/releases/download/xmlsec-1_2_39/xmlsec1-1.2.39.tar.gz
+-    URL_HASH SHA256=15f2f55ea5968e578fcd24b3b427e553876c86c147dc7f03923e98fc2768a1fa
++    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory "@XMLSEC_SOURCE@" <SOURCE_DIR>
++    COMMAND chmod -R u+w <SOURCE_DIR>
+     CONFIGURE_COMMAND <SOURCE_DIR>/configure
+       --prefix=${XMLSEC_INSTALL_DIR}
+       --disable-shared
+@@ -253,8 +235,8 @@
+ 
+   ExternalProject_Add(curl_external
+     DEPENDS openssl_external
+-    URL https://github.com/curl/curl/releases/download/curl-7_88_1/curl-7.88.1.tar.gz
+-    URL_HASH SHA256=cdb38b72e36bc5d33d5b8810f8018ece1baa29a8f215b4495e495ded82bbf3c7
++    DOWNLOAD_COMMAND ${CMAKE_COMMAND} -E copy_directory "@CURL_SOURCE@" <SOURCE_DIR>
++    COMMAND chmod -R u+w <SOURCE_DIR>
+     CONFIGURE_COMMAND <SOURCE_DIR>/configure
+       --prefix=${CURL_INSTALL_DIR}
+       --with-openssl=${OPENSSL_INSTALL_DIR}
+@@ -357,7 +339,7 @@
+   PRIVATE
+     src
+     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+-    ${regorus_SOURCE_DIR}/bindings/ffi
++    @REGORUS_INCLUDE@
+     # spdlog and fmt include dirs (linked statically via TARGET_FILE below)
+     ${spdlog_SOURCE_DIR}/include
+     ${fmt_SOURCE_DIR}/include
+@@ -408,7 +390,7 @@
+ )
+ 
+ # Ensure dependencies are built before nvat
+-add_dependencies(nvat regorus_ffi spdlog fmt curl_external xmlsec_external openssl_external)
++add_dependencies(nvat spdlog fmt curl_external xmlsec_external openssl_external)
+ 
+ # todo (p0): remove cmake configuration helpers
+ install(TARGETS nvat

--- a/nix/patches/openssl-reproducible-buildinfo.patch
+++ b/nix/patches/openssl-reproducible-buildinfo.patch
@@ -1,0 +1,11 @@
+--- a/util/mkbuildinf.pl
++++ b/util/mkbuildinf.pl
+@@ -10,7 +10,7 @@
+ use strict;
+ use warnings;
+ 
+ my $platform = pop @ARGV;
+-my $cflags = join(' ', @ARGV);
++my $cflags = "gcc";
+ $cflags =~ s(\\)(\\\\)g;
+ $cflags = "compiler: $cflags";

--- a/nix/patches/regorus-pinned-revision.patch
+++ b/nix/patches/regorus-pinned-revision.patch
@@ -1,0 +1,15 @@
+--- a/build.rs
++++ b/build.rs
+@@ -18,11 +18,7 @@
+     // Supply information as compile-time environment variables.
+     #[cfg(feature = "opa-runtime")]
+     {
+-        let output = std::process::Command::new("git")
+-            .args(["rev-parse", "HEAD"])
+-            .output()
+-            .expect("`git rev-parse HEAD` failed.");
+-        let git_hash = String::from_utf8(output.stdout).unwrap();
++        let git_hash = "@REGORUS_REVISION@";
+         println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+     }
+ 


### PR DESCRIPTION
## Summary
- build the pinned NVIDIA attestation SDK and CLI inside the shared pinned Nix boundary
- replace upstream network fetches with checksum-pinned Nix inputs
- use standard Nixpkgs Rust and C/C++ builders while retaining the upstream CMake build
- export only the FHS `nvattest` binary and `libnvat.so.1.2.2`

## Review boundary
This is stacked on #275 and independent of the kernel/NVIDIA module stack, so both producer reviews can proceed in parallel.

The small upstream patches only disconnect network fetches and normalize embedded build metadata. The standalone experimental Nix entrypoint is not included; this PR uses the project-wide Nixpkgs pin from #275.

## Validation
- clean sandboxed build completed on Box3 in 7m47s
- full forced `--check` rebuild completed in 8m03s and was byte-identical
- `nvattest`: `f93c1f3781e51a27a943b71d4c9783e86306d941cfb02642fbafec3da8e6094b`
- `libnvat.so.1.2.2`: `299a98219412ef88d0d150caad3f79d8ee80fd548a0e12954b08d1e901125822`
- fixed FHS loader, no RPATH/RUNPATH, Nix store path, randomized build root, or closure reference
- Ubuntu 26.04 dependency resolution, `--help`, and `version` passed
- `git diff --check`

Merge #275 before this PR. Cross-host INF14 evidence will be added separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds `nvattest` and `libnvat.so.1.2.2` with Nix from pinned, checksum-verified sources to avoid network fetches and produce reproducible outputs. Exposes only FHS-friendly artifacts and adds `nvattest` to `default.nix`.

- **New Features**
  - Adds `nix/nvattest.nix` to build the CLI/SDK with Nixpkgs Rust and C/C++ using upstream CMake; exports `nvattest` via `default.nix`; builds it once in CI.
  - Replaces CMake `FetchContent` with pinned local sources and a static `regorus-ffi` (pinned revision).
  - Statically builds `OpenSSL`, vendors `xmlsec`/`curl` (uses `/etc/ssl/certs/ca-certificates.crt`), strips RPATH and build-ids, sets the ELF loader, and installs only `/usr/bin/nvattest` and `/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2`.
  - Adds explicit CLI link deps (`libxml2`, `zlib`, threads, `dl`) for predictable runtime resolution.

- **Dependencies**
  - Pins `OpenSSL` 3.6.1, `xmlsec` 1.2.39, `curl` 7.88.1, `CLI11`, `jwt-cpp`, `fmt`, `spdlog`, and `nlohmann/json`.
  - Pins `regorus-ffi` revision and applies an `OpenSSL` reproducible-build patch.

<sup>Written for commit 3facb23e591634036697a70243331c56cdbaa92d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

