### PR TITLE
Restore metrics in the restricted proc view

### DIFF
--- a/tinfoil/internal/pid1/hardening/filesystems_linux.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux.go
@@ -45,7 +45,7 @@ func restrictServiceFilesystems(kernel filesystemKernel) error {
 
 func mountRestrictedProc(kernel filesystemKernel) error {
 	flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
-	if err := kernel.mount("proc", "/proc", "proc", flags, "hidepid=2,subset=pid"); err != nil {
+	if err := kernel.mount("proc", "/proc", "proc", flags, "hidepid=2"); err != nil {
 		return fmt.Errorf("mount restricted /proc: %w", err)
 	}
 	if err := kernel.mount("", "/proc", "", flags|unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {

--- a/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
@@ -55,7 +55,7 @@ func TestRestrictServiceFilesystemsUsesFixedPrivateReadOnlyLayout(t *testing.T) 
 	want := []mountCall{
 		{source: "unshare", flags: unix.CLONE_NEWNS},
 		{target: "/", flags: unix.MS_REC | unix.MS_PRIVATE},
-		{source: "proc", target: "/proc", filesystemType: "proc", flags: baseFlags, data: "hidepid=2,subset=pid"},
+		{source: "proc", target: "/proc", filesystemType: "proc", flags: baseFlags, data: "hidepid=2"},
 		{target: "/proc", flags: baseFlags | unix.MS_REMOUNT | unix.MS_RDONLY},
 		{source: "tmpfs", target: "/dev", filesystemType: "tmpfs", flags: baseFlags, data: "size=4k,nr_inodes=1,mode=0555"},
 		{target: "/dev", flags: baseFlags | unix.MS_REMOUNT | unix.MS_RDONLY},


### PR DESCRIPTION
## Summary
- keep the hardened service `/proc` mount read-only with `hidepid=2`
- remove `subset=pid`, which hides the global kernel files used by the existing shim metrics endpoint
- preserve the empty read-only `/dev` and `/sys` service views and all syscall/capability restrictions

## Why
Hardware qualification of the final Nix candidate found `/.well-known/tinfoil-metrics` returning HTTP 500. The debug console showed the shim failing to open `/proc/meminfo`; `subset=pid` also removes `/proc/stat` and `/proc/cpuinfo`. These are the fixed read-only inputs consumed by the current metrics implementation.

## Validation
- `gofmt`
- `go build ./...`
- `go test ./...`
- `go test -race ./internal/pid1/hardening ./internal/metrics ./cmd/init`
- `go vet ./...`
- `git diff --check`

End-to-end candidate requalification follows on Box3 and INF14.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore shim metrics by removing the subset=pid option from the restricted /proc mount while keeping hidepid=2 and read-only. This re-exposes /proc/meminfo, /proc/stat, and /proc/cpuinfo and fixes HTTP 500 from /.well-known/tinfoil-metrics; empty read-only /dev and /sys and all other restrictions remain.

<sup>Written for commit b7c92b1b6a5c556b81a114ac62a5301505835b06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

