### PR TITLE
Materialize the additive rootfs with Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,17 @@ let
   kernel = import ./nix/kernel.nix { inherit pkgs; };
   nvidia = import ./nix/nvidia-modules.nix { inherit pkgs kernel; };
   nvattest = import ./nix/nvattest.nix { inherit pkgs; };
+  rootfs = import ./nix/rootfs.nix {
+    inherit pkgs;
+    runtimeGo = go.packages."runtime-go";
+    debugInit = go.packages."debug-init";
+    inherit (nvattest) nvattest;
+    nvidiaModules = map (name: "${nvidia.modules}/${name}") [
+      "nvidia.ko"
+      "nvidia-uvm.ko"
+      "nvidia-modeset.ko"
+    ];
+  };
 in
 go.packages
 // {
@@ -27,4 +38,6 @@ go.packages
   "kernel-artifacts" = kernel.artifacts;
   "nvidia-modules" = nvidia.modules;
   inherit (nvattest) nvattest;
+  "rootfs-archive" = rootfs.rootfs;
+  "debug-rootfs-layer" = rootfs.debugLayer;
 }

--- a/nix/rootfs.nix
+++ b/nix/rootfs.nix
@@ -1,0 +1,165 @@
+{
+  pkgs,
+  runtimeGo,
+  debugInit,
+  nvattest,
+  nvidiaModules,
+}:
+
+let
+  lock = builtins.fromJSON (builtins.readFile ../image/runtime-packages.lock.json);
+  sources = import ./runtime-sources.nix;
+
+  fetchDeb = package: pkgs.fetchurl {
+    name = "${package.name}.deb";
+    urls = package.urls or [ package.url ];
+    sha256 = package.sha256;
+  };
+
+  ubuntuDebs = map fetchDeb lock.packages;
+  nvidiaDebs = map fetchDeb sources.nvidiaDebs;
+  busyboxDeb = fetchDeb sources.busybox;
+  dockerArchive = pkgs.fetchurl {
+    inherit (sources.docker) name url;
+    sha256 = sources.docker.sha256;
+  };
+
+  repositoryFiles = [
+    { source = ../image/rootfs/etc/.pwd.lock; target = "etc/.pwd.lock"; mode = "0600"; }
+    { source = ../image/rootfs/etc/containerd/config.toml; target = "etc/containerd/config.toml"; mode = "0644"; }
+    { source = ../image/rootfs/etc/docker/daemon.json; target = "etc/docker/daemon.json"; mode = "0644"; }
+    { source = ../image/rootfs/etc/group; target = "etc/group"; mode = "0644"; }
+    { source = ../image/rootfs/etc/gshadow; target = "etc/gshadow"; mode = "0640"; }
+    { source = ../image/rootfs/etc/hostname; target = "etc/hostname"; mode = "0644"; }
+    { source = ../image/rootfs/etc/hosts; target = "etc/hosts"; mode = "0644"; }
+    { source = ../image/rootfs/etc/nsswitch.conf; target = "etc/nsswitch.conf"; mode = "0644"; }
+    { source = ../image/rootfs/etc/nvidia-container-runtime/config.toml; target = "etc/nvidia-container-runtime/config.toml"; mode = "0644"; }
+    { source = ../image/rootfs/etc/passwd; target = "etc/passwd"; mode = "0644"; }
+    { source = ../image/rootfs/etc/resolv.conf; target = "etc/resolv.conf"; mode = "0644"; }
+    { source = ../image/rootfs/etc/shadow; target = "etc/shadow"; mode = "0640"; }
+    { source = ../image/rootfs/etc/systemd/system-preset/00-tinfoil.preset; target = "etc/systemd/system-preset/00-tinfoil.preset"; mode = "0644"; }
+    { source = ../image/rootfs/usr/lib/clock-epoch; target = "usr/lib/clock-epoch"; mode = "0644"; }
+    { source = ../image/rootfs/usr/lib/os-release; target = "usr/lib/os-release"; mode = "0644"; }
+  ];
+
+  repositoryReplacements = [
+    { source = ../image/rootfs/etc/nftables.conf; target = "etc/nftables.conf"; mode = "0644"; }
+    { source = ../image/rootfs/usr/share/nvidia/nvswitch/fabricmanager.cfg; target = "usr/share/nvidia/nvswitch/fabricmanager.cfg"; mode = "0644"; }
+  ];
+
+  extractDebs = pkgs.lib.concatMapStringsSep "\n" (deb: ''
+    ${pkgs.dpkg}/bin/dpkg-deb --fsys-tarfile ${deb} |
+      ${pkgs.gnutar}/bin/tar --extract --file=- --directory "$root" \
+        --no-same-owner --keep-old-files
+  '') (ubuntuDebs ++ nvidiaDebs);
+
+  repositoryInstalls = pkgs.lib.concatMapStringsSep "\n" (file: ''
+    test ! -e "$root/${file.target}"
+    test ! -L "$root/${file.target}"
+    install -D -m ${file.mode} ${file.source} "$root/${file.target}"
+  '') repositoryFiles;
+
+  repositoryReplacementInstalls = pkgs.lib.concatMapStringsSep "\n" (file: ''
+    install -D -m ${file.mode} ${file.source} "$root/${file.target}"
+  '') repositoryReplacements;
+
+  moduleInstalls = pkgs.lib.concatMapStringsSep "\n" (module: ''
+    test ! -e "$root/usr/lib/tinfoil/kernel-modules/${builtins.baseNameOf module}"
+    test ! -L "$root/usr/lib/tinfoil/kernel-modules/${builtins.baseNameOf module}"
+    install -m 0644 ${module} \
+      "$root/usr/lib/tinfoil/kernel-modules/${builtins.baseNameOf module}"
+  '') nvidiaModules;
+
+  deterministicTar = root: output: ''
+    ${pkgs.gnutar}/bin/tar --create --file ${output} --directory ${root} \
+      --sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner \
+      --format=gnu .
+  '';
+
+  rootfs = pkgs.runCommand "cvmimage-rootfs.tar" {
+    allowedReferences = [ ];
+    nativeBuildInputs = [ pkgs.coreutils pkgs.findutils pkgs.gnutar ];
+  } ''
+    set -o pipefail
+    root="$TMPDIR/root"
+    mkdir -p "$root"
+
+    ${extractDebs}
+    chmod 0755 "$root"
+
+    docker="$TMPDIR/docker"
+    mkdir -p "$docker" "$root/usr/bin"
+    ${pkgs.gnutar}/bin/tar --extract --gzip --file ${dockerArchive} \
+      --directory "$docker" --strip-components=1
+    for command in containerd containerd-shim-runc-v2 dockerd runc; do
+      test ! -e "$root/usr/bin/$command"
+      test ! -L "$root/usr/bin/$command"
+      install -m 0755 "$docker/$command" "$root/usr/bin/$command"
+    done
+
+    for command in boot container-status egress init shim; do
+      test ! -e "$root/usr/bin/tinfoil-$command"
+      test ! -L "$root/usr/bin/tinfoil-$command"
+      install -m 0755 ${runtimeGo}/bin/tinfoil-$command \
+        "$root/usr/bin/tinfoil-$command"
+    done
+
+    test ! -e "$root/usr/bin/nvattest"
+    test ! -L "$root/usr/bin/nvattest"
+    test ! -e "$root/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2"
+    test ! -L "$root/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2"
+    install -D -m 0755 ${nvattest}/usr/bin/nvattest "$root/usr/bin/nvattest"
+    install -D -m 0644 ${nvattest}/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2 \
+      "$root/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2"
+    test ! -e "$root/usr/lib/x86_64-linux-gnu/libnvat.so.1"
+    test ! -L "$root/usr/lib/x86_64-linux-gnu/libnvat.so.1"
+    ln -s libnvat.so.1.2.2 \
+      "$root/usr/lib/x86_64-linux-gnu/libnvat.so.1"
+
+    mkdir -p "$root/usr/lib/tinfoil/kernel-modules"
+    ${moduleInstalls}
+
+    ${repositoryInstalls}
+    ${repositoryReplacementInstalls}
+    chmod 0755 "$root"
+
+    mkdir -p "$root/dev" "$root/mnt/ramdisk" "$root/proc" "$root/run" \
+      "$root/sys" "$root/tmp" "$root/var/tmp" "$root/usr/lib64" \
+      "$root/etc/ssl/certs"
+    chmod 0755 "$root" "$root/dev" "$root/mnt" "$root/mnt/ramdisk" \
+      "$root/proc" "$root/run" "$root/sys" "$root/tmp" "$root/var" \
+      "$root/var/tmp"
+
+    ln -s usr/lib64 "$root/lib64"
+    ln -s usr/sbin "$root/sbin"
+    ln -s ../run "$root/var/run"
+
+    find "$root/usr/share/ca-certificates" -type f -name '*.crt' -print0 |
+      sort -z |
+      xargs -0 cat > "$root/etc/ssl/certs/ca-certificates.crt"
+    chmod 0644 "$root/etc/ssl/certs/ca-certificates.crt"
+
+    ${deterministicTar "$root" "$out"}
+  '';
+
+  debugLayer = pkgs.runCommand "cvmimage-debug-layer.tar" {
+    allowedReferences = [ ];
+    nativeBuildInputs = [ pkgs.coreutils pkgs.gnutar ];
+  } ''
+    set -o pipefail
+    root="$TMPDIR/root"
+    mkdir -p "$root"
+    ${pkgs.dpkg}/bin/dpkg-deb --fsys-tarfile ${busyboxDeb} |
+      ${pkgs.gnutar}/bin/tar --extract --file=- --directory "$root" \
+        --no-same-owner --no-overwrite-dir
+    test ! -e "$root/usr/bin/tinfoil-init"
+    test ! -L "$root/usr/bin/tinfoil-init"
+    install -D -m 0755 ${debugInit}/bin/tinfoil-init \
+      "$root/usr/bin/tinfoil-init"
+    install -d -m 0700 "$root/root"
+    ${deterministicTar "$root" "$out"}
+  '';
+in
+{
+  inherit rootfs debugLayer;
+}

--- a/nix/runtime-sources.nix
+++ b/nix/runtime-sources.nix
@@ -1,0 +1,30 @@
+{
+  busybox = {
+    name = "busybox-static";
+    url = "https://snapshot.ubuntu.com/ubuntu/20260721T000000Z/pool/main/b/busybox/busybox-static_1.37.0-7ubuntu1_amd64.deb";
+    sha256 = "fd605342f62268753076aa7d9321ff098b36ba53e47434145a9aedc28fd141a4";
+  };
+
+  docker = {
+    name = "docker-29.5.3-static";
+    url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.5.3.tgz";
+    sha256 = "34eea64e9c3435f5af1b760827a56a561cd67fc2d6e9cd1813b8bb1e3ff7930b";
+  };
+
+  nvidiaDebs = [
+    { name = "libnvidia-cfg1"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-cfg1_595.71.05-1ubuntu1_amd64.deb"; sha256 = "dc18f61a73350cb4c19a775172c3090d794aae93eba5e0413a559b2337dff092"; }
+    { name = "libnvidia-compute"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-compute_595.71.05-1ubuntu1_amd64.deb"; sha256 = "6e934848e693668ee678bd5346d7688774925700a0a35d943a2adfff2c8b4076"; }
+    { name = "libnvidia-container-tools"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-container-tools_1.19.1-1_amd64.deb"; sha256 = "c6e01e92ded92e6819df0db183cc74e65d1d8c421ca2a0d1bb5a7f2b244a11f6"; }
+    { name = "libnvidia-container1"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-container1_1.19.1-1_amd64.deb"; sha256 = "661f8cf7a97eb0c6dbf0786d0814d781235a96c4730fe012bba4436b6de4417f"; }
+    { name = "libnvidia-decode"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-decode_595.71.05-1ubuntu1_amd64.deb"; sha256 = "cf32fee8eefcca3be9181b94b2103886ac9dda577d1667b8d6f2544b2ea24138"; }
+    { name = "libnvidia-gl"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-gl_595.71.05-1ubuntu1_amd64.deb"; sha256 = "28debe13d2032f2216954a925e1f937956017c1557e6c47251b7694dd205f379"; }
+    { name = "libnvidia-gpucomp"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-gpucomp_595.71.05-1ubuntu1_amd64.deb"; sha256 = "c541c308a25773471a5826897e8025d1fcf9cb742e0da566de19d4ca15f6050e"; }
+    { name = "libnvidia-nscq"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-nscq_595.71.05-1ubuntu1_amd64.deb"; sha256 = "d02d606e3ab10db7ae5c7abd9c4dc803365d19de75261e1424f5af723992ea0f"; }
+    { name = "nvidia-container-toolkit"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-container-toolkit_1.19.1-1_amd64.deb"; sha256 = "721a0e18ea6a25d1a2d4b569e3f4fa057c86badc64cfb441f782c020d8ca1535"; }
+    { name = "nvidia-container-toolkit-base"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-container-toolkit-base_1.19.1-1_amd64.deb"; sha256 = "3ee2a9202294fdd27cd79e23f35b7a1f24ea0fa934ab03229f25c89b3245defe"; }
+    { name = "nvidia-fabricmanager"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-fabricmanager_595.71.05-1ubuntu1_amd64.deb"; sha256 = "480d185ebb109cc3f1ebe73a6c5cff4a072a1b0ddde08017fd2f1bf9048afe66"; }
+    { name = "nvidia-firmware"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-firmware_595.71.05-1ubuntu1_amd64.deb"; sha256 = "105ceeae7c20cce66109a636f5a9bcd4bb4a820e0937f7407b91945dceaa5086"; }
+    { name = "nvidia-kernel-common"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-kernel-common_595.71.05-1ubuntu1_amd64.deb"; sha256 = "6529833b65de8aeeafd176cf063686963ceaddd3ca159e7a28c05881f11267c4"; }
+    { name = "nvidia-persistenced"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-persistenced_595.71.05-1ubuntu1_amd64.deb"; sha256 = "6c4c02e6a9f596fa95ff036d87ff7d0c9040faf3e7f51ad8fdc8f6e6bf938f65"; }
+  ];
+}


### PR DESCRIPTION
## Summary
- fetch the locked Ubuntu, NVIDIA, Docker, Go, kernel-module, and nvattest payloads through Nix
- assemble the measured rootfs additively with an explicit 17-file repository policy list
- fail closed on package and producer path collisions; retain only two explicit policy-owned replacements
- produce deterministic shipping and debug rootfs tar archives

## Validation
- sandboxed rootfs build on Box3 and INF14
- all 56 DEB payloads audited: no package-to-package non-directory collisions
- consumed by the byte-identical final images qualified downstream

## Merge order
Depends on #278.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds the additive rootfs with Nix and outputs deterministic tar archives for shipping and debug. Fetches locked Ubuntu/NVIDIA DEBs and static Docker to make images reproducible.

- **New Features**
  - Adds `nix/rootfs.nix` to materialize the rootfs from `runtime-packages.lock.json` and `nix/runtime-sources.nix` (Ubuntu/NVIDIA DEBs, static Docker).
  - Assembles rootfs additively with an explicit repository policy; hard-fails on path collisions; only replaces `etc/nftables.conf` and `usr/share/nvidia/nvswitch/fabricmanager.cfg`.
  - Installs `tinfoil-*` from `runtime-go` and `tinfoil-init` from `debug-init`; adds `nvattest` (+ `libnvat.so` symlink); installs `nvidia.ko`, `nvidia-uvm.ko`, `nvidia-modeset.ko` to `/usr/lib/tinfoil/kernel-modules`.
  - Produces deterministic archives: `cvmimage-rootfs.tar` and `cvmimage-debug-layer.tar` (BusyBox + `tinfoil-init`) with sorted, zero-mtime tarballs.
  - Exposes new outputs in `default.nix`: `rootfs-archive` and `debug-rootfs-layer`.

<sup>Written for commit ccdb76aa6037b36483cf6b65ebadc00ffda5598a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

