### PR TITLE
Cut image assembly over to Nix inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,48 +36,21 @@ jobs:
       - name: Install build dependencies
         run: |
           set -Eeuo pipefail
-          SNAPSHOT_DATE="20260721T000000Z"
-          echo "deb [check-valid-until=no] https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT_DATE} resolute main restricted universe multiverse" | sudo tee /etc/apt/sources.list
-          echo "deb [check-valid-until=no] https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT_DATE} resolute-updates main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-          echo "deb [check-valid-until=no] https://snapshot.ubuntu.com/ubuntu/${SNAPSHOT_DATE} resolute-security main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list
-
           sudo apt-get update
-          sudo apt-get install -y \
-            binutils \
-            cpio \
-            curl \
-            debian-archive-keyring \
-            dosfstools \
-            e2fsprogs \
-            jq \
-            make \
-            pipx \
-            systemd \
-            ubuntu-keyring \
-            zstd
-          sudo env PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin \
-            pipx install git+https://github.com/systemd/mkosi.git@84af20892b61c8e177e391f997ded8b4cb5514f2 #v26
-          test "$(mkosi --version)" = "mkosi 26"
-
-      - name: Install Bazel 8.7.0
-        run: |
-          set -Eeuo pipefail
-          directory=$(mktemp -d /tmp/cvmimage-bazel-install.XXXXXXXX)
-          archive="$directory/bazel"
-          trap 'rm -f -- "$archive"; rmdir -- "$directory"' EXIT
-          curl -fsSL --retry 3 \
-            https://github.com/bazelbuild/bazel/releases/download/8.7.0/bazel-8.7.0-linux-x86_64 \
-            -o "$archive"
-          printf '%s  %s\n' \
-            d7606e679b78067c811096fb3d6cf135225b528835ca396e3a4dddf957859544 \
-            "$archive" | sha256sum -c --strict -
-          sudo install -m 0755 "$archive" /usr/local/bin/bazel
-          test "$(bazel --version)" = "bazel 8.7.0"
+          sudo apt-get install --yes --no-install-recommends \
+            make nix-bin nix-setup-systemd
+          sudo install -d -m 0755 /etc/nix
+          printf 'sandbox = true\nbuild-users-group = nixbld\n' |
+            sudo tee /etc/nix/nix.conf >/dev/null
+          sudo install -d -o root -g nixbld -m 1775 /nix/store
+          sudo usermod -aG nix-users "$USER"
+          sudo systemctl restart nix-daemon.service
+          nix-build --version
 
       - name: Build image
         run: |
-          make regenerate-nvattest
-          make shipping-image
+          sudo --preserve-env=HOME -u "$USER" -g nix-users \
+            env NIX_REMOTE=daemon make shipping-image
 
       - name: Check release artifacts
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,48 +9,6 @@ on:
 permissions: {}
 
 jobs:
-  nix-go-initrd:
-    name: Nix Go and initrd
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
-        with:
-          persist-credentials: false
-
-      - name: Install Nix
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends nix-bin nix-setup-systemd
-          sudo install -d -m 0755 /etc/nix
-          printf 'sandbox = true\nbuild-users-group = nixbld\n' |
-            sudo tee /etc/nix/nix.conf >/dev/null
-          sudo install -d -o root -g nixbld -m 1775 /nix/store
-          sudo usermod -aG nix-users "$USER"
-          sudo systemctl restart nix-daemon.service
-          nix-build --version
-
-      - name: Build and compare Nix outputs
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-          sudo --preserve-env=HOME -u "$USER" -g nix-users \
-            env NIX_REMOTE=daemon bash -Eeuo pipefail <<'NIX_BUILD'
-            set -Eeuo pipefail
-            build_targets=(runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd nvattest)
-            for target in "${build_targets[@]}"; do
-              nix-build --no-out-link -A "$target"
-            done
-            reproducibility_targets=(runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd)
-            for target in "${reproducibility_targets[@]}"; do
-              nix-build --no-out-link --check -A "$target"
-            done
-          NIX_BUILD
-
   test:
     name: Build and Test
     runs-on: ubuntu-latest
@@ -67,21 +25,29 @@ jobs:
         with:
           go-version: '1.25'
 
-      - name: Install Bazel 8.7.0
+      - name: Install Nix
         shell: bash
         run: |
           set -Eeuo pipefail
-          directory=$(mktemp -d /tmp/cvmimage-bazel-install.XXXXXXXX)
-          archive="$directory/bazel"
-          trap 'rm -f -- "$archive"; rmdir -- "$directory"' EXIT
-          curl -fsSL --retry 3 \
-            https://github.com/bazelbuild/bazel/releases/download/8.7.0/bazel-8.7.0-linux-x86_64 \
-            -o "$archive"
-          printf '%s  %s\n' \
-            d7606e679b78067c811096fb3d6cf135225b528835ca396e3a4dddf957859544 \
-            "$archive" | sha256sum -c --strict -
-          sudo install -m 0755 "$archive" /usr/local/bin/bazel
-          test "$(bazel --version)" = "bazel 8.7.0"
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends nix-bin nix-setup-systemd
+          sudo install -d -m 0755 /etc/nix
+          printf 'sandbox = true\nbuild-users-group = nixbld\n' |
+            sudo tee /etc/nix/nix.conf >/dev/null
+          sudo install -d -o root -g nixbld -m 1775 /nix/store
+          sudo usermod -aG nix-users "$USER"
+          sudo systemctl restart nix-daemon.service
+          nix-build --version
 
       - name: Test
-        run: make test
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          sudo --preserve-env=HOME -u "$USER" -g nix-users \
+            env NIX_REMOTE=daemon bash -Eeuo pipefail <<'TEST'
+            make test
+            nix-build --no-out-link -A nvattest
+            for target in runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd; do
+              nix-build --no-out-link --check -A "$target"
+            done
+          TEST

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,8 +43,11 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
+          setup_go_bin="$(dirname "$(command -v go)")"
           sudo --preserve-env=HOME -u "$USER" -g nix-users \
-            env NIX_REMOTE=daemon bash -Eeuo pipefail <<'TEST'
+            env NIX_REMOTE=daemon \
+              PATH="$setup_go_bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+              bash -Eeuo pipefail <<'TEST'
             make test
             nix-build --no-out-link -A nvattest
             for target in runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd; do

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,14 @@ TRUSTED_PATH := /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 .PHONY: rootfs shipping-image debug-image test clean
 
 rootfs:
-	@mkdir -p build
-	@rootfs="$$($(NIX_BUILD) default.nix -A rootfs-archive $(NIX_FLAGS))"; \
+	@set -eu; \
+		mkdir -p build; \
+		rootfs="$$($(NIX_BUILD) default.nix -A rootfs-archive $(NIX_FLAGS))"; \
 		install -m 0644 "$$rootfs" build/rootfs.tar
 
 shipping-image:
-	@inputs="$$($(NIX_BUILD) default.nix -A image-inputs $(NIX_FLAGS))"; \
+	@set -eu; \
+		inputs="$$($(NIX_BUILD) default.nix -A image-inputs $(NIX_FLAGS))"; \
 		mkosi="$$($(NIX_BUILD) default.nix -A mkosi $(NIX_FLAGS))/bin/mkosi"; \
 		rm -f tinfoilcvm tinfoilcvm.raw tinfoilcvm.roothash tinfoilcvm.hash \
 			tinfoilcvm.vmlinuz tinfoilcvm.initrd; \
@@ -30,7 +32,8 @@ shipping-image:
 		echo "image hash: $$(cat tinfoilcvm.hash)"
 
 debug-image:
-	@inputs="$$($(NIX_BUILD) default.nix -A image-inputs $(NIX_FLAGS))"; \
+	@set -eu; \
+		inputs="$$($(NIX_BUILD) default.nix -A image-inputs $(NIX_FLAGS))"; \
 		mkosi="$$($(NIX_BUILD) default.nix -A mkosi $(NIX_FLAGS))/bin/mkosi"; \
 		rm -f tinfoilcvm-debug tinfoilcvm-debug.raw tinfoilcvm-debug.roothash \
 			tinfoilcvm-debug.hash tinfoilcvm-debug.vmlinuz tinfoilcvm-debug.initrd; \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 NIX_BUILD ?= nix-build
 NIX_FLAGS := --no-out-link --option sandbox true
-TRUSTED_PATH := /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 .PHONY: rootfs shipping-image debug-image test clean
 
@@ -16,10 +15,10 @@ shipping-image:
 		mkosi="$$($(NIX_BUILD) default.nix -A mkosi $(NIX_FLAGS))/bin/mkosi"; \
 		rm -f tinfoilcvm tinfoilcvm.raw tinfoilcvm.roothash tinfoilcvm.hash \
 			tinfoilcvm.vmlinuz tinfoilcvm.initrd; \
-		sudo env PATH="$(TRUSTED_PATH)" "$$mkosi" --force \
+		sudo "$$mkosi" --force \
 			--base-tree="$$inputs/rootfs.tar"; \
-		sudo env PATH="$(TRUSTED_PATH)" chmod 0644 tinfoilcvm.raw tinfoilcvm.roothash; \
-		sudo env PATH="$(TRUSTED_PATH)" chown "$$(id -u):$$(id -g)" \
+		sudo chmod 0644 tinfoilcvm.raw tinfoilcvm.roothash; \
+		sudo chown "$$(id -u):$$(id -g)" \
 			tinfoilcvm.raw tinfoilcvm.roothash; \
 		install -m 0644 "$$inputs/tinfoil-custom.vmlinuz" tinfoilcvm.vmlinuz; \
 		install -m 0644 "$$inputs/initrd.cpio.zst" tinfoilcvm.initrd; \
@@ -37,13 +36,13 @@ debug-image:
 		mkosi="$$($(NIX_BUILD) default.nix -A mkosi $(NIX_FLAGS))/bin/mkosi"; \
 		rm -f tinfoilcvm-debug tinfoilcvm-debug.raw tinfoilcvm-debug.roothash \
 			tinfoilcvm-debug.hash tinfoilcvm-debug.vmlinuz tinfoilcvm-debug.initrd; \
-		sudo env PATH="$(TRUSTED_PATH)" "$$mkosi" --force \
+		sudo "$$mkosi" --force \
 			--output=tinfoilcvm-debug \
 			--base-tree="$$inputs/rootfs.tar" \
 			--base-tree="$$inputs/debug-rootfs-layer.tar"; \
-		sudo env PATH="$(TRUSTED_PATH)" chmod 0644 \
+		sudo chmod 0644 \
 			tinfoilcvm-debug.raw tinfoilcvm-debug.roothash; \
-		sudo env PATH="$(TRUSTED_PATH)" chown "$$(id -u):$$(id -g)" \
+		sudo chown "$$(id -u):$$(id -g)" \
 			tinfoilcvm-debug.raw tinfoilcvm-debug.roothash; \
 		install -m 0644 "$$inputs/tinfoil-custom.vmlinuz" tinfoilcvm-debug.vmlinuz; \
 		install -m 0644 "$$inputs/initrd.cpio.zst" tinfoilcvm-debug.initrd; \
@@ -63,6 +62,6 @@ test:
 	$(NIX_BUILD) default.nix -A initrd $(NIX_FLAGS)
 
 clean:
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm tinfoilcvm.*
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm-debug tinfoilcvm-debug.*
+	sudo rm -rf tinfoilcvm tinfoilcvm.*
+	sudo rm -rf tinfoilcvm-debug tinfoilcvm-debug.*
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -1,93 +1,65 @@
+NIX_BUILD ?= nix-build
+NIX_FLAGS := --no-out-link --option sandbox true
 TRUSTED_PATH := /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-MKOSI ?= sudo env PATH="$(TRUSTED_PATH)" mkosi
-BAZEL ?= bazel
-BUILDER_IMAGE := cvmimage-runtime-builder
-SHIPPING_KERNEL := kernel/out/tinfoil-custom.vmlinuz
-SHIPPING_INITRD := build/stage/initrd.cpio.zst
-NVATTEST_OUTPUT := build/rootfs-artifacts/nvattest
-NVATTEST_BINARY := $(NVATTEST_OUTPUT)/usr/bin/nvattest
-NVATTEST_LIBRARY := $(NVATTEST_OUTPUT)/usr/lib/x86_64-linux-gnu/libnvat.so.1.2.2
 
-.PHONY: rootfs initrd debug-layer shipping-image debug-image test regenerate-nvattest clean
+.PHONY: rootfs shipping-image debug-image test clean
 
 rootfs:
-	docker build --pull --file builder/Dockerfile --tag $(BUILDER_IMAGE) builder
-	./builder/run.sh runtime-go
-	@test -x "$(NVATTEST_BINARY)" || { \
-		echo "missing nvattest runtime binary; run 'make regenerate-nvattest'" >&2; \
-		exit 1; \
-	}
-	@test -f "$(NVATTEST_LIBRARY)" || { \
-		echo "missing libnvat runtime library; run 'make regenerate-nvattest'" >&2; \
-		exit 1; \
-	}
-	./builder/run.sh kernel
-	./builder/run.sh nvidia
-	$(BAZEL) build --lockfile_mode=error //image:rootfs
-	mkdir -p build/stage
-	install -m 0644 "$$($(BAZEL) info bazel-bin)/image/bazel-rootfs.tar" build/stage/bazel-rootfs.tar
+	@mkdir -p build
+	@rootfs="$$($(NIX_BUILD) default.nix -A rootfs-archive $(NIX_FLAGS))"; \
+		install -m 0644 "$$rootfs" build/rootfs.tar
 
-initrd: rootfs
-	$(BAZEL) build -c opt --lockfile_mode=error //image/initrd:initrd
-	mkdir -p build/stage
-	install -m 0644 "$$($(BAZEL) info -c opt bazel-bin)/image/initrd/initrd.cpio.zst" "$(SHIPPING_INITRD)"
+shipping-image:
+	@inputs="$$($(NIX_BUILD) default.nix -A image-inputs $(NIX_FLAGS))"; \
+		mkosi="$$($(NIX_BUILD) default.nix -A mkosi $(NIX_FLAGS))/bin/mkosi"; \
+		rm -f tinfoilcvm tinfoilcvm.raw tinfoilcvm.roothash tinfoilcvm.hash \
+			tinfoilcvm.vmlinuz tinfoilcvm.initrd; \
+		sudo env PATH="$(TRUSTED_PATH)" "$$mkosi" --force \
+			--base-tree="$$inputs/rootfs.tar"; \
+		sudo env PATH="$(TRUSTED_PATH)" chmod 0644 tinfoilcvm.raw tinfoilcvm.roothash; \
+		sudo env PATH="$(TRUSTED_PATH)" chown "$$(id -u):$$(id -g)" \
+			tinfoilcvm.raw tinfoilcvm.roothash; \
+		install -m 0644 "$$inputs/tinfoil-custom.vmlinuz" tinfoilcvm.vmlinuz; \
+		install -m 0644 "$$inputs/initrd.cpio.zst" tinfoilcvm.initrd; \
+		test -s tinfoilcvm.raw; \
+		test -s tinfoilcvm.vmlinuz; \
+		test -s tinfoilcvm.initrd; \
+		test "$$(wc -c < tinfoilcvm.roothash)" -eq 64; \
+		grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm.roothash; \
+		cp tinfoilcvm.roothash tinfoilcvm.hash; \
+		echo "image hash: $$(cat tinfoilcvm.hash)"
 
-debug-layer: rootfs
-	./builder/run.sh debug-init
-	$(BAZEL) build --lockfile_mode=error //image:debug-layer
-	mkdir -p build/stage
-	install -m 0644 "$$($(BAZEL) info bazel-bin)/image/bazel-debug-layer.tar" build/stage/bazel-debug-layer.tar
-
-shipping-image: initrd
-	rm -f tinfoilcvm tinfoilcvm.raw tinfoilcvm.roothash tinfoilcvm.hash \
-		tinfoilcvm.vmlinuz tinfoilcvm.initrd
-	$(MKOSI) --force
-	sudo env PATH="$(TRUSTED_PATH)" chmod 0644 tinfoilcvm.raw tinfoilcvm.roothash
-	sudo env PATH="$(TRUSTED_PATH)" chown "$$(id -u):$$(id -g)" tinfoilcvm.raw tinfoilcvm.roothash
-	install -m 0644 "$(SHIPPING_KERNEL)" tinfoilcvm.vmlinuz
-	install -m 0644 "$(SHIPPING_INITRD)" tinfoilcvm.initrd
-	test -s tinfoilcvm.raw
-	test -s tinfoilcvm.vmlinuz
-	test -s tinfoilcvm.initrd
-	test "$$(wc -c < tinfoilcvm.roothash)" -eq 64
-	grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm.roothash
-	cp tinfoilcvm.roothash tinfoilcvm.hash
-	@echo "image hash: $$(cat tinfoilcvm.hash)"
-
-debug-image: initrd debug-layer
-	rm -f tinfoilcvm-debug tinfoilcvm-debug.raw tinfoilcvm-debug.roothash \
-		tinfoilcvm-debug.hash tinfoilcvm-debug.vmlinuz tinfoilcvm-debug.initrd
-	$(MKOSI) --force --output=tinfoilcvm-debug \
-		--base-tree="$(CURDIR)/build/stage/bazel-debug-layer.tar"
-	sudo env PATH="$(TRUSTED_PATH)" chmod 0644 tinfoilcvm-debug.raw tinfoilcvm-debug.roothash
-	sudo env PATH="$(TRUSTED_PATH)" chown "$$(id -u):$$(id -g)" \
-		tinfoilcvm-debug.raw tinfoilcvm-debug.roothash
-	install -m 0644 "$(SHIPPING_KERNEL)" tinfoilcvm-debug.vmlinuz
-	install -m 0644 "$(SHIPPING_INITRD)" tinfoilcvm-debug.initrd
-	test -s tinfoilcvm-debug.raw
-	test -s tinfoilcvm-debug.vmlinuz
-	test -s tinfoilcvm-debug.initrd
-	test "$$(wc -c < tinfoilcvm-debug.roothash)" -eq 64
-	grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm-debug.roothash
-	cp tinfoilcvm-debug.roothash tinfoilcvm-debug.hash
-	@echo "debug image hash: $$(cat tinfoilcvm-debug.hash)"
+debug-image:
+	@inputs="$$($(NIX_BUILD) default.nix -A image-inputs $(NIX_FLAGS))"; \
+		mkosi="$$($(NIX_BUILD) default.nix -A mkosi $(NIX_FLAGS))/bin/mkosi"; \
+		rm -f tinfoilcvm-debug tinfoilcvm-debug.raw tinfoilcvm-debug.roothash \
+			tinfoilcvm-debug.hash tinfoilcvm-debug.vmlinuz tinfoilcvm-debug.initrd; \
+		sudo env PATH="$(TRUSTED_PATH)" "$$mkosi" --force \
+			--output=tinfoilcvm-debug \
+			--base-tree="$$inputs/rootfs.tar" \
+			--base-tree="$$inputs/debug-rootfs-layer.tar"; \
+		sudo env PATH="$(TRUSTED_PATH)" chmod 0644 \
+			tinfoilcvm-debug.raw tinfoilcvm-debug.roothash; \
+		sudo env PATH="$(TRUSTED_PATH)" chown "$$(id -u):$$(id -g)" \
+			tinfoilcvm-debug.raw tinfoilcvm-debug.roothash; \
+		install -m 0644 "$$inputs/tinfoil-custom.vmlinuz" tinfoilcvm-debug.vmlinuz; \
+		install -m 0644 "$$inputs/initrd.cpio.zst" tinfoilcvm-debug.initrd; \
+		test -s tinfoilcvm-debug.raw; \
+		test -s tinfoilcvm-debug.vmlinuz; \
+		test -s tinfoilcvm-debug.initrd; \
+		test "$$(wc -c < tinfoilcvm-debug.roothash)" -eq 64; \
+		grep -Eq '^[a-f0-9]{64}$$' tinfoilcvm-debug.roothash; \
+		cp tinfoilcvm-debug.roothash tinfoilcvm-debug.hash; \
+		echo "debug image hash: $$(cat tinfoilcvm-debug.hash)"
 
 test:
 	cd tinfoil && go test ./...
 	cd tinfoil && go test -race ./cmd/init ./internal/boot/...
 	cd tinfoil && go test -tags=tinfoil_debug_image ./cmd/init
 	cd tinfoil && go vet ./...
-	$(BAZEL) test -c opt --lockfile_mode=error //tinfoil/... //image/initrd:writer_test
-	$(BAZEL) build -c opt --lockfile_mode=error //image/initrd:initrd
-
-regenerate-nvattest:
-	docker build --pull --file builder/Dockerfile --tag $(BUILDER_IMAGE) builder
-	rm -rf "$(NVATTEST_OUTPUT)"
-	./builder/run.sh nvattest
-	test -x "$(NVATTEST_BINARY)"
-	test -f "$(NVATTEST_LIBRARY)"
+	$(NIX_BUILD) default.nix -A initrd $(NIX_FLAGS)
 
 clean:
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm.*
+	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm tinfoilcvm.*
 	sudo env PATH="$(TRUSTED_PATH)" rm -rf tinfoilcvm-debug tinfoilcvm-debug.*
-	sudo env PATH="$(TRUSTED_PATH)" rm -rf build/stage build/artifacts
+	rm -rf build

--- a/default.nix
+++ b/default.nix
@@ -30,6 +30,12 @@ let
       "nvidia-modeset.ko"
     ];
   };
+  imageInputs = pkgs.linkFarm "cvmimage-image-inputs" [
+    { name = "rootfs.tar"; path = rootfs.rootfs; }
+    { name = "debug-rootfs-layer.tar"; path = rootfs.debugLayer; }
+    { name = "initrd.cpio.zst"; path = initrd.archive; }
+    { name = "tinfoil-custom.vmlinuz"; path = "${kernel.artifacts}/tinfoil-custom.vmlinuz"; }
+  ];
 in
 go.packages
 // {
@@ -40,4 +46,6 @@ go.packages
   inherit (nvattest) nvattest;
   "rootfs-archive" = rootfs.rootfs;
   "debug-rootfs-layer" = rootfs.debugLayer;
+  "image-inputs" = imageInputs;
+  inherit (pkgs) mkosi;
 }

--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,7 @@ let
   kernel = import ./nix/kernel.nix { inherit pkgs; };
   nvidia = import ./nix/nvidia-modules.nix { inherit pkgs kernel; };
   nvattest = import ./nix/nvattest.nix { inherit pkgs; };
+  mkosi = import ./nix/mkosi.nix { inherit pkgs; };
   rootfs = import ./nix/rootfs.nix {
     inherit pkgs;
     runtimeGo = go.packages."runtime-go";
@@ -47,5 +48,5 @@ go.packages
   "rootfs-archive" = rootfs.rootfs;
   "debug-rootfs-layer" = rootfs.debugLayer;
   "image-inputs" = imageInputs;
-  inherit (pkgs) mkosi;
+  inherit mkosi;
 }

--- a/mkosi.conf
+++ b/mkosi.conf
@@ -11,7 +11,6 @@ SplitArtifacts=roothash
 Seed=48c56959-5579-5709-85af-f5393936a4d8
 
 [Content]
-BaseTrees=build/stage/bazel-rootfs.tar
 CleanPackageMetadata=no
 SourceDateEpoch=0
 Bootable=no

--- a/nix/mkosi.nix
+++ b/nix/mkosi.nix
@@ -1,0 +1,12 @@
+{ pkgs }:
+
+let
+  tools = pkgs.buildEnv {
+    name = "cvmimage-mkosi-tools";
+    paths = [ pkgs.systemd pkgs.e2fsprogs pkgs.dosfstools ];
+    pathsToLink = [ "/bin" ];
+  };
+in
+pkgs.writeShellScriptBin "mkosi" ''
+  exec ${pkgs.mkosi}/bin/mkosi --extra-search-path=${tools}/bin "$@"
+''


### PR DESCRIPTION
## Summary
- make the narrow Make interface consume Nix-owned rootfs, initrd, kernel, and debug-layer outputs
- retain mkosi only as the offline disk/verity finalizer
- pin mkosi, systemd-repart, mke2fs, and mkfs.vfat through Nix ExtraSearchPaths
- remove hidden producer ordering and fail immediately when any producer fails

## Validation
- Box3 and INF14 both used Nix mke2fs 1.47.4 and mkfs.fat 4.2
- shipping raw SHA-256: `4bf6ec67d3cb413d49352a04bdb68f1f35fbf6d44303b9ba8701a1eb201b1f94` on both hosts
- debug raw SHA-256: `9a7034d7458da9c2997cddc0c14f2da9d499d962f286b96d88375ed023603011` on both hosts
- Box3 shipping/debug boot, SNP attestation, endpoints, toolbox SSH, hvc0/hvc1 consoles, and daemon adoption pass
- INF14 exact images passed TDX plus 1-GPU and 2-GPU B300 attestation; workload readiness is still running

## Merge order
Depends on the additive-rootfs PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches image assembly to Nix-built inputs and uses a Nix-pinned `mkosi` only for disk/verity finalization. Builds are reproducible, simpler, and fail fast on producer errors.

- **Refactors**
  - `shipping-image`/`debug-image` consume `image-inputs` from `default.nix`; call Nix-provided `mkosi`.
  - Replaced Docker/Bazel with `nix-build`; removed `regenerate-nvattest`.
  - Pass base trees to `mkosi` at runtime; `mkosi.conf` no longer hard-codes `BaseTrees`.
  - Image rules validate artifacts and roothash to fail early.
  - Tests run Go suites and Nix `--check` builds; CI preserves the `setup-go` toolchain PATH.

- **Dependencies**
  - Added `nix/mkosi.nix` wrapper to pin `mkosi` and filesystem tools (`systemd`, `e2fsprogs`, `dosfstools`) via `--extra-search-path`.
  - CI installs `nix-daemon` and builds via `nix-build`; Bazel and ad‑hoc APT packages removed. Release uses `nix-bin`/`nix-setup-systemd` and runs `make shipping-image` with `NIX_REMOTE=daemon`.

<sup>Written for commit ded2a898fabe421bda2a4338351b03dfa8a04bf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

