### PR TITLE
Upload releases with the Nix-pinned AWS CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,20 @@ jobs:
         run: |
           make shipping-image
 
+      - name: Resolve release upload CLI
+        id: release-upload-cli
+        run: |
+          set -Eeuo pipefail
+          output="$(/nix/var/nix/profiles/default/bin/nix-build \
+            --no-out-link -A release-upload-cli)"
+          aws="$output/bin/aws"
+          test -x "$aws"
+          case "$aws" in
+            /nix/store/*/bin/aws) ;;
+            *) exit 1 ;;
+          esac
+          echo "aws=$aws" >> "$GITHUB_OUTPUT"
+
       - name: Check release artifacts
         run: |
           set -Eeuo pipefail
@@ -77,7 +91,7 @@ jobs:
 
           # Generate checksums
           cd /tmp/out
-          sha256sum * | tee "tinfoil-inference-${REF_NAME}-checksums.sha256"
+          sha256sum ./* | tee "tinfoil-inference-${REF_NAME}-checksums.sha256"
 
           echo "digest=sha256:$(sha256sum "tinfoil-inference-${REF_NAME}-manifest.json" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
@@ -89,16 +103,36 @@ jobs:
             /tmp/out/tinfoil-inference-${{ github.ref_name }}.initrd
             /tmp/out/tinfoil-inference-${{ github.ref_name }}.vmlinuz
             /tmp/out/tinfoil-inference-${{ github.ref_name }}.raw
+            /tmp/out/tinfoil-inference-${{ github.ref_name }}-checksums.sha256
 
-      - name: Upload artifact
-        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c
-        with:
-          r2-account-id: ${{ secrets.R2_IMAGES_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.R2_IMAGES_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.R2_IMAGES_SECRET_ACCESS_KEY }}
-          r2-bucket: ${{ secrets.R2_IMAGES_BUCKET }}
-          source-dir: /tmp/out
-          destination-dir: ./cvm
+      - name: Upload attested artifacts to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_IMAGES_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_IMAGES_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_EC2_METADATA_DISABLED: "true"
+          AWS_CONFIG_FILE: /dev/null
+          AWS_SHARED_CREDENTIALS_FILE: /dev/null
+          AWS_CLI: ${{ steps.release-upload-cli.outputs.aws }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_IMAGES_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_IMAGES_BUCKET }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -Eeuo pipefail
+          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          destination="s3://${R2_BUCKET}/cvm"
+          artifacts=(
+            "tinfoil-inference-${REF_NAME}-manifest.json"
+            "tinfoil-inference-${REF_NAME}.initrd"
+            "tinfoil-inference-${REF_NAME}.vmlinuz"
+            "tinfoil-inference-${REF_NAME}.raw"
+            "tinfoil-inference-${REF_NAME}-checksums.sha256"
+          )
+          for artifact in "${artifacts[@]}"; do
+            "$AWS_CLI" --endpoint-url "$endpoint" s3 cp \
+              "/tmp/out/$artifact" "$destination/$artifact" \
+              --only-show-errors --no-progress
+          done
 
       - name: Create release
         env:

--- a/default.nix
+++ b/default.nix
@@ -68,6 +68,7 @@ go.packages
   "rootfs-archive" = rootfs.rootfs;
   "debug-rootfs-layer" = rootfs.debugLayer;
   "runtime-package-lock" = runtimePackages.lock;
+  "release-upload-cli" = pkgs.awscli2;
   "shipping-image" = shippingImage;
   "debug-image" = debugImage;
 }


### PR DESCRIPTION
## Summary

- remove `ryand56/r2-upload-action`
- expose pinned Nixpkgs `awscli2` as `release-upload-cli`
- resolve and execute the exact Nix-store AWS CLI binary
- attest and explicitly upload the five prepared release files
- scope R2 credentials and endpoint configuration to the upload step only

## Contract

The upload step does not build or modify image artifacts. It publishes only the manifest, initrd, kernel, raw disk, and checksum file already prepared and attested by preceding steps to the explicit R2 bucket `cvm/` prefix with `--only-show-errors --no-progress`.

## Validation

- `nix-instantiate -A release-upload-cli`
- `nix-build --no-out-link -A release-upload-cli`
- pinned AWS CLI reports `aws-cli/2.34.24`
- `actionlint` on `.github/workflows/release.yml`
- `zizmor` on `.github/workflows/release.yml`
- `go build ./...`
- `go test ./...`
- focused race tests
- debug-tag init test
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace `ryand56/r2-upload-action` with a Nix-pinned `awscli2` to publish releases to Cloudflare R2. This makes uploads reproducible and limits credential scope to the upload step.

- **Dependencies**
  - Added `release-upload-cli` (Nix-pinned `pkgs.awscli2`).
  - Removed `ryand56/r2-upload-action`.

- **Refactors**
  - Resolve and run the exact Nix-store `aws` binary in CI.
  - Upload only attested artifacts (manifest, initrd, vmlinuz, raw, checksums) to `cvm/` via S3-compatible endpoint with `--only-show-errors --no-progress`.
  - Scope R2 creds and AWS config to the upload step; disable shared config and EC2 metadata.
  - Fix checksum generation (`sha256sum ./*`) and include the checksum file in uploads.

<sup>Written for commit c090f0d3971ec01edbc95ad6820d0a9c87a75899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

