### PR TITLE
Normalize NVIDIA module source paths

### DIFF
--- a/nix/nvidia-modules.nix
+++ b/nix/nvidia-modules.nix
@@ -8,6 +8,7 @@ let
   _versionCheck =
     assert kernelPackages.nvidiaPackages.production.version == version;
     true;
+  kernelSource = "${kernelPackages.kernel.dev}/lib/modules/${release}/source";
   nvidiaOpen = kernelPackages.nvidiaPackages.production.open.overrideAttrs (old: {
     env = (old.env or { }) // {
       CONFIG_X86_KERNEL_IBT = "";
@@ -15,6 +16,7 @@ let
       NV_EXCLUDE_KERNEL_MODULES = "nvidia-drm nvidia-peermem";
       NV_BUILD_HOST = "tinfoil-builder";
       NV_BUILD_USER = "tinfoil";
+      KCFLAGS = "-ffile-prefix-map=${kernelSource}=/usr/src/linux -fmacro-prefix-map=${kernelSource}=/usr/src/linux -fdebug-prefix-map=${kernelSource}=/usr/src/linux";
     };
     makeFlags = builtins.filter (flag: !(lib.hasPrefix "KBUILD_BUILD_TIMESTAMP=" flag)) (
       old.makeFlags or [ ]
@@ -85,6 +87,10 @@ let
 
         for module in "''${expected_modules[@]}"; do
           module_path="$out/$module"
+          if grep -aFq /nix/store/ "$module_path"; then
+            echo "$module contains a Nix store path" >&2
+            exit 1
+          fi
           actual_version=$(modinfo -F version "$module_path")
           actual_vermagic=$(modinfo -F vermagic "$module_path")
           case "$module" in


### PR DESCRIPTION
## Summary

- pass conventional kbuild `KCFLAGS` prefix maps to the upstream NVIDIA open-module build
- replace Nix-store kernel-header filenames embedded in module diagnostics with fixed `/usr/src/linux` paths
- fail the producing derivation if any selected module still contains `/nix/store/`

## Validation

- rebuilt the upstream NVIDIA open modules in the pinned Nix 2.35.1 sandbox
- retained the exact three-module set, versions, vermagic, dependencies, and imported-symbol CRC validation
- confirmed all three modules contain no Nix-store paths
- rebuilt rootfs, shipping image, and debug image
- confirmed the extracted rootfs contains no Nix-store paths
- confirmed the shipping image remains shell-free
- ran the Nix-owned Go checks
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize source paths in the NVIDIA open kernel modules so embedded paths resolve to `/usr/src/linux` and never include Nix store paths. We derive the kernel source from `${kernelPackages.kernel.dev}/lib/modules/${release}/source`, pass prefix maps via `KCFLAGS` (`-ffile-prefix-map`, `-fmacro-prefix-map`, `-fdebug-prefix-map`), and fail the build if any module still contains `/nix/store/`.

<sup>Written for commit 1d1783dc35f8d99a32ec1afb4b8963d9a679259c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

