### PR TITLE
Tighten release workflow inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             echo "WARN: This is a prerelease"
           fi
 
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -80,8 +80,7 @@ jobs:
             "root": "$(tr -d '\n' < result/tinfoilcvm.roothash)",
             "initrd": "$(sha256sum result/tinfoilcvm.initrd | awk '{print $1}')",
             "kernel": "$(sha256sum result/tinfoilcvm.vmlinuz | awk '{print $1}')",
-            "raw": "$(sha256sum result/tinfoilcvm.raw | awk '{print $1}')",
-            "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            "raw": "$(sha256sum result/tinfoilcvm.raw | awk '{print $1}')"
           }
           EOF
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/update-config-repos.yml
+++ b/.github/workflows/update-config-repos.yml
@@ -49,7 +49,7 @@ jobs:
             REPOS='[]'
           fi
 
-          echo "repos=$REPOS" >> $GITHUB_OUTPUT
+          echo "repos=$REPOS" >> "$GITHUB_OUTPUT"
           echo "Found repos: $REPOS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,8 +78,10 @@ jobs:
           private-key: ${{ secrets.VERSION_UPDATER_PRIVATE_KEY }}
           owner: ${{ steps.parse.outputs.owner }}
           repositories: ${{ steps.parse.outputs.name }}
+          permission-contents: write
+          permission-pull-requests: write
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ${{ matrix.repo }}
           token: ${{ steps.app-token.outputs.token }}

--- a/image/rootfs/etc/systemd/system-preset/00-tinfoil.preset
+++ b/image/rootfs/etc/systemd/system-preset/00-tinfoil.preset
@@ -1,1 +1,0 @@
-disable *

--- a/nix/rootfs.nix
+++ b/nix/rootfs.nix
@@ -36,7 +36,6 @@ let
     { source = ../image/rootfs/etc/passwd; target = "etc/passwd"; mode = "0644"; }
     { source = ../image/rootfs/etc/resolv.conf; target = "etc/resolv.conf"; mode = "0644"; }
     { source = ../image/rootfs/etc/shadow; target = "etc/shadow"; mode = "0640"; }
-    { source = ../image/rootfs/etc/systemd/system-preset/00-tinfoil.preset; target = "etc/systemd/system-preset/00-tinfoil.preset"; mode = "0644"; }
     { source = ../image/rootfs/usr/lib/clock-epoch; target = "usr/lib/clock-epoch"; mode = "0644"; }
     { source = ../image/rootfs/usr/lib/os-release; target = "usr/lib/os-release"; mode = "0644"; }
   ];


### PR DESCRIPTION
## Summary

- remove the nondeterministic `built_at` release-manifest field
- standardize every workflow on the reviewed SHA-pinned `actions/checkout` v6.0.2 commit
- constrain the version-updater GitHub App token to contents and pull-request writes
- delete the unused systemd preset and its additive rootfs declaration
- fix the touched workflow's unquoted `GITHUB_OUTPUT` write

## Validation

- actionlint passes for all workflows
- zizmor reports no findings across the repository workflows
- every external GitHub Action remains pinned to a full commit SHA
- parsed every Nix expression
- Nix-owned Go checks pass
- rebuilt rootfs, shipping image, and debug image in the pinned Nix sandbox
- confirmed the package closure remains exactly 42 packages
- confirmed no Nix-store paths enter the rootfs and the shipping image remains shell-free
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CI workflows and makes the release manifest deterministic. Pins `actions/checkout` to v6.0.2 (SHA) across workflows, removes the `built_at` field, quotes `$GITHUB_OUTPUT` writes, limits the version-updater app token to contents and pull-request writes, and deletes an unused systemd preset and its rootfs entry.

<sup>Written for commit 7eeb025aa783e2b75a37d0de2de366df5d65e974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

