### PR TITLE
Fail closed when Nix sandboxing is unavailable

### DIFF
--- a/.github/actions/install-nix/action.yml
+++ b/.github/actions/install-nix/action.yml
@@ -26,7 +26,7 @@ runs:
           "$tmp/$archive" | sha256sum --check --strict
         tar --extract --xz --file "$tmp/$archive" --directory "$tmp"
 
-        printf 'sandbox = true\n' > "$tmp/nix.conf"
+        printf 'sandbox = true\nsandbox-fallback = false\n' > "$tmp/nix.conf"
         "$tmp/nix-$version-x86_64-linux/install" \
           --daemon --yes --no-channel-add --no-modify-profile \
           --nix-extra-conf-file "$tmp/nix.conf"
@@ -40,3 +40,4 @@ runs:
           "$expected_store_path/bin/nix-daemon"
         test "$("$profile/bin/nix" --version)" = "nix (Nix) $version"
         test "$("$profile/bin/nix" config show sandbox)" = true
+        test "$("$profile/bin/nix" config show sandbox-fallback)" = false

--- a/docs/build.md
+++ b/docs/build.md
@@ -68,10 +68,12 @@ CI and release builders install the official Nix 2.35.1 binary release pinned
 by `nix/nix-version`, `nix/nix-x86_64-linux.sha256`, and the expected Nix store
 path. The installer refuses a pre-existing, unverified Nix installation. Box3,
 INF14, and release qualification builders must use the same official release
-for both the client and daemon, with `sandbox = true`. The remaining host
-prerequisites are an x86_64 Linux host with systemd, `sudo`, `curl`, `tar`,
-`xz`, and the kernel features required by the Nix sandbox. GitHub
-runner images may float. Artifact construction runs inside the Nix sandbox.
+for both the client and daemon, with `sandbox = true` and
+`sandbox-fallback = false`. A sandbox setup failure therefore stops the build
+rather than changing its isolation boundary. The remaining host prerequisites
+are an x86_64 Linux host with systemd, `sudo`, `curl`, `tar`, `xz`, and the
+kernel features required by the Nix sandbox. GitHub runner images may float.
+Artifact construction runs inside the Nix sandbox.
 
 The pinned Nixpkgs source is imported with an empty configuration and no
 overlays. Developer or machine-local Nixpkgs configuration is not part of the


### PR DESCRIPTION
## Summary

- configure the pinned official Nix installer with `sandbox-fallback = false`
- verify both `sandbox = true` and disabled fallback after installation
- document the same exact client/daemon and fail-closed sandbox contract for CI, Box3, INF14, and qualification builders

Box3 and INF14 have both been aligned to the pinned official Nix 2.35.1 client and daemon with this configuration, and a sandbox probe succeeded on each host.

## Validation

- Nix parsing and Nix-owned checks
- actionlint for all workflows
- repository-wide zizmor with no findings
- exact Nix 2.35.1 client and daemon on Box3 and INF14
- `sandbox = true` and `sandbox-fallback = false` on both hosts
- sandbox isolation probes on both hosts
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-closed Nix sandboxing: the pinned installer now sets `sandbox = true` and `sandbox-fallback = false`, and we verify both after install. Docs now require the same Nix 2.35.1 client/daemon and fail-closed sandbox on CI, Box3, INF14, and qualification builders; sandbox setup failure stops the build instead of changing isolation.

<sup>Written for commit 47dcc84840168ed183892b9e57c20756d34b7507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

