### PR TITLE
Publish attested releases with Nix-owned tools

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,6 @@ jobs:
           /nix/var/nix/profiles/default/bin/nix-build \
             -I . -A shipping-image -o result
 
-      - name: Resolve release upload CLI
-        id: release-upload-cli
-        run: |
-          set -Eeuo pipefail
-          output="$(/nix/var/nix/profiles/default/bin/nix-build \
-            --no-out-link -I . -A release-upload-cli)"
-          aws="$output/bin/aws"
-          test -x "$aws"
-          echo "aws=$aws" >> "$GITHUB_OUTPUT"
       - name: Generate manifest
         id: manifest
         env:
@@ -96,28 +87,15 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_IMAGES_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_IMAGES_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          AWS_EC2_METADATA_DISABLED: "true"
-          AWS_CONFIG_FILE: /dev/null
-          AWS_SHARED_CREDENTIALS_FILE: /dev/null
-          AWS_CLI: ${{ steps.release-upload-cli.outputs.aws }}
-          R2_ACCOUNT_ID: ${{ secrets.R2_IMAGES_ACCOUNT_ID }}
+          AWS_ENDPOINT_URL: https://${{ secrets.R2_IMAGES_ACCOUNT_ID }}.r2.cloudflarestorage.com
           R2_BUCKET: ${{ secrets.R2_IMAGES_BUCKET }}
-          REF_NAME: ${{ github.ref_name }}
         run: |
           set -Eeuo pipefail
-          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
-          destination="s3://${R2_BUCKET}/cvm"
-          artifacts=(
-            "tinfoil-inference-${REF_NAME}-manifest.json"
-            "tinfoil-inference-${REF_NAME}.initrd"
-            "tinfoil-inference-${REF_NAME}.vmlinuz"
-            "tinfoil-inference-${REF_NAME}.raw"
-            "tinfoil-inference-${REF_NAME}-checksums.sha256"
-          )
-          for artifact in "${artifacts[@]}"; do
-            "$AWS_CLI" --endpoint-url "$endpoint" s3 cp \
-              "/tmp/out/$artifact" "$destination/$artifact" \
+          aws="$(/nix/var/nix/profiles/default/bin/nix-build \
+            --no-out-link -I . -A release-upload-cli)/bin/aws"
+          for file in /tmp/out/*; do
+            "$aws" s3 cp "$file" \
+              "s3://${R2_BUCKET}/cvm/$(basename "$file")" \
               --only-show-errors --no-progress
           done
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             echo "WARN: This is a prerelease"
           fi
 
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
@@ -44,6 +44,15 @@ jobs:
           /nix/var/nix/profiles/default/bin/nix-build \
             -I . -A shipping-image -o result
 
+      - name: Resolve release upload CLI
+        id: release-upload-cli
+        run: |
+          set -Eeuo pipefail
+          output="$(/nix/var/nix/profiles/default/bin/nix-build \
+            --no-out-link -I . -A release-upload-cli)"
+          aws="$output/bin/aws"
+          test -x "$aws"
+          echo "aws=$aws" >> "$GITHUB_OUTPUT"
       - name: Generate manifest
         id: manifest
         env:
@@ -58,8 +67,7 @@ jobs:
             "root": "$(tr -d '\n' < result/tinfoilcvm.roothash)",
             "initrd": "$(sha256sum result/tinfoilcvm.initrd | awk '{print $1}')",
             "kernel": "$(sha256sum result/tinfoilcvm.vmlinuz | awk '{print $1}')",
-            "raw": "$(sha256sum result/tinfoilcvm.raw | awk '{print $1}')",
-            "built_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            "raw": "$(sha256sum result/tinfoilcvm.raw | awk '{print $1}')"
           }
           EOF
 
@@ -70,7 +78,7 @@ jobs:
 
           # Generate checksums
           cd /tmp/out
-          sha256sum * | tee "tinfoil-inference-${REF_NAME}-checksums.sha256"
+          sha256sum ./* | tee "tinfoil-inference-${REF_NAME}-checksums.sha256"
 
           echo "digest=sha256:$(sha256sum "tinfoil-inference-${REF_NAME}-manifest.json" | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
@@ -82,16 +90,36 @@ jobs:
             /tmp/out/tinfoil-inference-${{ github.ref_name }}.initrd
             /tmp/out/tinfoil-inference-${{ github.ref_name }}.vmlinuz
             /tmp/out/tinfoil-inference-${{ github.ref_name }}.raw
+            /tmp/out/tinfoil-inference-${{ github.ref_name }}-checksums.sha256
 
-      - name: Upload artifact
-        uses: ryand56/r2-upload-action@b801a390acbdeb034c5e684ff5e1361c06639e7c
-        with:
-          r2-account-id: ${{ secrets.R2_IMAGES_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.R2_IMAGES_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.R2_IMAGES_SECRET_ACCESS_KEY }}
-          r2-bucket: ${{ secrets.R2_IMAGES_BUCKET }}
-          source-dir: /tmp/out
-          destination-dir: ./cvm
+      - name: Upload attested artifacts to R2
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_IMAGES_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_IMAGES_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_EC2_METADATA_DISABLED: "true"
+          AWS_CONFIG_FILE: /dev/null
+          AWS_SHARED_CREDENTIALS_FILE: /dev/null
+          AWS_CLI: ${{ steps.release-upload-cli.outputs.aws }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_IMAGES_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_IMAGES_BUCKET }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          set -Eeuo pipefail
+          endpoint="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+          destination="s3://${R2_BUCKET}/cvm"
+          artifacts=(
+            "tinfoil-inference-${REF_NAME}-manifest.json"
+            "tinfoil-inference-${REF_NAME}.initrd"
+            "tinfoil-inference-${REF_NAME}.vmlinuz"
+            "tinfoil-inference-${REF_NAME}.raw"
+            "tinfoil-inference-${REF_NAME}-checksums.sha256"
+          )
+          for artifact in "${artifacts[@]}"; do
+            "$AWS_CLI" --endpoint-url "$endpoint" s3 cp \
+              "/tmp/out/$artifact" "$destination/$artifact" \
+              --only-show-errors --no-progress
+          done
 
       - name: Create release
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/update-config-repos.yml
+++ b/.github/workflows/update-config-repos.yml
@@ -49,7 +49,7 @@ jobs:
             REPOS='[]'
           fi
 
-          echo "repos=$REPOS" >> $GITHUB_OUTPUT
+          echo "repos=$REPOS" >> "$GITHUB_OUTPUT"
           echo "Found repos: $REPOS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,8 +78,10 @@ jobs:
           private-key: ${{ secrets.VERSION_UPDATER_PRIVATE_KEY }}
           owner: ${{ steps.parse.outputs.owner }}
           repositories: ${{ steps.parse.outputs.name }}
+          permission-contents: write
+          permission-pull-requests: write
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ${{ matrix.repo }}
           token: ${{ steps.app-token.outputs.token }}

--- a/default.nix
+++ b/default.nix
@@ -65,6 +65,7 @@ go.packages
   "rootfs-archive" = rootfs.rootfs;
   "debug-rootfs-layer" = rootfs.debugLayer;
   "runtime-package-lock" = runtimePackages.lock;
+  "release-upload-cli" = pkgs.awscli2;
   "shipping-image" = shippingImage;
   "debug-image" = debugImage;
 }


### PR DESCRIPTION
## Summary

- publish with the exact Nixpkgs `awscli2` store binary
- remove the opaque third-party R2 upload action
- scope R2 credentials only to the upload step
- upload only the already-built and attested artifact set
- normalize reviewed action SHAs and permissions
- remove build time from the deterministic release manifest

This replaces #288 and the workflow portion of #291. It does not rebuild during publication.

## Validation

- all Nix expressions parse
- `checks`, `release-upload-cli`, and `shipping-image` build successfully
- the complete five-PR tree exactly matches the qualified #275–#292 tree
- layering independent #279 reproduces every Box3/INF14-qualified artifact hash exactly
- `git diff --check`

Part 5 of 5. Stacked on the pinned Nix interface PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish attested release artifacts with Nix-owned tools and direct R2 uploads. Uses the exact Nixpkgs `awscli2` store binary, and ships a deterministic manifest plus a checksums file.

- **Refactors**
  - Resolve `release-upload-cli` inline via `nix-build` and upload to R2 with `aws s3 cp` using an explicit endpoint; scope R2 creds to the upload step.
  - Build `shipping-image` via `nix-build` (`result`); copy only attested files to `/tmp/out`, generate `...-checksums.sha256` (via `sha256sum ./*`), include it in attestation and upload; remove `built_at` from the manifest.

- **Dependencies**
  - Expose `release-upload-cli` = `pkgs.awscli2` in `default.nix`; bump `actions/checkout` to `v6.0.2` in `release`, `test`, and `update-config-repos`; quote `GITHUB_OUTPUT` and set app permissions (contents, pull-requests) in `update-config-repos`.

<sup>Written for commit d5c24825a07e77c48ea5fd011edabdc5dfa0ea46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

