### PR TITLE
Separate PR checks from complete image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+name: Build images
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build complete images
+    runs-on: large
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: ./.github/actions/install-nix
+
+      - name: Build checks and images
+        shell: bash
+        env:
+          PATH: /nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        run: |
+          set -Eeuo pipefail
+          /nix/var/nix/profiles/default/bin/nix-build \
+            --no-out-link -I . \
+            -A checks \
+            -A shipping-image \
+            -A debug-image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,17 @@
-name: Test
+name: PR checks
 
 on:
   pull_request:
-    branches: [main, jules/harden-tcb]
-  push:
-    branches: [main]
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   test:
-    name: Build and Test
+    name: PR checks
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -18,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install Nix
@@ -41,13 +43,56 @@ jobs:
             "$nix_instantiate" --no-gc-warning -I . -A runtime-go)"
           test "$configured" = "$baseline"
 
-      - name: Test
+      - name: Build changed check targets
         shell: bash
         env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PATH: /nix/var/nix/profiles/default/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
         run: |
           set -Eeuo pipefail
-          for target in checks runtime-go debug-init tinfoil-initrd fixed-cpio-writer initrd nvattest; do
-            /nix/var/nix/profiles/default/bin/nix-build \
-              --no-out-link -I . -A "$target"
+
+          base_parent="$(mktemp -d)"
+          base_tree="$base_parent/base"
+          cleanup() {
+            git worktree remove --force "$base_tree" 2>/dev/null || true
+            rmdir "$base_parent" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+          git worktree add --detach "$base_tree" "$BASE_SHA"
+
+          force_all=false
+          while IFS= read -r path; do
+            case "$path" in
+              .github/actions/install-nix/* | .github/workflows/test.yml | nix/nix-*)
+                force_all=true
+                ;;
+            esac
+          done < <(git diff --name-only "$BASE_SHA" HEAD)
+
+          nix_instantiate=/nix/var/nix/profiles/default/bin/nix-instantiate
+          build_args=(--no-out-link -I .)
+          selected=()
+          for target in checks runtime-go debug-init initrd; do
+            head_drv="$("$nix_instantiate" --no-gc-warning -I . -A "$target")"
+            base_drv=""
+            if test "$force_all" = false; then
+              base_drv="$(
+                cd "$base_tree"
+                "$nix_instantiate" --no-gc-warning -I . -A "$target"
+              )" || true
+            fi
+            if test "$force_all" = true || test -z "$base_drv" || test "$head_drv" != "$base_drv"; then
+              selected+=("$target")
+              build_args+=(-A "$target")
+            else
+              echo "$target is unchanged"
+            fi
           done
+
+          if test "${#selected[@]}" -eq 0; then
+            echo "No check target changed"
+            exit 0
+          fi
+
+          printf 'Building %s\n' "${selected[*]}"
+          /nix/var/nix/profiles/default/bin/nix-build "${build_args[@]}"

--- a/docs/build.md
+++ b/docs/build.md
@@ -160,12 +160,28 @@ cp --no-preserve=mode result-package-lock nix/runtime-packages-lock.nix
 rm result-package-lock
 ```
 
+## Continuous integration
+
+Pull-request CI always checks the pinned Nix installation and isolated Nixpkgs
+evaluation. It compares the `checks`, `runtime-go`, `debug-init`, and `initrd`
+derivation paths with the pull request's base and builds only the changed
+outputs. Changes to the Nix installer or this workflow build all four. The
+`initrd` output already builds the initrd command and fixed CPIO writer and runs
+the writer tests, so CI does not request those dependencies separately.
+
+Pushes to `main`, and explicit manual runs, build `checks`, `shipping-image`,
+and `debug-image` on one runner. The two image outputs transitively build the
+kernel, NVIDIA modules, nvattest, initrd, runtime binaries, and rootfs without a
+second producer list. These workflows neither publish artifacts nor qualify a
+release. Derivation comparison only schedules CI work; it is not an integrity
+check or a release policy.
+
 ## Release qualification
 
-Normal pull-request CI checks evaluation, focused builds, and source tests. It
-does not rebuild expensive producers twice. Before promoting a release, build
-the exact candidate independently on the qualified builders, compare the
-kernel, initrd, rootfs, raw disk, and dm-verity root, then boot and exercise the
-same artifacts on the required CPU and GPU hardware. Promote only the tested
-measurement. This is a release process, not another verifier embedded in the
-build graph.
+Before promoting a release, build the exact candidate independently on the
+qualified builders and compare the kernel, initrd, rootfs, raw disk, and
+dm-verity root. Boot and exercise the same artifacts through the operator-run
+CPU and GPU qualification that is available for the release; hardware
+qualification is not a GitHub Actions job and unavailable hardware blocks the
+corresponding gate. Promote only the tested measurement. This is a release
+process, not another verifier embedded in the build graph.


### PR DESCRIPTION
## Summary

- compare fast Nix check derivations with the PR base and build only changed outputs
- build complete shipping and debug images only on `main` pushes or manual dispatch
- document the boundary between PR checks, integration builds, and external release qualification

This replays the patch from #300 onto the squash-merged #298 base; #300 was accidentally merged into #298's retired head branch.

## Verification

- unchanged-target and force-all scheduler paths
- `nix-build --no-out-link -I . -A checks -A shipping-image -A debug-image`
- actionlint
- zizmor
- YAML parsing and `git diff --check`

No Nix derivation, measured artifact, release, cache, credential, or publication behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split CI so PRs build only changed Nix check targets, while full images build only on `main` or manual runs. Updated docs to clarify the boundary between PR checks, integration builds, and release qualification.

- **New Features**
  - Added `Build images` workflow for `main` and `workflow_dispatch`; builds `checks`, `shipping-image`, and `debug-image` on one runner.
  - PR workflow now compares derivation paths for `checks`, `runtime-go`, `debug-init`, and `initrd` against the base and builds only changed targets; Nix installer/workflow changes force a full run.
  - Concurrency prevents duplicate runs (by PR number for checks, by ref for builds), and CI explicitly avoids publishing artifacts or acting as release policy.

<sup>Written for commit c7fe04a289ee521e4653bafca47d897831a4a5bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

