### PR TITLE
Minimize the measured Nix rootfs payload

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -96,7 +96,9 @@ integration, systemd units, Turing-only firmware, and legacy NVIDIA
 runtime-hook compatibility are likewise excluded. The CUDA compute, CDI
 container, attestation, firmware, and NVSwitch payloads remain; diagnostic
 commands belong inside debug or workload containers rather than the measured
-host rootfs.
+shipping rootfs. The separately measured debug image adds the pinned
+`nvidia-smi` client so CDI can expose it to GPU workload containers inspected
+through the SSH toolbox.
 
 The Nix expressions also reject store references in runtime binaries and use
 fixed ownership, modes, archive ordering, and timestamps. Reproducibility is a

--- a/docs/build.md
+++ b/docs/build.md
@@ -85,11 +85,18 @@ overlays. Developer or machine-local Nixpkgs configuration is not part of the
 build graph.
 
 `nix/rootfs.nix` is additive: it starts from an empty tree and installs only
-the declared archive members, Nix-built outputs, and repository files. Package
-maintainer scripts do not run and no producer filesystem is copied into the
-image. Complete package payloads are accepted where they are the clearest
-contract; later TCB reduction should remove them only with evidence that the
-smaller contract is correct.
+the declared package paths, Nix-built outputs, and repository files. Package
+archives are extracted into build-only staging trees; package maintainer
+scripts do not run, and manuals, headers, service units, package helpers, and
+other undeclared paths never enter the image. The Ubuntu package closure is
+still the pinned source of runtime libraries and the CA bundle, but the
+measured rootfs contains only its declared runtime payload. NVIDIA graphics,
+video, OpenCL, host diagnostics, CUDA debugger and MPS tools, distro boot
+integration, service-manager payloads, Turing-only firmware, and legacy NVIDIA
+runtime-hook compatibility are likewise excluded. The CUDA compute, CDI
+container, attestation, firmware, and NVSwitch payloads remain; diagnostic
+commands belong inside debug or workload containers rather than the measured
+host rootfs.
 
 The Nix expressions also reject store references in runtime binaries and use
 fixed ownership, modes, archive ordering, and timestamps. Reproducibility is a

--- a/docs/build.md
+++ b/docs/build.md
@@ -92,7 +92,7 @@ other undeclared paths never enter the image. The Ubuntu package closure is
 still the pinned source of runtime libraries and the CA bundle, but the
 measured rootfs contains only its declared runtime payload. NVIDIA graphics,
 video, OpenCL, host diagnostics, CUDA debugger and MPS tools, distro boot
-integration, service-manager payloads, Turing-only firmware, and legacy NVIDIA
+integration, systemd units, Turing-only firmware, and legacy NVIDIA
 runtime-hook compatibility are likewise excluded. The CUDA compute, CDI
 container, attestation, firmware, and NVSwitch payloads remain; diagnostic
 commands belong inside debug or workload containers rather than the measured

--- a/nix/rootfs.nix
+++ b/nix/rootfs.nix
@@ -16,6 +16,7 @@ let
     sha256 = package.sha256;
   };
 
+  nvidiaComputeDeb = fetchDeb sources.nvidiaCompute;
   nvidiaDebs = map fetchDeb sources.nvidiaDebs;
   busyboxDeb = fetchDeb sources.busybox;
   dockerArchive = pkgs.fetchurl {
@@ -241,6 +242,13 @@ let
     ${pkgs.dpkg}/bin/dpkg-deb --fsys-tarfile ${busyboxDeb} |
       ${pkgs.gnutar}/bin/tar --extract --file=- --directory "$root" \
         --no-same-owner --no-overwrite-dir
+    nvidia="$TMPDIR/nvidia"
+    mkdir "$nvidia"
+    ${pkgs.dpkg}/bin/dpkg-deb --fsys-tarfile ${nvidiaComputeDeb} |
+      ${pkgs.gnutar}/bin/tar --extract --file=- --directory "$nvidia" \
+        --no-same-owner ./usr/bin/nvidia-smi
+    install_new 0755 "$nvidia/usr/bin/nvidia-smi" \
+      "$root/usr/bin/nvidia-smi" -D
     install_new 0755 ${debugInit}/bin/tinfoil-init \
       "$root/usr/bin/tinfoil-init" -D
     install -d -m 0700 "$root/root"

--- a/nix/rootfs.nix
+++ b/nix/rootfs.nix
@@ -22,21 +22,59 @@ let
     inherit (sources.docker) name url;
     sha256 = sources.docker.sha256;
   };
-  matchesDebPackage = package: deb:
-    builtins.match ".*-${package}_[^/]+[.]deb"
-      (builtins.baseNameOf (toString deb)) != null;
-  caCertificatesDeb =
-    pkgs.lib.findFirst (matchesDebPackage "ca-certificates")
-      (throw "ca-certificates deb missing from runtime package closure")
-      ubuntuDebs;
-  provenanceOnlyUbuntuPackages = [
-    "debconf"
-    "libcap2-bin"
+  # Keep library directories whole for NSS, provider, and other dlopen-only edges.
+  ubuntuPayloadPaths = [
+    "etc/bindresvport.blacklist"
+    "etc/gai.conf"
+    "etc/ld.so.conf"
+    "etc/ld.so.conf.d"
+    "etc/netconfig"
+    "etc/ssl/openssl.cnf"
+    "usr/bin/ip"
+    "usr/lib/ssl/cert.pem"
+    "usr/lib/ssl/certs"
+    "usr/lib/ssl/openssl.cnf"
+    "usr/lib/ssl/private"
+    "usr/lib/x86_64-linux-gnu"
+    "usr/lib64/ld-linux-x86-64.so.2"
+    "usr/sbin/ip"
+    "usr/sbin/ldconfig"
+    "usr/sbin/nft"
   ];
-  isProvenanceOnlyDeb = deb:
-    pkgs.lib.any (package: matchesDebPackage package deb)
-      provenanceOnlyUbuntuPackages;
-  runtimeUbuntuDebs = pkgs.lib.filter (deb: !(isProvenanceOnlyDeb deb)) ubuntuDebs;
+
+  # The measured host owns CUDA, CDI, attestation, and fabric operation only.
+  nvidiaPayloadPaths = [
+    "lib/firmware/nvidia/595.71.05/gsp_ga10x.bin"
+    "usr/bin/nv-fabricmanager"
+    "usr/bin/nvidia-cdi-hook"
+    "usr/bin/nvidia-container-runtime"
+    "usr/bin/nvidia-ctk"
+    "usr/bin/nvidia-persistenced"
+    "usr/lib/x86_64-linux-gnu/libcuda.so"
+    "usr/lib/x86_64-linux-gnu/libcuda.so.1"
+    "usr/lib/x86_64-linux-gnu/libcuda.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvfm.so.1"
+    "usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.1"
+    "usr/lib/x86_64-linux-gnu/libnvidia-cfg.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvidia-gpucomp.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1"
+    "usr/lib/x86_64-linux-gnu/libnvidia-ml.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvidia-nscq.so"
+    "usr/lib/x86_64-linux-gnu/libnvidia-nscq.so.2"
+    "usr/lib/x86_64-linux-gnu/libnvidia-nscq.so.2.0"
+    "usr/lib/x86_64-linux-gnu/libnvidia-nscq.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.4"
+    "usr/lib/x86_64-linux-gnu/libnvidia-nvvm.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvidia-nvvm70.so.4"
+    "usr/lib/x86_64-linux-gnu/libnvidia-pkcs11-openssl3.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.1"
+    "usr/lib/x86_64-linux-gnu/libnvidia-ptxjitcompiler.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvidia-sandboxutils.so.1"
+    "usr/lib/x86_64-linux-gnu/libnvidia-sandboxutils.so.595.71.05"
+    "usr/lib/x86_64-linux-gnu/libnvidia-tileiras.so.595.71.05"
+    "usr/share/nvidia/files.d"
+    "usr/share/nvidia/nvswitch"
+  ];
 
   repositoryFiles = [
     { source = ../image/rootfs/etc/.pwd.lock; target = "etc/.pwd.lock"; mode = "0600"; }
@@ -60,11 +98,19 @@ let
     { source = ../image/rootfs/usr/share/nvidia/nvswitch/fabricmanager.cfg; target = "usr/share/nvidia/nvswitch/fabricmanager.cfg"; mode = "0644"; }
   ];
 
-  extractDebs = pkgs.lib.concatMapStringsSep "\n" (deb: ''
+  stageDebs = debs: destination:
+    pkgs.lib.concatMapStringsSep "\n" (deb: ''
     ${pkgs.dpkg}/bin/dpkg-deb --fsys-tarfile ${deb} |
+      ${pkgs.gnutar}/bin/tar --extract --file=- --directory ${destination} \
+        --no-same-owner --keep-old-files
+  '') debs;
+
+  copyPayload = source: paths: ''
+    ${pkgs.gnutar}/bin/tar --create --file=- --directory ${source} \
+      ${pkgs.lib.escapeShellArgs paths} |
       ${pkgs.gnutar}/bin/tar --extract --file=- --directory "$root" \
         --no-same-owner --keep-old-files
-  '') (runtimeUbuntuDebs ++ nvidiaDebs);
+  '';
 
   repositoryInstalls = pkgs.lib.concatMapStringsSep "\n" (file: ''
     install_new ${file.mode} ${file.source} "$root/${file.target}" -D
@@ -117,10 +163,15 @@ let
   } ''
     set -o pipefail
     root="$TMPDIR/root"
-    mkdir -p "$root"
+    ubuntu="$TMPDIR/ubuntu"
+    nvidia="$TMPDIR/nvidia"
+    mkdir -p "$root" "$ubuntu" "$nvidia"
     ${shellInstallHelpers}
 
-    ${extractDebs}
+    ${stageDebs ubuntuDebs "$ubuntu"}
+    ${stageDebs nvidiaDebs "$nvidia"}
+    ${copyPayload "$ubuntu" ubuntuPayloadPaths}
+    ${copyPayload "$nvidia" nvidiaPayloadPaths}
     chmod 0755 "$root"
 
     docker="$TMPDIR/docker"
@@ -151,7 +202,8 @@ let
 
     mkdir -p "$root/dev" "$root/mnt/ramdisk" "$root/proc" "$root/run" \
       "$root/sys" "$root/tmp" "$root/var/tmp" "$root/usr/lib64" \
-      "$root/etc/ssl/certs"
+      "$root/etc/ssl/certs" "$root/var/cache/ldconfig"
+    install -d -m 0700 "$root/etc/ssl/private"
     chmod 0755 "$root" "$root/dev" "$root/mnt" "$root/mnt/ramdisk" \
       "$root/proc" "$root/run" "$root/sys" "$root/tmp" "$root/var" \
       "$root/var/tmp"
@@ -160,21 +212,15 @@ let
     link_new usr/sbin "$root/sbin"
     link_new ../run "$root/var/run"
 
-    ca_control="$TMPDIR/ca-certificates-control"
-    mkdir -p "$ca_control"
-    ${pkgs.dpkg}/bin/dpkg-deb --control ${caCertificatesDeb} "$ca_control"
-    sed -n 's/^CERTS_LIST="\(.*\)"$/\1/p' "$ca_control/config" |
-      tr ',' '\n' |
-      sed -e 's/^[[:space:]]*//' -e '/^$/d' \
-      > "$root/etc/ca-certificates.conf"
-    test -s "$root/etc/ca-certificates.conf"
-
     # Keep update-ca-certificates' hashed symlinks as build intermediates.
     ca_output="$TMPDIR/ca-certificates-output"
+    ca_config="$TMPDIR/ca-certificates.conf"
     mkdir "$ca_output"
-    ${pkgs.dash}/bin/dash -e "$root/usr/sbin/update-ca-certificates" \
-      --certsconf "$root/etc/ca-certificates.conf" \
-      --certsdir "$root/usr/share/ca-certificates" \
+    touch "$ca_config"
+    ${pkgs.dash}/bin/dash -e "$ubuntu/usr/sbin/update-ca-certificates" \
+      --default \
+      --certsconf "$ca_config" \
+      --certsdir "$ubuntu/usr/share/ca-certificates" \
       --localcertsdir "$TMPDIR/no-local-certificates" \
       --etccertsdir "$ca_output" \
       --hooksdir "$TMPDIR/no-ca-hooks"

--- a/nix/runtime-sources.nix
+++ b/nix/runtime-sources.nix
@@ -1,3 +1,10 @@
+let
+  nvidiaCompute = {
+    name = "libnvidia-compute";
+    url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-compute_595.71.05-1ubuntu1_amd64.deb";
+    sha256 = "6e934848e693668ee678bd5346d7688774925700a0a35d943a2adfff2c8b4076";
+  };
+in
 {
   busybox = {
     name = "busybox-static";
@@ -13,7 +20,7 @@
 
   nvidiaDebs = [
     { name = "libnvidia-cfg1"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-cfg1_595.71.05-1ubuntu1_amd64.deb"; sha256 = "dc18f61a73350cb4c19a775172c3090d794aae93eba5e0413a559b2337dff092"; }
-    { name = "libnvidia-compute"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-compute_595.71.05-1ubuntu1_amd64.deb"; sha256 = "6e934848e693668ee678bd5346d7688774925700a0a35d943a2adfff2c8b4076"; }
+    nvidiaCompute
     { name = "libnvidia-gpucomp"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-gpucomp_595.71.05-1ubuntu1_amd64.deb"; sha256 = "c541c308a25773471a5826897e8025d1fcf9cb742e0da566de19d4ca15f6050e"; }
     { name = "libnvidia-nscq"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-nscq_595.71.05-1ubuntu1_amd64.deb"; sha256 = "d02d606e3ab10db7ae5c7abd9c4dc803365d19de75261e1424f5af723992ea0f"; }
     { name = "nvidia-container-toolkit-base"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-container-toolkit-base_1.19.1-1_amd64.deb"; sha256 = "3ee2a9202294fdd27cd79e23f35b7a1f24ea0fa934ab03229f25c89b3245defe"; }
@@ -21,4 +28,6 @@
     { name = "nvidia-firmware"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-firmware_595.71.05-1ubuntu1_amd64.deb"; sha256 = "105ceeae7c20cce66109a636f5a9bcd4bb4a820e0937f7407b91945dceaa5086"; }
     { name = "nvidia-persistenced"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-persistenced_595.71.05-1ubuntu1_amd64.deb"; sha256 = "6c4c02e6a9f596fa95ff036d87ff7d0c9040faf3e7f51ad8fdc8f6e6bf938f65"; }
   ];
+
+  inherit nvidiaCompute;
 }

--- a/nix/runtime-sources.nix
+++ b/nix/runtime-sources.nix
@@ -14,17 +14,11 @@
   nvidiaDebs = [
     { name = "libnvidia-cfg1"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-cfg1_595.71.05-1ubuntu1_amd64.deb"; sha256 = "dc18f61a73350cb4c19a775172c3090d794aae93eba5e0413a559b2337dff092"; }
     { name = "libnvidia-compute"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-compute_595.71.05-1ubuntu1_amd64.deb"; sha256 = "6e934848e693668ee678bd5346d7688774925700a0a35d943a2adfff2c8b4076"; }
-    { name = "libnvidia-container-tools"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-container-tools_1.19.1-1_amd64.deb"; sha256 = "c6e01e92ded92e6819df0db183cc74e65d1d8c421ca2a0d1bb5a7f2b244a11f6"; }
-    { name = "libnvidia-container1"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-container1_1.19.1-1_amd64.deb"; sha256 = "661f8cf7a97eb0c6dbf0786d0814d781235a96c4730fe012bba4436b6de4417f"; }
-    { name = "libnvidia-decode"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-decode_595.71.05-1ubuntu1_amd64.deb"; sha256 = "cf32fee8eefcca3be9181b94b2103886ac9dda577d1667b8d6f2544b2ea24138"; }
-    { name = "libnvidia-gl"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-gl_595.71.05-1ubuntu1_amd64.deb"; sha256 = "28debe13d2032f2216954a925e1f937956017c1557e6c47251b7694dd205f379"; }
     { name = "libnvidia-gpucomp"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-gpucomp_595.71.05-1ubuntu1_amd64.deb"; sha256 = "c541c308a25773471a5826897e8025d1fcf9cb742e0da566de19d4ca15f6050e"; }
     { name = "libnvidia-nscq"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/libnvidia-nscq_595.71.05-1ubuntu1_amd64.deb"; sha256 = "d02d606e3ab10db7ae5c7abd9c4dc803365d19de75261e1424f5af723992ea0f"; }
-    { name = "nvidia-container-toolkit"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-container-toolkit_1.19.1-1_amd64.deb"; sha256 = "721a0e18ea6a25d1a2d4b569e3f4fa057c86badc64cfb441f782c020d8ca1535"; }
     { name = "nvidia-container-toolkit-base"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-container-toolkit-base_1.19.1-1_amd64.deb"; sha256 = "3ee2a9202294fdd27cd79e23f35b7a1f24ea0fa934ab03229f25c89b3245defe"; }
     { name = "nvidia-fabricmanager"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-fabricmanager_595.71.05-1ubuntu1_amd64.deb"; sha256 = "480d185ebb109cc3f1ebe73a6c5cff4a072a1b0ddde08017fd2f1bf9048afe66"; }
     { name = "nvidia-firmware"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-firmware_595.71.05-1ubuntu1_amd64.deb"; sha256 = "105ceeae7c20cce66109a636f5a9bcd4bb4a820e0937f7407b91945dceaa5086"; }
-    { name = "nvidia-kernel-common"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-kernel-common_595.71.05-1ubuntu1_amd64.deb"; sha256 = "6529833b65de8aeeafd176cf063686963ceaddd3ca159e7a28c05881f11267c4"; }
     { name = "nvidia-persistenced"; url = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2604/x86_64/nvidia-persistenced_595.71.05-1ubuntu1_amd64.deb"; sha256 = "6c4c02e6a9f596fa95ff036d87ff7d0c9040faf3e7f51ad8fdc8f6e6bf938f65"; }
   ];
 }


### PR DESCRIPTION
## Summary

- stage pinned Ubuntu and NVIDIA packages as build-only inputs, then copy only explicit runtime paths into the empty rootfs
- keep CA source material and update-ca-certificates outside the image while preserving the exact generated CA bundle
- narrow NVIDIA userspace to CUDA, CDI, attestation, firmware, and fabric operation; omit graphics, video/decode, OpenCL, host diagnostics, debugger/MPS tools, Turing firmware, and legacy runtime-hook compatibility
- keep `nvidia-smi` out of the shipping rootfs and add the pinned CLI only to the separately measured debug layer, where CDI can inject it into workload containers
- reduce the deterministic rootfs tar from 1,313,157,120 bytes / 1,649 entries to 855,316,480 bytes / 496 entries

## Verification

- `nix-build --no-out-link -I . -A checks -A rootfs-archive -A shipping-image -A debug-image`
- `nix-build --no-out-link -I . --check -A rootfs-archive`
- CA bundle is byte-identical to the base rootfs
- final rootfs has no Nix store references
- independent INF14 build produced the same rootfs, shipping-image, and debug-image store paths
- full-CC INF14 B300 boot passed CPU and GPU attestation, network, firewall, CDI generation, containers, and shim
- final debug image injected its pinned `nvidia-smi` through CDI; both the workload and `tinfoil-nvidia-smi` helper identified the B300, while the toolbox itself remained GPU-unprivileged
- direct CUDA Driver API probe and pinned containerized `nvidia-smi` both identified the B300
- pinned vLLM/PyTorch gpt-oss-safeguard-120b loaded 68.71 GiB of weights, compiled and warmed its SM100 FlashInfer path, reached `/health`, and completed an inference request

INF14 has no NVSwitches, so this qualification did not exercise the retained H200/NVSwitch Fabric Manager path.