### PR TITLE
Expose a debug-only container boot API

### DIFF
--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -177,7 +177,6 @@ func (m *manager) boot(override []byte) error {
 	if err := writeRuntimeArtifacts(config, source); err != nil {
 		return err
 	}
-	launchConfig := withoutPreservedContainers(config, preserved)
 	tracker, err := boot.ResumeTracker()
 	if err != nil {
 		return err
@@ -188,24 +187,10 @@ func (m *manager) boot(override []byte) error {
 		return err
 	}
 	tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
-	if err := containers.LaunchAndWaitHealthy(m.ctx, tracker, launchConfig, external, m.debug); err != nil {
+	if err := containers.LaunchAndWaitHealthyExcept(m.ctx, tracker, config, external, m.debug, preserved); err != nil {
 		return err
 	}
 	return restartRuntimeServices(m.ctx)
-}
-
-func withoutPreservedContainers(config *runtimeconfig.Config, preserved map[string]bool) *runtimeconfig.Config {
-	if len(preserved) == 0 {
-		return config
-	}
-	copy := *config
-	copy.Containers = nil
-	for _, container := range config.Containers {
-		if !preserved[container.Name] {
-			copy.Containers = append(copy.Containers, container)
-		}
-	}
-	return &copy
 }
 
 func writeError(w http.ResponseWriter, status int, err error) {

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -2,11 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
+	"net"
+	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -17,6 +22,18 @@ import (
 	"tinfoil/internal/kernelcmdline"
 	"tinfoil/internal/runtimeconfig"
 )
+
+const bootPath = "/v1/boot"
+
+type manager struct {
+	bootMu sync.Mutex
+	ctx    context.Context
+	debug  bool
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
 
 func main() {
 	log.SetFlags(0)
@@ -31,9 +48,27 @@ func run(ctx context.Context) error {
 	if err := os.MkdirAll("/run/tinfoil", 0o700); err != nil {
 		return err
 	}
+	debug, err := kernelcmdline.DebugEnabled()
+	if err != nil {
+		return err
+	}
+	runtimeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	manager := &manager{ctx: runtimeCtx, debug: debug}
+
+	var listener net.Listener
+	if debug {
+		listener, err = listenDebugSocket()
+		if err != nil {
+			return err
+		}
+		defer listener.Close()
+		defer os.Remove(boot.ContainersSocket)
+	}
+
 	_ = os.Remove(boot.ContainersReadyPath)
 	if _, err := os.Stat(boot.RuntimeBootedPath); errors.Is(err, os.ErrNotExist) {
-		if err := bootDefaultRuntime(ctx); err != nil {
+		if err := manager.boot(nil); err != nil {
 			return err
 		}
 		if err := atomicWrite(boot.RuntimeBootedPath, []byte("booted\n"), 0o600); err != nil {
@@ -46,19 +81,74 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("publishing readiness: %w", err)
 	}
 
-	return containers.RunStatusPublisher(ctx)
+	statusDone := make(chan error, 1)
+	go func() { statusDone <- containers.RunStatusPublisher(runtimeCtx) }()
+	if !debug {
+		return <-statusDone
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(bootPath, manager.handleBoot)
+	httpServer := &http.Server{Handler: mux}
+	go func() {
+		<-runtimeCtx.Done()
+		_ = httpServer.Shutdown(context.Background())
+	}()
+	log.Printf("tinfoil-containers: debug API listening on %s", boot.ContainersSocket)
+	serveErr := httpServer.Serve(listener)
+	if errors.Is(serveErr, http.ErrServerClosed) {
+		serveErr = nil
+	}
+	cancel()
+	return errors.Join(serveErr, <-statusDone)
 }
 
-func bootDefaultRuntime(ctx context.Context) error {
-	debug, err := kernelcmdline.DebugEnabled()
+func listenDebugSocket() (net.Listener, error) {
+	_ = os.Remove(boot.ContainersSocket)
+	listener, err := net.Listen("unix", boot.ContainersSocket)
 	if err != nil {
-		return err
+		return nil, fmt.Errorf("listening on %s: %w", boot.ContainersSocket, err)
 	}
-	source, err := os.ReadFile(boot.ConfigPath)
+	if err := os.Chmod(boot.ContainersSocket, 0o660); err != nil {
+		listener.Close()
+		return nil, err
+	}
+	return listener, nil
+}
+
+func (m *manager) handleBoot(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	override, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 8<<20))
 	if err != nil {
-		return fmt.Errorf("reading verified config: %w", err)
+		writeError(w, http.StatusBadRequest, err)
+		return
 	}
-	config, err := runtimeconfig.Decode(source, debug)
+	if err := m.boot(override); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if err := containers.PublishStatus(m.ctx); err != nil {
+		log.Printf("container status publish failed after debug boot: %v", err)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (m *manager) boot(override []byte) error {
+	m.bootMu.Lock()
+	defer m.bootMu.Unlock()
+
+	source := override
+	if len(source) == 0 {
+		var err error
+		source, err = os.ReadFile(boot.ConfigPath)
+		if err != nil {
+			return fmt.Errorf("reading verified config: %w", err)
+		}
+	}
+	config, err := runtimeconfig.Decode(source, m.debug)
 	if err != nil {
 		return err
 	}
@@ -74,12 +164,20 @@ func bootDefaultRuntime(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("reading installed config: %w", err)
 	}
-	if err := containers.RemoveManagedExcept(ctx, previous, nil); err != nil {
+	preserved := map[string]bool{}
+	if previous != nil && runtimeconfig.HasReservedDebugContainer(previous) {
+		if !runtimeconfig.HasReservedDebugContainer(config) {
+			return errors.New("debug config must retain tinfoil-debug-toolbox")
+		}
+		preserved[runtimeconfig.ReservedDebugContainerName] = true
+	}
+	if err := containers.RemoveManagedExcept(m.ctx, previous, preserved); err != nil {
 		return err
 	}
 	if err := writeRuntimeArtifacts(config, source); err != nil {
 		return err
 	}
+	launchConfig := withoutPreservedContainers(config, preserved)
 	tracker, err := boot.ResumeTracker()
 	if err != nil {
 		return err
@@ -90,5 +188,28 @@ func bootDefaultRuntime(ctx context.Context) error {
 		return err
 	}
 	tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
-	return containers.LaunchAndWaitHealthy(ctx, tracker, config, external, debug)
+	if err := containers.LaunchAndWaitHealthy(m.ctx, tracker, launchConfig, external, m.debug); err != nil {
+		return err
+	}
+	return restartRuntimeServices(m.ctx)
+}
+
+func withoutPreservedContainers(config *runtimeconfig.Config, preserved map[string]bool) *runtimeconfig.Config {
+	if len(preserved) == 0 {
+		return config
+	}
+	copy := *config
+	copy.Containers = nil
+	for _, container := range config.Containers {
+		if !preserved[container.Name] {
+			copy.Containers = append(copy.Containers, container)
+		}
+	}
+	return &copy
+}
+
+func writeError(w http.ResponseWriter, status int, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: err.Error()})
 }

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -46,6 +46,7 @@ const (
 	InitBinary       = "/usr/bin/tinfoil-pid1"
 	BootBinary       = "/usr/bin/tinfoil-boot"
 	ContainersBinary = "/usr/bin/tinfoil-containers"
+	ContainersSocket = "/run/tinfoil/containers.sock"
 	EgressBinary     = "/usr/bin/tinfoil-egress"
 	ShimBinary       = "/usr/bin/tinfoil-shim"
 

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -114,6 +114,10 @@ func networkCreateOptions(name string) dockernetwork.CreateOptions {
 // health checking. Each container is tracked as a substage of "containers"
 // with per-phase sub-substages (pull, start, healthy).
 func LaunchAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
+	return LaunchAndWaitHealthyExcept(ctx, tracker, config, extConfig, debug, nil)
+}
+
+func LaunchAndWaitHealthyExcept(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, debug bool, preserved map[string]bool) error {
 	if len(config.Containers) == 0 {
 		log.Println("No containers to launch")
 		tracker.Record(boot.StageContainers, boot.StatusSkipped, 0, "no containers")
@@ -129,12 +133,18 @@ func LaunchAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Co
 	if err := setupContainerNetwork(ctx, cli, config, debug); err != nil {
 		return fmt.Errorf("creating container network: %w", err)
 	}
+	launchContainers := containersToLaunch(config.Containers, preserved)
+	if len(launchContainers) == 0 {
+		log.Println("No containers to launch")
+		tracker.Record(boot.StageContainers, boot.StatusSkipped, 0, "all containers preserved")
+		return nil
+	}
 
 	start := time.Now()
 
 	// Initialize substages: one per container, each with phase sub-substages.
 	var substages []boot.Stage
-	for _, c := range config.Containers {
+	for _, c := range launchContainers {
 		phases := []boot.Stage{
 			{Name: "pull", Status: boot.StatusPending},
 			{Name: "start", Status: boot.StatusPending},
@@ -155,9 +165,9 @@ func LaunchAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Co
 	var mu sync.Mutex
 	flush := func() { tracker.RecordSubstages(boot.StageContainers, substages) }
 
-	errs := make([]error, len(config.Containers))
+	errs := make([]error, len(launchContainers))
 	var wg sync.WaitGroup
-	for i, c := range config.Containers {
+	for i, c := range launchContainers {
 		wg.Add(1)
 		go func(i int, c Container) {
 			defer wg.Done()
@@ -180,6 +190,19 @@ func LaunchAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Co
 
 	tracker.Record(boot.StageContainers, boot.StatusOK, time.Since(start), "")
 	return nil
+}
+
+func containersToLaunch(configured []Container, preserved map[string]bool) []Container {
+	if len(preserved) == 0 {
+		return configured
+	}
+	launch := make([]Container, 0, len(configured))
+	for _, current := range configured {
+		if !preserved[current.Name] {
+			launch = append(launch, current)
+		}
+	}
+	return launch
 }
 
 func RemoveManagedExcept(ctx context.Context, config *Config, preserved map[string]bool) error {

--- a/tinfoil/internal/containers/preserve_test.go
+++ b/tinfoil/internal/containers/preserve_test.go
@@ -1,0 +1,14 @@
+package containers
+
+import "testing"
+
+func TestContainersToLaunchExcludesOnlyPreservedContainers(t *testing.T) {
+	configured := []Container{{Name: reservedDebugContainerName}, {Name: "app"}}
+	launch := containersToLaunch(configured, map[string]bool{reservedDebugContainerName: true})
+	if len(launch) != 1 || launch[0].Name != "app" {
+		t.Fatalf("containers to launch = %#v", launch)
+	}
+	if len(configured) != 2 {
+		t.Fatalf("configured containers mutated: %#v", configured)
+	}
+}

--- a/tinfoil/internal/containers/status.go
+++ b/tinfoil/internal/containers/status.go
@@ -90,6 +90,15 @@ func RunStatusPublisher(ctx context.Context) error {
 	}
 }
 
+func PublishStatus(ctx context.Context) error {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return fmt.Errorf("creating docker client: %w", err)
+	}
+	defer cli.Close()
+	return publishContainerStatus(ctx, cli, boot.RuntimeConfigPath, boot.ContainerStatusPath)
+}
+
 func publishAndLog(ctx context.Context, cli containerStatusClient) {
 	if err := publishContainerStatus(ctx, cli, boot.RuntimeConfigPath, boot.ContainerStatusPath); err != nil {
 		log.Printf("container status publish failed: %v", err)

--- a/tinfoil/internal/runtimeconfig/types.go
+++ b/tinfoil/internal/runtimeconfig/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ReservedDebugContainerName = "tinfoil-ssh-installer"
+	ReservedDebugContainerName = "tinfoil-debug-toolbox"
 	ReservedDebugPort          = "2222/tcp"
 	ReservedDebugHostPort      = 2222
 	ReservedDebugSerialDevice  = "/dev/hvc1"

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -24,6 +24,7 @@ const (
 	maxHostnameLength         = 253
 	maxBridgeNameLen          = 15
 	debugDockerSocketBind     = "/run/docker.sock:/var/run/docker.sock"
+	debugManagerSocketBind    = "/run/tinfoil/containers.sock:/run/tinfoil/containers.sock"
 )
 
 var (
@@ -152,7 +153,7 @@ func validateContainerPolicy(index int, container *Container, debug bool) error 
 		return fmt.Errorf("containers[%d].ipc must be private or host", index)
 	}
 	for volumeIndex, volume := range container.Volumes {
-		if ReservedDebugRuntimeEnabled(container.Name, debug) && volume == debugDockerSocketBind {
+		if ReservedDebugRuntimeEnabled(container.Name, debug) && (volume == debugDockerSocketBind || volume == debugManagerSocketBind) {
 			continue
 		}
 		source, _, found := strings.Cut(volume, ":")


### PR DESCRIPTION
## Summary
- stack the debug toolbox on the direct production boot flow from #305
- create `/run/tinfoil/containers.sock` only when the exact kernel token `tinfoil-debug=on` is present
- expose only `POST /v1/boot`; there are no template, status, stop, check, apply, reset, plan, revision, or rollback endpoints
- create the socket before the initial direct boot so it can be bind-mounted into the toolbox
- preserve the running `tinfoil-debug-toolbox` across replacement boots
- publish container status immediately after a successful debug boot
- rename the modern reserved container to `tinfoil-debug-toolbox` and allow its Docker and manager socket mounts

The verified config remains immutable. `tindbg template` and `tindbg status` read the public `/tinfoil` files directly in the toolbox PR.

## Dependency
Stacked on #305.

## Validation
- `go test ./...`
- `nix-build -A checks -A runtime-go`
- `git diff --check`