### PR TITLE
Fix v0.11 debug runtime compatibility

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -94,11 +94,10 @@ measured rootfs contains only its declared runtime payload. NVIDIA graphics,
 video, OpenCL, host diagnostics, CUDA debugger and MPS tools, distro boot
 integration, systemd units, Turing-only firmware, and legacy NVIDIA
 runtime-hook compatibility are likewise excluded. The CUDA compute, CDI
-container, attestation, firmware, and NVSwitch payloads remain; diagnostic
-commands belong inside debug or workload containers rather than the measured
-shipping rootfs. The separately measured debug image adds the pinned
-`nvidia-smi` client so CDI can expose it to GPU workload containers inspected
-through the SSH toolbox.
+container, attestation, firmware, and NVSwitch payloads remain. The measured
+rootfs retains the pinned `nvidia-smi` client solely so CDI can expose it inside
+GPU workload and diagnostic containers; other diagnostic commands belong in
+those containers rather than the measured shipping rootfs.
 
 The Nix expressions also reject store references in runtime binaries and use
 fixed ownership, modes, archive ordering, and timestamps. Reproducibility is a

--- a/nix/rootfs.nix
+++ b/nix/rootfs.nix
@@ -51,6 +51,7 @@ let
     "usr/bin/nvidia-container-runtime"
     "usr/bin/nvidia-ctk"
     "usr/bin/nvidia-persistenced"
+    "usr/bin/nvidia-smi"
     "usr/lib/x86_64-linux-gnu/libcuda.so"
     "usr/lib/x86_64-linux-gnu/libcuda.so.1"
     "usr/lib/x86_64-linux-gnu/libcuda.so.595.71.05"
@@ -242,13 +243,6 @@ let
     ${pkgs.dpkg}/bin/dpkg-deb --fsys-tarfile ${busyboxDeb} |
       ${pkgs.gnutar}/bin/tar --extract --file=- --directory "$root" \
         --no-same-owner --no-overwrite-dir
-    nvidia="$TMPDIR/nvidia"
-    mkdir "$nvidia"
-    ${pkgs.dpkg}/bin/dpkg-deb --fsys-tarfile ${nvidiaComputeDeb} |
-      ${pkgs.gnutar}/bin/tar --extract --file=- --directory "$nvidia" \
-        --no-same-owner ./usr/bin/nvidia-smi
-    install_new 0755 "$nvidia/usr/bin/nvidia-smi" \
-      "$root/usr/bin/nvidia-smi" -D
     install_new 0755 ${debugPID1}/bin/tinfoil-pid1 \
       "$root/usr/bin/tinfoil-pid1" -D
     install -d -m 0700 "$root/root"

--- a/tinfoil/internal/runtimeconfig/types.go
+++ b/tinfoil/internal/runtimeconfig/types.go
@@ -19,6 +19,7 @@ const (
 )
 
 type Config struct {
+	CVMVersion string                  `yaml:"cvm-version"`
 	ShimRaw    yaml.Node               `yaml:"shim"`
 	ShimCfg    *shimconfig.Config      `yaml:"-"`
 	CVMNetwork CVMNetworkConfig        `yaml:"cvm-network"`

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 const validConfig = `
+cvm-version: 0.11.0
 shim:
   upstream-port: 8080
 networks:


### PR DESCRIPTION
## Summary
- accept the standard top-level `cvm-version` field in the strict runtime config decoder
- retain the pinned `nvidia-smi` client in the measured rootfs so CDI can expose it inside GPU workload and diagnostic containers
- remove the now-redundant debug-layer copy and document the narrow runtime purpose

## Why
Box3 end-to-end validation initially failed because the strict decoder rejected every normal `0.11.0` deployment config. INF14 then confirmed full CPU/GPU attestation, but showed that the documented toolbox GPU diagnostic could not run because the shipping image omitted the host client that CDI normally injects.

## Validation
- `go test ./internal/runtimeconfig ./cmd/boot ./cmd/containers`
- `nix-build -I . -A rootfs-archive --no-out-link`
- box3 tip-image boot, boot-stage reporting, toolbox console, SSH, resize, status, logs, exec, run, config boot, and template reset
- INF14 full-CC CPU and one-GPU attestation through the pre-fix image; final GPU-container retest follows the updated image build