### PR TITLE
Allow transient service recovery before readiness

### DIFF
--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -699,10 +699,7 @@ func (r *readinessState) Publish() error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.published = true
-	if r.failed || !r.allReadyLocked() {
-		return errors.New("required services are not ready")
-	}
-	if err := r.set(true); err != nil {
+	if err := r.set(!r.failed && r.allReadyLocked()); err != nil {
 		return err
 	}
 	return nil

--- a/tinfoil/cmd/pid1/main_test.go
+++ b/tinfoil/cmd/pid1/main_test.go
@@ -687,6 +687,22 @@ func TestRequiredServiceDeathFailsClosedDuringSupervision(t *testing.T) {
 	}
 }
 
+func TestReadinessPublicationAllowsTransientRecovery(t *testing.T) {
+	var states []bool
+	readiness := newReadiness([]string{"first", "second"}, func(ready bool) error {
+		states = append(states, ready)
+		return nil
+	})
+	readiness.Update(supervisor.State{Name: "first", Required: true, Ready: true})
+	if err := readiness.Publish(); err != nil {
+		t.Fatal(err)
+	}
+	readiness.Update(supervisor.State{Name: "second", Required: true, Ready: true})
+	if got := fmt.Sprint(states); got != "[false true]" {
+		t.Fatalf("published readiness states = %s, want [false true]", got)
+	}
+}
+
 func TestHardeningWrapperAppliesPolicyBeforeExec(t *testing.T) {
 	var calls []string
 	err := execService(


### PR DESCRIPTION
## Summary
- publish the current readiness state without treating a transiently restarting required service as fatal
- allow supervisor recovery to transition the CVM to ready after publication
- add regression coverage for unready-at-publication followed by recovery

## Why
The real Gemma 4 31B debug E2E exposed a race after its long health check: `tinfoil-boot` restarted the shim to load final artifacts, `tinfoil-containers` became ready first, and PID1 immediately failed because the shim restart had not completed. Docker and the toolbox were then shut down even though the shim was recoverable.

## Validation
- `go test ./...`
- full box3 and INF14 retest follows with the rebuilt image
- Gemma 4 31B cold boot and inference will be rerun and left active

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow transient service recovery during readiness publication so the CVM doesn’t fail when a required service restarts. We now publish “not ready” first and transition to ready after recovery.

- **Bug Fixes**
  - Updated `readinessState.Publish()` to set readiness with `!r.failed && r.allReadyLocked()` instead of erroring when not all services are ready.
  - Added regression test to verify publication emits [false, true] as services recover.

<sup>Written for commit 48ca852eb7257c19f8572ac3b5a2aac9e895da7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

