### PR TITLE
Harden live container network policy updates

### DIFF
--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -154,7 +154,7 @@ func (m *manager) handleBoot(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (m *manager) boot(override []byte) error {
+func (m *manager) boot(override []byte) (result error) {
 	m.bootMu.Lock()
 	defer m.bootMu.Unlock()
 
@@ -189,13 +189,18 @@ func (m *manager) boot(override []byte) error {
 		}
 		preserved[runtimeconfig.ReservedDebugContainerName] = true
 	}
-	frozenEgressPID, err := freezeFromPIDFile(boot.EgressPIDPath)
+	frozenEgress, err := freezeFromPIDFile(boot.EgressPIDPath)
 	if err != nil {
 		return fmt.Errorf("freezing current egress policy: %w", err)
 	}
+	if frozenEgress != nil {
+		defer frozenEgress.close()
+	}
 	defer func() {
-		if frozenEgressPID != 0 {
-			_ = syscall.Kill(frozenEgressPID, syscall.SIGCONT)
+		if frozenEgress != nil {
+			if err := restartFrozenFromPIDFile(context.Background(), boot.EgressPIDPath, frozenEgress); err != nil {
+				result = errors.Join(result, fmt.Errorf("restoring egress policy service: %w", err))
+			}
 		}
 	}()
 	if err := containers.RemoveManagedExcept(m.ctx, previous, preserved); err != nil {
@@ -218,10 +223,10 @@ func (m *manager) boot(override []byte) error {
 		return fmt.Errorf("preparing container networks: %w", err)
 	}
 	tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
-	if err := restartFrozenFromPIDFile(m.ctx, boot.EgressPIDPath, frozenEgressPID); err != nil {
+	if err := restartFrozenFromPIDFile(m.ctx, boot.EgressPIDPath, frozenEgress); err != nil {
 		return fmt.Errorf("restarting egress policy: %w", err)
 	}
-	frozenEgressPID = 0
+	frozenEgress = nil
 	if err := containers.LaunchAndWaitHealthyExcept(m.ctx, tracker, config, external, m.debug, preserved); err != nil {
 		return err
 	}

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -189,6 +189,15 @@ func (m *manager) boot(override []byte) error {
 		}
 		preserved[runtimeconfig.ReservedDebugContainerName] = true
 	}
+	frozenEgressPID, err := freezeFromPIDFile(boot.EgressPIDPath)
+	if err != nil {
+		return fmt.Errorf("freezing current egress policy: %w", err)
+	}
+	defer func() {
+		if frozenEgressPID != 0 {
+			_ = syscall.Kill(frozenEgressPID, syscall.SIGCONT)
+		}
+	}()
 	if err := containers.RemoveManagedExcept(m.ctx, previous, preserved); err != nil {
 		return err
 	}
@@ -204,7 +213,15 @@ func (m *manager) boot(override []byte) error {
 		tracker.Record(boot.StageFirewall, boot.StatusFailed, time.Since(start), err.Error())
 		return err
 	}
+	if err := containers.PrepareNetworks(m.ctx, config, m.debug); err != nil {
+		tracker.Record(boot.StageFirewall, boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("preparing container networks: %w", err)
+	}
 	tracker.Record(boot.StageFirewall, boot.StatusOK, time.Since(start), "")
+	if err := restartFrozenFromPIDFile(m.ctx, boot.EgressPIDPath, frozenEgressPID); err != nil {
+		return fmt.Errorf("restarting egress policy: %w", err)
+	}
+	frozenEgressPID = 0
 	if err := containers.LaunchAndWaitHealthyExcept(m.ctx, tracker, config, external, m.debug, preserved); err != nil {
 		return err
 	}

--- a/tinfoil/cmd/containers/runtime.go
+++ b/tinfoil/cmd/containers/runtime.go
@@ -18,8 +18,6 @@ import (
 )
 
 const (
-	shimPIDPath         = "/run/tinfoil/pids/tinfoil-shim.pid"
-	egressPIDPath       = "/run/tinfoil/pids/tinfoil-egress.pid"
 	restartWaitTimeout  = 15 * time.Second
 	restartPollInterval = 100 * time.Millisecond
 )
@@ -71,7 +69,7 @@ func writeRuntimeArtifacts(config *runtimeconfig.Config, source []byte) error {
 
 func restartRuntimeServices(ctx context.Context) error {
 	var errs []error
-	for _, path := range []string{shimPIDPath, egressPIDPath} {
+	for _, path := range []string{boot.ShimPIDPath} {
 		if err := restartFromPIDFile(ctx, path); err != nil {
 			errs = append(errs, err)
 		}
@@ -79,21 +77,60 @@ func restartRuntimeServices(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-func restartFromPIDFile(ctx context.Context, path string) error {
+func freezeFromPIDFile(path string) (int, error) {
+	pid, err := readPIDFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("freezing pid %d: %w", pid, err)
+	}
+	return pid, nil
+}
+
+func restartFrozenFromPIDFile(ctx context.Context, path string, pid int) error {
+	if pid == 0 {
+		return nil
+	}
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("killing frozen pid %d: %w", pid, err)
+	}
+	return waitForReplacementPID(ctx, path, pid)
+}
+
+func readPIDFile(path string) (int, error) {
 	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 1 {
+		return 0, fmt.Errorf("invalid pid in %s", path)
+	}
+	return pid, nil
+}
+
+func restartFromPIDFile(ctx context.Context, path string) error {
+	oldPID, err := readPIDFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	oldPID, err := strconv.Atoi(strings.TrimSpace(string(data)))
-	if err != nil || oldPID <= 1 {
-		return fmt.Errorf("invalid pid in %s", path)
-	}
 	if err := syscall.Kill(oldPID, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
 		return fmt.Errorf("signaling pid %d: %w", oldPID, err)
 	}
+	return waitForReplacementPID(ctx, path, oldPID)
+}
+
+func waitForReplacementPID(ctx context.Context, path string, oldPID int) error {
 	deadline := time.NewTimer(restartWaitTimeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(restartPollInterval)

--- a/tinfoil/cmd/containers/runtime.go
+++ b/tinfoil/cmd/containers/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -20,7 +21,20 @@ import (
 const (
 	restartWaitTimeout  = 15 * time.Second
 	restartPollInterval = 100 * time.Millisecond
+	pidFileLimit        = 32
 )
+
+type serviceInstance struct {
+	pid  int
+	file *os.File
+	info os.FileInfo
+}
+
+func (instance *serviceInstance) close() {
+	if instance != nil {
+		_ = instance.file.Close()
+	}
+}
 
 func loadRuntimeConfig() (*runtimeconfig.Config, error) {
 	data, err := os.ReadFile(boot.RuntimeConfigPath)
@@ -77,60 +91,82 @@ func restartRuntimeServices(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-func freezeFromPIDFile(path string) (int, error) {
-	pid, err := readPIDFile(path)
+func freezeFromPIDFile(path string) (*serviceInstance, error) {
+	instance, err := openServiceInstance(path)
 	if errors.Is(err, os.ErrNotExist) {
-		return 0, nil
+		return nil, nil
 	}
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	if err := syscall.Kill(pid, syscall.SIGSTOP); err != nil {
+	if err := signalProcessGroup(instance.pid, syscall.SIGSTOP); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
-			return 0, nil
+			instance.close()
+			return nil, nil
 		}
-		return 0, fmt.Errorf("freezing pid %d: %w", pid, err)
+		instance.close()
+		return nil, fmt.Errorf("freezing pid %d process group: %w", instance.pid, err)
 	}
-	return pid, nil
+	return instance, nil
 }
 
-func restartFrozenFromPIDFile(ctx context.Context, path string, pid int) error {
-	if pid == 0 {
+func restartFrozenFromPIDFile(ctx context.Context, path string, instance *serviceInstance) error {
+	if instance == nil {
 		return nil
 	}
-	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
-		return fmt.Errorf("killing frozen pid %d: %w", pid, err)
+	if err := signalProcessGroup(instance.pid, syscall.SIGKILL); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("killing frozen pid %d process group: %w", instance.pid, err)
 	}
-	return waitForReplacementPID(ctx, path, pid)
+	return waitForReplacementPID(ctx, path, instance)
 }
 
-func readPIDFile(path string) (int, error) {
-	data, err := os.ReadFile(path)
+func openServiceInstance(path string) (*serviceInstance, error) {
+	file, err := os.Open(path)
 	if err != nil {
-		return 0, err
+		return nil, err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, pidFileLimit+1))
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	if len(data) > pidFileLimit {
+		file.Close()
+		return nil, fmt.Errorf("%s exceeds %d bytes", path, pidFileLimit)
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil || pid <= 1 {
-		return 0, fmt.Errorf("invalid pid in %s", path)
+		file.Close()
+		return nil, fmt.Errorf("invalid pid in %s", path)
 	}
-	return pid, nil
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, err
+	}
+	return &serviceInstance{pid: pid, file: file, info: info}, nil
 }
 
 func restartFromPIDFile(ctx context.Context, path string) error {
-	oldPID, err := readPIDFile(path)
+	instance, err := openServiceInstance(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	if err := syscall.Kill(oldPID, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
-		return fmt.Errorf("signaling pid %d: %w", oldPID, err)
+	defer instance.close()
+	if err := signalProcessGroup(instance.pid, syscall.SIGTERM); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("signaling pid %d process group: %w", instance.pid, err)
 	}
-	return waitForReplacementPID(ctx, path, oldPID)
+	return waitForReplacementPID(ctx, path, instance)
 }
 
-func waitForReplacementPID(ctx context.Context, path string, oldPID int) error {
+func signalProcessGroup(pid int, signal syscall.Signal) error {
+	return syscall.Kill(-pid, signal)
+}
+
+func waitForReplacementPID(ctx context.Context, path string, previous *serviceInstance) error {
 	deadline := time.NewTimer(restartWaitTimeout)
 	defer deadline.Stop()
 	ticker := time.NewTicker(restartPollInterval)
@@ -142,7 +178,7 @@ func waitForReplacementPID(ctx context.Context, path string, oldPID int) error {
 		case <-deadline.C:
 			return fmt.Errorf("waiting for %s to restart", path)
 		case <-ticker.C:
-			restarted, err := replacementPIDAvailable(path, oldPID)
+			restarted, err := replacementPIDAvailable(path, previous)
 			if err != nil {
 				return err
 			}
@@ -153,16 +189,16 @@ func waitForReplacementPID(ctx context.Context, path string, oldPID int) error {
 	}
 }
 
-func replacementPIDAvailable(path string, oldPID int) (bool, error) {
-	current, err := os.ReadFile(path)
+func replacementPIDAvailable(path string, previous *serviceInstance) (bool, error) {
+	current, err := openServiceInstance(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 	if err != nil {
 		return false, err
 	}
-	newPID, err := strconv.Atoi(strings.TrimSpace(string(current)))
-	return err == nil && newPID > 1 && newPID != oldPID, nil
+	defer current.close()
+	return !os.SameFile(previous.info, current.info), nil
 }
 
 func atomicWrite(path string, data []byte, mode os.FileMode) error {

--- a/tinfoil/cmd/containers/runtime_test.go
+++ b/tinfoil/cmd/containers/runtime_test.go
@@ -16,21 +16,33 @@ func TestParseInvocation(t *testing.T) {
 	}
 }
 
-func TestReplacementPIDAvailable(t *testing.T) {
+func TestReplacementPIDAvailableUsesFileGeneration(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "service.pid")
-	if available, err := replacementPIDAvailable(path, 41); err != nil || available {
-		t.Fatalf("missing pid file: available=%v error=%v", available, err)
-	}
 	if err := os.WriteFile(path, []byte("41\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if available, err := replacementPIDAvailable(path, 41); err != nil || available {
-		t.Fatalf("old pid: available=%v error=%v", available, err)
-	}
-	if err := os.WriteFile(path, []byte("42\n"), 0o600); err != nil {
+	previous, err := openServiceInstance(path)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if available, err := replacementPIDAvailable(path, 41); err != nil || !available {
+	defer previous.close()
+	if available, err := replacementPIDAvailable(path, previous); err != nil || available {
+		t.Fatalf("old pid: available=%v error=%v", available, err)
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if available, err := replacementPIDAvailable(path, previous); err != nil || available {
+		t.Fatalf("missing pid file: available=%v error=%v", available, err)
+	}
+	replacement := filepath.Join(filepath.Dir(path), "replacement.pid")
+	if err := os.WriteFile(replacement, []byte("41\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, path); err != nil {
+		t.Fatal(err)
+	}
+	if available, err := replacementPIDAvailable(path, previous); err != nil || !available {
 		t.Fatalf("replacement pid: available=%v error=%v", available, err)
 	}
 }

--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -234,7 +234,7 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 		Name: shimName, Required: true, Restart: true,
 		Command: hardenedCommand(hardening.ServiceShim, boot.ShimBinary),
 		Ready:   endpointReady("tcp", "127.0.0.1:443", shimReadyLimit),
-		PIDFile: "/run/tinfoil/pids/tinfoil-shim.pid",
+		PIDFile: boot.ShimPIDPath,
 	}); err != nil {
 		return err
 	}
@@ -256,7 +256,7 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	if err := deps.services.Start(bootCtx, supervisor.Service{
 		Name: egressName, Restart: true,
 		Command: hardenedCommand(hardening.ServiceEgress, boot.EgressBinary),
-		PIDFile: "/run/tinfoil/pids/tinfoil-egress.pid",
+		PIDFile: boot.EgressPIDPath,
 	}); err != nil {
 		return err
 	}

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -34,6 +34,8 @@ const (
 	// for NVIDIA bring-up readiness.
 	NVIDIABootstrapStatusPath = "/run/tinfoil/nvidia-bootstrap-status"
 	ContainersReadyPath       = "/run/tinfoil/containers.ready"
+	ShimPIDPath               = "/run/tinfoil/pids/tinfoil-shim.pid"
+	EgressPIDPath             = "/run/tinfoil/pids/tinfoil-egress.pid"
 
 	// ShimListenPort is the public TLS port served by tinfoil-shim.
 	ShimListenPort = 443

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -46,6 +46,15 @@ func setupContainerNetwork(ctx context.Context, cli *client.Client, cfg *Config,
 	return setupContainerNetworkFirewall(ctx, cfg, debug)
 }
 
+func PrepareNetworks(ctx context.Context, config *Config, debug bool) error {
+	cli, err := newDockerClient()
+	if err != nil {
+		return fmt.Errorf("creating docker client: %w", err)
+	}
+	defer cli.Close()
+	return setupContainerNetwork(ctx, cli, config, debug)
+}
+
 func ensureNetwork(ctx context.Context, cli *client.Client, name string) error {
 	_, err := cli.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	if err == nil {
@@ -129,9 +138,6 @@ func LaunchAndWaitHealthyExcept(ctx context.Context, tracker *boot.Tracker, conf
 	}
 	defer cli.Close()
 
-	if err := setupContainerNetwork(ctx, cli, config, debug); err != nil {
-		return fmt.Errorf("creating container network: %w", err)
-	}
 	launchContainers := containersToLaunch(config.Containers, preserved)
 	if len(launchContainers) == 0 {
 		log.Println("No containers to launch")

--- a/tinfoil/internal/egress/egress.go
+++ b/tinfoil/internal/egress/egress.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"sort"
 	"strings"
@@ -38,7 +39,7 @@ type Engine struct {
 	interval time.Duration
 }
 
-// Load reads the boot-generated config and previous resolved-address state.
+// Load reads the boot-generated allowlist config.
 func Load() (*Engine, error) {
 	cfg, err := loadConfig(boot.EgressConfigPath)
 	if err != nil {
@@ -134,13 +135,15 @@ func resolve(ctx context.Context, domains []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("resolving %s: %w", domain, err)
 		}
-		for _, addr := range addrs {
-			if net.ParseIP(addr).To4() == nil {
+		for _, value := range addrs {
+			addr, err := netip.ParseAddr(value)
+			if err != nil || !publicIPv4(addr) {
 				continue
 			}
-			if !seen[addr] {
-				seen[addr] = true
-				ips = append(ips, addr)
+			canonical := addr.String()
+			if !seen[canonical] {
+				seen[canonical] = true
+				ips = append(ips, canonical)
 			}
 		}
 	}
@@ -148,4 +151,26 @@ func resolve(ctx context.Context, domains []string) ([]string, error) {
 		return nil, fmt.Errorf("no IPv4 addresses resolved for %v", domains)
 	}
 	return ips, nil
+}
+
+func publicIPv4(addr netip.Addr) bool {
+	if !addr.Is4() {
+		return false
+	}
+	for _, prefix := range nonPublicIPv4Prefixes {
+		if prefix.Contains(addr) {
+			return false
+		}
+	}
+	return true
+}
+
+var nonPublicIPv4Prefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"), netip.MustParsePrefix("10.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"), netip.MustParsePrefix("127.0.0.0/8"),
+	netip.MustParsePrefix("169.254.0.0/16"), netip.MustParsePrefix("172.16.0.0/12"),
+	netip.MustParsePrefix("192.0.0.0/24"), netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.168.0.0/16"), netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"), netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("224.0.0.0/4"), netip.MustParsePrefix("240.0.0.0/4"),
 }

--- a/tinfoil/internal/egress/egress_test.go
+++ b/tinfoil/internal/egress/egress_test.go
@@ -3,6 +3,7 @@ package egress
 import (
 	"context"
 	"errors"
+	"net/netip"
 	"strings"
 	"testing"
 	"time"
@@ -96,5 +97,18 @@ func TestRefreshThreadsCancellationIntoResolution(t *testing.T) {
 
 	if err := engine.Refresh(ctx); !errors.Is(err, context.Canceled) {
 		t.Fatalf("Refresh() error = %v, want context cancellation", err)
+	}
+}
+
+func TestPublicIPv4RejectsNonPublicAnswers(t *testing.T) {
+	for _, value := range []string{"10.0.0.1", "192.0.0.8", "192.0.0.9", "192.0.0.10", "192.0.2.1", "224.0.0.1", "2001:db8::1"} {
+		if publicIPv4(netip.MustParseAddr(value)) {
+			t.Errorf("publicIPv4(%s) = true", value)
+		}
+	}
+	for _, value := range []string{"8.8.8.8"} {
+		if !publicIPv4(netip.MustParseAddr(value)) {
+			t.Errorf("publicIPv4(%s) = false", value)
+		}
 	}
 }

--- a/tinfoil/internal/firewall/containers.go
+++ b/tinfoil/internal/firewall/containers.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	nonPublicIPv4Ranges = "{ 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.2.0/24, 192.168.0.0/16, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 240.0.0.0/4, 255.255.255.255/32 }"
+	nonPublicIPv4Ranges = "{ 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8, 169.254.0.0/16, 172.16.0.0/12, 192.0.0.0/24, 192.0.2.0/24, 192.168.0.0/16, 198.18.0.0/15, 198.51.100.0/24, 203.0.113.0/24, 224.0.0.0/4, 240.0.0.0/4, 255.255.255.255/32 }"
 	nonPublicIPv6Ranges = "{ fc00::/7, fe80::/10, ff00::/8, ::ffff:0:0/96, 64:ff9b::/96, 100::/64, 2001:db8::/32, ::1/128 }"
 )
 
@@ -61,8 +61,10 @@ func writeBridgeRules(script *strings.Builder, bridge string, network *runtimeco
 	fmt.Fprintf(script, "add rule inet tinfoil container_input iifname %q ct state new drop\n", bridge)
 	switch network.Egress {
 	case "open":
-		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip daddr != %s accept\n", bridge, nonPublicIPv4Ranges)
-		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip6 daddr != %s accept\n", bridge, nonPublicIPv6Ranges)
+		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip daddr %s drop\n", bridge, nonPublicIPv4Ranges)
+		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip accept\n", bridge)
+		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip6 daddr %s drop\n", bridge, nonPublicIPv6Ranges)
+		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip6 accept\n", bridge)
 	case "allowlist":
 		setName := containernet.AllowSetPrefix + bridge
 		fmt.Fprintf(script, "destroy set inet tinfoil %s\n", setName)

--- a/tinfoil/internal/firewall/containers.go
+++ b/tinfoil/internal/firewall/containers.go
@@ -62,9 +62,9 @@ func writeBridgeRules(script *strings.Builder, bridge string, network *runtimeco
 	switch network.Egress {
 	case "open":
 		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip daddr %s drop\n", bridge, nonPublicIPv4Ranges)
-		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip accept\n", bridge)
+		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q meta nfproto ipv4 accept\n", bridge)
 		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip6 daddr %s drop\n", bridge, nonPublicIPv6Ranges)
-		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q ip6 accept\n", bridge)
+		fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q meta nfproto ipv6 accept\n", bridge)
 	case "allowlist":
 		setName := containernet.AllowSetPrefix + bridge
 		fmt.Fprintf(script, "destroy set inet tinfoil %s\n", setName)

--- a/tinfoil/internal/firewall/containers_test.go
+++ b/tinfoil/internal/firewall/containers_test.go
@@ -20,7 +20,8 @@ func TestContainerNetworkPolicyModes(t *testing.T) {
 		"flush chain inet tinfoil container_forward",
 		`iifname "closed" oifname "closed" accept`,
 		`iifname "open" ip daddr { 0.0.0.0/8`,
-		`iifname "open" ip accept`,
+		`iifname "open" meta nfproto ipv4 accept`,
+		`iifname "open" meta nfproto ipv6 accept`,
 		"destroy set inet tinfoil allow-control",
 		"create set inet tinfoil allow-control",
 		`iifname "control" ip daddr @allow-control accept`,
@@ -47,7 +48,7 @@ func TestOpenEgressRejectsProtocolAssignments(t *testing.T) {
 	}}
 	script := renderContainerNetworkScript(config, false)
 	drop := strings.Index(script, `ip daddr { 0.0.0.0/8`)
-	accept := strings.Index(script, `iifname "open" ip accept`)
+	accept := strings.Index(script, `iifname "open" meta nfproto ipv4 accept`)
 	if drop < 0 || accept < 0 || drop > accept || strings.Contains(script, "192.0.0.9") || strings.Contains(script, "192.0.0.10") {
 		t.Fatalf("unexpected open IPv4 rule order:\n%s", script)
 	}

--- a/tinfoil/internal/firewall/containers_test.go
+++ b/tinfoil/internal/firewall/containers_test.go
@@ -19,7 +19,8 @@ func TestContainerNetworkPolicyModes(t *testing.T) {
 		"flush chain inet tinfoil container_input",
 		"flush chain inet tinfoil container_forward",
 		`iifname "closed" oifname "closed" accept`,
-		`iifname "open" ip daddr != {`,
+		`iifname "open" ip daddr { 0.0.0.0/8`,
+		`iifname "open" ip accept`,
 		"destroy set inet tinfoil allow-control",
 		"create set inet tinfoil allow-control",
 		`iifname "control" ip daddr @allow-control accept`,
@@ -37,6 +38,18 @@ func TestContainerNetworkPolicyModes(t *testing.T) {
 	drop := strings.Index(script, `iifname "control" ip daddr {`)
 	if accept < 0 || drop < 0 || accept > drop {
 		t.Fatalf("allowlist accept must precede private-range drop:\n%s", script)
+	}
+}
+
+func TestOpenEgressRejectsProtocolAssignments(t *testing.T) {
+	config := &runtimeconfig.Config{Networks: map[string]*runtimeconfig.NetworkSpec{
+		"open": {Egress: "open"},
+	}}
+	script := renderContainerNetworkScript(config, false)
+	drop := strings.Index(script, `ip daddr { 0.0.0.0/8`)
+	accept := strings.Index(script, `iifname "open" ip accept`)
+	if drop < 0 || accept < 0 || drop > accept || strings.Contains(script, "192.0.0.9") || strings.Contains(script, "192.0.0.10") {
+		t.Fatalf("unexpected open IPv4 rule order:\n%s", script)
 	}
 }
 

--- a/tinfoil/internal/firewall/inbound_test.go
+++ b/tinfoil/internal/firewall/inbound_test.go
@@ -22,4 +22,9 @@ func TestInboundRulesTargetDedicatedChain(t *testing.T) {
 			t.Errorf("missing %q from:\n%s", fragment, script)
 		}
 	}
+	flush := strings.Index(script, "flush chain inet tinfoil inbound")
+	firstRule := strings.Index(script, "add rule inet tinfoil inbound")
+	if flush < 0 || firstRule < 0 || flush > firstRule {
+		t.Fatalf("inbound chain must be flushed before rules are added:\n%s", script)
+	}
 }


### PR DESCRIPTION
## Summary

- freeze the active egress policy while debug boot replaces managed containers and networks
- install the new container-network firewall state before restarting the egress resolver
- reject non-public DNS answers, including all of 192.0.0.0/24
- preserve deterministic nftables rule replacement and restart ordering

## Validation

- go test ./...
- go vet ./...
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens live network policy updates. We freeze the running egress service while updating container networks and firewall, then restart it; DNS allowlist now keeps only public IPv4 and nftables rule updates are deterministic.

- **New Features**
  - Freeze the egress resolver during boot, install firewall and networks, then kill and wait for a replacement by PID-file generation before continuing.
  - Open egress drops non-public ranges (now including 192.0.0.0/24) then accepts per-protocol; DNS resolution keeps only public IPv4 answers.

- **Refactors**
  - Added `boot.ShimPIDPath` and `boot.EgressPIDPath`; restart helpers (`freezeFromPIDFile`, `restartFrozenFromPIDFile`, `openServiceInstance`) signal process groups, bound PID-file reads, and wait for replacement via file generation; `restartRuntimeServices` now restarts only the shim.
  - Moved network creation to `containers.PrepareNetworks`; inbound chain is flushed before adding rules.

<sup>Written for commit 07faf349645a90f2121c24a69628f4ea5c3ee5a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

