### PR TITLE
Contain supervised services in dedicated cgroups

### DIFF
--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -568,18 +568,13 @@ func runOneShot(ctx context.Context, manager *supervisor.Manager, cmd supervisor
 	}
 	exit, waitErr := process.Wait(ctx)
 	if waitErr == nil {
-		return annotateOneShotFailure(cmd.Name, exit.Err(), boot.Load)
+		return errors.Join(
+			annotateOneShotFailure(cmd.Name, exit.Err(), boot.Load),
+			process.Stop(0, grace),
+		)
 	}
-	_ = process.Signal(syscall.SIGTERM)
-	timer := time.NewTimer(grace)
-	defer timer.Stop()
-	select {
-	case <-process.Done():
-	case <-timer.C:
-	}
-	cleanupErr := process.KillCgroup()
+	cleanupErr := process.Stop(grace, grace)
 	cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), grace)
-	cleanupErr = errors.Join(cleanupErr, process.WaitCgroupEmpty(cleanupCtx))
 	_, directWaitErr := process.Wait(cleanupCtx)
 	cancelCleanup()
 	return fmt.Errorf("%s interrupted: %w", cmd.Name, errors.Join(waitErr, cleanupErr, directWaitErr))

--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -576,10 +576,13 @@ func runOneShot(ctx context.Context, manager *supervisor.Manager, cmd supervisor
 	select {
 	case <-process.Done():
 	case <-timer.C:
-		_ = process.Signal(syscall.SIGKILL)
-		_, _ = process.Wait(context.Background())
 	}
-	return fmt.Errorf("%s interrupted: %w", cmd.Name, waitErr)
+	cleanupErr := process.KillCgroup()
+	cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), grace)
+	cleanupErr = errors.Join(cleanupErr, process.WaitCgroupEmpty(cleanupCtx))
+	_, directWaitErr := process.Wait(cleanupCtx)
+	cancelCleanup()
+	return fmt.Errorf("%s interrupted: %w", cmd.Name, errors.Join(waitErr, cleanupErr, directWaitErr))
 }
 
 func annotateOneShotFailure(

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
@@ -4,96 +4,24 @@ package supervisor
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"path/filepath"
-	"syscall"
 	"time"
 )
 
 // StartConsole starts one debug-image child as a new session with console as
 // its controlling terminal. The manager remains the sole wait4 owner.
 func (m *Manager) StartConsole(command Command, console *os.File) (*Process, error) {
-	if command.Name == "" {
-		return nil, errors.New("child name is required")
-	}
-	if !filepath.IsAbs(command.Path) {
-		return nil, fmt.Errorf("child path must be absolute: %q", command.Path)
-	}
 	if console == nil {
 		return nil, errors.New("console is required")
 	}
-
-	reply := make(chan startResponse, 1)
-	m.ops <- func(children map[int]*Process) {
-		backend, ok := m.backend.(*osBackend)
-		if !ok {
-			reply <- startResponse{err: errors.New("debug console requires the OS process backend")}
-			return
-		}
-		cgroup, cgroupFD, err := backend.createCgroup()
-		if err != nil {
-			reply <- startResponse{err: fmt.Errorf("prepare cgroup for %s: %w", command.Name, err)}
-			return
-		}
-		defer cgroupFD.Close()
-		environment := command.Env
-		if environment == nil {
-			environment = os.Environ()
-		}
-		process, err := os.StartProcess(
-			command.Path,
-			append([]string{command.Path}, command.Args...),
-			&os.ProcAttr{
-				Dir:   command.Dir,
-				Env:   environment,
-				Files: []*os.File{console, console, console},
-				Sys: &syscall.SysProcAttr{
-					Setsid:      true,
-					Setctty:     true,
-					Ctty:        0,
-					UseCgroupFD: true,
-					CgroupFD:    int(cgroupFD.Fd()),
-				},
-			},
-		)
-		if err != nil {
-			_ = os.Remove(cgroup.path)
-			reply <- startResponse{err: fmt.Errorf("start %s: %w", command.Name, err)}
-			return
-		}
-		managed := newConsoleProcess(process, command.Name, cgroup)
-		children[managed.PID()] = managed
-		reply <- startResponse{process: managed}
-	}
-	response := <-reply
-	return response.process, response.err
-}
-
-func newConsoleProcess(process *os.Process, name string, cgroup *processCgroup) *Process {
-	pid := process.Pid
-	child := &osChild{process: process, processID: pid, cgroup: cgroup}
-	return &Process{pid: pid, name: name, child: child, done: make(chan struct{})}
+	return m.start(command, "", startOptions{
+		files:   []*os.File{console, console, console},
+		console: true,
+	})
 }
 
 // StopConsole terminates the complete console process group with bounded
 // escalation, including background descendants left after the shell exits.
 func (p *Process) StopConsole(termGrace, killGrace time.Duration) error {
-	var errs []error
-	if err := p.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		errs = append(errs, err)
-	}
-	alive, waitErrs := waitProcessGroups([]*Process{p}, time.After(termGrace))
-	errs = append(errs, waitErrs...)
-	for _, process := range alive {
-		if err := process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
-			errs = append(errs, err)
-		}
-	}
-	alive, waitErrs = waitProcessGroups(alive, time.After(killGrace))
-	errs = append(errs, waitErrs...)
-	for _, process := range alive {
-		errs = append(errs, fmt.Errorf("debug console process group %d survived SIGKILL", process.PID()))
-	}
-	return errors.Join(errs...)
+	return p.Stop(termGrace, killGrace)
 }

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
@@ -26,6 +26,17 @@ func (m *Manager) StartConsole(command Command, console *os.File) (*Process, err
 
 	reply := make(chan startResponse, 1)
 	m.ops <- func(children map[int]*Process) {
+		backend, ok := m.backend.(*osBackend)
+		if !ok {
+			reply <- startResponse{err: errors.New("debug console requires the OS process backend")}
+			return
+		}
+		cgroup, cgroupFD, err := backend.createCgroup()
+		if err != nil {
+			reply <- startResponse{err: fmt.Errorf("prepare cgroup for %s: %w", command.Name, err)}
+			return
+		}
+		defer cgroupFD.Close()
 		environment := command.Env
 		if environment == nil {
 			environment = os.Environ()
@@ -38,17 +49,20 @@ func (m *Manager) StartConsole(command Command, console *os.File) (*Process, err
 				Env:   environment,
 				Files: []*os.File{console, console, console},
 				Sys: &syscall.SysProcAttr{
-					Setsid:  true,
-					Setctty: true,
-					Ctty:    0,
+					Setsid:      true,
+					Setctty:     true,
+					Ctty:        0,
+					UseCgroupFD: true,
+					CgroupFD:    int(cgroupFD.Fd()),
 				},
 			},
 		)
 		if err != nil {
+			_ = os.Remove(cgroup.path)
 			reply <- startResponse{err: fmt.Errorf("start %s: %w", command.Name, err)}
 			return
 		}
-		managed := newConsoleProcess(process, command.Name)
+		managed := newConsoleProcess(process, command.Name, cgroup)
 		children[managed.PID()] = managed
 		reply <- startResponse{process: managed}
 	}
@@ -56,9 +70,9 @@ func (m *Manager) StartConsole(command Command, console *os.File) (*Process, err
 	return response.process, response.err
 }
 
-func newConsoleProcess(process *os.Process, name string) *Process {
+func newConsoleProcess(process *os.Process, name string, cgroup *processCgroup) *Process {
 	pid := process.Pid
-	child := osChild{process: process, processID: pid}
+	child := &osChild{process: process, processID: pid, cgroup: cgroup}
 	return &Process{pid: pid, name: name, child: child, done: make(chan struct{})}
 }
 

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
@@ -12,12 +12,16 @@ func TestNewConsoleProcessCachesIdentity(t *testing.T) {
 		pid  = 1234
 		name = "debug-console"
 	)
-	process := newConsoleProcess(&os.Process{Pid: pid}, name)
+	cgroup := &processCgroup{path: "/sys/fs/cgroup/test"}
+	process := newConsoleProcess(&os.Process{Pid: pid}, name, cgroup)
 	if process.PID() != pid || process.name != name {
 		t.Fatalf("process identity = (%d, %q), want (%d, %q)", process.PID(), process.name, pid, name)
 	}
-	child, ok := process.child.(osChild)
-	if !ok || child.processID != pid {
-		t.Fatalf("child process ID = %d, %v; want %d, true", child.processID, ok, pid)
+	child, ok := process.child.(*osChild)
+	if !ok {
+		t.Fatalf("child process type = %T, want *osChild", process.child)
+	}
+	if child.processID != pid || child.cgroup != cgroup {
+		t.Fatalf("child identity = (%d, %p), want (%d, %p)", child.processID, child.cgroup, pid, cgroup)
 	}
 }

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
@@ -7,21 +7,32 @@ import (
 	"testing"
 )
 
-func TestNewConsoleProcessCachesIdentity(t *testing.T) {
-	const (
-		pid  = 1234
-		name = "debug-console"
-	)
-	cgroup := &processCgroup{path: "/sys/fs/cgroup/test"}
-	process := newConsoleProcess(&os.Process{Pid: pid}, name, cgroup)
-	if process.PID() != pid || process.name != name {
-		t.Fatalf("process identity = (%d, %q), want (%d, %q)", process.PID(), process.name, pid, name)
+func TestStartConsoleUsesManagedEphemeralScope(t *testing.T) {
+	sigchld := make(chan os.Signal, 1)
+	backend := newFakeBackend(sigchld)
+	manager := newManager(backend, sigchld, nil)
+	console, err := os.CreateTemp(t.TempDir(), "console")
+	if err != nil {
+		t.Fatal(err)
 	}
-	child, ok := process.child.(*osChild)
-	if !ok {
-		t.Fatalf("child process type = %T, want *osChild", process.child)
+	defer console.Close()
+
+	process, err := manager.StartConsole(Command{Name: "debug-console", Path: "/bin/sh"}, console)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if child.processID != pid || child.cgroup != cgroup {
-		t.Fatalf("child identity = (%d, %p), want (%d, %p)", child.processID, child.cgroup, pid, cgroup)
+	backend.mu.Lock()
+	child := backend.children[process.PID()]
+	backend.mu.Unlock()
+	if child.scope != "" {
+		t.Fatalf("console scope = %q, want ephemeral scope", child.scope)
+	}
+	if !child.options.console || len(child.options.files) != 3 {
+		t.Fatalf("console options = %#v", child.options)
+	}
+	for index, file := range child.options.files {
+		if file != console {
+			t.Fatalf("console file %d = %p, want %p", index, file, console)
+		}
 	}
 }

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -537,7 +537,7 @@ func (s *Supervisor) Start(ctx context.Context, service Service) error {
 	}
 	s.services[service.Name] = record
 	process, err := s.startLocked(record)
-	if err != nil {
+	if err != nil && record.process == nil {
 		s.retireLocked(record)
 	}
 	s.mu.Unlock()
@@ -566,12 +566,21 @@ func (s *Supervisor) startLocked(record *serviceRecord) (*Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := writePIDFile(record.spec.PIDFile, process.PID()); err != nil {
-		_ = stopProcesses([]*Process{process}, 0, initialCleanupGrace, realClock{})
-		_, _ = process.Wait(context.Background())
-		return nil, fmt.Errorf("writing %s pid file: %w", record.spec.Name, err)
-	}
 	record.process = process
+	if err := writePIDFile(record.spec.PIDFile, process.PID()); err != nil {
+		cleanupErr := stopProcesses([]*Process{process}, 0, initialCleanupGrace, realClock{})
+		waitCtx, cancel := context.WithTimeout(context.Background(), initialCleanupGrace)
+		_, waitErr := process.Wait(waitCtx)
+		cancel()
+		if cleanupErr == nil && waitErr == nil {
+			record.process = nil
+		}
+		return nil, fmt.Errorf(
+			"writing %s pid file: %w",
+			record.spec.Name,
+			errors.Join(err, cleanupErr, waitErr),
+		)
+	}
 	record.started = s.clock.Now()
 	return process, nil
 }
@@ -860,5 +869,8 @@ func processSlice(processes map[*Process]bool) []*Process {
 	for process := range processes {
 		result = append(result, process)
 	}
+	sort.Slice(result, func(left, right int) bool {
+		return result[left].PID() < result[right].PID()
+	})
 	return result
 }

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -3,6 +3,7 @@
 package supervisor
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -15,6 +16,13 @@ import (
 	"sync"
 	"syscall"
 	"time"
+)
+
+const (
+	childCgroupRoot     = "/sys/fs/cgroup/tinfoil-pid1"
+	cgroupEventsLimit   = 4096
+	cgroupPollInterval  = 10 * time.Millisecond
+	initialCleanupGrace = 5 * time.Second
 )
 
 // Command describes a direct child of PID 1.
@@ -54,6 +62,9 @@ type backendProcess interface {
 	pid() int
 	signal(syscall.Signal) error
 	groupAlive() (bool, error)
+	cgroupPopulated() (bool, error)
+	killCgroup() error
+	removeCgroup() error
 	release() error
 }
 
@@ -93,7 +104,38 @@ func (p *Process) Signal(sig syscall.Signal) error {
 	return p.child.signal(sig)
 }
 
+// KillCgroup recursively kills every process in this child instance's cgroup.
+func (p *Process) KillCgroup() error { return p.child.killCgroup() }
+
+// WaitCgroupEmpty waits for cgroup.events to report populated 0, then removes
+// the per-child cgroup directory.
+func (p *Process) WaitCgroupEmpty(ctx context.Context) error {
+	for {
+		populated, err := p.cgroupPopulated()
+		if err != nil {
+			return err
+		}
+		if !populated {
+			return p.removeCgroup()
+		}
+		timer := time.NewTimer(cgroupPollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
 func (p *Process) groupAlive() (bool, error) { return p.child.groupAlive() }
+func (p *Process) cgroupPopulated() (bool, error) {
+	return p.child.cgroupPopulated()
+}
+func (p *Process) killCgroup() error   { return p.child.killCgroup() }
+func (p *Process) removeCgroup() error { return p.child.removeCgroup() }
 
 type startResponse struct {
 	process *Process
@@ -115,7 +157,7 @@ type Manager struct {
 func NewManager(log func(string, ...any)) *Manager {
 	sigchld := make(chan os.Signal, 1)
 	signal.Notify(sigchld, syscall.SIGCHLD)
-	manager := newManager(osBackend{}, sigchld, log)
+	manager := newManager(&osBackend{cgroupRoot: childCgroupRoot}, sigchld, log)
 	return manager
 }
 
@@ -191,6 +233,14 @@ func (m *Manager) reapChildren(children map[int]*Process) {
 		if err := process.child.release(); err != nil {
 			m.logf("releasing child pid=%d: %v", pid, err)
 		}
+		populated, err := process.cgroupPopulated()
+		if err != nil {
+			m.logf("reading child cgroup pid=%d: %v", pid, err)
+		} else if !populated {
+			if err := process.removeCgroup(); err != nil {
+				m.logf("removing child cgroup pid=%d: %v", pid, err)
+			}
+		}
 	}
 }
 
@@ -200,26 +250,74 @@ func (m *Manager) logf(format string, args ...any) {
 	}
 }
 
-type osBackend struct{}
+type osBackend struct {
+	cgroupRoot string
+	nextCgroup uint64
+}
 
-func (osBackend) start(command Command) (backendProcess, error) {
+func (b *osBackend) start(command Command) (backendProcess, error) {
 	env := command.Env
 	if env == nil {
 		env = os.Environ()
 	}
+	cgroup, cgroupFD, err := b.createCgroup()
+	if err != nil {
+		return nil, fmt.Errorf("prepare cgroup for %s: %w", command.Name, err)
+	}
+	defer cgroupFD.Close()
 	process, err := os.StartProcess(command.Path, append([]string{command.Path}, command.Args...), &os.ProcAttr{
 		Dir:   command.Dir,
 		Env:   env,
 		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
-		Sys:   &syscall.SysProcAttr{Setpgid: true},
+		Sys: &syscall.SysProcAttr{
+			Setpgid:     true,
+			UseCgroupFD: true,
+			CgroupFD:    int(cgroupFD.Fd()),
+		},
 	})
 	if err != nil {
+		_ = os.Remove(cgroup.path)
 		return nil, fmt.Errorf("start %s: %w", command.Name, err)
 	}
-	return osChild{process: process, processID: process.Pid}, nil
+	return &osChild{process: process, processID: process.Pid, cgroup: cgroup}, nil
 }
 
-func (osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
+func (b *osBackend) createCgroup() (*processCgroup, *os.File, error) {
+	if err := os.Mkdir(b.cgroupRoot, 0700); err != nil && !errors.Is(err, os.ErrExist) {
+		return nil, nil, err
+	}
+	for {
+		b.nextCgroup++
+		path := filepath.Join(b.cgroupRoot, fmt.Sprintf("child-%016x", b.nextCgroup))
+		if err := os.Mkdir(path, 0700); errors.Is(err, os.ErrExist) {
+			continue
+		} else if err != nil {
+			return nil, nil, err
+		}
+		cgroup := &processCgroup{path: path}
+		if _, err := cgroup.populated(); err != nil {
+			_ = os.Remove(path)
+			return nil, nil, err
+		}
+		killFile, err := os.OpenFile(filepath.Join(path, "cgroup.kill"), os.O_WRONLY, 0)
+		if err != nil {
+			_ = os.Remove(path)
+			return nil, nil, err
+		}
+		if err := killFile.Close(); err != nil {
+			_ = os.Remove(path)
+			return nil, nil, err
+		}
+		fd, err := os.Open(path)
+		if err != nil {
+			_ = os.Remove(path)
+			return nil, nil, err
+		}
+		return cgroup, fd, nil
+	}
+}
+
+func (*osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
 	var status syscall.WaitStatus
 	pid, err := syscall.Wait4(-1, &status, syscall.WNOHANG, nil)
 	return pid, status, err
@@ -228,17 +326,18 @@ func (osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
 type osChild struct {
 	process   *os.Process
 	processID int
+	cgroup    *processCgroup
 }
 
-func (p osChild) pid() int { return p.processID }
-func (p osChild) signal(sig syscall.Signal) error {
+func (p *osChild) pid() int { return p.processID }
+func (p *osChild) signal(sig syscall.Signal) error {
 	err := syscall.Kill(-p.processID, sig)
 	if errors.Is(err, syscall.ESRCH) {
 		return os.ErrProcessDone
 	}
 	return err
 }
-func (p osChild) groupAlive() (bool, error) {
+func (p *osChild) groupAlive() (bool, error) {
 	err := syscall.Kill(-p.processID, 0)
 	if errors.Is(err, syscall.ESRCH) {
 		return false, nil
@@ -248,7 +347,64 @@ func (p osChild) groupAlive() (bool, error) {
 	}
 	return err == nil, err
 }
-func (p osChild) release() error { return p.process.Release() }
+func (p *osChild) cgroupPopulated() (bool, error) { return p.cgroup.populated() }
+func (p *osChild) killCgroup() error              { return p.cgroup.kill() }
+func (p *osChild) removeCgroup() error            { return p.cgroup.remove() }
+func (p *osChild) release() error                 { return p.process.Release() }
+
+type processCgroup struct {
+	path string
+}
+
+func (c *processCgroup) populated() (bool, error) {
+	data, err := os.ReadFile(filepath.Join(c.path, "cgroup.events"))
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if len(data) > cgroupEventsLimit {
+		return false, fmt.Errorf("cgroup.events exceeds %d bytes", cgroupEventsLimit)
+	}
+	for len(data) > 0 {
+		end := bytes.IndexByte(data, '\n')
+		if end < 0 {
+			return false, errors.New("cgroup.events has unterminated line")
+		}
+		line := data[:end]
+		data = data[end+1:]
+		switch {
+		case bytes.Equal(line, []byte("populated 0")):
+			return false, nil
+		case bytes.Equal(line, []byte("populated 1")):
+			return true, nil
+		case bytes.HasPrefix(line, []byte("populated ")):
+			return false, fmt.Errorf("invalid cgroup.events populated line %q", line)
+		}
+	}
+	return false, errors.New("cgroup.events lacks populated state")
+}
+
+func (c *processCgroup) kill() error {
+	file, err := os.OpenFile(filepath.Join(c.path, "cgroup.kill"), os.O_WRONLY, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	_, writeErr := file.WriteString("1")
+	return errors.Join(writeErr, file.Close())
+}
+
+func (c *processCgroup) remove() error {
+	err := os.Remove(c.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
 
 // State reports whether a managed service is ready. A required service is
 // marked unready before restart delay begins, allowing callers to fail closed.
@@ -384,8 +540,11 @@ func (s *Supervisor) startLocked(record *serviceRecord) (*Process, error) {
 		return nil, err
 	}
 	if err := writePIDFile(record.spec.PIDFile, process.PID()); err != nil {
-		_ = process.Signal(syscall.SIGKILL)
-		_, _ = process.Wait(context.Background())
+		_ = process.KillCgroup()
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), initialCleanupGrace)
+		_ = process.WaitCgroupEmpty(cleanupCtx)
+		_, _ = process.Wait(cleanupCtx)
+		cancel()
 		return nil, fmt.Errorf("writing %s pid file: %w", record.spec.Name, err)
 	}
 	record.process = process
@@ -396,9 +555,7 @@ func (s *Supervisor) startLocked(record *serviceRecord) (*Process, error) {
 
 func (s *Supervisor) stopInitial(record *serviceRecord, process *Process) error {
 	var errs []error
-	if err := process.Signal(syscall.SIGKILL); err != nil && !errors.Is(err, os.ErrProcessDone) {
-		errs = append(errs, err)
-	}
+	errs = append(errs, s.killCgroups([]*Process{process}, initialCleanupGrace))
 	if _, err := process.Wait(context.Background()); err != nil {
 		errs = append(errs, err)
 	}
@@ -425,7 +582,10 @@ func (s *Supervisor) ready(ctx context.Context, record *serviceRecord, process *
 	select {
 	case <-process.Done():
 		exit, _ := process.Wait(context.Background())
-		return exit.Err()
+		if err := exit.Err(); err != nil {
+			return err
+		}
+		return fmt.Errorf("%s exited before readiness", record.spec.Name)
 	default:
 		return nil
 	}
@@ -442,8 +602,8 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 		if record.process == process {
 			record.process = nil
 		}
-		alive, aliveErr := process.groupAlive()
-		if aliveErr == nil && !alive {
+		populated, populatedErr := process.cgroupPopulated()
+		if populatedErr == nil && !populated && process.removeCgroup() == nil {
 			delete(record.groups, process)
 		}
 		draining := s.draining
@@ -482,19 +642,23 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 			}
 			if readyErr := s.ready(s.context, record, next); readyErr != nil {
 				s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: readyErr})
-				_ = next.Signal(syscall.SIGKILL)
+				cleanupErr := s.killCgroups([]*Process{next}, initialCleanupGrace)
 				_, _ = next.Wait(context.Background())
+				removePIDFile(record.spec.PIDFile, next.PID())
 				s.mu.Lock()
 				if record.process == next {
 					record.process = nil
 				}
-				if alive, err := next.groupAlive(); err == nil && !alive {
+				if populated, err := next.cgroupPopulated(); err == nil && !populated && next.removeCgroup() == nil {
 					delete(record.groups, next)
 				}
 				if s.clock.Now().Sub(record.started) >= s.stable {
 					record.delay = s.base
 				}
 				s.mu.Unlock()
+				if cleanupErr != nil {
+					s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: cleanupErr})
+				}
 				continue
 			}
 			s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Ready: true})
@@ -557,7 +721,7 @@ func (s *Supervisor) emit(state State) {
 }
 
 // Drain prevents new starts, then stops each dependency group with TERM and a
-// bounded wait before escalating remaining members to KILL.
+// bounded wait before recursively killing each remaining child cgroup.
 func (s *Supervisor) Drain(groups [][]string, termGrace, killGrace time.Duration) error {
 	s.mu.Lock()
 	s.draining = true
@@ -614,21 +778,64 @@ func (s *Supervisor) drainGroup(names []string, termGrace, killGrace time.Durati
 		}
 		alive = append(alive, process)
 	}
-	alive, waitErrs := waitProcessGroups(alive, s.clock.After(termGrace))
+	_, waitErrs := waitProcessGroups(alive, s.clock.After(termGrace))
 	errs = append(errs, waitErrs...)
-	killed := alive[:0]
-	for _, process := range alive {
-		if err := process.Signal(syscall.SIGKILL); errors.Is(err, os.ErrProcessDone) {
+	errs = append(errs, s.killCgroups(processes, killGrace))
+	return errors.Join(errs...)
+}
+
+func (s *Supervisor) killCgroups(processes []*Process, grace time.Duration) error {
+	pending := make(map[*Process]bool, len(processes))
+	var errs []error
+	for _, process := range processes {
+		populated, err := process.cgroupPopulated()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("pid %d cgroup state: %w", process.PID(), err))
 			continue
-		} else if err != nil {
-			errs = append(errs, err)
 		}
-		killed = append(killed, process)
+		if !populated {
+			if err := process.removeCgroup(); err != nil {
+				errs = append(errs, fmt.Errorf("remove pid %d cgroup: %w", process.PID(), err))
+			}
+			continue
+		}
+		if err := process.killCgroup(); err != nil {
+			errs = append(errs, fmt.Errorf("kill pid %d cgroup: %w", process.PID(), err))
+		}
+		pending[process] = true
 	}
-	alive, waitErrs = waitProcessGroups(killed, s.clock.After(killGrace))
-	errs = append(errs, waitErrs...)
-	for _, process := range alive {
-		errs = append(errs, fmt.Errorf("pid %d did not exit after SIGKILL", process.PID()))
+	if len(pending) == 0 {
+		return errors.Join(errs...)
+	}
+
+	timeout := s.clock.After(grace)
+	for len(pending) > 0 {
+		for process := range pending {
+			populated, err := process.cgroupPopulated()
+			if err != nil {
+				errs = append(errs, fmt.Errorf("pid %d cgroup state after kill: %w", process.PID(), err))
+				delete(pending, process)
+				continue
+			}
+			if populated {
+				continue
+			}
+			if err := process.removeCgroup(); err != nil {
+				errs = append(errs, fmt.Errorf("remove pid %d cgroup: %w", process.PID(), err))
+			}
+			delete(pending, process)
+		}
+		if len(pending) == 0 {
+			break
+		}
+		select {
+		case <-timeout:
+			for process := range pending {
+				errs = append(errs, fmt.Errorf("pid %d cgroup remained populated after cgroup.kill", process.PID()))
+			}
+			return errors.Join(errs...)
+		case <-s.clock.After(cgroupPollInterval):
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -61,7 +61,6 @@ func (e Exit) Err() error {
 type backendProcess interface {
 	pid() int
 	signal(syscall.Signal) error
-	groupAlive() (bool, error)
 	cgroupPopulated() (bool, error)
 	killCgroup() error
 	removeCgroup() error
@@ -69,8 +68,13 @@ type backendProcess interface {
 }
 
 type processBackend interface {
-	start(Command) (backendProcess, error)
+	start(Command, string, startOptions) (backendProcess, error)
 	waitNoHang() (int, syscall.WaitStatus, error)
+}
+
+type startOptions struct {
+	files   []*os.File
+	console bool
 }
 
 // Process is a child whose status is owned by Manager. Wait may be called by
@@ -81,6 +85,7 @@ type Process struct {
 	child backendProcess
 	done  chan struct{}
 	exit  Exit
+	stop  sync.Mutex
 }
 
 func (p *Process) PID() int              { return p.pid }
@@ -104,33 +109,12 @@ func (p *Process) Signal(sig syscall.Signal) error {
 	return p.child.signal(sig)
 }
 
-// KillCgroup recursively kills every process in this child instance's cgroup.
-func (p *Process) KillCgroup() error { return p.child.killCgroup() }
-
-// WaitCgroupEmpty waits for cgroup.events to report populated 0, then removes
-// the per-child cgroup directory.
-func (p *Process) WaitCgroupEmpty(ctx context.Context) error {
-	for {
-		populated, err := p.cgroupPopulated()
-		if err != nil {
-			return err
-		}
-		if !populated {
-			return p.removeCgroup()
-		}
-		timer := time.NewTimer(cgroupPollInterval)
-		select {
-		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
-			return ctx.Err()
-		case <-timer.C:
-		}
-	}
+// Stop terminates the process group gracefully, then recursively kills any
+// descendants that remain in the process cgroup.
+func (p *Process) Stop(termGrace, killGrace time.Duration) error {
+	return stopProcesses([]*Process{p}, termGrace, killGrace, realClock{})
 }
 
-func (p *Process) groupAlive() (bool, error) { return p.child.groupAlive() }
 func (p *Process) cgroupPopulated() (bool, error) {
 	return p.child.cgroupPopulated()
 }
@@ -173,6 +157,10 @@ func newManager(backend processBackend, sigchld chan os.Signal, log func(string,
 }
 
 func (m *Manager) Start(command Command) (*Process, error) {
+	return m.start(command, "", startOptions{})
+}
+
+func (m *Manager) start(command Command, scope string, options startOptions) (*Process, error) {
 	if command.Name == "" {
 		return nil, errors.New("child name is required")
 	}
@@ -181,7 +169,7 @@ func (m *Manager) Start(command Command) (*Process, error) {
 	}
 	reply := make(chan startResponse, 1)
 	m.ops <- func(children map[int]*Process) {
-		child, err := m.backend.start(command)
+		child, err := m.backend.start(command, scope, options)
 		if err != nil {
 			reply <- startResponse{err: err}
 			return
@@ -233,14 +221,6 @@ func (m *Manager) reapChildren(children map[int]*Process) {
 		if err := process.child.release(); err != nil {
 			m.logf("releasing child pid=%d: %v", pid, err)
 		}
-		populated, err := process.cgroupPopulated()
-		if err != nil {
-			m.logf("reading child cgroup pid=%d: %v", pid, err)
-		} else if !populated {
-			if err := process.removeCgroup(); err != nil {
-				m.logf("removing child cgroup pid=%d: %v", pid, err)
-			}
-		}
 	}
 }
 
@@ -255,36 +235,67 @@ type osBackend struct {
 	nextCgroup uint64
 }
 
-func (b *osBackend) start(command Command) (backendProcess, error) {
+func (b *osBackend) start(command Command, scope string, options startOptions) (backendProcess, error) {
 	env := command.Env
 	if env == nil {
 		env = os.Environ()
 	}
-	cgroup, cgroupFD, err := b.createCgroup()
+	cgroup, cgroupFD, err := b.createCgroup(scope)
 	if err != nil {
 		return nil, fmt.Errorf("prepare cgroup for %s: %w", command.Name, err)
 	}
 	defer cgroupFD.Close()
+	files := options.files
+	if files == nil {
+		files = []*os.File{os.Stdin, os.Stdout, os.Stderr}
+	}
+	system := &syscall.SysProcAttr{
+		UseCgroupFD: true,
+		CgroupFD:    int(cgroupFD.Fd()),
+	}
+	if options.console {
+		system.Setsid = true
+		system.Setctty = true
+		system.Ctty = 0
+	} else {
+		system.Setpgid = true
+	}
 	process, err := os.StartProcess(command.Path, append([]string{command.Path}, command.Args...), &os.ProcAttr{
 		Dir:   command.Dir,
 		Env:   env,
-		Files: []*os.File{os.Stdin, os.Stdout, os.Stderr},
-		Sys: &syscall.SysProcAttr{
-			Setpgid:     true,
-			UseCgroupFD: true,
-			CgroupFD:    int(cgroupFD.Fd()),
-		},
+		Files: files,
+		Sys:   system,
 	})
 	if err != nil {
-		_ = os.Remove(cgroup.path)
+		_ = cgroup.remove()
 		return nil, fmt.Errorf("start %s: %w", command.Name, err)
 	}
 	return &osChild{process: process, processID: process.Pid, cgroup: cgroup}, nil
 }
 
-func (b *osBackend) createCgroup() (*processCgroup, *os.File, error) {
+func (b *osBackend) createCgroup(scope string) (*cgroupScope, *os.File, error) {
 	if err := os.Mkdir(b.cgroupRoot, 0700); err != nil && !errors.Is(err, os.ErrExist) {
 		return nil, nil, err
+	}
+	if scope != "" {
+		if !validScopeName(scope) {
+			return nil, nil, fmt.Errorf("invalid service scope %q", scope)
+		}
+		path := filepath.Join(b.cgroupRoot, "service-"+scope)
+		created := false
+		if err := os.Mkdir(path, 0700); err == nil {
+			created = true
+		} else if !errors.Is(err, os.ErrExist) {
+			return nil, nil, err
+		}
+		cgroup, fd, err := openCgroupScope(path, true)
+		if err != nil {
+			if created {
+				_ = os.Remove(path)
+			}
+			return nil, nil, err
+		}
+		return cgroup, fd, nil
 	}
 	for {
 		b.nextCgroup++
@@ -294,27 +305,49 @@ func (b *osBackend) createCgroup() (*processCgroup, *os.File, error) {
 		} else if err != nil {
 			return nil, nil, err
 		}
-		cgroup := &processCgroup{path: path}
-		if _, err := cgroup.populated(); err != nil {
-			_ = os.Remove(path)
-			return nil, nil, err
-		}
-		killFile, err := os.OpenFile(filepath.Join(path, "cgroup.kill"), os.O_WRONLY, 0)
-		if err != nil {
-			_ = os.Remove(path)
-			return nil, nil, err
-		}
-		if err := killFile.Close(); err != nil {
-			_ = os.Remove(path)
-			return nil, nil, err
-		}
-		fd, err := os.Open(path)
+		cgroup, fd, err := openCgroupScope(path, false)
 		if err != nil {
 			_ = os.Remove(path)
 			return nil, nil, err
 		}
 		return cgroup, fd, nil
 	}
+}
+
+func openCgroupScope(path string, persistent bool) (*cgroupScope, *os.File, error) {
+	cgroup := &cgroupScope{path: path, persistent: persistent}
+	populated, err := cgroup.populated()
+	if err != nil {
+		return nil, nil, err
+	}
+	if populated {
+		return nil, nil, errors.New("cgroup is still populated")
+	}
+	killFile, err := os.OpenFile(filepath.Join(path, "cgroup.kill"), os.O_WRONLY, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := killFile.Close(); err != nil {
+		return nil, nil, err
+	}
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cgroup, fd, nil
+}
+
+func validScopeName(name string) bool {
+	for _, character := range name {
+		if character >= 'a' && character <= 'z' ||
+			character >= 'A' && character <= 'Z' ||
+			character >= '0' && character <= '9' ||
+			character == '-' || character == '_' || character == '.' {
+			continue
+		}
+		return false
+	}
+	return name != "" && name != "." && name != ".."
 }
 
 func (*osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
@@ -326,7 +359,7 @@ func (*osBackend) waitNoHang() (int, syscall.WaitStatus, error) {
 type osChild struct {
 	process   *os.Process
 	processID int
-	cgroup    *processCgroup
+	cgroup    *cgroupScope
 }
 
 func (p *osChild) pid() int { return p.processID }
@@ -337,26 +370,19 @@ func (p *osChild) signal(sig syscall.Signal) error {
 	}
 	return err
 }
-func (p *osChild) groupAlive() (bool, error) {
-	err := syscall.Kill(-p.processID, 0)
-	if errors.Is(err, syscall.ESRCH) {
-		return false, nil
-	}
-	if errors.Is(err, syscall.EPERM) {
-		return true, nil
-	}
-	return err == nil, err
-}
 func (p *osChild) cgroupPopulated() (bool, error) { return p.cgroup.populated() }
 func (p *osChild) killCgroup() error              { return p.cgroup.kill() }
 func (p *osChild) removeCgroup() error            { return p.cgroup.remove() }
 func (p *osChild) release() error                 { return p.process.Release() }
 
-type processCgroup struct {
-	path string
+// cgroupScope is persistent for a logical service and ephemeral for a one-shot
+// or debug-console process.
+type cgroupScope struct {
+	path       string
+	persistent bool
 }
 
-func (c *processCgroup) populated() (bool, error) {
+func (c *cgroupScope) populated() (bool, error) {
 	data, err := os.ReadFile(filepath.Join(c.path, "cgroup.events"))
 	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
@@ -386,7 +412,7 @@ func (c *processCgroup) populated() (bool, error) {
 	return false, errors.New("cgroup.events lacks populated state")
 }
 
-func (c *processCgroup) kill() error {
+func (c *cgroupScope) kill() error {
 	file, err := os.OpenFile(filepath.Join(c.path, "cgroup.kill"), os.O_WRONLY, 0)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -398,7 +424,10 @@ func (c *processCgroup) kill() error {
 	return errors.Join(writeErr, file.Close())
 }
 
-func (c *processCgroup) remove() error {
+func (c *cgroupScope) remove() error {
+	if c.persistent {
+		return nil
+	}
 	err := os.Remove(c.path)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil
@@ -448,7 +477,6 @@ type Config struct {
 type serviceRecord struct {
 	spec    Service
 	process *Process
-	groups  map[*Process]struct{}
 	started time.Time
 	delay   time.Duration
 	done    chan struct{}
@@ -496,8 +524,7 @@ func New(parent context.Context, manager *Manager, config Config) *Supervisor {
 
 func (s *Supervisor) Start(ctx context.Context, service Service) error {
 	record := &serviceRecord{
-		spec: service, groups: map[*Process]struct{}{},
-		delay: s.base, done: make(chan struct{}),
+		spec: service, delay: s.base, done: make(chan struct{}),
 	}
 	s.mu.Lock()
 	if s.draining {
@@ -535,27 +562,23 @@ func (s *Supervisor) startLocked(record *serviceRecord) (*Process, error) {
 	if s.draining {
 		return nil, context.Canceled
 	}
-	process, err := s.manager.Start(record.spec.Command)
+	process, err := s.manager.start(record.spec.Command, record.spec.Name, startOptions{})
 	if err != nil {
 		return nil, err
 	}
 	if err := writePIDFile(record.spec.PIDFile, process.PID()); err != nil {
-		_ = process.KillCgroup()
-		cleanupCtx, cancel := context.WithTimeout(context.Background(), initialCleanupGrace)
-		_ = process.WaitCgroupEmpty(cleanupCtx)
-		_, _ = process.Wait(cleanupCtx)
-		cancel()
+		_ = stopProcesses([]*Process{process}, 0, initialCleanupGrace, realClock{})
+		_, _ = process.Wait(context.Background())
 		return nil, fmt.Errorf("writing %s pid file: %w", record.spec.Name, err)
 	}
 	record.process = process
-	record.groups[process] = struct{}{}
 	record.started = s.clock.Now()
 	return process, nil
 }
 
 func (s *Supervisor) stopInitial(record *serviceRecord, process *Process) error {
 	var errs []error
-	errs = append(errs, s.killCgroups([]*Process{process}, initialCleanupGrace))
+	errs = append(errs, stopProcesses([]*Process{process}, 0, initialCleanupGrace, realClock{}))
 	if _, err := process.Wait(context.Background()); err != nil {
 		errs = append(errs, err)
 	}
@@ -599,20 +622,17 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 		}
 		removePIDFile(record.spec.PIDFile, process.PID())
 		s.mu.Lock()
-		if record.process == process {
-			record.process = nil
-		}
-		populated, populatedErr := process.cgroupPopulated()
-		if populatedErr == nil && !populated && process.removeCgroup() == nil {
-			delete(record.groups, process)
-		}
 		draining := s.draining
 		runtime := s.clock.Now().Sub(record.started)
 		if runtime >= s.stable {
 			record.delay = s.base
 		}
 		s.mu.Unlock()
-		s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: exit.Err()})
+		var cleanupErr error
+		if !draining {
+			cleanupErr = stopProcesses([]*Process{process}, 0, initialCleanupGrace, realClock{})
+		}
+		s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: errors.Join(exit.Err(), cleanupErr)})
 		if draining || !record.spec.Restart {
 			return
 		}
@@ -642,16 +662,10 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 			}
 			if readyErr := s.ready(s.context, record, next); readyErr != nil {
 				s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: readyErr})
-				cleanupErr := s.killCgroups([]*Process{next}, initialCleanupGrace)
+				cleanupErr := stopProcesses([]*Process{next}, 0, initialCleanupGrace, realClock{})
 				_, _ = next.Wait(context.Background())
 				removePIDFile(record.spec.PIDFile, next.PID())
 				s.mu.Lock()
-				if record.process == next {
-					record.process = nil
-				}
-				if populated, err := next.cgroupPopulated(); err == nil && !populated && next.removeCgroup() == nil {
-					delete(record.groups, next)
-				}
 				if s.clock.Now().Sub(record.started) >= s.stable {
 					record.delay = s.base
 				}
@@ -752,69 +766,61 @@ func (s *Supervisor) Drain(groups [][]string, termGrace, killGrace time.Duration
 func (s *Supervisor) drainGroup(names []string, termGrace, killGrace time.Duration) error {
 	s.mu.Lock()
 	processes := make([]*Process, 0, len(names))
-	seen := map[*Process]bool{}
 	for _, name := range names {
-		if record := s.services[name]; record != nil {
-			for process := range record.groups {
-				if !seen[process] {
-					seen[process] = true
-					processes = append(processes, process)
-				}
-			}
+		if record := s.services[name]; record != nil && record.process != nil {
+			processes = append(processes, record.process)
 		}
 	}
 	s.mu.Unlock()
+	return stopProcesses(processes, termGrace, killGrace, s.clock)
+}
+
+func stopProcesses(processes []*Process, termGrace, killGrace time.Duration, clock Clock) error {
 	if len(processes) == 0 {
 		return nil
 	}
-
-	var errs []error
-	alive := processes[:0]
-	for _, process := range processes {
-		if err := process.Signal(syscall.SIGTERM); errors.Is(err, os.ErrProcessDone) {
+	locked := append([]*Process(nil), processes...)
+	sort.Slice(locked, func(left, right int) bool {
+		return locked[left].PID() < locked[right].PID()
+	})
+	for index, process := range locked {
+		if index > 0 && process == locked[index-1] {
 			continue
-		} else if err != nil {
-			errs = append(errs, err)
 		}
-		alive = append(alive, process)
+		process.stop.Lock()
+		defer process.stop.Unlock()
 	}
-	_, waitErrs := waitProcessGroups(alive, s.clock.After(termGrace))
-	errs = append(errs, waitErrs...)
-	errs = append(errs, s.killCgroups(processes, killGrace))
-	return errors.Join(errs...)
-}
-
-func (s *Supervisor) killCgroups(processes []*Process, grace time.Duration) error {
-	pending := make(map[*Process]bool, len(processes))
 	var errs []error
-	for _, process := range processes {
-		populated, err := process.cgroupPopulated()
-		if err != nil {
-			errs = append(errs, fmt.Errorf("pid %d cgroup state: %w", process.PID(), err))
-			continue
+	pending, waitErrs := waitCgroups(processes, 0, clock)
+	errs = append(errs, waitErrs...)
+	for _, process := range pending {
+		if err := process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			errs = append(errs, fmt.Errorf("terminate pid %d process group: %w", process.PID(), err))
 		}
-		if !populated {
-			if err := process.removeCgroup(); err != nil {
-				errs = append(errs, fmt.Errorf("remove pid %d cgroup: %w", process.PID(), err))
-			}
-			continue
-		}
+	}
+	pending, waitErrs = waitCgroups(pending, termGrace, clock)
+	errs = append(errs, waitErrs...)
+	for _, process := range pending {
 		if err := process.killCgroup(); err != nil {
 			errs = append(errs, fmt.Errorf("kill pid %d cgroup: %w", process.PID(), err))
 		}
-		pending[process] = true
 	}
-	if len(pending) == 0 {
-		return errors.Join(errs...)
+	pending, waitErrs = waitCgroups(pending, killGrace, clock)
+	errs = append(errs, waitErrs...)
+	for _, process := range pending {
+		errs = append(errs, fmt.Errorf("pid %d cgroup remained populated after cgroup.kill", process.PID()))
 	}
+	return errors.Join(errs...)
+}
 
-	timeout := s.clock.After(grace)
-	for len(pending) > 0 {
+func waitCgroups(processes []*Process, grace time.Duration, clock Clock) ([]*Process, []error) {
+	pending := make(map[*Process]bool, len(processes))
+	check := func() []error {
+		var errs []error
 		for process := range pending {
 			populated, err := process.cgroupPopulated()
 			if err != nil {
-				errs = append(errs, fmt.Errorf("pid %d cgroup state after kill: %w", process.PID(), err))
-				delete(pending, process)
+				errs = append(errs, fmt.Errorf("pid %d cgroup state: %w", process.PID(), err))
 				continue
 			}
 			if populated {
@@ -825,60 +831,28 @@ func (s *Supervisor) killCgroups(processes []*Process, grace time.Duration) erro
 			}
 			delete(pending, process)
 		}
-		if len(pending) == 0 {
-			break
-		}
-		select {
-		case <-timeout:
-			for process := range pending {
-				errs = append(errs, fmt.Errorf("pid %d cgroup remained populated after cgroup.kill", process.PID()))
-			}
-			return errors.Join(errs...)
-		case <-s.clock.After(cgroupPollInterval):
-		}
+		return errs
 	}
-	return errors.Join(errs...)
-}
-
-func waitProcessGroups(processes []*Process, timeout <-chan time.Time) ([]*Process, []error) {
-	if len(processes) == 0 {
-		return nil, nil
-	}
-	exited := make(chan *Process, len(processes))
-	alive := make(map[*Process]bool, len(processes))
 	for _, process := range processes {
-		alive[process] = true
-		go func(process *Process) {
-			<-process.Done()
-			exited <- process
-		}(process)
+		pending[process] = true
 	}
-	for len(alive) > 0 {
+	errs := check()
+	if len(pending) == 0 || grace <= 0 {
+		return processSlice(pending), errs
+	}
+
+	timeout := clock.After(grace)
+	ticker := time.NewTicker(cgroupPollInterval)
+	defer ticker.Stop()
+	for len(pending) > 0 {
 		select {
-		case process := <-exited:
-			groupAlive, err := process.groupAlive()
-			if err != nil {
-				return processSlice(alive), []error{err}
-			}
-			if !groupAlive {
-				delete(alive, process)
-			}
 		case <-timeout:
-			var errs []error
-			for process := range alive {
-				groupAlive, err := process.groupAlive()
-				if err != nil {
-					errs = append(errs, err)
-					continue
-				}
-				if !groupAlive {
-					delete(alive, process)
-				}
-			}
-			return processSlice(alive), errs
+			return processSlice(pending), errs
+		case <-ticker.C:
+			errs = append(errs, check()...)
 		}
 	}
-	return nil, nil
+	return nil, errs
 }
 
 func processSlice(processes map[*Process]bool) []*Process {

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -19,26 +19,29 @@ type fakeWait struct {
 }
 
 type fakeBackend struct {
-	mu            sync.Mutex
-	nextPID       int
-	waits         []fakeWait
-	children      map[int]*fakeProcess
-	sigchld       chan os.Signal
-	started       chan int
-	signaled      chan string
-	startErrs     []error
-	beforeStart   func()
-	exitOnTERM    map[string]bool
-	groupSurvives map[string]bool
+	mu             sync.Mutex
+	nextPID        int
+	waits          []fakeWait
+	children       map[int]*fakeProcess
+	sigchld        chan os.Signal
+	started        chan int
+	signaled       chan string
+	startErrs      []error
+	beforeStart    func()
+	exitOnTERM     map[string]bool
+	groupSurvives  map[string]bool
+	cgroupSurvives map[string]bool
+	orphanPIDs     map[string][]int
 }
 
 type fakeProcess struct {
-	backend      *fakeBackend
-	id           int
-	pgid         int
-	name         string
-	exited       bool
-	groupRunning bool
+	backend       *fakeBackend
+	id            int
+	pgid          int
+	name          string
+	exited        bool
+	groupRunning  bool
+	cgroupRunning bool
 }
 
 func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
@@ -46,6 +49,7 @@ func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
 		nextPID: 100, children: map[int]*fakeProcess{}, sigchld: sigchld,
 		started: make(chan int, 32), signaled: make(chan string, 32),
 		exitOnTERM: map[string]bool{}, groupSurvives: map[string]bool{},
+		cgroupSurvives: map[string]bool{}, orphanPIDs: map[string][]int{},
 	}
 }
 
@@ -61,7 +65,10 @@ func (b *fakeBackend) start(command Command) (backendProcess, error) {
 		return nil, err
 	}
 	b.nextPID++
-	child := &fakeProcess{backend: b, id: b.nextPID, pgid: b.nextPID, name: command.Name, groupRunning: true}
+	child := &fakeProcess{
+		backend: b, id: b.nextPID, pgid: b.nextPID, name: command.Name,
+		groupRunning: true, cgroupRunning: true,
+	}
 	b.children[child.id] = child
 	b.started <- child.id
 	return child, nil
@@ -84,6 +91,9 @@ func (b *fakeBackend) exit(pid int, status syscall.WaitStatus) {
 		child.exited = true
 		if !b.groupSurvives[child.name] {
 			child.groupRunning = false
+		}
+		if !b.groupSurvives[child.name] && !b.cgroupSurvives[child.name] {
+			child.cgroupRunning = false
 		}
 	}
 	b.waits = append(b.waits, fakeWait{pid: pid, status: status})
@@ -120,6 +130,32 @@ func (p *fakeProcess) groupAlive() (bool, error) {
 	defer p.backend.mu.Unlock()
 	return p.groupRunning, nil
 }
+
+func (p *fakeProcess) cgroupPopulated() (bool, error) {
+	p.backend.mu.Lock()
+	defer p.backend.mu.Unlock()
+	return p.cgroupRunning, nil
+}
+
+func (p *fakeProcess) killCgroup() error {
+	p.backend.signaled <- fmt.Sprintf("%s:cgroup.kill", p.name)
+	p.backend.mu.Lock()
+	exited := p.exited
+	p.groupRunning = false
+	p.cgroupRunning = false
+	orphans := append([]int(nil), p.backend.orphanPIDs[p.name]...)
+	p.backend.orphanPIDs[p.name] = nil
+	p.backend.mu.Unlock()
+	if !exited {
+		p.backend.exit(p.pgid, syscall.WaitStatus(uint32(syscall.SIGKILL)&0x7f))
+	}
+	for _, pid := range orphans {
+		p.backend.exit(pid, syscall.WaitStatus(uint32(syscall.SIGKILL)&0x7f))
+	}
+	return nil
+}
+
+func (p *fakeProcess) removeCgroup() error { return nil }
 
 func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
@@ -217,7 +253,7 @@ func TestInitialStartFailureRetiresRegistrationAndPermitsRetry(t *testing.T) {
 	_ = receive(t, backend.started)
 }
 
-func TestInitialReadinessFailureKillsGroupWaitsAndPermitsRetry(t *testing.T) {
+func TestInitialReadinessFailureKillsCgroupWaitsAndPermitsRetry(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
 	backend.groupSurvives["service"] = true
@@ -246,8 +282,8 @@ func TestInitialReadinessFailureKillsGroupWaitsAndPermitsRetry(t *testing.T) {
 	if err := supervisor.Start(context.Background(), service); err == nil {
 		t.Fatal("readiness failure was ignored")
 	}
-	if got := receive(t, backend.signaled); got != "service:killed" {
-		t.Fatalf("cleanup signal = %q, want service:killed", got)
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("cleanup signal = %q, want service:cgroup.kill", got)
 	}
 	if failedRecord == nil {
 		t.Fatal("failed readiness record was not captured")
@@ -448,7 +484,7 @@ func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := []string{
-		"egress:terminated", "shim:terminated", "egress:killed",
+		"egress:terminated", "shim:terminated", "egress:cgroup.kill",
 		"dockerd:terminated", "containerd:terminated",
 	}
 	if fmt.Sprint(got) != fmt.Sprint(want) {
@@ -461,7 +497,7 @@ func TestDrainOrdersGroupsAndEscalatesTermToKill(t *testing.T) {
 	}
 }
 
-func TestDrainKillsSurvivingGroupAfterDirectChildExit(t *testing.T) {
+func TestDrainKillsSurvivingCgroupAfterDirectChildExit(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
 	backend.exitOnTERM["service"] = true
@@ -488,10 +524,126 @@ func TestDrainKillsSurvivingGroupAfterDirectChildExit(t *testing.T) {
 	}
 	receive(t, process.Done())
 	clock.fire(t, time.Second)
-	if got := receive(t, backend.signaled); got != "service:killed" {
-		t.Fatalf("KILL signal = %q", got)
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("cgroup kill = %q", got)
 	}
 	if err := receive(t, result); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestProcessCgroupReadsFixedPopulatedEvent(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		events    string
+		populated bool
+		wantErr   bool
+	}{
+		{name: "empty", events: "populated 0\nfrozen 0\n"},
+		{name: "populated", events: "populated 1\nfrozen 0\n", populated: true},
+		{name: "invalid value", events: "populated 2\n", wantErr: true},
+		{name: "missing", events: "frozen 0\n", wantErr: true},
+		{name: "unterminated", events: "populated 0", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			directory := t.TempDir()
+			if err := os.WriteFile(filepath.Join(directory, "cgroup.events"), []byte(test.events), 0600); err != nil {
+				t.Fatal(err)
+			}
+			populated, err := (&processCgroup{path: directory}).populated()
+			if (err != nil) != test.wantErr {
+				t.Fatalf("populated error = %v, wantErr %v", err, test.wantErr)
+			}
+			if populated != test.populated {
+				t.Fatalf("populated = %v, want %v", populated, test.populated)
+			}
+		})
+	}
+}
+
+func TestDrainKillsSetsidDescendantOutsideStableProcessGroup(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	backend.exitOnTERM["service"] = true
+	backend.cgroupSurvives["service"] = true
+	manager := newManager(backend, sigchld, nil)
+	supervisor := New(context.Background(), manager, Config{Clock: newFakeClock()})
+	if err := supervisor.Start(context.Background(), Service{
+		Name: "service", Command: Command{Name: "service", Path: "/service"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pid := receive(t, backend.started)
+
+	result := make(chan error, 1)
+	go func() {
+		result <- supervisor.Drain([][]string{{"service"}}, time.Second, 2*time.Second)
+	}()
+	if got := receive(t, backend.signaled); got != "service:terminated" {
+		t.Fatalf("TERM signal = %q", got)
+	}
+	backend.mu.Lock()
+	process := backend.children[pid]
+	groupRunning := process.groupRunning
+	cgroupRunning := process.cgroupRunning
+	backend.mu.Unlock()
+	if groupRunning || !cgroupRunning {
+		t.Fatalf("after setsid escape: groupRunning=%v cgroupRunning=%v", groupRunning, cgroupRunning)
+	}
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("final cleanup = %q", got)
+	}
+	if err := receive(t, result); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDrainKillsAndReapsOrphanedDescendant(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	backend.cgroupSurvives["service"] = true
+	backend.orphanPIDs["service"] = []int{777}
+	var logsMu sync.Mutex
+	var logs []string
+	manager := newManager(backend, sigchld, func(format string, args ...any) {
+		logsMu.Lock()
+		logs = append(logs, fmt.Sprintf(format, args...))
+		logsMu.Unlock()
+	})
+	supervisor := New(context.Background(), manager, Config{Clock: newFakeClock()})
+	if err := supervisor.Start(context.Background(), Service{
+		Name: "service", Command: Command{Name: "service", Path: "/service"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pid := receive(t, backend.started)
+	supervisor.mu.Lock()
+	process := supervisor.services["service"].process
+	supervisor.mu.Unlock()
+	backend.exit(pid, 0)
+	receive(t, process.Done())
+
+	if err := supervisor.Drain([][]string{{"service"}}, time.Second, 2*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if got := receive(t, backend.signaled); got != "service:terminated" {
+		t.Fatalf("TERM signal = %q", got)
+	}
+	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+		t.Fatalf("orphan cleanup = %q", got)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		logsMu.Lock()
+		got := strings.Join(logs, "\n")
+		logsMu.Unlock()
+		if strings.Contains(got, "reaped adopted child pid=777") {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	logsMu.Lock()
+	defer logsMu.Unlock()
+	t.Fatalf("orphan was not reaped by manager:\n%s", strings.Join(logs, "\n"))
 }

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -30,6 +30,7 @@ type fakeBackend struct {
 	beforeStart    func()
 	exitOnTERM     map[string]bool
 	cgroupSurvives map[string]bool
+	cgroupKillErrs map[string]error
 	orphanPIDs     map[string][]int
 }
 
@@ -48,7 +49,7 @@ func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
 	return &fakeBackend{
 		nextPID: 100, children: map[int]*fakeProcess{}, sigchld: sigchld,
 		started: make(chan int, 32), signaled: make(chan string, 32),
-		exitOnTERM: map[string]bool{}, cgroupSurvives: map[string]bool{},
+		exitOnTERM: map[string]bool{}, cgroupSurvives: map[string]bool{}, cgroupKillErrs: map[string]error{},
 		orphanPIDs: map[string][]int{},
 	}
 }
@@ -129,6 +130,7 @@ func (p *fakeProcess) killCgroup() error {
 	p.backend.signaled <- fmt.Sprintf("%s:cgroup.kill", p.name)
 	p.backend.mu.Lock()
 	exited := p.exited
+	killErr := p.backend.cgroupKillErrs[p.name]
 	p.cgroupRunning = false
 	orphans := append([]int(nil), p.backend.orphanPIDs[p.name]...)
 	p.backend.orphanPIDs[p.name] = nil
@@ -139,7 +141,7 @@ func (p *fakeProcess) killCgroup() error {
 	for _, pid := range orphans {
 		p.backend.exit(pid, syscall.WaitStatus(uint32(syscall.SIGKILL)&0x7f))
 	}
-	return nil
+	return killErr
 }
 
 func (p *fakeProcess) removeCgroup() error { return nil }
@@ -262,6 +264,54 @@ func TestInitialStartFailureRetiresRegistrationAndPermitsRetry(t *testing.T) {
 		t.Fatalf("retry start: %v", err)
 	}
 	_ = receive(t, backend.started)
+}
+
+func TestPIDFileFailureReportsCleanupAndRetainsFailedCleanup(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		cleanupErr error
+		retained   bool
+	}{
+		{name: "cleaned"},
+		{name: "cleanup failed", cleanupErr: errors.New("cgroup kill failed"), retained: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sigchld := make(chan os.Signal, 4)
+			backend := newFakeBackend(sigchld)
+			backend.cgroupKillErrs["service"] = test.cleanupErr
+			manager := newManager(backend, sigchld, nil)
+			supervisor := New(context.Background(), manager, Config{})
+			parent := filepath.Join(t.TempDir(), "not-a-directory")
+			if err := os.WriteFile(parent, []byte("blocked"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			err := supervisor.Start(context.Background(), Service{
+				Name: "service", Command: Command{Name: "service", Path: "/service"},
+				PIDFile: filepath.Join(parent, "service.pid"),
+			})
+			if err == nil {
+				t.Fatal("PID file failure was ignored")
+			}
+			if test.cleanupErr != nil && !errors.Is(err, test.cleanupErr) {
+				t.Fatalf("cleanup error missing from %v", err)
+			}
+			if got := receive(t, backend.signaled); got != "service:terminated" {
+				t.Fatalf("graceful cleanup signal = %q", got)
+			}
+			if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
+				t.Fatalf("forced cleanup signal = %q", got)
+			}
+			supervisor.mu.Lock()
+			record := supervisor.services["service"]
+			supervisor.mu.Unlock()
+			if (record != nil) != test.retained {
+				t.Fatalf("retained registration = %t, want %t", record != nil, test.retained)
+			}
+			if record != nil && record.process == nil {
+				t.Fatal("retained registration lost its process")
+			}
+		})
+	}
 }
 
 func TestInitialReadinessFailureKillsCgroupWaitsAndPermitsRetry(t *testing.T) {

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -29,7 +29,6 @@ type fakeBackend struct {
 	startErrs      []error
 	beforeStart    func()
 	exitOnTERM     map[string]bool
-	groupSurvives  map[string]bool
 	cgroupSurvives map[string]bool
 	orphanPIDs     map[string][]int
 }
@@ -39,8 +38,9 @@ type fakeProcess struct {
 	id            int
 	pgid          int
 	name          string
+	scope         string
+	options       startOptions
 	exited        bool
-	groupRunning  bool
 	cgroupRunning bool
 }
 
@@ -48,12 +48,12 @@ func newFakeBackend(sigchld chan os.Signal) *fakeBackend {
 	return &fakeBackend{
 		nextPID: 100, children: map[int]*fakeProcess{}, sigchld: sigchld,
 		started: make(chan int, 32), signaled: make(chan string, 32),
-		exitOnTERM: map[string]bool{}, groupSurvives: map[string]bool{},
-		cgroupSurvives: map[string]bool{}, orphanPIDs: map[string][]int{},
+		exitOnTERM: map[string]bool{}, cgroupSurvives: map[string]bool{},
+		orphanPIDs: map[string][]int{},
 	}
 }
 
-func (b *fakeBackend) start(command Command) (backendProcess, error) {
+func (b *fakeBackend) start(command Command, scope string, options startOptions) (backendProcess, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.beforeStart != nil {
@@ -67,7 +67,7 @@ func (b *fakeBackend) start(command Command) (backendProcess, error) {
 	b.nextPID++
 	child := &fakeProcess{
 		backend: b, id: b.nextPID, pgid: b.nextPID, name: command.Name,
-		groupRunning: true, cgroupRunning: true,
+		scope: scope, options: options, cgroupRunning: true,
 	}
 	b.children[child.id] = child
 	b.started <- child.id
@@ -89,10 +89,7 @@ func (b *fakeBackend) exit(pid int, status syscall.WaitStatus) {
 	b.mu.Lock()
 	if child := b.children[pid]; child != nil {
 		child.exited = true
-		if !b.groupSurvives[child.name] {
-			child.groupRunning = false
-		}
-		if !b.groupSurvives[child.name] && !b.cgroupSurvives[child.name] {
+		if !b.cgroupSurvives[child.name] {
 			child.cgroupRunning = false
 		}
 	}
@@ -110,25 +107,16 @@ func (p *fakeProcess) signal(signal syscall.Signal) error {
 	p.backend.signaled <- fmt.Sprintf("%s:%s", p.name, signal)
 	p.backend.mu.Lock()
 	exited := p.exited
-	groupAlive := p.groupRunning
+	cgroupAlive := p.cgroupRunning
 	exitOnTERM := p.backend.exitOnTERM[p.name]
-	if signal == syscall.SIGKILL {
-		p.groupRunning = false
-	}
 	p.backend.mu.Unlock()
-	if !groupAlive {
+	if !cgroupAlive {
 		return os.ErrProcessDone
 	}
 	if !exited && (signal == syscall.SIGKILL || (signal == syscall.SIGTERM && exitOnTERM)) {
 		p.backend.exit(p.pgid, syscall.WaitStatus(uint32(signal)&0x7f))
 	}
 	return nil
-}
-
-func (p *fakeProcess) groupAlive() (bool, error) {
-	p.backend.mu.Lock()
-	defer p.backend.mu.Unlock()
-	return p.groupRunning, nil
 }
 
 func (p *fakeProcess) cgroupPopulated() (bool, error) {
@@ -141,7 +129,6 @@ func (p *fakeProcess) killCgroup() error {
 	p.backend.signaled <- fmt.Sprintf("%s:cgroup.kill", p.name)
 	p.backend.mu.Lock()
 	exited := p.exited
-	p.groupRunning = false
 	p.cgroupRunning = false
 	orphans := append([]int(nil), p.backend.orphanPIDs[p.name]...)
 	p.backend.orphanPIDs[p.name] = nil
@@ -176,6 +163,8 @@ func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	requireScope(t, backend, managed.PID(), "")
+	requireScope(t, backend, oneShot.PID(), "")
 	backend.exit(999, 0)
 	backend.exit(oneShot.PID(), syscall.WaitStatus(3<<8))
 	backend.exit(managed.PID(), 0)
@@ -214,6 +203,28 @@ func TestManagerRejectsUnboundedCommands(t *testing.T) {
 		if _, err := manager.Start(command); err == nil {
 			t.Fatalf("Start accepted command %#v", command)
 		}
+	}
+}
+
+func TestStopDoesNotSignalEmptyCgroup(t *testing.T) {
+	sigchld := make(chan os.Signal, 2)
+	backend := newFakeBackend(sigchld)
+	manager := newManager(backend, sigchld, nil)
+	process, err := manager.Start(Command{Name: "one-shot", Path: "/one-shot"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	backend.exit(process.PID(), 0)
+	if _, err := process.Wait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := process.Stop(time.Second, time.Second); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case signal := <-backend.signaled:
+		t.Fatalf("empty cgroup received signal %q", signal)
+	default:
 	}
 }
 
@@ -256,7 +267,7 @@ func TestInitialStartFailureRetiresRegistrationAndPermitsRetry(t *testing.T) {
 func TestInitialReadinessFailureKillsCgroupWaitsAndPermitsRetry(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
-	backend.groupSurvives["service"] = true
+	backend.cgroupSurvives["service"] = true
 	manager := newManager(backend, sigchld, nil)
 	supervisor := New(context.Background(), manager, Config{})
 	var failedRecord *serviceRecord
@@ -281,6 +292,9 @@ func TestInitialReadinessFailureKillsCgroupWaitsAndPermitsRetry(t *testing.T) {
 
 	if err := supervisor.Start(context.Background(), service); err == nil {
 		t.Fatal("readiness failure was ignored")
+	}
+	if got := receive(t, backend.signaled); got != "service:terminated" {
+		t.Fatalf("graceful cleanup signal = %q, want service:terminated", got)
 	}
 	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
 		t.Fatalf("cleanup signal = %q, want service:cgroup.kill", got)
@@ -403,6 +417,15 @@ func waitForServiceProcess(t *testing.T, supervisor *Supervisor, name string, pi
 	t.Fatalf("service %q did not publish pid %d", name, pid)
 }
 
+func requireScope(t *testing.T, backend *fakeBackend, pid int, want string) {
+	t.Helper()
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	if got := backend.children[pid].scope; got != want {
+		t.Fatalf("pid %d scope = %q, want %q", pid, got, want)
+	}
+}
+
 func TestRestartBackoffCapsAndResetsOnlyAfterStableRun(t *testing.T) {
 	sigchld := make(chan os.Signal, 16)
 	backend := newFakeBackend(sigchld)
@@ -420,12 +443,14 @@ func TestRestartBackoffCapsAndResetsOnlyAfterStableRun(t *testing.T) {
 		t.Fatal(err)
 	}
 	pid := receive(t, backend.started)
+	requireScope(t, backend, pid, "required")
 	waitForServiceProcess(t, supervisor, "required", pid)
 
 	for _, delay := range []time.Duration{time.Second, 2 * time.Second, 4 * time.Second, 4 * time.Second} {
 		backend.exit(pid, syscall.WaitStatus(1<<8))
 		clock.fire(t, delay)
 		pid = receive(t, backend.started)
+		requireScope(t, backend, pid, "required")
 		waitForServiceProcess(t, supervisor, "required", pid)
 	}
 
@@ -501,7 +526,7 @@ func TestDrainKillsSurvivingCgroupAfterDirectChildExit(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
 	backend.exitOnTERM["service"] = true
-	backend.groupSurvives["service"] = true
+	backend.cgroupSurvives["service"] = true
 	manager := newManager(backend, sigchld, nil)
 	clock := newFakeClock()
 	supervisor := New(context.Background(), manager, Config{Clock: clock})
@@ -532,7 +557,7 @@ func TestDrainKillsSurvivingCgroupAfterDirectChildExit(t *testing.T) {
 	}
 }
 
-func TestProcessCgroupReadsFixedPopulatedEvent(t *testing.T) {
+func TestCgroupScopeReadsFixedPopulatedEvent(t *testing.T) {
 	for _, test := range []struct {
 		name      string
 		events    string
@@ -550,7 +575,7 @@ func TestProcessCgroupReadsFixedPopulatedEvent(t *testing.T) {
 			if err := os.WriteFile(filepath.Join(directory, "cgroup.events"), []byte(test.events), 0600); err != nil {
 				t.Fatal(err)
 			}
-			populated, err := (&processCgroup{path: directory}).populated()
+			populated, err := (&cgroupScope{path: directory}).populated()
 			if (err != nil) != test.wantErr {
 				t.Fatalf("populated error = %v, wantErr %v", err, test.wantErr)
 			}
@@ -561,13 +586,27 @@ func TestProcessCgroupReadsFixedPopulatedEvent(t *testing.T) {
 	}
 }
 
+func TestServiceScopeNamesAreSingleComponents(t *testing.T) {
+	for _, name := range []string{"tinfoil-shim", "nvidia_fabric.manager", "service1"} {
+		if !validScopeName(name) {
+			t.Fatalf("valid scope %q rejected", name)
+		}
+	}
+	for _, name := range []string{"", ".", "..", "../shim", "shim/service", "shim service"} {
+		if validScopeName(name) {
+			t.Fatalf("invalid scope %q accepted", name)
+		}
+	}
+}
+
 func TestDrainKillsSetsidDescendantOutsideStableProcessGroup(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)
 	backend.exitOnTERM["service"] = true
 	backend.cgroupSurvives["service"] = true
 	manager := newManager(backend, sigchld, nil)
-	supervisor := New(context.Background(), manager, Config{Clock: newFakeClock()})
+	clock := newFakeClock()
+	supervisor := New(context.Background(), manager, Config{Clock: clock})
 	if err := supervisor.Start(context.Background(), Service{
 		Name: "service", Command: Command{Name: "service", Path: "/service"},
 	}); err != nil {
@@ -584,12 +623,12 @@ func TestDrainKillsSetsidDescendantOutsideStableProcessGroup(t *testing.T) {
 	}
 	backend.mu.Lock()
 	process := backend.children[pid]
-	groupRunning := process.groupRunning
 	cgroupRunning := process.cgroupRunning
 	backend.mu.Unlock()
-	if groupRunning || !cgroupRunning {
-		t.Fatalf("after setsid escape: groupRunning=%v cgroupRunning=%v", groupRunning, cgroupRunning)
+	if !cgroupRunning {
+		t.Fatal("setsid descendant escaped the service cgroup")
 	}
+	clock.fire(t, time.Second)
 	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
 		t.Fatalf("final cleanup = %q", got)
 	}
@@ -622,15 +661,14 @@ func TestDrainKillsAndReapsOrphanedDescendant(t *testing.T) {
 	supervisor.mu.Unlock()
 	backend.exit(pid, 0)
 	receive(t, process.Done())
-
-	if err := supervisor.Drain([][]string{{"service"}}, time.Second, 2*time.Second); err != nil {
-		t.Fatal(err)
-	}
 	if got := receive(t, backend.signaled); got != "service:terminated" {
 		t.Fatalf("TERM signal = %q", got)
 	}
 	if got := receive(t, backend.signaled); got != "service:cgroup.kill" {
 		t.Fatalf("orphan cleanup = %q", got)
+	}
+	if err := supervisor.Drain([][]string{{"service"}}, time.Second, 2*time.Second); err != nil {
+		t.Fatal(err)
 	}
 
 	deadline := time.Now().Add(time.Second)


### PR DESCRIPTION
## Summary

- create one cgroup v2 subtree per PID1-managed child and place the child atomically with UseCgroupFD
- use cgroup.kill and cgroup.events to terminate and verify complete descendant trees
- retain cgroups across service restarts until they are empty, then remove them deterministically
- place the debug console under the same manager-owned cgroup lifecycle
- keep PID1 as the sole child reaper

## Validation

- go test ./...
- go vet ./...
- go test -tags tinfoil_debug_image ./cmd/pid1 ./internal/pid1/supervisor
- nix-build --no-out-link -I . -A checks
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run each supervised service in a dedicated cgroup v2 scope; one-shots and the debug console run in ephemeral scopes for isolation and deterministic teardown. Draining polls `cgroup.events` and escalates with `cgroup.kill` while keeping PID1 as the only reaper.

- **New Features**
  - Create per-child cgroups under `/sys/fs/cgroup/tinfoil-pid1`: `service-<name>` (persistent, validated) and `child-<id>` (ephemeral); place children atomically via `UseCgroupFD`.
  - Added `Process.Stop(term, kill)` to stop whole cgroups; cleanup waits for `populated 0`, skips signaling empty cgroups, then uses `cgroup.kill` if needed and removes ephemeral scopes.
  - Drain and restarts clean up cgroups even after the direct child exits, ensuring `setsid` descendants are terminated.
  - Readiness fails fast with “exited before readiness”; restarts and initial failures trigger the same cgroup-based cleanup.
  - PID file write failures fail closed: stop the new cgroup (TERM → `cgroup.kill`), surface cleanup errors, and retain the registration if cleanup fails.
  - Debug console runs in a managed ephemeral scope with `Setsid` + `Setctty`; `StopConsole` and one-shots use the same `Process.Stop` path; orphans are adopted and reaped by PID1.

<sup>Written for commit 4000ab44e2972ec3564b2ccf8a722bc9b4da57b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

