### PR TITLE
Resolve measured root from its fixed controller

### DIFF
--- a/tinfoil/cmd/initrd/main.go
+++ b/tinfoil/cmd/initrd/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
 	"log"
@@ -16,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"tinfoil/internal/boot"
+	"tinfoil/internal/device"
 	"tinfoil/internal/devicemapper"
 )
 
@@ -66,21 +66,13 @@ func run() error {
 	}
 	roothash = strings.ToLower(roothash)
 
-	// systemd-repart assigns the data partition the first 128 bits of the
-	// roothash and the hash partition the final 128 bits.
-	rootHex32, verityHex32 := splitRoothash(roothash)
-	rootPartUUID := guidFromHex32(rootHex32)
-	verityPartUUID := guidFromHex32(verityHex32)
-
-	initrdLogf("waiting for root PARTUUID %s", rootPartUUID)
-	rootDevice, err := findPartUUID(rootPartUUID, 30*time.Second)
+	initrdLogf("waiting for measured root at its fixed controller")
+	rootDevice, verityDevice, err := device.RootPartitions()
 	if err != nil {
-		return fmt.Errorf("root data partition not found: %w", err)
+		return fmt.Errorf("measured root not found: %w", err)
 	}
-	initrdLogf("waiting for verity PARTUUID %s", verityPartUUID)
-	verityDevice, err := findPartUUID(verityPartUUID, 30*time.Second)
-	if err != nil {
-		return fmt.Errorf("root verity partition not found: %w", err)
+	if !isBlockDevice(rootDevice) || !isBlockDevice(verityDevice) {
+		return errors.New("measured root partition is not a block device")
 	}
 
 	// Partition size comes from kernel sysfs. Every other verity parameter is
@@ -240,68 +232,6 @@ func isHex64(value string) bool {
 		}
 	}
 	return true
-}
-
-func splitRoothash(roothash string) (string, string) {
-	return roothash[:32], roothash[32:]
-}
-
-func guidFromHex32(value string) string {
-	value = strings.ToLower(value)
-	return fmt.Sprintf(
-		"%s-%s-%s-%s-%s",
-		value[:8], value[8:12], value[12:16], value[16:20], value[20:],
-	)
-}
-
-func findPartUUID(want string, timeout time.Duration) (string, error) {
-	want = strings.ToLower(want)
-	deadline := time.Now().Add(timeout)
-	for {
-		var matches []string
-		uevents, _ := filepath.Glob("/sys/block/*/*/uevent")
-		for _, path := range uevents {
-			fields, err := readUevent(path)
-			if err != nil ||
-				fields["DEVTYPE"] != "partition" ||
-				strings.ToLower(fields["PARTUUID"]) != want {
-				continue
-			}
-			device := filepath.Join("/dev", fields["DEVNAME"])
-			if isBlockDevice(device) {
-				matches = append(matches, device)
-			}
-		}
-		switch len(matches) {
-		case 1:
-			return matches[0], nil
-		case 0:
-			if time.Now().After(deadline) {
-				return "", os.ErrNotExist
-			}
-			time.Sleep(100 * time.Millisecond)
-		default:
-			return "", fmt.Errorf("PARTUUID %s is ambiguous", want)
-		}
-	}
-}
-
-func readUevent(path string) (map[string]string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	fields := make(map[string]string)
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		key, value, ok := strings.Cut(scanner.Text(), "=")
-		if ok {
-			fields[key] = value
-		}
-	}
-	return fields, scanner.Err()
 }
 
 func isBlockDevice(path string) bool {

--- a/tinfoil/cmd/initrd/main_test.go
+++ b/tinfoil/cmd/initrd/main_test.go
@@ -74,23 +74,6 @@ func TestIsHex64(t *testing.T) {
 	}
 }
 
-func TestSplitRoothashAndGUID(t *testing.T) {
-	roothash := "0123456789abcdef0123456789abcdefabcDEF0123456789ABCDef0123456789"
-	root, verity := splitRoothash(roothash)
-	if root != "0123456789abcdef0123456789abcdef" {
-		t.Fatalf("root half = %q", root)
-	}
-	if verity != "abcDEF0123456789ABCDef0123456789" {
-		t.Fatalf("verity half = %q", verity)
-	}
-	if got := guidFromHex32(root); got != "01234567-89ab-cdef-0123-456789abcdef" {
-		t.Fatalf("root GUID = %q", got)
-	}
-	if got := guidFromHex32(verity); got != "abcdef01-2345-6789-abcd-ef0123456789" {
-		t.Fatalf("verity GUID = %q", got)
-	}
-}
-
 func TestCmdlineValueFromRejectsAmbiguity(t *testing.T) {
 	value, err := cmdlineValueFrom("console=hvc0 roothash=abcd", "roothash")
 	if err != nil || value != "abcd" {

--- a/tinfoil/internal/device/topology.go
+++ b/tinfoil/internal/device/topology.go
@@ -13,15 +13,40 @@ import (
 const (
 	// These are the measured PCI addresses QEMU assigned before tinfoild made
 	// them explicit. They MUST match tinfoild/admin/guest_topology.go.
+	rootDiskPCIAddress     = "0000:00:04.0"
 	configDiskPCIAddress   = "0000:00:05.0"
 	externalDiskPCIAddress = "0000:00:06.0"
 	firstModelDiskPCISlot  = 7
 	lastUsableDiskPCISlot  = 30 // Q35 reserves slot 31 for ISA/SATA/SMBus.
 
+	rootDataPartition    = 1
+	rootVerityPartition  = 2
 	EMWPPayloadPartition = 1
 	// MaxModelDisks is the number of Q35 slots reserved for model disks.
 	MaxModelDisks = lastUsableDiskPCISlot - firstModelDiskPCISlot + 1
 )
+
+// RootPartitions returns the fixed data and verity partitions below the
+// measured root controller.
+func RootPartitions() (string, string, error) {
+	deadline := time.Now().Add(deviceWaitTimeout)
+	var lastErr error
+	for {
+		disk, err := findDiskByPCIAddress(rootDiskPCIAddress)
+		if err == nil {
+			root, verity, partitionErr := findRootPartitions(disk)
+			if partitionErr == nil {
+				return root, verity, nil
+			}
+			err = partitionErr
+		}
+		lastErr = err
+		if !time.Now().Before(deadline) {
+			return "", "", lastErr
+		}
+		time.Sleep(deviceWaitDelay)
+	}
+}
 
 var (
 	sysBusPCIDevices = "/sys/bus/pci/devices"
@@ -108,21 +133,63 @@ func findDiskByPCIAddress(pciAddress string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("finding disk below PCI device %s: %w", pciAddress, err)
 	}
-	var matches []string
-	for _, blockPath := range blockPaths {
-		path := filepath.Join(devDir, filepath.Base(blockPath))
-		if _, err := os.Stat(path); err == nil {
-			matches = append(matches, path)
+	sort.Strings(blockPaths)
+	if len(blockPaths) != 1 {
+		return "", fmt.Errorf(
+			"expected one disk below PCI device %s, found %d",
+			pciAddress, len(blockPaths),
+		)
+	}
+	path := filepath.Join(devDir, filepath.Base(blockPaths[0]))
+	if _, err := os.Stat(path); err != nil {
+		return "", fmt.Errorf("disk node %s not ready: %w", path, err)
+	}
+	return path, nil
+}
+
+func findRootPartitions(diskPath string) (string, string, error) {
+	disk := filepath.Base(diskPath)
+	partitionFiles, err := filepath.Glob(filepath.Join(sysBlockDir, disk, "*", "partition"))
+	if err != nil {
+		return "", "", fmt.Errorf("reading partitions for %s: %w", diskPath, err)
+	}
+	var root, verity string
+	for _, partitionFile := range partitionFiles {
+		name := filepath.Base(filepath.Dir(partitionFile))
+		data, err := os.ReadFile(partitionFile)
+		if err != nil {
+			return "", "", fmt.Errorf("reading partition number for %s: %w", name, err)
+		}
+		number, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			return "", "", fmt.Errorf("invalid partition number for %s", name)
+		}
+		path := filepath.Join(devDir, name)
+		if _, err := os.Stat(path); err != nil {
+			return "", "", fmt.Errorf("partition node %s not ready: %w", path, err)
+		}
+		switch number {
+		case rootDataPartition:
+			if root != "" {
+				return "", "", fmt.Errorf("duplicate root data partition on %s", diskPath)
+			}
+			root = path
+		case rootVerityPartition:
+			if verity != "" {
+				return "", "", fmt.Errorf("duplicate root verity partition on %s", diskPath)
+			}
+			verity = path
+		default:
+			return "", "", fmt.Errorf("unexpected partition %d on %s", number, diskPath)
 		}
 	}
-	sort.Strings(matches)
-	if len(matches) == 1 {
-		return matches[0], nil
+	if root == "" || verity == "" {
+		return "", "", fmt.Errorf(
+			"expected root partitions %d and %d on %s",
+			rootDataPartition, rootVerityPartition, diskPath,
+		)
 	}
-	return "", fmt.Errorf(
-		"expected one disk below PCI device %s, found %d",
-		pciAddress, len(matches),
-	)
+	return root, verity, nil
 }
 
 func findPartition(diskPath string, partition int) (string, error) {

--- a/tinfoil/internal/device/topology.go
+++ b/tinfoil/internal/device/topology.go
@@ -29,23 +29,18 @@ const (
 // RootPartitions returns the fixed data and verity partitions below the
 // measured root controller.
 func RootPartitions() (string, string, error) {
-	deadline := time.Now().Add(deviceWaitTimeout)
-	var lastErr error
-	for {
+	partitions, err := waitForDevice(func() ([2]string, error) {
 		disk, err := findDiskByPCIAddress(rootDiskPCIAddress)
-		if err == nil {
-			root, verity, partitionErr := findRootPartitions(disk)
-			if partitionErr == nil {
-				return root, verity, nil
-			}
-			err = partitionErr
+		if err != nil {
+			return [2]string{}, err
 		}
-		lastErr = err
-		if !time.Now().Before(deadline) {
-			return "", "", lastErr
-		}
-		time.Sleep(deviceWaitDelay)
+		root, verity, err := findRootPartitions(disk)
+		return [2]string{root, verity}, err
+	})
+	if err != nil {
+		return "", "", err
 	}
+	return partitions[0], partitions[1], nil
 }
 
 var (
@@ -106,17 +101,18 @@ func modelDiskPCIAddress(index int) (string, error) {
 	return fmt.Sprintf("0000:00:%02x.0", slot), nil
 }
 
-func waitForDevice(find func() (string, error)) (string, error) {
+func waitForDevice[T any](find func() (T, error)) (T, error) {
 	deadline := time.Now().Add(deviceWaitTimeout)
 	var lastErr error
 	for {
-		path, err := find()
+		device, err := find()
 		if err == nil {
-			return path, nil
+			return device, nil
 		}
 		lastErr = err
 		if time.Now().After(deadline) {
-			return "", lastErr
+			var zero T
+			return zero, lastErr
 		}
 		time.Sleep(deviceWaitDelay)
 	}

--- a/tinfoil/internal/device/topology_test.go
+++ b/tinfoil/internal/device/topology_test.go
@@ -3,6 +3,7 @@ package device
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 )
 
@@ -48,6 +49,64 @@ func TestConfigDiskUsesFixedController(t *testing.T) {
 	if want := filepath.Join(fixture.dev, "sda"); got != want {
 		t.Fatalf("ConfigDisk() = %q, want %q", got, want)
 	}
+}
+
+func TestRootPartitionsUseFixedControllerAndPositions(t *testing.T) {
+	fixture := withFixture(t)
+	addPCIDisk(t, fixture, rootDiskPCIAddress, "sda")
+	addPartition(t, fixture, "sda", "sda1", rootDataPartition)
+	addPartition(t, fixture, "sda", "sda2", rootVerityPartition)
+	addPCIDisk(t, fixture, configDiskPCIAddress, "sdb")
+	addPartition(t, fixture, "sdb", "sdb1", rootDataPartition)
+
+	root, verity, err := RootPartitions()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join(fixture.dev, "sda1"); root != want {
+		t.Fatalf("root partition = %q, want %q", root, want)
+	}
+	if want := filepath.Join(fixture.dev, "sda2"); verity != want {
+		t.Fatalf("verity partition = %q, want %q", verity, want)
+	}
+}
+
+func TestRootPartitionsRejectInvalidTopology(t *testing.T) {
+	t.Run("wrong controller", func(t *testing.T) {
+		fixture := withFixture(t)
+		addPCIDisk(t, fixture, configDiskPCIAddress, "sda")
+		addPartition(t, fixture, "sda", "sda1", rootDataPartition)
+		addPartition(t, fixture, "sda", "sda2", rootVerityPartition)
+		if _, _, err := RootPartitions(); err == nil {
+			t.Fatal("root partitions below the wrong controller were accepted")
+		}
+	})
+	t.Run("ambiguous controller", func(t *testing.T) {
+		fixture := withFixture(t)
+		addPCIDisk(t, fixture, rootDiskPCIAddress, "sda")
+		addPCIDisk(t, fixture, rootDiskPCIAddress, "sdb")
+		if _, _, err := RootPartitions(); err == nil {
+			t.Fatal("ambiguous root controller was accepted")
+		}
+	})
+	t.Run("missing partition", func(t *testing.T) {
+		fixture := withFixture(t)
+		addPCIDisk(t, fixture, rootDiskPCIAddress, "sda")
+		addPartition(t, fixture, "sda", "sda1", rootDataPartition)
+		if _, _, err := RootPartitions(); err == nil {
+			t.Fatal("missing root verity partition was accepted")
+		}
+	})
+	t.Run("extra partition", func(t *testing.T) {
+		fixture := withFixture(t)
+		addPCIDisk(t, fixture, rootDiskPCIAddress, "sda")
+		addPartition(t, fixture, "sda", "sda1", rootDataPartition)
+		addPartition(t, fixture, "sda", "sda2", rootVerityPartition)
+		addPartition(t, fixture, "sda", "sda3", 3)
+		if _, _, err := RootPartitions(); err == nil {
+			t.Fatal("extra root partition was accepted")
+		}
+	})
 }
 
 func TestExternalConfigDiskUsesFixedController(t *testing.T) {
@@ -133,6 +192,14 @@ func addPCIDisk(t *testing.T, fixture deviceFixture, controller, name string) {
 	)
 	mustMkdir(t, blockDir)
 	mustMkdir(t, filepath.Join(fixture.sys, name))
+	mustWrite(t, filepath.Join(fixture.dev, name), "")
+}
+
+func addPartition(t *testing.T, fixture deviceFixture, disk, name string, number int) {
+	t.Helper()
+	partitionDir := filepath.Join(fixture.sys, disk, name)
+	mustMkdir(t, partitionDir)
+	mustWrite(t, filepath.Join(partitionDir, "partition"), strconv.Itoa(number)+"\n")
 	mustWrite(t, filepath.Join(fixture.dev, name), "")
 }
 


### PR DESCRIPTION
## Summary

- locate exactly one root disk below the measured PCI controller at 0000:00:04.0
- select fixed data and verity partition positions 1 and 2
- reject wrong, ambiguous, missing, duplicate, or extra root topology
- preserve block-node, geometry, device-mapper, and dm-verity checks
- delete global PARTUUID discovery and the generic partition uevent parser

## Validation

- go test ./...
- go vet ./...
- nix-build --no-out-link -I . -A checks -A initrd
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve measured root from the fixed PCI controller at 0000:00:04.0 and use partitions 1 (data) and 2 (verity). Removes PARTUUID-based discovery and tightens validation while keeping dm-verity and device-mapper checks.

- **Refactors**
  - Added `device.RootPartitions()` to locate root and verity under the fixed controller using a shared, bounded `waitForDevice` with readiness and timeout checks.
  - Enforce exactly one disk under the root controller; reject wrong/ambiguous controller and missing/duplicate/extra partitions.
  - Removed global PARTUUID discovery, GUID helpers, and the generic partition uevent parser from initrd; added topology tests for valid and invalid root setups.

- **Migration**
  - Root disk must be attached at PCI 0000:00:04.0 with partitions 1 (data) and 2 (verity).

<sup>Written for commit 1f793ff7b9b671f127966c6382dcd2cdcb5d3bb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

