### PR TITLE
Fix post-cgroup runtime startup regressions

### DIFF
--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -32,24 +32,25 @@ const (
 	oneShotStopGrace     = 2 * time.Second
 	serviceTermGrace     = 10 * time.Second
 	serviceKillGrace     = 5 * time.Second
-	nvidiaChildLimit     = 4 * time.Minute
 	nvidiaDeviceWait     = 15 * time.Second
 	nvidiaDevicePoll     = 500 * time.Millisecond
 	cdiGenerateLimit     = 30 * time.Second
 
-	containerdName   = "containerd"
-	dockerName       = "dockerd"
-	containersName   = "tinfoil-containers"
-	shimName         = "tinfoil-shim"
-	egressName       = "tinfoil-egress"
-	containerdSocket = "/run/containerd/containerd.sock"
-	dockerSocket     = "/run/docker.sock"
-	readyPath        = "/run/tinfoil-pid1.ready"
-	selfExecPath     = "/proc/self/exe"
-	pid1Env          = "TINFOIL_PID1"
-	pid1EnvValue     = "tinfoil-pid1"
-	kmsgInfoPrefix   = "<6>"
-	fabricConfigPath = "/usr/share/nvidia/nvswitch/fabricmanager.cfg"
+	containerdName    = "containerd"
+	dockerName        = "dockerd"
+	containersName    = "tinfoil-containers"
+	shimName          = "tinfoil-shim"
+	egressName        = "tinfoil-egress"
+	persistencedName  = "nvidia-persistenced"
+	fabricManagerName = "nvidia-fabricmanager"
+	containerdSocket  = "/run/containerd/containerd.sock"
+	dockerSocket      = "/run/docker.sock"
+	readyPath         = "/run/tinfoil-pid1.ready"
+	selfExecPath      = "/proc/self/exe"
+	pid1Env           = "TINFOIL_PID1"
+	pid1EnvValue      = "tinfoil-pid1"
+	kmsgInfoPrefix    = "<6>"
+	fabricConfigPath  = "/usr/share/nvidia/nvswitch/fabricmanager.cfg"
 )
 
 var consoleMu sync.Mutex
@@ -410,18 +411,16 @@ func runNVIDIABootstrapSteps(
 	if err := control.PreparePersistencedRuntime(); err != nil {
 		return fmt.Errorf("prepare nvidia-persistenced runtime: %w", err)
 	}
-	persistencedCtx, cancelPersistenced := context.WithTimeout(ctx, nvidiaChildLimit)
-	err := oneShot(persistencedCtx, command(
-		"nvidia-persistenced",
+	persistenced := command(
+		persistencedName,
 		"/usr/bin/nvidia-persistenced",
 		"--user", "nvidia-persistenced", "--uvm-persistence-mode", "--verbose",
-	))
-	cancelPersistenced()
-	if err != nil {
+	)
+	if err := startService(ctx, supervisor.Service{
+		Name: persistenced.Name, Restart: true, Forking: true, Command: persistenced,
+		Ready: control.WaitForPersistenced,
+	}); err != nil {
 		return fmt.Errorf("start nvidia-persistenced: %w", err)
-	}
-	if err := control.WaitForPersistenced(ctx); err != nil {
-		return fmt.Errorf("wait for nvidia-persistenced: %w", err)
 	}
 	if err := control.LoadUVMKernelModules(); err != nil {
 		return fmt.Errorf("load NVIDIA UVM kernel modules: %w", err)
@@ -510,7 +509,7 @@ func waitForNVIDIADeviceNodes(
 
 func fabricManagerCommand() supervisor.Command {
 	cmd := command(
-		"nvidia-fabricmanager",
+		fabricManagerName,
 		"/usr/bin/nv-fabricmanager",
 		"-c", fabricConfigPath,
 	)
@@ -533,6 +532,7 @@ func shutdownGroups() [][]string {
 	return [][]string{
 		{egressName, shimName},
 		{containersName},
+		{fabricManagerName, persistencedName},
 		{dockerName},
 		{containerdName},
 	}

--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -96,8 +96,13 @@ type serviceControl interface {
 	Drain([][]string, time.Duration, time.Duration) error
 }
 
+type consoleControl interface {
+	stop(time.Duration, time.Duration) error
+}
+
 type lifecycleDeps struct {
 	services     serviceControl
+	startConsole func(context.Context) (consoleControl, error)
 	oneShot      func(context.Context, supervisor.Command) error
 	nvidia       func(context.Context) error
 	lockModules  func() error
@@ -120,16 +125,12 @@ func run(parent context.Context) (result error) {
 	}
 	readiness := newReadiness(requiredServiceNames(), setReady)
 	manager := supervisor.NewManager(initLogf)
-	console, err := startDebugConsole(parent, manager)
-	if err != nil {
-		return fmt.Errorf("start debug console: %w", err)
-	}
-	defer func() {
-		result = errors.Join(result, console.stop(serviceTermGrace, serviceKillGrace))
-	}()
 	services := supervisor.New(parent, manager, supervisor.Config{Observe: readiness.Update})
 	deps := lifecycleDeps{
 		services: services,
+		startConsole: func(ctx context.Context) (consoleControl, error) {
+			return startDebugConsole(ctx, manager)
+		},
 		oneShot: func(ctx context.Context, command supervisor.Command) error {
 			return runOneShot(ctx, manager, command, oneShotStopGrace)
 		},
@@ -163,6 +164,12 @@ func run(parent context.Context) (result error) {
 }
 
 func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readinessState) (result error) {
+	var console consoleControl
+	defer func() {
+		if console != nil {
+			result = errors.Join(result, console.stop(deps.term, deps.kill))
+		}
+	}()
 	bootCtx := parent
 	runtimeCtx, cancelRuntime := context.WithCancel(parent)
 	defer func() {
@@ -176,7 +183,7 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 		}
 	}()
 	defer func() {
-		if result != nil && deps.debugFailure != nil {
+		if result != nil && console != nil && deps.debugFailure != nil {
 			deps.debugFailure(parent, result)
 		}
 	}()
@@ -184,6 +191,11 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	initLogf("starting CPU lifecycle")
 	if err := deps.setupFS(initLogf); err != nil {
 		return fmt.Errorf("runtime filesystems: %w", err)
+	}
+	var err error
+	console, err = deps.startConsole(parent)
+	if err != nil {
+		return fmt.Errorf("start debug console: %w", err)
 	}
 	if err := deps.sysctls(initLogf); err != nil {
 		return fmt.Errorf("runtime sysctls: %w", err)

--- a/tinfoil/cmd/pid1/main_test.go
+++ b/tinfoil/cmd/pid1/main_test.go
@@ -234,22 +234,16 @@ func TestNVIDIABootstrapExactOrderAndCommandContracts(t *testing.T) {
 	control := newFakeNVIDIA(t, 8)
 	control.fabricMode = nvidia.FabricModeFabricManager
 	var commands []supervisor.Command
-	var persistencedLimit time.Duration
+	var services []supervisor.Service
 	oneShot := func(ctx context.Context, command supervisor.Command) error {
 		control.calls = append(control.calls, "exec:"+command.Name)
 		commands = append(commands, command)
-		if command.Name == "nvidia-persistenced" {
-			deadline, ok := ctx.Deadline()
-			if !ok {
-				t.Fatal("nvidia-persistenced context has no deadline")
-			}
-			persistencedLimit = time.Until(deadline)
-		}
 		return nil
 	}
 	startService := func(ctx context.Context, service supervisor.Service) error {
 		control.calls = append(control.calls, "exec:"+service.Command.Name)
 		commands = append(commands, service.Command)
+		services = append(services, service)
 		return startTestService(ctx, service)
 	}
 	var statuses []nvidia.BootstrapStatus
@@ -272,9 +266,6 @@ func TestNVIDIABootstrapExactOrderAndCommandContracts(t *testing.T) {
 	if !slices.Equal(control.calls, wantOrder) {
 		t.Fatalf("calls = %v, want %v", control.calls, wantOrder)
 	}
-	if persistencedLimit > nvidiaChildLimit || persistencedLimit < nvidiaChildLimit-time.Second {
-		t.Fatalf("persistenced child limit = %s, want %s", persistencedLimit, nvidiaChildLimit)
-	}
 	if len(statuses) != 1 || statuses[0] != nvidia.ReadyBootstrapStatus(8) {
 		t.Fatalf("statuses = %#v", statuses)
 	}
@@ -287,6 +278,9 @@ func TestNVIDIABootstrapExactOrderAndCommandContracts(t *testing.T) {
 		[]string{"-c", fabricConfigPath})
 	assertCommand(t, commands[2], "nvidia-ctk-cdi", "/usr/bin/nvidia-ctk",
 		[]string{"cdi", "generate", "--output=" + control.temporary})
+	if len(services) != 2 || !services[0].Forking || !services[0].Restart || services[1].Forking || !services[1].Restart {
+		t.Fatalf("NVIDIA services = %#v", services)
+	}
 	env := environmentMap(commands[1].Env)
 	if _, ok := env["FM_CONFIG_FILE"]; ok {
 		t.Fatalf("Fabric Manager inherited FM_CONFIG_FILE: %#v", env)

--- a/tinfoil/cmd/pid1/main_test.go
+++ b/tinfoil/cmd/pid1/main_test.go
@@ -71,6 +71,10 @@ type lifecycleHarness struct {
 	existing  map[string]bool
 }
 
+type fakeConsole struct{}
+
+func (*fakeConsole) stop(time.Duration, time.Duration) error { return nil }
+
 func newLifecycleHarness() *lifecycleHarness {
 	harness := &lifecycleHarness{
 		services: newFakeServices(),
@@ -84,7 +88,10 @@ func newLifecycleHarness() *lifecycleHarness {
 	harness.services.observe = harness.readiness.Update
 	noSetup := func(pidruntime.LogFunc) error { return nil }
 	harness.deps = lifecycleDeps{
-		services:     harness.services,
+		services: harness.services,
+		startConsole: func(context.Context) (consoleControl, error) {
+			return &fakeConsole{}, nil
+		},
 		oneShot:      func(context.Context, supervisor.Command) error { return nil },
 		nvidia:       func(context.Context) error { return nil },
 		lockModules:  func() error { return nil },
@@ -475,6 +482,14 @@ func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
 		record(command.Name)
 		return nil
 	}
+	harness.deps.setupFS = func(pidruntime.LogFunc) error {
+		record("runtime-filesystems")
+		return nil
+	}
+	harness.deps.startConsole = func(context.Context) (consoleControl, error) {
+		record("debug-console")
+		return &fakeConsole{}, nil
+	}
 	harness.deps.nvidia = func(context.Context) error {
 		record("nvidia-bootstrap")
 		return nil
@@ -496,6 +511,8 @@ func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
 	}
 	mu.Lock()
 	defer mu.Unlock()
+	filesystems := slices.Index(events, "runtime-filesystems")
+	console := slices.Index(events, "debug-console")
 	loopback := slices.Index(events, "loopback")
 	bootstrap := slices.Index(events, "nvidia-bootstrap")
 	lock := slices.Index(events, "module-lock")
@@ -505,7 +522,7 @@ func TestLifecycleOrdersLoopbackThenNVIDIABeforeContainerd(t *testing.T) {
 	containers := slices.Index(events, containersName)
 	shim := slices.Index(events, shimName)
 	boot := slices.Index(events, string(hardening.ServiceBoot))
-	if loopback < 0 || bootstrap != loopback+1 || lock != bootstrap+1 || nftables != lock+1 || containerd <= nftables || docker <= containerd || shim <= docker || boot <= shim || containers <= boot {
+	if filesystems < 0 || console != filesystems+1 || loopback != console+1 || bootstrap != loopback+1 || lock != bootstrap+1 || nftables != lock+1 || containerd <= nftables || docker <= containerd || shim <= docker || boot <= shim || containers <= boot {
 		t.Fatalf("startup events = %v", events)
 	}
 }
@@ -538,8 +555,8 @@ func TestModuleLockFailureStopsBootBeforeServices(t *testing.T) {
 
 func TestLifecycleFailureParksBeforeServiceDrain(t *testing.T) {
 	harness := newLifecycleHarness()
-	setupErr := errors.New("filesystem setup failed")
-	harness.deps.setupFS = func(pidruntime.LogFunc) error { return setupErr }
+	setupErr := errors.New("sysctl setup failed")
+	harness.deps.sysctls = func(pidruntime.LogFunc) error { return setupErr }
 	parked := make(chan error, 1)
 	release := make(chan struct{})
 	harness.deps.debugFailure = func(_ context.Context, err error) {
@@ -564,6 +581,21 @@ func TestLifecycleFailureParksBeforeServiceDrain(t *testing.T) {
 		t.Fatalf("drain groups = %v, want %v", groups, shutdownGroups())
 	}
 	if err := receiveTest(t, result); !errors.Is(err, setupErr) {
+		t.Fatalf("runLifecycle error = %v, want %v", err, setupErr)
+	}
+}
+
+func TestFilesystemSetupFailureDoesNotStartConsole(t *testing.T) {
+	harness := newLifecycleHarness()
+	setupErr := errors.New("filesystem setup failed")
+	harness.deps.setupFS = func(pidruntime.LogFunc) error { return setupErr }
+	harness.deps.startConsole = func(context.Context) (consoleControl, error) {
+		t.Fatal("console started before filesystem setup completed")
+		return nil, nil
+	}
+
+	err := runLifecycle(context.Background(), harness.deps, harness.readiness)
+	if !errors.Is(err, setupErr) {
 		t.Fatalf("runLifecycle error = %v, want %v", err, setupErr)
 	}
 }

--- a/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/hardening/seccomp_linux_amd64_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
@@ -13,6 +14,7 @@ import (
 
 func TestServiceSocketDomains(t *testing.T) {
 	if os.Getenv("TINFOIL_SOCKET_DOMAIN_CHILD") == "1" {
+		runtime.LockOSThread()
 		service := Service(os.Getenv("TINFOIL_SOCKET_SERVICE"))
 		domain, err := strconv.Atoi(os.Getenv("TINFOIL_SOCKET_DOMAIN"))
 		if err != nil {
@@ -95,6 +97,7 @@ func TestServiceSocketDomains(t *testing.T) {
 
 func TestServiceDangerousSyscalls(t *testing.T) {
 	if os.Getenv("TINFOIL_DANGEROUS_SYSCALL_CHILD") == "1" {
+		runtime.LockOSThread()
 		service := Service(os.Getenv("TINFOIL_SYSCALL_SERVICE"))
 		operation := os.Getenv("TINFOIL_SYSCALL_OPERATION")
 		policy, ok := policyFor(service)

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -118,6 +118,25 @@ func (p *Process) Stop(termGrace, killGrace time.Duration) error {
 func (p *Process) cgroupPopulated() (bool, error) {
 	return p.child.cgroupPopulated()
 }
+
+func (p *Process) waitCgroupEmpty(ctx context.Context) error {
+	ticker := time.NewTicker(cgroupPollInterval)
+	defer ticker.Stop()
+	for {
+		populated, err := p.cgroupPopulated()
+		if err != nil {
+			return err
+		}
+		if !populated {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
 func (p *Process) killCgroup() error   { return p.child.killCgroup() }
 func (p *Process) removeCgroup() error { return p.child.removeCgroup() }
 
@@ -445,12 +464,14 @@ type State struct {
 }
 
 // Service is a long-lived child. Ready is called after every start and must
-// return only when that instance is usable.
+// return only when that instance is usable. Forking permits a successful
+// launcher to exit while the service remains contained in its cgroup.
 type Service struct {
 	Name     string
 	Command  Command
 	Required bool
 	Restart  bool
+	Forking  bool
 	Ready    func(context.Context) error
 	PIDFile  string
 }
@@ -523,6 +544,9 @@ func New(parent context.Context, manager *Manager, config Config) *Supervisor {
 }
 
 func (s *Supervisor) Start(ctx context.Context, service Service) error {
+	if service.Forking && service.Ready == nil {
+		return fmt.Errorf("forking service %s requires readiness", service.Name)
+	}
 	record := &serviceRecord{
 		spec: service, delay: s.base, done: make(chan struct{}),
 	}
@@ -617,7 +641,17 @@ func (s *Supervisor) ready(ctx context.Context, record *serviceRecord, process *
 		if err := exit.Err(); err != nil {
 			return err
 		}
-		return fmt.Errorf("%s exited before readiness", record.spec.Name)
+		if !record.spec.Forking {
+			return fmt.Errorf("%s exited before readiness", record.spec.Name)
+		}
+		populated, err := process.cgroupPopulated()
+		if err != nil {
+			return fmt.Errorf("inspect %s cgroup after launcher exit: %w", record.spec.Name, err)
+		}
+		if !populated {
+			return fmt.Errorf("%s cgroup emptied before readiness", record.spec.Name)
+		}
+		return nil
 	default:
 		return nil
 	}
@@ -628,6 +662,15 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 		exit, err := process.Wait(context.Background())
 		if err != nil {
 			return
+		}
+		serviceErr := exit.Err()
+		if serviceErr == nil && record.spec.Forking {
+			if err := process.waitCgroupEmpty(s.context); err != nil {
+				if s.context.Err() != nil {
+					return
+				}
+				serviceErr = fmt.Errorf("wait for %s cgroup: %w", record.spec.Name, err)
+			}
 		}
 		removePIDFile(record.spec.PIDFile, process.PID())
 		s.mu.Lock()
@@ -641,7 +684,7 @@ func (s *Supervisor) monitor(record *serviceRecord, process *Process) {
 		if !draining {
 			cleanupErr = stopProcesses([]*Process{process}, 0, initialCleanupGrace, realClock{})
 		}
-		s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: errors.Join(exit.Err(), cleanupErr)})
+		s.emit(State{Name: record.spec.Name, Required: record.spec.Required, Err: errors.Join(serviceErr, cleanupErr)})
 		if draining || !record.spec.Restart {
 			return
 		}

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -370,6 +371,69 @@ func TestInitialReadinessFailureKillsCgroupWaitsAndPermitsRetry(t *testing.T) {
 		t.Fatalf("retry start: %v", err)
 	}
 	_ = receive(t, backend.started)
+}
+
+func TestForkingServiceTracksCgroupAfterLauncherExit(t *testing.T) {
+	sigchld := make(chan os.Signal, 8)
+	backend := newFakeBackend(sigchld)
+	backend.cgroupSurvives["service"] = true
+	manager := newManager(backend, sigchld, nil)
+	clock := newFakeClock()
+	states := make(chan State, 8)
+	var readyCalls atomic.Int32
+	supervisor := New(context.Background(), manager, Config{
+		Clock: clock,
+		Observe: func(state State) {
+			states <- state
+		},
+	})
+	service := Service{
+		Name: "service", Restart: true, Forking: true,
+		Command: Command{Name: "service", Path: "/service"},
+		Ready: func(context.Context) error {
+			if readyCalls.Add(1) == 1 {
+				backend.exit(receive(t, backend.started), 0)
+			}
+			return nil
+		},
+	}
+	if err := supervisor.Start(context.Background(), service); err != nil {
+		t.Fatal(err)
+	}
+	if state := receive(t, states); !state.Ready || state.Err != nil {
+		t.Fatalf("initial state = %+v", state)
+	}
+	select {
+	case state := <-states:
+		t.Fatalf("forking service failed while its cgroup remained populated: %+v", state)
+	case <-time.After(4 * cgroupPollInterval):
+	}
+
+	backend.mu.Lock()
+	for _, process := range backend.children {
+		process.cgroupRunning = false
+	}
+	backend.mu.Unlock()
+	if state := receive(t, states); state.Ready || state.Err != nil {
+		t.Fatalf("empty cgroup state = %+v", state)
+	}
+	clock.fire(t, 2*time.Second)
+	_ = receive(t, backend.started)
+	if err := supervisor.Drain([][]string{{"service"}}, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestForkingServiceRequiresReadiness(t *testing.T) {
+	sigchld := make(chan os.Signal, 1)
+	supervisor := New(context.Background(), newManager(newFakeBackend(sigchld), sigchld, nil), Config{})
+	err := supervisor.Start(context.Background(), Service{
+		Name: "service", Forking: true,
+		Command: Command{Name: "service", Path: "/service"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "requires readiness") {
+		t.Fatalf("forking service error = %v", err)
+	}
 }
 
 func TestRestartMaximumIsNeverBelowBase(t *testing.T) {


### PR DESCRIPTION
## Summary
- start the debug console only after PID1 mounts runtime filesystems, including cgroup2
- keep the console alive through later debug lifecycle failures and orderly teardown
- enforce the filesystem-before-console ordering in lifecycle tests

## Qualification
- `go test ./cmd/pid1 ./internal/pid1/...`
- `go test -tags tinfoil_debug_image ./cmd/pid1 ./internal/pid1/...`
- `nix-build -I . -A checks -A shipping-image -A debug-image`
- box3 debug boot reaches ready; SSH, `tindbg status`, Docker aliases, `tindbg template`, and `tindbg boot` pass

Fixes the release blocker found while qualifying merged main: the debug image parked because `/sys/fs/cgroup/tinfoil-pid1` was created before cgroup2 was mounted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start the debug console only after PID1 mounts runtime filesystems (including cgroup2) to prevent parking, and cleanly supervise self-daemonizing NVIDIA persistence. Also pins seccomp test children to one OS thread.

- **Bug Fixes**
  - Delay console startup until after `setupFS`; enforce filesystem-before-console ordering and skip console if FS setup fails.
  - Keep the console running through debug failures and orderly shutdown; stop it via a deferred path using service grace periods.
  - Supervise `nvidia-persistenced` as a forking service with cgroup tracking; accept launcher exit and wait for cgroup empty on shutdown/restart.
  - Add `nvidia-fabricmanager` and `nvidia-persistenced` to the drain order; require readiness for forking services.

<sup>Written for commit ba638bebd1658eb9dd739db6b1708a2b7dd93570. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

