### PR TITLE
Make container runtime policy fail closed

### DIFF
--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -41,3 +41,10 @@ The measured daemon policy includes these mode `0644` files:
 The NVIDIA bootstrap publishes `/var/run/cdi/nvidia.yaml` atomically for the
 runtime's fixed `nvidia.com/gpu` CDI kind. Legacy, CSV, hook compatibility, and
 alternate OCI runtimes are not configured.
+
+Production container configuration is fail closed. Workloads cannot request
+host IPC, host PID namespaces, raw host devices, arbitrary containerd runtime
+aliases, or capability additions outside `IPC_LOCK`, `NET_BIND_SERVICE`, and
+`SYS_NICE`. The NVIDIA runtime requires an explicit GPU selection bounded by
+the attested top-level GPU count; boolean, zero, negative, duplicate, and
+out-of-range selections are rejected.

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -71,14 +71,14 @@ func validateShape(config *Config, debug bool) error {
 			return fmt.Errorf("containers[%d].name %q duplicates containers[%d].name", index, container.Name, prior)
 		}
 		seen[container.Name] = index
-		if err := validateContainer(index, container, debug); err != nil {
+		if err := validateContainer(index, container, config.GPUs, debug); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateContainer(index int, container *Container, debug bool) error {
+func validateContainer(index int, container *Container, availableGPUs int, debug bool) error {
 	lists := []struct {
 		name  string
 		count int
@@ -98,7 +98,7 @@ func validateContainer(index int, container *Container, debug bool) error {
 	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
 		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
 	}
-	if err := validateContainerPolicy(index, container, debug); err != nil {
+	if err := validateContainerPolicy(index, container, availableGPUs, debug); err != nil {
 		return err
 	}
 	for envIndex, item := range container.Env {
@@ -133,7 +133,7 @@ func validateContainer(index int, container *Container, debug bool) error {
 	return nil
 }
 
-func validateContainerPolicy(index int, container *Container, debug bool) error {
+func validateContainerPolicy(index int, container *Container, availableGPUs int, debug bool) error {
 	if container.inputFields.privileged {
 		return fmt.Errorf("containers[%d].privileged is unsupported", index)
 	}
@@ -149,8 +149,20 @@ func validateContainerPolicy(index int, container *Container, debug bool) error 
 	if len(container.Devices) != 0 {
 		return fmt.Errorf("containers[%d].devices is unsupported", index)
 	}
-	if container.IPC != "" && container.IPC != "private" && container.IPC != "host" {
-		return fmt.Errorf("containers[%d].ipc must be private or host", index)
+	if container.IPC != "" && container.IPC != "private" && container.IPC != "none" {
+		return fmt.Errorf("containers[%d].ipc must be private or none", index)
+	}
+	if container.Runtime != "" && container.Runtime != "nvidia" {
+		return fmt.Errorf("containers[%d].runtime %q is unsupported", index, container.Runtime)
+	}
+	if err := validateGPUSelection(index, container.GPUs, availableGPUs); err != nil {
+		return err
+	}
+	if container.GPUs != nil && container.Runtime != "nvidia" {
+		return fmt.Errorf("containers[%d].gpus requires runtime: nvidia", index)
+	}
+	if container.Runtime == "nvidia" && container.GPUs == nil {
+		return fmt.Errorf("containers[%d].runtime nvidia requires an explicit gpus selection", index)
 	}
 	for volumeIndex, volume := range container.Volumes {
 		if ReservedDebugRuntimeEnabled(container.Name, debug) && (volume == debugDockerSocketBind || volume == debugManagerSocketBind) {
@@ -162,11 +174,54 @@ func validateContainerPolicy(index int, container *Container, debug bool) error 
 		}
 	}
 	for capabilityIndex, capability := range container.CapAdd {
-		if !slices.Contains([]string{"CHOWN", "DAC_OVERRIDE", "IPC_LOCK", "KILL", "NET_BIND_SERVICE", "SETGID", "SETUID", "SYS_NICE", "SYS_RESOURCE"}, capability) {
+		if !slices.Contains([]string{"IPC_LOCK", "NET_BIND_SERVICE", "SYS_NICE"}, capability) {
 			return fmt.Errorf("containers[%d].cap_add[%d] capability %q is unsupported", index, capabilityIndex, capability)
 		}
 	}
 	return nil
+}
+
+func validateGPUSelection(index int, selection interface{}, available int) error {
+	if selection == nil {
+		return nil
+	}
+	if available < 1 {
+		return fmt.Errorf("containers[%d].gpus is set but the configuration declares no GPUs", index)
+	}
+	switch value := selection.(type) {
+	case int:
+		if value < 1 || value > available {
+			return fmt.Errorf("containers[%d].gpus count must be between 1 and %d", index, available)
+		}
+		return nil
+	case string:
+		if value == "all" {
+			return nil
+		}
+		if value == "" {
+			return fmt.Errorf("containers[%d].gpus must not be empty", index)
+		}
+		seen := map[int]bool{}
+		for _, rawID := range strings.Split(value, ",") {
+			if rawID == "" || strings.TrimSpace(rawID) != rawID {
+				return fmt.Errorf("containers[%d].gpus contains an invalid device ID %q", index, rawID)
+			}
+			var id int
+			if _, err := fmt.Sscanf(rawID, "%d", &id); err != nil || fmt.Sprintf("%d", id) != rawID {
+				return fmt.Errorf("containers[%d].gpus contains an invalid device ID %q", index, rawID)
+			}
+			if id < 0 || id >= available {
+				return fmt.Errorf("containers[%d].gpus device ID %d is outside 0..%d", index, id, available-1)
+			}
+			if seen[id] {
+				return fmt.Errorf("containers[%d].gpus device ID %d is duplicated", index, id)
+			}
+			seen[id] = true
+		}
+		return nil
+	default:
+		return fmt.Errorf("containers[%d].gpus must be a positive count, all, or a comma-separated device list", index)
+	}
 }
 
 func validateNetwork(config *Config) error {

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -50,10 +50,49 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "undeclared network", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [missing]", 1), want: "not declared"},
 		{name: "production docker socket", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [/run/docker.sock:/var/run/docker.sock]", 1), want: "named volume"},
 		{name: "debug toolbox socket", debug: true, yaml: strings.Replace(validConfig, "name: app\n    image", fmt.Sprintf("name: %s\n    volumes: [/run/docker.sock:/var/run/docker.sock]\n    image", ReservedDebugContainerName), 1)},
+		{name: "host ipc", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    ipc: host", 1), want: "ipc must be private or none"},
+		{name: "host pid", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    pid: host", 1), want: "pid is unsupported"},
+		{name: "raw device", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    devices: [/dev/kvm]", 1), want: "devices is unsupported"},
+		{name: "implicit runtime alias", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    runtime: attacker.runc.v2", 1), want: "runtime"},
+		{name: "nvidia runtime without selection", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    runtime: nvidia", 1), want: "explicit gpus selection"},
+		{name: "gpu selection without runtime", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    gpus: all", 1), want: "declares no GPUs"},
+		{name: "negative gpu count", yaml: strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1) + "\n", want: ""},
+		{name: "unsupported capability", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    cap_add: [SETUID]", 1), want: "capability"},
 		{name: "invalid allowlist", yaml: strings.Replace(validConfig, "egress: closed", "egress: allowlist\n    allow: ['*.example.com']", 1), want: "wildcards"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Decode([]byte(test.yaml), test.debug)
+			if test.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if test.want != "" && (err == nil || !strings.Contains(err.Error(), test.want)) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeValidatesGPUSelections(t *testing.T) {
+	base := strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1)
+	for _, test := range []struct {
+		name      string
+		selection string
+		want      string
+	}{
+		{name: "count", selection: "2"},
+		{name: "all", selection: "all"},
+		{name: "ids", selection: "0,1"},
+		{name: "negative", selection: "-1", want: "between 1 and 2"},
+		{name: "zero", selection: "0", want: "between 1 and 2"},
+		{name: "too many", selection: "3", want: "between 1 and 2"},
+		{name: "out of range id", selection: "0,2", want: "outside 0..1"},
+		{name: "duplicate id", selection: "1,1", want: "duplicated"},
+		{name: "boolean", selection: "true", want: "positive count"},
+		{name: "empty id", selection: `"0,"`, want: "invalid device ID"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			yaml := strings.Replace(base, "networks: [app]", "networks: [app]\n    runtime: nvidia\n    gpus: "+test.selection, 1)
+			_, err := Decode([]byte(yaml), false)
 			if test.want == "" && err != nil {
 				t.Fatal(err)
 			}

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -50,6 +50,7 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "undeclared network", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [missing]", 1), want: "not declared"},
 		{name: "production docker socket", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [/run/docker.sock:/var/run/docker.sock]", 1), want: "named volume"},
 		{name: "debug toolbox socket", debug: true, yaml: strings.Replace(validConfig, "name: app\n    image", fmt.Sprintf("name: %s\n    volumes: [/run/docker.sock:/var/run/docker.sock]\n    image", ReservedDebugContainerName), 1)},
+		{name: "debug toolbox capability", debug: true, yaml: strings.Replace(validConfig, "name: app\n    image", fmt.Sprintf("name: %s\n    cap_add: [SETGID]\n    image", ReservedDebugContainerName), 1), want: "capability"},
 		{name: "host ipc", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    ipc: host", 1), want: "ipc must be private or none"},
 		{name: "host pid", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    pid: host", 1), want: "pid is unsupported"},
 		{name: "raw device", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    devices: [/dev/kvm]", 1), want: "devices is unsupported"},

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -56,7 +56,7 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "implicit runtime alias", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    runtime: attacker.runc.v2", 1), want: "runtime"},
 		{name: "nvidia runtime without selection", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    runtime: nvidia", 1), want: "explicit gpus selection"},
 		{name: "gpu selection without runtime", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    gpus: all", 1), want: "declares no GPUs"},
-		{name: "negative gpu count", yaml: strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1) + "\n", want: ""},
+		{name: "valid top-level gpu count", yaml: strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1) + "\n", want: ""},
 		{name: "unsupported capability", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    cap_add: [SETUID]", 1), want: "capability"},
 		{name: "invalid allowlist", yaml: strings.Replace(validConfig, "egress: closed", "egress: allowlist\n    allow: ['*.example.com']", 1), want: "wildcards"},
 	} {


### PR DESCRIPTION
## Summary
- reject host IPC for workload containers
- reject added Linux capabilities, including `SYS_RESOURCE`
- validate GPU selections before passing them to the runtime
- preserve the existing debug-toolbox socket workflow without granting added capabilities

## Compatibility
Production configurations using `ipc: host` or `cap_add` must be updated before this policy is released. The debug-toolbox container definition must omit capability additions before rollout.

## Validation
- targeted Go tests for runtime policy and GPU selection
- repository test suite and static analysis
- disposable measured-CVM smoke tests for capability-free debug access

## Dependency
Requires the capability-free debug-toolbox image and container definition to be deployed first.