### PR TITLE
Require immutable container image digests

### DIFF
--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -48,3 +48,9 @@ aliases, or capability additions outside `IPC_LOCK`, `NET_BIND_SERVICE`, and
 `SYS_NICE`. The NVIDIA runtime requires an explicit GPU selection bounded by
 the attested top-level GPU count; boolean, zero, negative, duplicate, and
 out-of-range selections are rejected.
+
+Every container image must be an OCI reference containing an immutable digest,
+including in measured debug mode. The container manager pulls that exact
+reference and verifies Docker's inspected repository digests before creating
+the container; mutable tag-only references are always rejected during
+configuration validation.

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/creasty/defaults v1.8.0
+	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.6.2+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/go-acme/lego/v4 v4.35.2
@@ -33,7 +34,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/distribution/reference"
 	dockerconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/container"
@@ -617,7 +618,36 @@ func pullImage(ctx context.Context, cli *client.Client, imageName string) error 
 			return fmt.Errorf("docker pull failed: %s", msg.Error)
 		}
 	}
+	inspect, err := cli.ImageInspect(ctx, imageName)
+	if err != nil {
+		return fmt.Errorf("inspect pulled image: %w", err)
+	}
+	if err := verifyPulledImageDigest(imageName, inspect.RepoDigests); err != nil {
+		return err
+	}
 	return nil
+}
+
+func verifyPulledImageDigest(imageName string, repoDigests []string) error {
+	named, err := reference.ParseNormalizedNamed(imageName)
+	if err != nil {
+		return fmt.Errorf("invalid image reference %q: %w", imageName, err)
+	}
+	expected, ok := named.(reference.Digested)
+	if !ok {
+		return fmt.Errorf("image reference %q does not contain a digest", imageName)
+	}
+	for _, repoDigest := range repoDigests {
+		actualNamed, err := reference.ParseNormalizedNamed(repoDigest)
+		if err != nil {
+			continue
+		}
+		actual, ok := actualNamed.(reference.Digested)
+		if ok && actual.Digest() == expected.Digest() {
+			return nil
+		}
+	}
+	return fmt.Errorf("pulled image does not advertise requested digest %s", expected.Digest())
 }
 
 func containerMemoryBytes(c *Container, cfg *Config) int64 {

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -58,6 +58,32 @@ func TestParseGPUs(t *testing.T) {
 	}
 }
 
+func TestVerifyPulledImageDigest(t *testing.T) {
+	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	for _, test := range []struct {
+		name        string
+		image       string
+		repoDigests []string
+		wantErr     bool
+	}{
+		{name: "matching repository", image: "example.com/team/app@" + digest, repoDigests: []string{"example.com/team/app@" + digest}},
+		{name: "matching canonical digest", image: "app@" + digest, repoDigests: []string{"docker.io/library/app@" + digest}},
+		{name: "missing digest", image: "example.com/team/app:latest", repoDigests: []string{"example.com/team/app@" + digest}, wantErr: true},
+		{name: "mismatch", image: "example.com/team/app@" + digest, repoDigests: []string{"example.com/team/app@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}, wantErr: true},
+		{name: "empty inspect result", image: "example.com/team/app@" + digest, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := verifyPulledImageDigest(test.image, test.repoDigests)
+			if test.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestBuildEnv(t *testing.T) {
 	ext := &shimconfig.ExternalConfig{
 		Env:     map[string]string{"DOMAIN": "test.example.com", "PORT": "8080"},

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/distribution/reference"
+
 	"tinfoil/internal/containernet"
 	"tinfoil/internal/device"
 )
@@ -98,6 +100,9 @@ func validateContainer(index int, container *Container, availableGPUs int, debug
 	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
 		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
 	}
+	if err := validateContainerImage(index, container.Image); err != nil {
+		return err
+	}
 	if err := validateContainerPolicy(index, container, availableGPUs, debug); err != nil {
 		return err
 	}
@@ -129,6 +134,20 @@ func validateContainer(index int, container *Container, availableGPUs int, debug
 		if !validEnvironmentName(secret) {
 			return fmt.Errorf("containers[%d].secrets[%d] has invalid environment name %q", index, secretIndex, secret)
 		}
+	}
+	return nil
+}
+
+func validateContainerImage(index int, image string) error {
+	if image == "" {
+		return fmt.Errorf("containers[%d].image is required", index)
+	}
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return fmt.Errorf("containers[%d].image %q is invalid: %w", index, image, err)
+	}
+	if _, ok := named.(reference.Digested); !ok {
+		return fmt.Errorf("containers[%d].image %q must include an immutable digest", index, image)
 	}
 	return nil
 }

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -30,7 +30,7 @@ networks:
     egress: closed
 containers:
   - name: app
-    image: example/app:latest
+    image: example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     networks: [app]
 `
 
@@ -43,10 +43,12 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 	}{
 		{name: "valid", yaml: validConfig},
 		{name: "unknown field", yaml: validConfig + "unknown: true\n", want: "field unknown not found"},
-		{name: "unknown container field", yaml: strings.Replace(validConfig, "image: example/app:latest", "image: example/app:latest\n    typo: true", 1), want: "unknown container field"},
-		{name: "duplicate container field", yaml: strings.Replace(validConfig, "image: example/app:latest", "image: example/app:latest\n    image: duplicate", 1), want: "duplicate container field"},
-		{name: "container merge key", yaml: "defaults: &defaults\n  image: example/app:latest\n" + strings.Replace(validConfig, "image: example/app:latest", "<<: *defaults", 1), want: "merge keys are unsupported"},
-		{name: "duplicate container", yaml: strings.Replace(validConfig, "containers:\n", "containers:\n  - name: app\n    image: duplicate\n", 1), want: "duplicates"},
+		{name: "unknown container field", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    typo: true", 1), want: "unknown container field"},
+		{name: "duplicate container field", yaml: strings.Replace(validConfig, "networks: [app]", "image: duplicate\n    networks: [app]", 1), want: "duplicate container field"},
+		{name: "container merge key", yaml: "defaults: &defaults\n  image: example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" + strings.Replace(validConfig, "    image: example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "    <<: *defaults", 1), want: "merge keys are unsupported"},
+		{name: "duplicate container", yaml: strings.Replace(validConfig, "containers:\n", "containers:\n  - name: app\n    image: example.com/duplicate@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n", 1), want: "duplicates"},
+		{name: "mutable image", yaml: strings.Replace(validConfig, "example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "example.com/app:latest", 1), want: "immutable digest"},
+		{name: "debug mutable image", debug: true, yaml: strings.Replace(validConfig, "example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "example.com/app:latest", 1), want: "immutable digest"},
 		{name: "undeclared network", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [missing]", 1), want: "not declared"},
 		{name: "production docker socket", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [/run/docker.sock:/var/run/docker.sock]", 1), want: "named volume"},
 		{name: "debug toolbox socket", debug: true, yaml: strings.Replace(validConfig, "name: app\n    image", fmt.Sprintf("name: %s\n    volumes: [/run/docker.sock:/var/run/docker.sock]\n    image", ReservedDebugContainerName), 1)},


### PR DESCRIPTION
## Summary
- require digest-bearing image references in every mode
- verify the requested digest against Docker's inspected repository digests after pull
- reject mutable tag-only references in measured debug mode as well as production

## Compatibility
All container image references, including debug configurations, must use immutable OCI digests.

## Validation
- `GOTOOLCHAIN=go1.26.5 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.5 go vet ./...`

## Merge Order
Position 2 of 9. Predecessor: #322. Successor: #324.
Full order: #322 → #323 → #324 → #325 → #326 → #327 → #328 → #329 → #330.