### PR TITLE
Enforce effective OCI container policy

### DIFF
--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -54,3 +54,13 @@ including in measured debug mode. The container manager pulls that exact
 reference and verifies Docker's inspected repository digests before creating
 the container; mutable tag-only references are always rejected during
 configuration validation.
+
+Images used in production must not define Docker health checks, volumes, or
+NVIDIA control environment variables. The container manager disables inherited
+health checks when no measured health check is configured, overwrites NVIDIA
+visibility and capability variables with its measured values, and inspects each
+newly created container before start. Any effective privileged mode, namespace,
+runtime, device, capability, security-option, volume, health-check, or NVIDIA
+environment value that differs from the measured request causes the stopped
+container to be removed. Health-check output is not copied into boot status or
+the host console; only the exit status is reported.

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"log"
 	"net/netip"
+	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/distribution/reference"
 	dockerconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/go-units"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
 	dockernetwork "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
@@ -353,9 +356,6 @@ func lastHealthLog(h *container.Health) string {
 		return ""
 	}
 	last := h.Log[len(h.Log)-1]
-	if last.Output != "" {
-		return last.Output
-	}
 	return fmt.Sprintf("exit %d", last.ExitCode)
 }
 
@@ -407,6 +407,15 @@ func createAndStartContainer(ctx context.Context, cli *client.Client, c Containe
 	if err != nil {
 		return fmt.Errorf("creating container: %w", err)
 	}
+	inspect, err := cli.ContainerInspect(ctx, resp.ID, client.ContainerInspectOptions{})
+	if err != nil {
+		_ = removeRejectedContainer(ctx, cli, resp.ID)
+		return fmt.Errorf("inspecting created container: %w", err)
+	}
+	if err := verifyCreatedContainerPolicy(containerConfig, hostConfig, inspect.Container); err != nil {
+		cleanupErr := removeRejectedContainer(ctx, cli, resp.ID)
+		return fmt.Errorf("created container violates runtime policy: %w", errors.Join(err, cleanupErr))
+	}
 
 	for _, n := range rest {
 		ep := endpointSettings(n, gatewayPriorityForNetwork(cfg, n))
@@ -433,6 +442,8 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 
 	// Build environment variables
 	env := buildEnv(c.Env, c.Secrets, extConfig)
+	env = setEnvironmentValue(env, "NVIDIA_VISIBLE_DEVICES", "none")
+	env = setEnvironmentValue(env, "NVIDIA_DRIVER_CAPABILITIES", "compute,utility")
 
 	// Container configuration
 	containerConfig := &container.Config{
@@ -455,6 +466,8 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 			Retries:     c.Healthcheck.Retries,
 			StartPeriod: parseDuration(c.Healthcheck.StartPeriod),
 		}
+	} else {
+		containerConfig.Healthcheck = &container.HealthConfig{Test: []string{"NONE"}}
 	}
 
 	pidsLimit := c.PidsLimit
@@ -541,6 +554,53 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 	return containerConfig, hostConfig, networkingConfig, rest, nil
 }
 
+func removeRejectedContainer(ctx context.Context, cli *client.Client, id string) error {
+	_, err := cli.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true, RemoveVolumes: true})
+	return err
+}
+
+func verifyCreatedContainerPolicy(expectedConfig *container.Config, expectedHost *container.HostConfig, actual container.InspectResponse) error {
+	if actual.Config == nil || actual.HostConfig == nil {
+		return errors.New("Docker inspect omitted container configuration")
+	}
+	if !reflect.DeepEqual(actual.Config.Healthcheck, expectedConfig.Healthcheck) {
+		return fmt.Errorf("effective healthcheck differs from measured request")
+	}
+	if len(actual.Config.Volumes) != 0 {
+		return fmt.Errorf("effective configuration contains image-defined volumes")
+	}
+	for _, key := range []string{"NVIDIA_VISIBLE_DEVICES", "NVIDIA_DRIVER_CAPABILITIES"} {
+		if environmentValue(actual.Config.Env, key) != environmentValue(expectedConfig.Env, key) {
+			return fmt.Errorf("effective %s differs from measured request", key)
+		}
+	}
+	if actual.HostConfig.Privileged {
+		return errors.New("effective configuration is privileged")
+	}
+	if actual.HostConfig.ReadonlyRootfs != expectedHost.ReadonlyRootfs {
+		return errors.New("effective read-only rootfs policy differs from measured request")
+	}
+	if actual.HostConfig.IpcMode != expectedHost.IpcMode || actual.HostConfig.PidMode != expectedHost.PidMode {
+		return errors.New("effective namespace policy differs from measured request")
+	}
+	if actual.HostConfig.Runtime != expectedHost.Runtime {
+		return errors.New("effective runtime differs from measured request")
+	}
+	if !reflect.DeepEqual(actual.HostConfig.Devices, expectedHost.Devices) {
+		return errors.New("effective host device mappings differ from measured request")
+	}
+	if !reflect.DeepEqual(actual.HostConfig.DeviceRequests, expectedHost.DeviceRequests) {
+		return errors.New("effective device requests differ from measured request")
+	}
+	if len(actual.HostConfig.CapDrop) != 1 || actual.HostConfig.CapDrop[0] != "ALL" {
+		return errors.New("effective capability drop is not ALL")
+	}
+	if !slices.Contains(actual.HostConfig.SecurityOpt, "no-new-privileges:true") {
+		return errors.New("effective configuration lacks no-new-privileges")
+	}
+	return nil
+}
+
 func gatewayPriorityForNetwork(cfg *Config, name string) int {
 	if cfg != nil && cfg.Networks[name] != nil && cfg.Networks[name].Egress != "closed" {
 		return openEgressGwPriority
@@ -625,6 +685,28 @@ func pullImage(ctx context.Context, cli *client.Client, imageName string) error 
 	if err := verifyPulledImageDigest(imageName, inspect.RepoDigests); err != nil {
 		return err
 	}
+	if err := validateImageMetadata(inspect.Config); err != nil {
+		return fmt.Errorf("image metadata violates runtime policy: %w", err)
+	}
+	return nil
+}
+
+func validateImageMetadata(config *dockerspec.DockerOCIImageConfig) error {
+	if config == nil {
+		return errors.New("image inspect omitted configuration")
+	}
+	if config.Healthcheck != nil {
+		return errors.New("image-defined healthchecks are unsupported")
+	}
+	if len(config.Volumes) != 0 {
+		return errors.New("image-defined volumes are unsupported")
+	}
+	for _, item := range config.Env {
+		key, _, _ := strings.Cut(item, "=")
+		if strings.HasPrefix(key, "NVIDIA_") {
+			return fmt.Errorf("image-defined NVIDIA environment variable %s is unsupported", key)
+		}
+	}
 	return nil
 }
 
@@ -660,6 +742,27 @@ func containerMemoryBytes(c *Container, cfg *Config) int64 {
 		return int64(cfg.Memory) * 1024 * 1024
 	}
 	return 0
+}
+
+func setEnvironmentValue(environment []string, key, value string) []string {
+	prefix := key + "="
+	filtered := environment[:0]
+	for _, item := range environment {
+		if !strings.HasPrefix(item, prefix) {
+			filtered = append(filtered, item)
+		}
+	}
+	return append(filtered, prefix+value)
+}
+
+func environmentValue(environment []string, key string) string {
+	prefix := key + "="
+	for index := len(environment) - 1; index >= 0; index-- {
+		if strings.HasPrefix(environment[index], prefix) {
+			return strings.TrimPrefix(environment[index], prefix)
+		}
+	}
+	return ""
 }
 
 // buildEnv parses env entries and secrets from external config

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 	"time"
 
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
 	dockernetwork "github.com/moby/moby/api/types/network"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/containernet"
@@ -268,4 +270,122 @@ func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testi
 			t.Fatalf("Devices = %v, want no synthesized serial device in production", hostConfig.Devices)
 		}
 	}
+}
+
+func TestValidateImageMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *dockerspec.DockerOCIImageConfig
+		wantErr bool
+	}{
+		{name: "clean", config: &dockerspec.DockerOCIImageConfig{}},
+		{name: "nil", config: nil, wantErr: true},
+		{name: "healthcheck", config: &dockerspec.DockerOCIImageConfig{DockerOCIImageConfigExt: dockerspec.DockerOCIImageConfigExt{Healthcheck: &dockerspec.HealthcheckConfig{Test: []string{"CMD", "true"}}}}, wantErr: true},
+		{name: "volume", config: &dockerspec.DockerOCIImageConfig{ImageConfig: ocispec.ImageConfig{Volumes: map[string]struct{}{`/data`: {}}}}, wantErr: true},
+		{name: "nvidia environment", config: &dockerspec.DockerOCIImageConfig{ImageConfig: ocispec.ImageConfig{Env: []string{"NVIDIA_VISIBLE_DEVICES=all"}}}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateImageMetadata(test.config)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validateImageMetadata() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildContainerCreateSpecNeutralizesImageControls(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{}}
+	containerConfig, _, _, _, err := buildContainerCreateSpec(Container{
+		Name:  "app",
+		Image: "example.invalid/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Env: []interface{}{
+			"NVIDIA_VISIBLE_DEVICES=all",
+			"NVIDIA_DRIVER_CAPABILITIES=all",
+		},
+	}, cfg, &shimconfig.ExternalConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildContainerCreateSpec: %v", err)
+	}
+	if got := containerConfig.Healthcheck.Test; !slices.Equal(got, []string{"NONE"}) {
+		t.Fatalf("Healthcheck.Test = %v, want [NONE]", got)
+	}
+	if got := environmentValue(containerConfig.Env, "NVIDIA_VISIBLE_DEVICES"); got != "none" {
+		t.Fatalf("NVIDIA_VISIBLE_DEVICES = %q, want none", got)
+	}
+	if got := environmentValue(containerConfig.Env, "NVIDIA_DRIVER_CAPABILITIES"); got != "compute,utility" {
+		t.Fatalf("NVIDIA_DRIVER_CAPABILITIES = %q, want compute,utility", got)
+	}
+}
+
+func TestVerifyCreatedContainerPolicy(t *testing.T) {
+	expectedConfig := &container.Config{
+		Env:         []string{"NVIDIA_VISIBLE_DEVICES=none", "NVIDIA_DRIVER_CAPABILITIES=compute,utility"},
+		Healthcheck: &container.HealthConfig{Test: []string{"NONE"}},
+	}
+	expectedHost := &container.HostConfig{
+		ReadonlyRootfs: true,
+		CapDrop:        []string{"ALL"},
+		SecurityOpt:    []string{"no-new-privileges:true"},
+	}
+	valid := func() container.InspectResponse {
+		return container.InspectResponse{
+			Config:     expectedConfig,
+			HostConfig: expectedHost,
+		}
+	}
+	if err := verifyCreatedContainerPolicy(expectedConfig, expectedHost, valid()); err != nil {
+		t.Fatalf("valid policy rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*container.InspectResponse)
+	}{
+		{name: "privileged", mutate: func(actual *container.InspectResponse) {
+			actual.HostConfig = cloneHostConfig(expectedHost)
+			actual.HostConfig.Privileged = true
+		}},
+		{name: "image volume", mutate: func(actual *container.InspectResponse) {
+			actual.Config = cloneContainerConfig(expectedConfig)
+			actual.Config.Volumes = map[string]struct{}{`/data`: {}}
+		}},
+		{name: "nvidia environment", mutate: func(actual *container.InspectResponse) {
+			actual.Config = cloneContainerConfig(expectedConfig)
+			actual.Config.Env[0] = "NVIDIA_VISIBLE_DEVICES=all"
+		}},
+		{name: "runtime", mutate: func(actual *container.InspectResponse) {
+			actual.HostConfig = cloneHostConfig(expectedHost)
+			actual.HostConfig.Runtime = "nvidia"
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := valid()
+			test.mutate(&actual)
+			if err := verifyCreatedContainerPolicy(expectedConfig, expectedHost, actual); err == nil {
+				t.Fatal("policy mismatch accepted")
+			}
+		})
+	}
+}
+
+func TestLastHealthLogRedactsOutput(t *testing.T) {
+	health := &container.Health{Log: []*container.HealthcheckResult{{ExitCode: 17, Output: "secret material"}}}
+	if got := lastHealthLog(health); got != "exit 17" {
+		t.Fatalf("lastHealthLog() = %q, want exit status only", got)
+	}
+}
+
+func cloneContainerConfig(config *container.Config) *container.Config {
+	clone := *config
+	clone.Env = slices.Clone(config.Env)
+	return &clone
+}
+
+func cloneHostConfig(config *container.HostConfig) *container.HostConfig {
+	clone := *config
+	clone.CapDrop = slices.Clone(config.CapDrop)
+	clone.SecurityOpt = slices.Clone(config.SecurityOpt)
+	return &clone
 }


### PR DESCRIPTION
## Summary
- reject image-defined health checks, volumes, and NVIDIA control environment variables
- explicitly disable inherited image health checks when none is configured
- inspect each newly created container before start and reject effective runtime state that differs from the measured request
- avoid publishing image-controlled health-check output into boot status or the host console

## Compatibility
Images must not define Docker `HEALTHCHECK`, `VOLUME`, or `NVIDIA_*` environment entries. Runtime policy is verified against Docker's effective created-container configuration before the container starts.

## Validation
- `GOTOOLCHAIN=go1.26.5 go test ./internal/containers -count=1`
- `GOTOOLCHAIN=go1.26.5 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.5 go vet ./...`

## Merge Order
Position 3 of 9. Predecessor: #323. Successor: #325.
Full order: #322 → #323 → #324 → #325 → #326 → #327 → #328 → #329 → #330.