### PR TITLE
Isolate container volumes and model mounts

### DIFF
--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -75,4 +75,7 @@ Production root filesystems remain read-only. Mutable storage uses Docker named
 volumes mounted only at `/data` or a clean path below it, with an explicit `ro`
 or `rw` mode when desired. A named volume can have at most one writable
 container owner; additional consumers must mount it read-only. Raw host bind
-sources remain reserved for the measured debug toolbox.
+sources supplied by workload configuration remain reserved for the measured
+debug toolbox; fixed public files and explicitly assigned verified models use
+first-party read-only binds. Configured tmpfs mounts are restricted to `/tmp`
+or a clean path below it.

--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -41,3 +41,10 @@ The measured daemon policy includes these mode `0644` files:
 The NVIDIA bootstrap publishes `/var/run/cdi/nvidia.yaml` atomically for the
 runtime's fixed `nvidia.com/gpu` CDI kind. Legacy, CSV, hook compatibility, and
 alternate OCI runtimes are not configured.
+
+Production container configuration is fail closed. Workloads cannot request
+host IPC, host PID namespaces, raw host devices, arbitrary containerd runtime
+aliases, or capability additions outside `IPC_LOCK`, `NET_BIND_SERVICE`, and
+`SYS_NICE`. The NVIDIA runtime requires an explicit GPU selection bounded by
+the attested top-level GPU count; boolean, zero, negative, duplicate, and
+out-of-range selections are rejected.

--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -54,3 +54,13 @@ containing an immutable digest. The container manager pulls that exact
 reference and verifies Docker's inspected repository digests before creating
 the container; mutable tag-only references are rejected during configuration
 validation.
+
+Images used in production must not define Docker health checks, volumes, or
+NVIDIA control environment variables. The container manager disables inherited
+health checks when no measured health check is configured, overwrites NVIDIA
+visibility and capability variables with its measured values, and inspects each
+newly created container before start. Any effective privileged mode, namespace,
+runtime, device, capability, security-option, volume, health-check, or NVIDIA
+environment value that differs from the measured request causes the stopped
+container to be removed. Health-check output is not copied into boot status or
+the host console; only the exit status is reported.

--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -48,3 +48,9 @@ aliases, or capability additions outside `IPC_LOCK`, `NET_BIND_SERVICE`, and
 `SYS_NICE`. The NVIDIA runtime requires an explicit GPU selection bounded by
 the attested top-level GPU count; boolean, zero, negative, duplicate, and
 out-of-range selections are rejected.
+
+Outside measured debug mode, every container image must be an OCI reference
+containing an immutable digest. The container manager pulls that exact
+reference and verifies Docker's inspected repository digests before creating
+the container; mutable tag-only references are rejected during configuration
+validation.

--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -64,3 +64,15 @@ runtime, device, capability, security-option, volume, health-check, or NVIDIA
 environment value that differs from the measured request causes the stopped
 container to be removed. Health-check output is not copied into boot status or
 the host console; only the exit status is reported.
+
+The public ramdisk is not mounted wholesale into workloads. Every container
+receives only the public configuration, attestation, and container-status files
+at their fixed `/tinfoil` paths. Model packs require an explicit container
+`models` assignment and only those verified model mount points are bound into
+that container, including the legacy `mpk` alias for the same selected pack.
+
+Production root filesystems remain read-only. Mutable storage uses Docker named
+volumes mounted only at `/data` or a clean path below it, with an explicit `ro`
+or `rw` mode when desired. A named volume can have at most one writable
+container owner; additional consumers must mount it read-only. Raw host bind
+sources remain reserved for the measured debug toolbox.

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -16,6 +16,7 @@ import (
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/device"
 	"tinfoil/internal/devicemapper"
+	"tinfoil/internal/runtimeconfig"
 )
 
 const (
@@ -181,40 +182,18 @@ const (
 )
 
 func modelPackRefForModel(model ModelSpec) (*modelPackRef, modelKind, error) {
-	refs := 0
-	if model.MPK != "" {
-		refs++
+	reference, err := runtimeconfig.ModelPackReference(model)
+	if err != nil {
+		return nil, "", err
 	}
-	if model.MWP != "" {
-		refs++
+	spec, err := parseModelPackRef(reference)
+	if err != nil {
+		return nil, "", err
 	}
 	if model.EMWP != "" {
-		refs++
+		return spec, modelKindEncrypted, nil
 	}
-	if refs != 1 {
-		return nil, "", fmt.Errorf("model %q must specify exactly one of mpk, mwp, or emwp", model.Name)
-	}
-
-	if model.MPK != "" {
-		spec, err := parseModelPackRef(model.MPK)
-		if err != nil {
-			return nil, "", fmt.Errorf("invalid legacy MPK format: %s: %w", model.MPK, err)
-		}
-		return spec, modelKindPlaintext, nil
-	}
-	if model.MWP != "" {
-		spec, err := parseModelPackRef(model.MWP)
-		if err != nil {
-			return nil, "", fmt.Errorf("invalid MWP format: %s: %w", model.MWP, err)
-		}
-		return spec, modelKindPlaintext, nil
-	}
-
-	spec, err := parseModelPackRef(model.EMWP)
-	if err != nil {
-		return nil, "", fmt.Errorf("invalid EMWP format: %s: %w", model.EMWP, err)
-	}
-	return spec, modelKindEncrypted, nil
+	return spec, modelKindPlaintext, nil
 }
 
 // modelPackRef wraps the shared artifact reference with cvmimage mount

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/creasty/defaults v1.8.0
+	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.6.2+incompatible
 	github.com/docker/go-units v0.5.0
 	github.com/go-acme/lego/v4 v4.35.2
@@ -33,7 +34,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker-credential-helpers v0.9.8 // indirect
 	github.com/docker/go-connections v0.8.1 // indirect
 	github.com/felixge/httpsnoop v1.1.0 // indirect

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -575,12 +575,9 @@ func selectedModelBinds(selected []string, models []ModelSpec) ([]string, error)
 		if !found {
 			return nil, fmt.Errorf("container references unknown model %q", name)
 		}
-		ref := model.MWP
-		if ref == "" {
-			ref = model.MPK
-		}
-		if ref == "" {
-			ref = model.EMWP
+		ref, err := runtimeconfig.ModelPackReference(model)
+		if err != nil {
+			return nil, err
 		}
 		parsed, err := modelwrap.ParseRef(ref)
 		if err != nil {

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"log"
 	"net/netip"
+	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -17,6 +19,7 @@ import (
 	"github.com/distribution/reference"
 	dockerconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/go-units"
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
 	dockernetwork "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
@@ -353,9 +356,6 @@ func lastHealthLog(h *container.Health) string {
 		return ""
 	}
 	last := h.Log[len(h.Log)-1]
-	if last.Output != "" {
-		return last.Output
-	}
 	return fmt.Sprintf("exit %d", last.ExitCode)
 }
 
@@ -407,6 +407,15 @@ func createAndStartContainer(ctx context.Context, cli *client.Client, c Containe
 	if err != nil {
 		return fmt.Errorf("creating container: %w", err)
 	}
+	inspect, err := cli.ContainerInspect(ctx, resp.ID, client.ContainerInspectOptions{})
+	if err != nil {
+		_ = removeRejectedContainer(ctx, cli, resp.ID)
+		return fmt.Errorf("inspecting created container: %w", err)
+	}
+	if err := verifyCreatedContainerPolicy(containerConfig, hostConfig, inspect.Container); err != nil {
+		cleanupErr := removeRejectedContainer(ctx, cli, resp.ID)
+		return fmt.Errorf("created container violates runtime policy: %w", errors.Join(err, cleanupErr))
+	}
 
 	for _, n := range rest {
 		ep := endpointSettings(n, gatewayPriorityForNetwork(cfg, n))
@@ -433,6 +442,8 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 
 	// Build environment variables
 	env := buildEnv(c.Env, c.Secrets, extConfig)
+	env = setEnvironmentValue(env, "NVIDIA_VISIBLE_DEVICES", "none")
+	env = setEnvironmentValue(env, "NVIDIA_DRIVER_CAPABILITIES", "compute,utility")
 
 	// Container configuration
 	containerConfig := &container.Config{
@@ -455,6 +466,8 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 			Retries:     c.Healthcheck.Retries,
 			StartPeriod: parseDuration(c.Healthcheck.StartPeriod),
 		}
+	} else {
+		containerConfig.Healthcheck = &container.HealthConfig{Test: []string{"NONE"}}
 	}
 
 	pidsLimit := c.PidsLimit
@@ -541,6 +554,53 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 	return containerConfig, hostConfig, networkingConfig, rest, nil
 }
 
+func removeRejectedContainer(ctx context.Context, cli *client.Client, id string) error {
+	_, err := cli.ContainerRemove(ctx, id, client.ContainerRemoveOptions{Force: true, RemoveVolumes: true})
+	return err
+}
+
+func verifyCreatedContainerPolicy(expectedConfig *container.Config, expectedHost *container.HostConfig, actual container.InspectResponse) error {
+	if actual.Config == nil || actual.HostConfig == nil {
+		return errors.New("Docker inspect omitted container configuration")
+	}
+	if !reflect.DeepEqual(actual.Config.Healthcheck, expectedConfig.Healthcheck) {
+		return fmt.Errorf("effective healthcheck differs from measured request")
+	}
+	if len(actual.Config.Volumes) != 0 {
+		return fmt.Errorf("effective configuration contains image-defined volumes")
+	}
+	for _, key := range []string{"NVIDIA_VISIBLE_DEVICES", "NVIDIA_DRIVER_CAPABILITIES"} {
+		if environmentValue(actual.Config.Env, key) != environmentValue(expectedConfig.Env, key) {
+			return fmt.Errorf("effective %s differs from measured request", key)
+		}
+	}
+	if actual.HostConfig.Privileged {
+		return errors.New("effective configuration is privileged")
+	}
+	if actual.HostConfig.ReadonlyRootfs != expectedHost.ReadonlyRootfs {
+		return errors.New("effective read-only rootfs policy differs from measured request")
+	}
+	if actual.HostConfig.IpcMode != expectedHost.IpcMode || actual.HostConfig.PidMode != expectedHost.PidMode {
+		return errors.New("effective namespace policy differs from measured request")
+	}
+	if actual.HostConfig.Runtime != expectedHost.Runtime {
+		return errors.New("effective runtime differs from measured request")
+	}
+	if !reflect.DeepEqual(actual.HostConfig.Devices, expectedHost.Devices) {
+		return errors.New("effective host device mappings differ from measured request")
+	}
+	if !reflect.DeepEqual(actual.HostConfig.DeviceRequests, expectedHost.DeviceRequests) {
+		return errors.New("effective device requests differ from measured request")
+	}
+	if len(actual.HostConfig.CapDrop) != 1 || actual.HostConfig.CapDrop[0] != "ALL" {
+		return errors.New("effective capability drop is not ALL")
+	}
+	if !slices.Contains(actual.HostConfig.SecurityOpt, "no-new-privileges:true") {
+		return errors.New("effective configuration lacks no-new-privileges")
+	}
+	return nil
+}
+
 func gatewayPriorityForNetwork(cfg *Config, name string) int {
 	if cfg != nil && cfg.Networks[name] != nil && cfg.Networks[name].Egress != "closed" {
 		return openEgressGwPriority
@@ -625,6 +685,28 @@ func pullImage(ctx context.Context, cli *client.Client, imageName string, debug 
 	if err := verifyPulledImagePolicy(imageName, inspect.RepoDigests, debug); err != nil {
 		return err
 	}
+	if err := validateImageMetadata(inspect.Config); err != nil {
+		return fmt.Errorf("image metadata violates runtime policy: %w", err)
+	}
+	return nil
+}
+
+func validateImageMetadata(config *dockerspec.DockerOCIImageConfig) error {
+	if config == nil {
+		return errors.New("image inspect omitted configuration")
+	}
+	if config.Healthcheck != nil {
+		return errors.New("image-defined healthchecks are unsupported")
+	}
+	if len(config.Volumes) != 0 {
+		return errors.New("image-defined volumes are unsupported")
+	}
+	for _, item := range config.Env {
+		key, _, _ := strings.Cut(item, "=")
+		if strings.HasPrefix(key, "NVIDIA_") {
+			return fmt.Errorf("image-defined NVIDIA environment variable %s is unsupported", key)
+		}
+	}
 	return nil
 }
 
@@ -667,6 +749,27 @@ func containerMemoryBytes(c *Container, cfg *Config) int64 {
 		return int64(cfg.Memory) * 1024 * 1024
 	}
 	return 0
+}
+
+func setEnvironmentValue(environment []string, key, value string) []string {
+	prefix := key + "="
+	filtered := environment[:0]
+	for _, item := range environment {
+		if !strings.HasPrefix(item, prefix) {
+			filtered = append(filtered, item)
+		}
+	}
+	return append(filtered, prefix+value)
+}
+
+func environmentValue(environment []string, key string) string {
+	prefix := key + "="
+	for index := len(environment) - 1; index >= 0; index-- {
+		if strings.HasPrefix(environment[index], prefix) {
+			return strings.TrimPrefix(environment[index], prefix)
+		}
+	}
+	return ""
 }
 
 // buildEnv parses env entries and secrets from external config

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	cerrdefs "github.com/containerd/errdefs"
+	"github.com/distribution/reference"
 	dockerconfig "github.com/docker/cli/cli/config"
 	"github.com/docker/go-units"
 	"github.com/moby/moby/api/types/container"
@@ -617,7 +618,36 @@ func pullImage(ctx context.Context, cli *client.Client, imageName string) error 
 			return fmt.Errorf("docker pull failed: %s", msg.Error)
 		}
 	}
+	inspect, err := cli.ImageInspect(ctx, imageName)
+	if err != nil {
+		return fmt.Errorf("inspect pulled image: %w", err)
+	}
+	if err := verifyPulledImageDigest(imageName, inspect.RepoDigests); err != nil {
+		return err
+	}
 	return nil
+}
+
+func verifyPulledImageDigest(imageName string, repoDigests []string) error {
+	named, err := reference.ParseNormalizedNamed(imageName)
+	if err != nil {
+		return fmt.Errorf("invalid image reference %q: %w", imageName, err)
+	}
+	expected, ok := named.(reference.Digested)
+	if !ok {
+		return fmt.Errorf("image reference %q does not contain a digest", imageName)
+	}
+	for _, repoDigest := range repoDigests {
+		actualNamed, err := reference.ParseNormalizedNamed(repoDigest)
+		if err != nil {
+			continue
+		}
+		actual, ok := actualNamed.(reference.Digested)
+		if ok && actual.Digest() == expected.Digest() {
+			return nil
+		}
+	}
+	return fmt.Errorf("pulled image does not advertise requested digest %s", expected.Digest())
 }
 
 func containerMemoryBytes(c *Container, cfg *Config) int64 {

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -264,7 +264,7 @@ func runContainer(
 	// Pull
 	pullStart := time.Now()
 	log.Printf("Pulling image %s (%s)", c.Name, c.Image)
-	if err := pullImage(ctx, cli, c.Image); err != nil {
+	if err := pullImage(ctx, cli, c.Image, debug); err != nil {
 		detail := fmt.Sprintf("pulling image: %v", err)
 		record("pull", boot.StatusFailed, time.Since(pullStart), detail)
 		finish(boot.StatusFailed, detail)
@@ -579,7 +579,7 @@ func endpointSettings(name string, gwPriority int) *dockernetwork.EndpointSettin
 }
 
 // pullImage pulls an image using the Docker SDK with auth from Docker config
-func pullImage(ctx context.Context, cli *client.Client, imageName string) error {
+func pullImage(ctx context.Context, cli *client.Client, imageName string, debug bool) error {
 	opts := client.ImagePullOptions{}
 
 	// Extract registry host and get auth
@@ -622,10 +622,17 @@ func pullImage(ctx context.Context, cli *client.Client, imageName string) error 
 	if err != nil {
 		return fmt.Errorf("inspect pulled image: %w", err)
 	}
-	if err := verifyPulledImageDigest(imageName, inspect.RepoDigests); err != nil {
+	if err := verifyPulledImagePolicy(imageName, inspect.RepoDigests, debug); err != nil {
 		return err
 	}
 	return nil
+}
+
+func verifyPulledImagePolicy(imageName string, repoDigests []string, debug bool) error {
+	if debug {
+		return nil
+	}
+	return verifyPulledImageDigest(imageName, repoDigests)
 }
 
 func verifyPulledImageDigest(imageName string, repoDigests []string) error {

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -23,6 +23,7 @@ import (
 	"github.com/moby/moby/api/types/container"
 	dockernetwork "github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/client"
+	"github.com/tinfoilsh/modelwrap"
 
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
@@ -488,7 +489,11 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 		SecurityOpt:    []string{"no-new-privileges:true"},
 		ReadonlyRootfs: c.ReadOnly == nil || *c.ReadOnly,
 		Tmpfs:          c.Tmpfs,
-		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
+		Binds: []string{
+			boot.ConfigPath + ":/tinfoil/config.yml:ro",
+			boot.AttestationPath + ":/tinfoil/attestation.json:ro",
+			boot.ContainerStatusPath + ":/tinfoil/container-status.json:ro",
+		},
 	}
 	hostConfig.Resources.PidsLimit = pidsLimit
 	if first == "" {
@@ -530,6 +535,11 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 	for _, vol := range c.Volumes {
 		hostConfig.Binds = append(hostConfig.Binds, vol)
 	}
+	modelBinds, err := selectedModelBinds(c.Models, cfg.Models)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	hostConfig.Binds = append(hostConfig.Binds, modelBinds...)
 
 	if reservedDebugRuntime {
 		applyReservedDebugRuntime(containerConfig, hostConfig)
@@ -552,6 +562,37 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 	}
 
 	return containerConfig, hostConfig, networkingConfig, rest, nil
+}
+
+func selectedModelBinds(selected []string, models []ModelSpec) ([]string, error) {
+	byName := make(map[string]ModelSpec, len(models))
+	for _, model := range models {
+		byName[model.Name] = model
+	}
+	binds := make([]string, 0, len(selected)*2)
+	for _, name := range selected {
+		model, found := byName[name]
+		if !found {
+			return nil, fmt.Errorf("container references unknown model %q", name)
+		}
+		ref := model.MWP
+		if ref == "" {
+			ref = model.MPK
+		}
+		if ref == "" {
+			ref = model.EMWP
+		}
+		parsed, err := modelwrap.ParseRef(ref)
+		if err != nil {
+			return nil, fmt.Errorf("parsing model %q reference: %w", name, err)
+		}
+		hostPath := boot.MWPDir + "/mwp-" + parsed.RootHash
+		binds = append(binds,
+			hostPath+":/tinfoil/mwp/mwp-"+parsed.RootHash+":ro",
+			hostPath+":/tinfoil/mpk/mpk-"+parsed.RootHash+":ro",
+		)
+	}
+	return binds, nil
 }
 
 func removeRejectedContainer(ctx context.Context, cli *client.Client, id string) error {
@@ -591,6 +632,9 @@ func verifyCreatedContainerPolicy(expectedConfig *container.Config, expectedHost
 	}
 	if !reflect.DeepEqual(actual.HostConfig.DeviceRequests, expectedHost.DeviceRequests) {
 		return errors.New("effective device requests differ from measured request")
+	}
+	if !reflect.DeepEqual(actual.HostConfig.Binds, expectedHost.Binds) {
+		return errors.New("effective bind mounts differ from measured request")
 	}
 	if len(actual.HostConfig.CapDrop) != 1 || actual.HostConfig.CapDrop[0] != "ALL" {
 		return errors.New("effective capability drop is not ALL")

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -2,6 +2,7 @@ package containers
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	dockernetwork "github.com/moby/moby/api/types/network"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/containernet"
 )
@@ -397,4 +399,43 @@ func cloneHostConfig(config *container.HostConfig) *container.HostConfig {
 	clone.CapDrop = slices.Clone(config.CapDrop)
 	clone.SecurityOpt = slices.Clone(config.SecurityOpt)
 	return &clone
+}
+
+func TestBuildContainerCreateSpecMountsOnlyAssignedModels(t *testing.T) {
+	const rootHash = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const modelRef = rootHash + "_4096_0eefa619-50b7-588f-a072-d405fb439d36"
+	cfg := &Config{
+		Networks: map[string]*NetworkSpec{},
+		Models: []ModelSpec{
+			{Name: "assigned", Repo: "org/assigned@v1", MWP: modelRef},
+			{Name: "other", Repo: "org/other@v1", MWP: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb_4096_0eefa619-50b7-588f-a072-d405fb439d36"},
+		},
+	}
+	_, hostConfig, _, _, err := buildContainerCreateSpec(Container{
+		Name:   "app",
+		Image:  "example.invalid/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Models: []string{"assigned"},
+	}, cfg, &shimconfig.ExternalConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildContainerCreateSpec: %v", err)
+	}
+	if slices.Contains(hostConfig.Binds, boot.PublicDir+":/tinfoil:ro") {
+		t.Fatalf("broad public ramdisk bind remains: %v", hostConfig.Binds)
+	}
+	for _, bind := range []string{
+		boot.ConfigPath + ":/tinfoil/config.yml:ro",
+		boot.AttestationPath + ":/tinfoil/attestation.json:ro",
+		boot.ContainerStatusPath + ":/tinfoil/container-status.json:ro",
+		boot.MWPDir + "/mwp-" + rootHash + ":/tinfoil/mwp/mwp-" + rootHash + ":ro",
+		boot.MWPDir + "/mwp-" + rootHash + ":/tinfoil/mpk/mpk-" + rootHash + ":ro",
+	} {
+		if !slices.Contains(hostConfig.Binds, bind) {
+			t.Fatalf("Binds = %v, missing %q", hostConfig.Binds, bind)
+		}
+	}
+	for _, bind := range hostConfig.Binds {
+		if strings.Contains(bind, strings.Repeat("b", 64)) {
+			t.Fatalf("unassigned model exposed through %q", bind)
+		}
+	}
 }

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -84,6 +84,15 @@ func TestVerifyPulledImageDigest(t *testing.T) {
 	}
 }
 
+func TestVerifyPulledImagePolicyAllowsDebugTags(t *testing.T) {
+	if err := verifyPulledImagePolicy("example.com/team/app:latest", nil, true); err != nil {
+		t.Fatalf("debug tag rejected: %v", err)
+	}
+	if err := verifyPulledImagePolicy("example.com/team/app:latest", nil, false); err == nil {
+		t.Fatal("production tag accepted")
+	}
+}
+
 func TestBuildEnv(t *testing.T) {
 	ext := &shimconfig.ExternalConfig{
 		Env:     map[string]string{"DOMAIN": "test.example.com", "PORT": "8080"},

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 	"time"
 
+	dockerspec "github.com/moby/docker-image-spec/specs-go/v1"
 	"github.com/moby/moby/api/types/container"
 	dockernetwork "github.com/moby/moby/api/types/network"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/containernet"
@@ -277,4 +279,122 @@ func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testi
 			t.Fatalf("Devices = %v, want no synthesized serial device in production", hostConfig.Devices)
 		}
 	}
+}
+
+func TestValidateImageMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  *dockerspec.DockerOCIImageConfig
+		wantErr bool
+	}{
+		{name: "clean", config: &dockerspec.DockerOCIImageConfig{}},
+		{name: "nil", config: nil, wantErr: true},
+		{name: "healthcheck", config: &dockerspec.DockerOCIImageConfig{DockerOCIImageConfigExt: dockerspec.DockerOCIImageConfigExt{Healthcheck: &dockerspec.HealthcheckConfig{Test: []string{"CMD", "true"}}}}, wantErr: true},
+		{name: "volume", config: &dockerspec.DockerOCIImageConfig{ImageConfig: ocispec.ImageConfig{Volumes: map[string]struct{}{`/data`: {}}}}, wantErr: true},
+		{name: "nvidia environment", config: &dockerspec.DockerOCIImageConfig{ImageConfig: ocispec.ImageConfig{Env: []string{"NVIDIA_VISIBLE_DEVICES=all"}}}, wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateImageMetadata(test.config)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("validateImageMetadata() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuildContainerCreateSpecNeutralizesImageControls(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{}}
+	containerConfig, _, _, _, err := buildContainerCreateSpec(Container{
+		Name:  "app",
+		Image: "example.invalid/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Env: []interface{}{
+			"NVIDIA_VISIBLE_DEVICES=all",
+			"NVIDIA_DRIVER_CAPABILITIES=all",
+		},
+	}, cfg, &shimconfig.ExternalConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildContainerCreateSpec: %v", err)
+	}
+	if got := containerConfig.Healthcheck.Test; !slices.Equal(got, []string{"NONE"}) {
+		t.Fatalf("Healthcheck.Test = %v, want [NONE]", got)
+	}
+	if got := environmentValue(containerConfig.Env, "NVIDIA_VISIBLE_DEVICES"); got != "none" {
+		t.Fatalf("NVIDIA_VISIBLE_DEVICES = %q, want none", got)
+	}
+	if got := environmentValue(containerConfig.Env, "NVIDIA_DRIVER_CAPABILITIES"); got != "compute,utility" {
+		t.Fatalf("NVIDIA_DRIVER_CAPABILITIES = %q, want compute,utility", got)
+	}
+}
+
+func TestVerifyCreatedContainerPolicy(t *testing.T) {
+	expectedConfig := &container.Config{
+		Env:         []string{"NVIDIA_VISIBLE_DEVICES=none", "NVIDIA_DRIVER_CAPABILITIES=compute,utility"},
+		Healthcheck: &container.HealthConfig{Test: []string{"NONE"}},
+	}
+	expectedHost := &container.HostConfig{
+		ReadonlyRootfs: true,
+		CapDrop:        []string{"ALL"},
+		SecurityOpt:    []string{"no-new-privileges:true"},
+	}
+	valid := func() container.InspectResponse {
+		return container.InspectResponse{
+			Config:     expectedConfig,
+			HostConfig: expectedHost,
+		}
+	}
+	if err := verifyCreatedContainerPolicy(expectedConfig, expectedHost, valid()); err != nil {
+		t.Fatalf("valid policy rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*container.InspectResponse)
+	}{
+		{name: "privileged", mutate: func(actual *container.InspectResponse) {
+			actual.HostConfig = cloneHostConfig(expectedHost)
+			actual.HostConfig.Privileged = true
+		}},
+		{name: "image volume", mutate: func(actual *container.InspectResponse) {
+			actual.Config = cloneContainerConfig(expectedConfig)
+			actual.Config.Volumes = map[string]struct{}{`/data`: {}}
+		}},
+		{name: "nvidia environment", mutate: func(actual *container.InspectResponse) {
+			actual.Config = cloneContainerConfig(expectedConfig)
+			actual.Config.Env[0] = "NVIDIA_VISIBLE_DEVICES=all"
+		}},
+		{name: "runtime", mutate: func(actual *container.InspectResponse) {
+			actual.HostConfig = cloneHostConfig(expectedHost)
+			actual.HostConfig.Runtime = "nvidia"
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := valid()
+			test.mutate(&actual)
+			if err := verifyCreatedContainerPolicy(expectedConfig, expectedHost, actual); err == nil {
+				t.Fatal("policy mismatch accepted")
+			}
+		})
+	}
+}
+
+func TestLastHealthLogRedactsOutput(t *testing.T) {
+	health := &container.Health{Log: []*container.HealthcheckResult{{ExitCode: 17, Output: "secret material"}}}
+	if got := lastHealthLog(health); got != "exit 17" {
+		t.Fatalf("lastHealthLog() = %q, want exit status only", got)
+	}
+}
+
+func cloneContainerConfig(config *container.Config) *container.Config {
+	clone := *config
+	clone.Env = slices.Clone(config.Env)
+	return &clone
+}
+
+func cloneHostConfig(config *container.HostConfig) *container.HostConfig {
+	clone := *config
+	clone.CapDrop = slices.Clone(config.CapDrop)
+	clone.SecurityOpt = slices.Clone(config.SecurityOpt)
+	return &clone
 }

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -58,6 +58,32 @@ func TestParseGPUs(t *testing.T) {
 	}
 }
 
+func TestVerifyPulledImageDigest(t *testing.T) {
+	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	for _, test := range []struct {
+		name        string
+		image       string
+		repoDigests []string
+		wantErr     bool
+	}{
+		{name: "matching repository", image: "example.com/team/app@" + digest, repoDigests: []string{"example.com/team/app@" + digest}},
+		{name: "matching canonical digest", image: "app@" + digest, repoDigests: []string{"docker.io/library/app@" + digest}},
+		{name: "missing digest", image: "example.com/team/app:latest", repoDigests: []string{"example.com/team/app@" + digest}, wantErr: true},
+		{name: "mismatch", image: "example.com/team/app@" + digest, repoDigests: []string{"example.com/team/app@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}, wantErr: true},
+		{name: "empty inspect result", image: "example.com/team/app@" + digest, wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := verifyPulledImageDigest(test.image, test.repoDigests)
+			if test.wantErr && err == nil {
+				t.Fatal("expected error")
+			}
+			if !test.wantErr && err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestBuildEnv(t *testing.T) {
 	ext := &shimconfig.ExternalConfig{
 		Env:     map[string]string{"DOMAIN": "test.example.com", "PORT": "8080"},

--- a/tinfoil/internal/runtimeconfig/types.go
+++ b/tinfoil/internal/runtimeconfig/types.go
@@ -93,6 +93,7 @@ type Container struct {
 	User        string            `yaml:"user,omitempty"`
 	Env         []interface{}     `yaml:"env,omitempty"`
 	Secrets     []string          `yaml:"secrets,omitempty"`
+	Models      []string          `yaml:"models,omitempty"`
 	Volumes     []string          `yaml:"volumes,omitempty"`
 	Devices     []string          `yaml:"devices,omitempty"`
 	CapAdd      []string          `yaml:"cap_add,omitempty"`
@@ -122,7 +123,7 @@ type containerInputFields struct {
 
 var containerFields = map[string]bool{
 	"name": true, "image": true, "command": true, "entrypoint": true,
-	"working_dir": true, "user": true, "env": true, "secrets": true,
+	"working_dir": true, "user": true, "env": true, "secrets": true, "models": true,
 	"volumes": true, "devices": true, "cap_add": true, "runtime": true,
 	"networks": true, "ipc": true, "pid": true, "gpus": true,
 	"shm_size": true, "memory": true, "cpus": true, "tmpfs": true,

--- a/tinfoil/internal/runtimeconfig/types.go
+++ b/tinfoil/internal/runtimeconfig/types.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/tinfoilsh/modelwrap"
 	"gopkg.in/yaml.v3"
 
 	shimconfig "tinfoil/internal/config"
@@ -82,6 +83,27 @@ type ModelSpec struct {
 	MWP       string `yaml:"mwp,omitempty"`
 	EMWP      string `yaml:"emwp,omitempty"`
 	KeySecret string `yaml:"key-secret,omitempty"`
+}
+
+func ModelPackReference(model ModelSpec) (string, error) {
+	references := []string{model.MPK, model.MWP, model.EMWP}
+	var selected string
+	for _, reference := range references {
+		if reference == "" {
+			continue
+		}
+		if selected != "" {
+			return "", fmt.Errorf("model %q must specify exactly one of mpk, mwp, or emwp", model.Name)
+		}
+		selected = reference
+	}
+	if selected == "" {
+		return "", fmt.Errorf("model %q must specify exactly one of mpk, mwp, or emwp", model.Name)
+	}
+	if _, err := modelwrap.ParseRef(selected); err != nil {
+		return "", fmt.Errorf("model %q has invalid pack reference: %w", model.Name, err)
+	}
+	return selected, nil
 }
 
 type Container struct {

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -3,6 +3,7 @@ package runtimeconfig
 import (
 	"fmt"
 	"net"
+	"path"
 	"regexp"
 	"slices"
 	"strings"
@@ -66,27 +67,38 @@ func validateShape(config *Config, debug bool) error {
 			return fmt.Errorf("networks.%s.allow exceeds limit %d", name, maxNetworkAllowEntries)
 		}
 	}
+	modelNames := make(map[string]int, len(config.Models))
+	for index, model := range config.Models {
+		if model.Name == "" {
+			return fmt.Errorf("models[%d].name must not be empty", index)
+		}
+		if prior, found := modelNames[model.Name]; found {
+			return fmt.Errorf("models[%d].name %q duplicates models[%d].name", index, model.Name, prior)
+		}
+		modelNames[model.Name] = index
+	}
 	seen := map[string]int{}
+	volumeWriters := map[string]int{}
 	for index := range config.Containers {
 		container := &config.Containers[index]
 		if prior, found := seen[container.Name]; found {
 			return fmt.Errorf("containers[%d].name %q duplicates containers[%d].name", index, container.Name, prior)
 		}
 		seen[container.Name] = index
-		if err := validateContainer(index, container, config.GPUs, debug); err != nil {
+		if err := validateContainer(index, container, config.GPUs, modelNames, volumeWriters, debug); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateContainer(index int, container *Container, availableGPUs int, debug bool) error {
+func validateContainer(index int, container *Container, availableGPUs int, modelNames map[string]int, volumeWriters map[string]int, debug bool) error {
 	lists := []struct {
 		name  string
 		count int
 	}{
 		{"command", len(container.Command)}, {"entrypoint", len(container.Entrypoint)}, {"env", len(container.Env)},
-		{"secrets", len(container.Secrets)}, {"volumes", len(container.Volumes)}, {"devices", len(container.Devices)},
+		{"secrets", len(container.Secrets)}, {"models", len(container.Models)}, {"volumes", len(container.Volumes)}, {"devices", len(container.Devices)},
 		{"cap_add", len(container.CapAdd)}, {"networks", len(container.Networks)},
 	}
 	for _, list := range lists {
@@ -103,7 +115,7 @@ func validateContainer(index int, container *Container, availableGPUs int, debug
 	if err := validateContainerImage(index, container.Image, debug); err != nil {
 		return err
 	}
-	if err := validateContainerPolicy(index, container, availableGPUs, debug); err != nil {
+	if err := validateContainerPolicy(index, container, availableGPUs, volumeWriters, debug); err != nil {
 		return err
 	}
 	for envIndex, item := range container.Env {
@@ -135,6 +147,16 @@ func validateContainer(index int, container *Container, availableGPUs int, debug
 			return fmt.Errorf("containers[%d].secrets[%d] has invalid environment name %q", index, secretIndex, secret)
 		}
 	}
+	seenModels := map[string]bool{}
+	for modelIndex, model := range container.Models {
+		if _, found := modelNames[model]; !found {
+			return fmt.Errorf("containers[%d].models[%d] references unknown model %q", index, modelIndex, model)
+		}
+		if seenModels[model] {
+			return fmt.Errorf("containers[%d].models[%d] duplicates model %q", index, modelIndex, model)
+		}
+		seenModels[model] = true
+	}
 	return nil
 }
 
@@ -155,7 +177,7 @@ func validateContainerImage(index int, image string, debug bool) error {
 	return nil
 }
 
-func validateContainerPolicy(index int, container *Container, availableGPUs int, debug bool) error {
+func validateContainerPolicy(index int, container *Container, availableGPUs int, volumeWriters map[string]int, debug bool) error {
 	if container.inputFields.privileged {
 		return fmt.Errorf("containers[%d].privileged is unsupported", index)
 	}
@@ -164,6 +186,9 @@ func validateContainerPolicy(index int, container *Container, availableGPUs int,
 	}
 	if container.inputFields.securityOpt {
 		return fmt.Errorf("containers[%d].security_opt is unsupported", index)
+	}
+	if container.ReadOnly != nil && !*container.ReadOnly && !ReservedDebugRuntimeEnabled(container.Name, debug) {
+		return fmt.Errorf("containers[%d].read_only must not disable the read-only root filesystem", index)
 	}
 	if container.PidMode != "" {
 		return fmt.Errorf("containers[%d].pid is unsupported", index)
@@ -190,9 +215,21 @@ func validateContainerPolicy(index int, container *Container, availableGPUs int,
 		if ReservedDebugRuntimeEnabled(container.Name, debug) && (volume == debugDockerSocketBind || volume == debugManagerSocketBind) {
 			continue
 		}
-		source, _, found := strings.Cut(volume, ":")
-		if !found || !validNamedVolume(source) {
-			return fmt.Errorf("containers[%d].volumes[%d] must use a named volume source", index, volumeIndex)
+		source, destination, writable, err := parseNamedVolume(volume)
+		if err != nil {
+			return fmt.Errorf("containers[%d].volumes[%d]: %w", index, volumeIndex, err)
+		}
+		if writable {
+			if prior, found := volumeWriters[source]; found {
+				return fmt.Errorf("containers[%d].volumes[%d] makes named volume %q writable after containers[%d]", index, volumeIndex, source, prior)
+			}
+			volumeWriters[source] = index
+		}
+		for priorIndex, prior := range container.Volumes[:volumeIndex] {
+			_, priorDestination, _, priorErr := parseNamedVolume(prior)
+			if priorErr == nil && priorDestination == destination {
+				return fmt.Errorf("containers[%d].volumes[%d] duplicates destination %q from volumes[%d]", index, volumeIndex, destination, priorIndex)
+			}
 		}
 	}
 	for capabilityIndex, capability := range container.CapAdd {
@@ -201,6 +238,25 @@ func validateContainerPolicy(index int, container *Container, availableGPUs int,
 		}
 	}
 	return nil
+}
+
+func parseNamedVolume(volume string) (source, destination string, writable bool, err error) {
+	parts := strings.Split(volume, ":")
+	if len(parts) < 2 || len(parts) > 3 || !validNamedVolume(parts[0]) {
+		return "", "", false, fmt.Errorf("must use source:destination[:ro|rw] with a named volume source")
+	}
+	destination = parts[1]
+	if destination != path.Clean(destination) || destination != "/data" && !strings.HasPrefix(destination, "/data/") {
+		return "", "", false, fmt.Errorf("destination %q must be /data or a clean path below /data", destination)
+	}
+	mode := "rw"
+	if len(parts) == 3 {
+		mode = parts[2]
+	}
+	if mode != "ro" && mode != "rw" {
+		return "", "", false, fmt.Errorf("mode %q must be ro or rw", mode)
+	}
+	return parts[0], destination, mode == "rw", nil
 }
 
 func validateGPUSelection(index int, selection interface{}, available int) error {

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -7,6 +7,8 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/distribution/reference"
+
 	"tinfoil/internal/containernet"
 	"tinfoil/internal/device"
 )
@@ -98,6 +100,9 @@ func validateContainer(index int, container *Container, availableGPUs int, debug
 	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
 		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
 	}
+	if err := validateContainerImage(index, container.Image, debug); err != nil {
+		return err
+	}
 	if err := validateContainerPolicy(index, container, availableGPUs, debug); err != nil {
 		return err
 	}
@@ -129,6 +134,23 @@ func validateContainer(index int, container *Container, availableGPUs int, debug
 		if !validEnvironmentName(secret) {
 			return fmt.Errorf("containers[%d].secrets[%d] has invalid environment name %q", index, secretIndex, secret)
 		}
+	}
+	return nil
+}
+
+func validateContainerImage(index int, image string, debug bool) error {
+	if image == "" {
+		return fmt.Errorf("containers[%d].image is required", index)
+	}
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return fmt.Errorf("containers[%d].image %q is invalid: %w", index, image, err)
+	}
+	if debug {
+		return nil
+	}
+	if _, ok := named.(reference.Digested); !ok {
+		return fmt.Errorf("containers[%d].image %q must include an immutable digest", index, image)
 	}
 	return nil
 }

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -71,14 +71,14 @@ func validateShape(config *Config, debug bool) error {
 			return fmt.Errorf("containers[%d].name %q duplicates containers[%d].name", index, container.Name, prior)
 		}
 		seen[container.Name] = index
-		if err := validateContainer(index, container, debug); err != nil {
+		if err := validateContainer(index, container, config.GPUs, debug); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateContainer(index int, container *Container, debug bool) error {
+func validateContainer(index int, container *Container, availableGPUs int, debug bool) error {
 	lists := []struct {
 		name  string
 		count int
@@ -98,7 +98,7 @@ func validateContainer(index int, container *Container, debug bool) error {
 	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
 		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
 	}
-	if err := validateContainerPolicy(index, container, debug); err != nil {
+	if err := validateContainerPolicy(index, container, availableGPUs, debug); err != nil {
 		return err
 	}
 	for envIndex, item := range container.Env {
@@ -133,7 +133,7 @@ func validateContainer(index int, container *Container, debug bool) error {
 	return nil
 }
 
-func validateContainerPolicy(index int, container *Container, debug bool) error {
+func validateContainerPolicy(index int, container *Container, availableGPUs int, debug bool) error {
 	if container.inputFields.privileged {
 		return fmt.Errorf("containers[%d].privileged is unsupported", index)
 	}
@@ -149,8 +149,20 @@ func validateContainerPolicy(index int, container *Container, debug bool) error 
 	if len(container.Devices) != 0 {
 		return fmt.Errorf("containers[%d].devices is unsupported", index)
 	}
-	if container.IPC != "" && container.IPC != "private" && container.IPC != "host" {
-		return fmt.Errorf("containers[%d].ipc must be private or host", index)
+	if container.IPC != "" && container.IPC != "private" && container.IPC != "none" {
+		return fmt.Errorf("containers[%d].ipc must be private or none", index)
+	}
+	if container.Runtime != "" && container.Runtime != "nvidia" {
+		return fmt.Errorf("containers[%d].runtime %q is unsupported", index, container.Runtime)
+	}
+	if err := validateGPUSelection(index, container.GPUs, availableGPUs); err != nil {
+		return err
+	}
+	if container.GPUs != nil && container.Runtime != "nvidia" {
+		return fmt.Errorf("containers[%d].gpus requires runtime: nvidia", index)
+	}
+	if container.Runtime == "nvidia" && container.GPUs == nil {
+		return fmt.Errorf("containers[%d].runtime nvidia requires an explicit gpus selection", index)
 	}
 	for volumeIndex, volume := range container.Volumes {
 		if ReservedDebugRuntimeEnabled(container.Name, debug) && (volume == debugDockerSocketBind || volume == debugManagerSocketBind) {
@@ -162,11 +174,54 @@ func validateContainerPolicy(index int, container *Container, debug bool) error 
 		}
 	}
 	for capabilityIndex, capability := range container.CapAdd {
-		if !slices.Contains([]string{"CHOWN", "DAC_OVERRIDE", "IPC_LOCK", "KILL", "NET_BIND_SERVICE", "SETGID", "SETUID", "SYS_NICE", "SYS_RESOURCE"}, capability) {
+		if !slices.Contains([]string{"IPC_LOCK", "NET_BIND_SERVICE", "SYS_NICE"}, capability) {
 			return fmt.Errorf("containers[%d].cap_add[%d] capability %q is unsupported", index, capabilityIndex, capability)
 		}
 	}
 	return nil
+}
+
+func validateGPUSelection(index int, selection interface{}, available int) error {
+	if selection == nil {
+		return nil
+	}
+	if available < 1 {
+		return fmt.Errorf("containers[%d].gpus is set but the configuration declares no GPUs", index)
+	}
+	switch value := selection.(type) {
+	case int:
+		if value < 1 || value > available {
+			return fmt.Errorf("containers[%d].gpus count must be between 1 and %d", index, available)
+		}
+		return nil
+	case string:
+		if value == "all" {
+			return nil
+		}
+		if value == "" {
+			return fmt.Errorf("containers[%d].gpus must not be empty", index)
+		}
+		seen := map[int]bool{}
+		for _, rawID := range strings.Split(value, ",") {
+			if rawID == "" || strings.TrimSpace(rawID) != rawID {
+				return fmt.Errorf("containers[%d].gpus contains an invalid device ID %q", index, rawID)
+			}
+			var id int
+			if _, err := fmt.Sscanf(rawID, "%d", &id); err != nil || fmt.Sprintf("%d", id) != rawID {
+				return fmt.Errorf("containers[%d].gpus contains an invalid device ID %q", index, rawID)
+			}
+			if id < 0 || id >= available {
+				return fmt.Errorf("containers[%d].gpus device ID %d is outside 0..%d", index, id, available-1)
+			}
+			if seen[id] {
+				return fmt.Errorf("containers[%d].gpus device ID %d is duplicated", index, id)
+			}
+			seen[id] = true
+		}
+		return nil
+	default:
+		return fmt.Errorf("containers[%d].gpus must be a positive count, all, or a comma-separated device list", index)
+	}
 }
 
 func validateNetwork(config *Config) error {

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -75,6 +75,9 @@ func validateShape(config *Config, debug bool) error {
 		if prior, found := modelNames[model.Name]; found {
 			return fmt.Errorf("models[%d].name %q duplicates models[%d].name", index, model.Name, prior)
 		}
+		if _, err := ModelPackReference(model); err != nil {
+			return fmt.Errorf("models[%d]: %w", index, err)
+		}
 		modelNames[model.Name] = index
 	}
 	seen := map[string]int{}
@@ -108,6 +111,11 @@ func validateContainer(index int, container *Container, availableGPUs int, model
 	}
 	if len(container.Tmpfs) > maxContainerTmpfsEntries {
 		return fmt.Errorf("containers[%d].tmpfs exceeds limit %d", index, maxContainerTmpfsEntries)
+	}
+	for destination := range container.Tmpfs {
+		if destination != path.Clean(destination) || destination != "/tmp" && !strings.HasPrefix(destination, "/tmp/") {
+			return fmt.Errorf("containers[%d].tmpfs destination %q must be /tmp or a clean path below /tmp", index, destination)
+		}
 	}
 	if container.Healthcheck != nil && len(container.Healthcheck.Test) > maxHealthcheckTestEntries {
 		return fmt.Errorf("containers[%d].healthcheck.test exceeds limit %d", index, maxHealthcheckTestEntries)
@@ -221,7 +229,9 @@ func validateContainerPolicy(index int, container *Container, availableGPUs int,
 		}
 		if writable {
 			if prior, found := volumeWriters[source]; found {
-				return fmt.Errorf("containers[%d].volumes[%d] makes named volume %q writable after containers[%d]", index, volumeIndex, source, prior)
+				if prior != index {
+					return fmt.Errorf("containers[%d].volumes[%d] makes named volume %q writable after containers[%d]", index, volumeIndex, source, prior)
+				}
 			}
 			volumeWriters[source] = index
 		}

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -54,6 +54,7 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "volume outside data", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [state:/etc]", 1), want: "below /data"},
 		{name: "volume invalid mode", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [state:/data:shared]", 1), want: "ro or rw"},
 		{name: "writable rootfs", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    read_only: false", 1), want: "read-only root filesystem"},
+		{name: "tmpfs outside tmp", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    tmpfs: {/etc: size=1m}", 1), want: "below /tmp"},
 		{name: "debug toolbox socket", debug: true, yaml: strings.Replace(validConfig, "name: app\n    image", fmt.Sprintf("name: %s\n    volumes: [/run/docker.sock:/var/run/docker.sock]\n    image", ReservedDebugContainerName), 1)},
 		{name: "host ipc", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    ipc: host", 1), want: "ipc must be private or none"},
 		{name: "host pid", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    pid: host", 1), want: "pid is unsupported"},
@@ -100,6 +101,12 @@ containers:
 	if _, err := Decode([]byte(strings.Replace(base, "models: [weights]", "models: [weights, weights]", 1)), false); err == nil || !strings.Contains(err.Error(), "duplicates model") {
 		t.Fatalf("duplicate model error = %v", err)
 	}
+	if _, err := Decode([]byte(strings.Replace(base, "    mwp: "+modelRef+"\n", "", 1)), false); err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("missing model reference error = %v", err)
+	}
+	if _, err := Decode([]byte(strings.Replace(base, "    mwp: "+modelRef, "    mpk: "+modelRef+"\n    mwp: "+modelRef, 1)), false); err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("multiple model references error = %v", err)
+	}
 }
 
 func TestDecodePermitsOnlyOneWritableVolumeOwner(t *testing.T) {
@@ -115,6 +122,13 @@ func TestDecodePermitsOnlyOneWritableVolumeOwner(t *testing.T) {
 	config = strings.Replace(config, "state:/data:ro", "state:/data:rw", 1)
 	if _, err := Decode([]byte(config), false); err == nil || !strings.Contains(err.Error(), "writable after") {
 		t.Fatalf("second writer error = %v", err)
+	}
+}
+
+func TestDecodeAllowsOneContainerToRemountItsWritableVolume(t *testing.T) {
+	config := strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [state:/data/primary:rw, state:/data/secondary:rw]", 1)
+	if _, err := Decode([]byte(config), false); err != nil {
+		t.Fatalf("same-owner volume remount rejected: %v", err)
 	}
 }
 

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -50,10 +50,49 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "undeclared network", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [missing]", 1), want: "not declared"},
 		{name: "production docker socket", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [/run/docker.sock:/var/run/docker.sock]", 1), want: "named volume"},
 		{name: "debug toolbox socket", debug: true, yaml: strings.Replace(validConfig, "name: app\n    image", fmt.Sprintf("name: %s\n    volumes: [/run/docker.sock:/var/run/docker.sock]\n    image", ReservedDebugContainerName), 1)},
+		{name: "host ipc", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    ipc: host", 1), want: "ipc must be private or none"},
+		{name: "host pid", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    pid: host", 1), want: "pid is unsupported"},
+		{name: "raw device", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    devices: [/dev/kvm]", 1), want: "devices is unsupported"},
+		{name: "implicit runtime alias", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    runtime: attacker.runc.v2", 1), want: "runtime"},
+		{name: "nvidia runtime without selection", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    runtime: nvidia", 1), want: "explicit gpus selection"},
+		{name: "gpu selection without runtime", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    gpus: all", 1), want: "declares no GPUs"},
+		{name: "negative gpu count", yaml: strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1) + "\n", want: ""},
+		{name: "unsupported capability", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    cap_add: [SETUID]", 1), want: "capability"},
 		{name: "invalid allowlist", yaml: strings.Replace(validConfig, "egress: closed", "egress: allowlist\n    allow: ['*.example.com']", 1), want: "wildcards"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Decode([]byte(test.yaml), test.debug)
+			if test.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if test.want != "" && (err == nil || !strings.Contains(err.Error(), test.want)) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDecodeValidatesGPUSelections(t *testing.T) {
+	base := strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1)
+	for _, test := range []struct {
+		name      string
+		selection string
+		want      string
+	}{
+		{name: "count", selection: "2"},
+		{name: "all", selection: "all"},
+		{name: "ids", selection: "0,1"},
+		{name: "negative", selection: "-1", want: "between 1 and 2"},
+		{name: "zero", selection: "0", want: "between 1 and 2"},
+		{name: "too many", selection: "3", want: "between 1 and 2"},
+		{name: "out of range id", selection: "0,2", want: "outside 0..1"},
+		{name: "duplicate id", selection: "1,1", want: "duplicated"},
+		{name: "boolean", selection: "true", want: "positive count"},
+		{name: "empty id", selection: `"0,"`, want: "invalid device ID"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			yaml := strings.Replace(base, "networks: [app]", "networks: [app]\n    runtime: nvidia\n    gpus: "+test.selection, 1)
+			_, err := Decode([]byte(yaml), false)
 			if test.want == "" && err != nil {
 				t.Fatal(err)
 			}

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -56,7 +56,7 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "implicit runtime alias", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    runtime: attacker.runc.v2", 1), want: "runtime"},
 		{name: "nvidia runtime without selection", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    runtime: nvidia", 1), want: "explicit gpus selection"},
 		{name: "gpu selection without runtime", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    gpus: all", 1), want: "declares no GPUs"},
-		{name: "negative gpu count", yaml: strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1) + "\n", want: ""},
+		{name: "valid top-level gpu count", yaml: strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1) + "\n", want: ""},
 		{name: "unsupported capability", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    cap_add: [SETUID]", 1), want: "capability"},
 		{name: "invalid allowlist", yaml: strings.Replace(validConfig, "egress: closed", "egress: allowlist\n    allow: ['*.example.com']", 1), want: "wildcards"},
 	} {

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -30,7 +30,7 @@ networks:
     egress: closed
 containers:
   - name: app
-    image: example/app:latest
+    image: example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     networks: [app]
 `
 
@@ -43,10 +43,12 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 	}{
 		{name: "valid", yaml: validConfig},
 		{name: "unknown field", yaml: validConfig + "unknown: true\n", want: "field unknown not found"},
-		{name: "unknown container field", yaml: strings.Replace(validConfig, "image: example/app:latest", "image: example/app:latest\n    typo: true", 1), want: "unknown container field"},
-		{name: "duplicate container field", yaml: strings.Replace(validConfig, "image: example/app:latest", "image: example/app:latest\n    image: duplicate", 1), want: "duplicate container field"},
-		{name: "container merge key", yaml: "defaults: &defaults\n  image: example/app:latest\n" + strings.Replace(validConfig, "image: example/app:latest", "<<: *defaults", 1), want: "merge keys are unsupported"},
-		{name: "duplicate container", yaml: strings.Replace(validConfig, "containers:\n", "containers:\n  - name: app\n    image: duplicate\n", 1), want: "duplicates"},
+		{name: "unknown container field", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    typo: true", 1), want: "unknown container field"},
+		{name: "duplicate container field", yaml: strings.Replace(validConfig, "networks: [app]", "image: duplicate\n    networks: [app]", 1), want: "duplicate container field"},
+		{name: "container merge key", yaml: "defaults: &defaults\n  image: example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" + strings.Replace(validConfig, "    image: example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "    <<: *defaults", 1), want: "merge keys are unsupported"},
+		{name: "duplicate container", yaml: strings.Replace(validConfig, "containers:\n", "containers:\n  - name: app\n    image: example.com/duplicate@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n", 1), want: "duplicates"},
+		{name: "mutable image", yaml: strings.Replace(validConfig, "example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "example.com/app:latest", 1), want: "immutable digest"},
+		{name: "debug mutable image", debug: true, yaml: strings.Replace(validConfig, "example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "example.com/app:latest", 1)},
 		{name: "undeclared network", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [missing]", 1), want: "not declared"},
 		{name: "production docker socket", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [/run/docker.sock:/var/run/docker.sock]", 1), want: "named volume"},
 		{name: "debug toolbox socket", debug: true, yaml: strings.Replace(validConfig, "name: app\n    image", fmt.Sprintf("name: %s\n    volumes: [/run/docker.sock:/var/run/docker.sock]\n    image", ReservedDebugContainerName), 1)},

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -51,6 +51,9 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "debug mutable image", debug: true, yaml: strings.Replace(validConfig, "example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "example.com/app:latest", 1)},
 		{name: "undeclared network", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [missing]", 1), want: "not declared"},
 		{name: "production docker socket", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [/run/docker.sock:/var/run/docker.sock]", 1), want: "named volume"},
+		{name: "volume outside data", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [state:/etc]", 1), want: "below /data"},
+		{name: "volume invalid mode", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    volumes: [state:/data:shared]", 1), want: "ro or rw"},
+		{name: "writable rootfs", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    read_only: false", 1), want: "read-only root filesystem"},
 		{name: "debug toolbox socket", debug: true, yaml: strings.Replace(validConfig, "name: app\n    image", fmt.Sprintf("name: %s\n    volumes: [/run/docker.sock:/var/run/docker.sock]\n    image", ReservedDebugContainerName), 1)},
 		{name: "host ipc", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    ipc: host", 1), want: "ipc must be private or none"},
 		{name: "host pid", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    pid: host", 1), want: "pid is unsupported"},
@@ -71,6 +74,47 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 				t.Fatalf("error = %v, want substring %q", err, test.want)
 			}
 		})
+	}
+}
+
+func TestDecodeRequiresExplicitModelAssignment(t *testing.T) {
+	const modelRef = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_4096_0eefa619-50b7-588f-a072-d405fb439d36"
+	base := fmt.Sprintf(`
+shim:
+  upstream-port: 8080
+models:
+  - name: weights
+    repo: org/weights@v1
+    mwp: %s
+containers:
+  - name: app
+    image: example.com/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    models: [weights]
+`, modelRef)
+	if _, err := Decode([]byte(base), false); err != nil {
+		t.Fatalf("valid model assignment rejected: %v", err)
+	}
+	if _, err := Decode([]byte(strings.Replace(base, "models: [weights]", "models: [missing]", 1)), false); err == nil || !strings.Contains(err.Error(), "unknown model") {
+		t.Fatalf("unknown model error = %v", err)
+	}
+	if _, err := Decode([]byte(strings.Replace(base, "models: [weights]", "models: [weights, weights]", 1)), false); err == nil || !strings.Contains(err.Error(), "duplicates model") {
+		t.Fatalf("duplicate model error = %v", err)
+	}
+}
+
+func TestDecodePermitsOnlyOneWritableVolumeOwner(t *testing.T) {
+	config := validConfig + `
+  - name: reader
+    image: example.com/reader@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+    volumes: [state:/data:ro]
+`
+	config = strings.Replace(config, "networks: [app]", "networks: [app]\n    volumes: [state:/data:rw]", 1)
+	if _, err := Decode([]byte(config), false); err != nil {
+		t.Fatalf("single writer with reader rejected: %v", err)
+	}
+	config = strings.Replace(config, "state:/data:ro", "state:/data:rw", 1)
+	if _, err := Decode([]byte(config), false); err == nil || !strings.Contains(err.Error(), "writable after") {
+		t.Fatalf("second writer error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- replace the broad public-ramdisk bind with fixed public-file mounts
- require explicit per-container model assignments and expose only selected verified model packs
- restrict mutable named volumes and tmpfs destinations
- enforce one writable container owner per named volume and keep production root filesystems read-only

## Compatibility
Workloads consuming models must declare `models: [...]`. Production named volumes are limited to `/data`, and configured tmpfs mounts are limited to `/tmp`.

## Validation
- `GOTOOLCHAIN=go1.26.5 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.5 go vet ./...`

## Merge Order
Position 4 of 9. Predecessor: #324. Successor: #326.
Full order: #322 → #323 → #324 → #325 → #326 → #327 → #328 → #329 → #330.