### PR TITLE
Isolate containers on Docker bridges

### DIFF
--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -79,3 +79,9 @@ sources supplied by workload configuration remain reserved for the measured
 debug toolbox; fixed public files and explicitly assigned verified models use
 first-party read-only binds. Configured tmpfs mounts are restricted to `/tmp`
 or a clean path below it.
+
+Every managed Docker bridge is created with inter-container communication
+disabled, and an existing bridge is reused only when its driver, Linux bridge
+name, and ICC setting match the measured policy. The nftables policy does not
+add a same-bridge forwarding exception, so containers sharing a logical network
+do not gain lateral connectivity merely by joining that bridge.

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -32,9 +32,11 @@ import (
 )
 
 const (
-	healthPollInterval         = 5 * time.Second
-	defaultPidsLimit     int64 = 65536
-	openEgressGwPriority       = 100
+	healthPollInterval           = 5 * time.Second
+	defaultPidsLimit       int64 = 65536
+	openEgressGwPriority         = 100
+	dockerBridgeNameOption       = "com.docker.network.bridge.name"
+	dockerBridgeICCOption        = "com.docker.network.bridge.enable_icc"
 )
 
 func setupContainerNetwork(ctx context.Context, cli *client.Client, cfg *Config, debug bool) error {
@@ -112,8 +114,8 @@ func networkCreateOptions(name string) client.NetworkCreateOptions {
 	opts := client.NetworkCreateOptions{
 		Driver: "bridge",
 		Options: map[string]string{
-			"com.docker.network.bridge.name":       name,
-			"com.docker.network.bridge.enable_icc": "false",
+			dockerBridgeNameOption: name,
+			dockerBridgeICCOption:  "false",
 		},
 	}
 	if name == containernet.ShimNetName {
@@ -131,10 +133,10 @@ func validateBridgeNetwork(name string, network dockernetwork.Inspect) error {
 	if network.Driver != "bridge" {
 		return fmt.Errorf("docker network %q uses driver %q, want bridge", name, network.Driver)
 	}
-	if network.Options["com.docker.network.bridge.name"] != name {
+	if network.Options[dockerBridgeNameOption] != name {
 		return fmt.Errorf("docker network %q has unexpected bridge identity", name)
 	}
-	if network.Options["com.docker.network.bridge.enable_icc"] != "false" {
+	if network.Options[dockerBridgeICCOption] != "false" {
 		return fmt.Errorf("docker network %q permits inter-container communication", name)
 	}
 	return nil

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -61,9 +61,9 @@ func PrepareNetworks(ctx context.Context, config *Config, debug bool) error {
 }
 
 func ensureNetwork(ctx context.Context, cli *client.Client, name string) error {
-	_, err := cli.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
+	result, err := cli.NetworkInspect(ctx, name, client.NetworkInspectOptions{})
 	if err == nil {
-		return nil
+		return validateBridgeNetwork(name, result.Network)
 	}
 	if !cerrdefs.IsNotFound(err) {
 		return fmt.Errorf("checking whether docker network %q exists: %w", name, err)
@@ -88,6 +88,9 @@ func ensureShimNetwork(ctx context.Context, cli *client.Client, upstreamContaine
 		return fmt.Errorf("checking whether docker network %q exists: %w", containernet.ShimNetName, err)
 	}
 	existing := result.Network
+	if err := validateBridgeNetwork(containernet.ShimNetName, existing); err != nil {
+		return err
+	}
 
 	if len(existing.IPAM.Config) != 1 ||
 		existing.IPAM.Config[0].Subnet.String() != containernet.ShimNetSubnetCIDR ||
@@ -109,7 +112,8 @@ func networkCreateOptions(name string) client.NetworkCreateOptions {
 	opts := client.NetworkCreateOptions{
 		Driver: "bridge",
 		Options: map[string]string{
-			"com.docker.network.bridge.name": name,
+			"com.docker.network.bridge.name":       name,
+			"com.docker.network.bridge.enable_icc": "false",
 		},
 	}
 	if name == containernet.ShimNetName {
@@ -121,6 +125,19 @@ func networkCreateOptions(name string) client.NetworkCreateOptions {
 		}
 	}
 	return opts
+}
+
+func validateBridgeNetwork(name string, network dockernetwork.Inspect) error {
+	if network.Driver != "bridge" {
+		return fmt.Errorf("docker network %q uses driver %q, want bridge", name, network.Driver)
+	}
+	if network.Options["com.docker.network.bridge.name"] != name {
+		return fmt.Errorf("docker network %q has unexpected bridge identity", name)
+	}
+	if network.Options["com.docker.network.bridge.enable_icc"] != "false" {
+		return fmt.Errorf("docker network %q permits inter-container communication", name)
+	}
+	return nil
 }
 
 // launchContainersAndWaitHealthy launches all containers in parallel with

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -1,6 +1,7 @@
 package containers
 
 import (
+	"maps"
 	"slices"
 	"strings"
 	"testing"
@@ -180,6 +181,9 @@ func TestParseDuration(t *testing.T) {
 
 func TestNetworkCreateOptionsStaticShimNet(t *testing.T) {
 	opts := networkCreateOptions(containernet.ShimNetName)
+	if got := opts.Options["com.docker.network.bridge.enable_icc"]; got != "false" {
+		t.Fatalf("enable_icc = %q, want false", got)
+	}
 	if opts.IPAM == nil || len(opts.IPAM.Config) != 1 {
 		t.Fatalf("expected static shim-net IPAM config, got %+v", opts.IPAM)
 	}
@@ -188,6 +192,38 @@ func TestNetworkCreateOptionsStaticShimNet(t *testing.T) {
 	}
 	if got := opts.IPAM.Config[0].Gateway.String(); got != containernet.ShimNetGatewayIP {
 		t.Errorf("gateway: got %q, want %q", got, containernet.ShimNetGatewayIP)
+	}
+}
+
+func TestValidateBridgeNetwork(t *testing.T) {
+	valid := dockernetwork.Inspect{
+		Network: dockernetwork.Network{
+			Driver: "bridge",
+			Options: map[string]string{
+				"com.docker.network.bridge.name":       "app",
+				"com.docker.network.bridge.enable_icc": "false",
+			},
+		},
+	}
+	if err := validateBridgeNetwork("app", valid); err != nil {
+		t.Fatalf("valid bridge rejected: %v", err)
+	}
+	for _, test := range []struct {
+		name   string
+		mutate func(*dockernetwork.Inspect)
+	}{
+		{name: "driver", mutate: func(network *dockernetwork.Inspect) { network.Driver = "macvlan" }},
+		{name: "identity", mutate: func(network *dockernetwork.Inspect) { network.Options["com.docker.network.bridge.name"] = "other" }},
+		{name: "icc", mutate: func(network *dockernetwork.Inspect) { network.Options["com.docker.network.bridge.enable_icc"] = "true" }},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			candidate := valid
+			candidate.Options = maps.Clone(valid.Options)
+			test.mutate(&candidate)
+			if err := validateBridgeNetwork("app", candidate); err == nil {
+				t.Fatal("invalid bridge accepted")
+			}
+		})
 	}
 }
 

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -181,7 +181,7 @@ func TestParseDuration(t *testing.T) {
 
 func TestNetworkCreateOptionsStaticShimNet(t *testing.T) {
 	opts := networkCreateOptions(containernet.ShimNetName)
-	if got := opts.Options["com.docker.network.bridge.enable_icc"]; got != "false" {
+	if got := opts.Options[dockerBridgeICCOption]; got != "false" {
 		t.Fatalf("enable_icc = %q, want false", got)
 	}
 	if opts.IPAM == nil || len(opts.IPAM.Config) != 1 {
@@ -200,8 +200,8 @@ func TestValidateBridgeNetwork(t *testing.T) {
 		Network: dockernetwork.Network{
 			Driver: "bridge",
 			Options: map[string]string{
-				"com.docker.network.bridge.name":       "app",
-				"com.docker.network.bridge.enable_icc": "false",
+				dockerBridgeNameOption: "app",
+				dockerBridgeICCOption:  "false",
 			},
 		},
 	}
@@ -213,8 +213,8 @@ func TestValidateBridgeNetwork(t *testing.T) {
 		mutate func(*dockernetwork.Inspect)
 	}{
 		{name: "driver", mutate: func(network *dockernetwork.Inspect) { network.Driver = "macvlan" }},
-		{name: "identity", mutate: func(network *dockernetwork.Inspect) { network.Options["com.docker.network.bridge.name"] = "other" }},
-		{name: "icc", mutate: func(network *dockernetwork.Inspect) { network.Options["com.docker.network.bridge.enable_icc"] = "true" }},
+		{name: "identity", mutate: func(network *dockernetwork.Inspect) { network.Options[dockerBridgeNameOption] = "other" }},
+		{name: "icc", mutate: func(network *dockernetwork.Inspect) { network.Options[dockerBridgeICCOption] = "true" }},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			candidate := valid

--- a/tinfoil/internal/firewall/containers.go
+++ b/tinfoil/internal/firewall/containers.go
@@ -56,7 +56,6 @@ func writeReservedDebugForwardRules(script *strings.Builder) {
 }
 
 func writeBridgeRules(script *strings.Builder, bridge string, network *runtimeconfig.NetworkSpec) {
-	fmt.Fprintf(script, "add rule inet tinfoil container_forward iifname %q oifname %q accept\n", bridge, bridge)
 	fmt.Fprintf(script, "add rule inet tinfoil container_forward oifname %q ct state established,related accept\n", bridge)
 	fmt.Fprintf(script, "add rule inet tinfoil container_input iifname %q ct state new drop\n", bridge)
 	switch network.Egress {

--- a/tinfoil/internal/firewall/containers_test.go
+++ b/tinfoil/internal/firewall/containers_test.go
@@ -18,7 +18,6 @@ func TestContainerNetworkPolicyModes(t *testing.T) {
 	for _, fragment := range []string{
 		"flush chain inet tinfoil container_input",
 		"flush chain inet tinfoil container_forward",
-		`iifname "closed" oifname "closed" accept`,
 		`iifname "open" ip daddr { 0.0.0.0/8`,
 		`iifname "open" meta nfproto ipv4 accept`,
 		`iifname "open" meta nfproto ipv6 accept`,
@@ -29,6 +28,9 @@ func TestContainerNetworkPolicyModes(t *testing.T) {
 		if !strings.Contains(script, fragment) {
 			t.Errorf("missing %q from:\n%s", fragment, script)
 		}
+	}
+	if strings.Contains(script, `iifname "closed" oifname "closed" accept`) || strings.Contains(script, `iifname "open" oifname "open" accept`) {
+		t.Fatalf("same-bridge traffic was accepted:\n%s", script)
 	}
 	destroy := strings.Index(script, "destroy set inet tinfoil allow-control")
 	create := strings.Index(script, "create set inet tinfoil allow-control")
@@ -60,7 +62,7 @@ func TestContainerNetworkPolicyKeepsShimClosed(t *testing.T) {
 		Networks: map[string]*runtimeconfig.NetworkSpec{},
 	}
 	script := renderContainerNetworkScript(config, false)
-	if !strings.Contains(script, `iifname "shim-net" oifname "shim-net" accept`) || strings.Contains(script, `iifname "shim-net" ip daddr !`) {
+	if strings.Contains(script, `iifname "shim-net" oifname "shim-net" accept`) || strings.Contains(script, `iifname "shim-net" ip daddr !`) {
 		t.Fatalf("unexpected shim policy:\n%s", script)
 	}
 }


### PR DESCRIPTION
## Summary
- create managed Docker bridges with inter-container communication disabled
- validate bridge driver, Linux bridge identity, and ICC settings before reuse
- remove same-bridge forwarding exceptions from the measured firewall policy

## Validation
- `GOTOOLCHAIN=go1.26.5 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.5 go vet ./...`

## Merge Order
Position 5 of 9. Predecessor: #325. Successor: #327.
Full order: #322 → #323 → #324 → #325 → #326 → #327 → #328 → #329 → #330.