### PR TITLE
Disable unsafe production hostname allowlists

### DIFF
--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -85,3 +85,8 @@ disabled, and an existing bridge is reused only when its driver, Linux bridge
 name, and ICC setting match the measured policy. The nftables policy does not
 add a same-bridge forwarding exception, so containers sharing a logical network
 do not gain lateral connectivity merely by joining that bridge.
+
+Hostname-based egress allowlists are rejected in production until enforcement
+can bind the authorized hostname to each outbound connection without relying on
+mutable DNS-to-IP cache state. Closed and open egress modes remain available;
+the legacy allowlist implementation is retained only for measured debug mode.

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -46,7 +46,7 @@ func Validate(config *Config, debug bool) error {
 	if err := validateShape(config, debug); err != nil {
 		return err
 	}
-	return validateNetwork(config)
+	return validateNetwork(config, debug)
 }
 
 func validateShape(config *Config, debug bool) error {
@@ -312,7 +312,7 @@ func validateGPUSelection(index int, selection interface{}, available int) error
 	}
 }
 
-func validateNetwork(config *Config) error {
+func validateNetwork(config *Config, debug bool) error {
 	for _, port := range config.CVMNetwork.InboundPorts {
 		if port < 1 || port > 65535 {
 			return fmt.Errorf("cvm-network.inbound-ports: %d is not in 1..65535", port)
@@ -321,6 +321,9 @@ func validateNetwork(config *Config) error {
 	for name, spec := range config.Networks {
 		if err := validateNetworkEntry(name, spec); err != nil {
 			return fmt.Errorf("networks.%s: %w", name, err)
+		}
+		if spec.Egress == "allowlist" && !debug {
+			return fmt.Errorf("networks.%s: egress allowlist is disabled until hostname identity can be enforced per connection", name)
 		}
 	}
 	for index, container := range config.Containers {

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -65,6 +65,8 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "valid top-level gpu count", yaml: strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1) + "\n", want: ""},
 		{name: "unsupported capability", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    cap_add: [SETUID]", 1), want: "capability"},
 		{name: "invalid allowlist", yaml: strings.Replace(validConfig, "egress: closed", "egress: allowlist\n    allow: ['*.example.com']", 1), want: "wildcards"},
+		{name: "production allowlist disabled", yaml: strings.Replace(validConfig, "egress: closed", "egress: allowlist\n    allow: [api.example.com]", 1), want: "allowlist is disabled"},
+		{name: "debug allowlist", debug: true, yaml: strings.Replace(validConfig, "egress: closed", "egress: allowlist\n    allow: [api.example.com]", 1)},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			_, err := Decode([]byte(test.yaml), test.debug)


### PR DESCRIPTION
## Summary
- reject production hostname allowlist mode until destination identity can be enforced per connection
- retain the existing implementation only in measured debug mode
- document the fail-closed compatibility boundary

## Compatibility
Production configurations must use closed or open egress mode for now.

## Validation
- `GOTOOLCHAIN=go1.26.5 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.5 go vet ./...`

## Merge Order
Position 6 of 9. Predecessor: #326. Successor: #328.
Full order: #322 → #323 → #324 → #325 → #326 → #327 → #328 → #329 → #330.