### PR TITLE
Strip caller identity before shim proxying

### DIFF
--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -90,3 +90,10 @@ Hostname-based egress allowlists are rejected in production until enforcement
 can bind the authorized hostname to each outbound connection without relying on
 mutable DNS-to-IP cache state. Closed and open egress modes remain available;
 the legacy allowlist implementation is retained only for measured debug mode.
+
+The public shim treats all caller-supplied proxy identity and credential headers
+as untrusted. Before forwarding a decrypted request it removes bearer and proxy
+credentials, `Forwarded`, every `X-Forwarded-*` and `X-Real-IP` value, EHBP
+transport metadata, and reserved `Tinfoil-*` headers. It then emits only fixed
+local `localhost`/HTTPS forwarding metadata; workloads cannot mistake a client
+header or validated API key for a trusted internal identity assertion.

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -6,11 +6,11 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"slices"
 	"strings"
 
@@ -196,23 +196,11 @@ func NewShimServer(
 	ehbpMiddleware := ehbpIdentity.Middleware()
 	mux := http.NewServeMux()
 
+	upstreamURL := &url.URL{Scheme: "http", Host: upstreamAddr}
 	proxy := httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			originalHost := req.Host
-
-			req.URL.Scheme = "http"
-			req.URL.Host = upstreamAddr
-			req.Header.Set("Host", "localhost")
-			req.Host = "localhost"
-			req.Header.Del(ehbpProtocol.EncapsulatedKeyHeader)
-
-			// Forward original host and protocol to the upstream
-			req.Header.Del("Forwarded")
-			req.Header.Del("X-Forwarded-Host")
-			req.Header.Set("Forwarded", fmt.Sprintf("host=\"%s\"", originalHost))
-			req.Header.Set("X-Forwarded-Host", originalHost)
-
-			// proxied
+		Rewrite: func(proxyRequest *httputil.ProxyRequest) {
+			proxyRequest.SetURL(upstreamURL)
+			rewriteUpstreamRequest(proxyRequest.Out)
 		},
 		Transport: &streamTransport{
 			base: http.DefaultTransport,
@@ -276,6 +264,19 @@ func NewShimServer(
 	registerObservabilityHandlers(mux, ehbpMiddleware, att, identityBody, expectedGPUs, ehbpIdentity, tlsCert, externalConfig)
 
 	return wrapShimMux(config, att, mux)
+}
+
+func rewriteUpstreamRequest(request *http.Request) {
+	request.Host = "localhost"
+	for header := range request.Header {
+		lower := strings.ToLower(header)
+		if lower == "authorization" || lower == "proxy-authorization" || lower == "forwarded" || lower == "x-real-ip" || strings.HasPrefix(lower, "x-forwarded-") || strings.HasPrefix(lower, "ehbp-") || strings.HasPrefix(lower, "tinfoil-") {
+			request.Header.Del(header)
+		}
+	}
+	request.Header.Set("Forwarded", `host="localhost";proto=https`)
+	request.Header.Set("X-Forwarded-Host", "localhost")
+	request.Header.Set("X-Forwarded-Proto", "https")
 }
 
 func NewObservabilityServer(

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -376,3 +376,45 @@ func TestFullServer_WorkloadReachesProxyPath(t *testing.T) {
 		t.Fatalf("ready proxy gate should not block workload path: %s", rec.Body.String())
 	}
 }
+
+func TestRewriteUpstreamRequestStripsCallerIdentity(t *testing.T) {
+	request := httptest.NewRequest(http.MethodPost, "https://attacker.example/v1/chat/completions", nil)
+	request.Host = "attacker.example"
+	for header, value := range map[string]string{
+		"Authorization":         "Bearer workload-secret",
+		"Proxy-Authorization":   "Basic proxy-secret",
+		"Forwarded":             `for=192.0.2.1;host=attacker.example;proto=http`,
+		"X-Forwarded-For":       "192.0.2.1",
+		"X-Forwarded-Host":      "attacker.example",
+		"X-Forwarded-Proto":     "http",
+		"X-Real-IP":             "192.0.2.1",
+		"Ehbp-Encapsulated-Key": "ciphertext",
+		"Tinfoil-Authenticated": "true",
+		"Content-Type":          "application/json",
+	} {
+		request.Header.Set(header, value)
+	}
+
+	rewriteUpstreamRequest(request)
+
+	if request.Host != "localhost" {
+		t.Fatalf("Host = %q, want localhost", request.Host)
+	}
+	for _, header := range []string{"Authorization", "Proxy-Authorization", "X-Forwarded-For", "X-Real-IP", "Ehbp-Encapsulated-Key", "Tinfoil-Authenticated"} {
+		if value := request.Header.Get(header); value != "" {
+			t.Fatalf("%s survived with value %q", header, value)
+		}
+	}
+	if got := request.Header.Get("Forwarded"); got != `host="localhost";proto=https` {
+		t.Fatalf("Forwarded = %q", got)
+	}
+	if got := request.Header.Get("X-Forwarded-Host"); got != "localhost" {
+		t.Fatalf("X-Forwarded-Host = %q", got)
+	}
+	if got := request.Header.Get("X-Forwarded-Proto"); got != "https" {
+		t.Fatalf("X-Forwarded-Proto = %q", got)
+	}
+	if got := request.Header.Get("Content-Type"); got != "application/json" {
+		t.Fatalf("ordinary header changed: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- use `httputil.ReverseProxy.Rewrite` for workload forwarding
- remove caller credentials, forwarding identity, transport metadata, and reserved internal headers
- generate only fixed local forwarding metadata for the workload

## Compatibility
Workloads no longer receive caller bearer credentials or client-supplied forwarding identity.

## Validation
- `GOTOOLCHAIN=go1.26.5 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.5 go vet ./...`

## Merge Order
Position 7 of 9. Predecessor: #327. Successor: #329.
Full order: #322 → #323 → #324 → #325 → #326 → #327 → #328 → #329 → #330.