### PR TITLE
Bind GPU readiness to appraised evidence

### DIFF
--- a/tinfoil/cmd/boot/gpuattest.go
+++ b/tinfoil/cmd/boot/gpuattest.go
@@ -1,157 +1,369 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
+	gpuattestation "tinfoil/internal/attestation"
 	"tinfoil/internal/nvml"
 )
 
 const (
-	nvattestTimeout = 5 * time.Minute
-	nvidiaVendorID  = "0x10de"
-	nvidiaGPUClass  = "0x030200" // 3D controller
-	gpuDeviceIDH100 = "0x2331"
-	gpuDeviceIDH200 = "0x2335"
-	gpuDeviceIDB200 = "0x2901"
-	gpuDeviceIDB300 = "0x3182"
+	nvattestTimeout           = 5 * time.Minute
+	gpuReadyStateAttempts     = 3
+	gpuReadyStateRetryBackoff = 100 * time.Millisecond
 )
 
-// forEachNVIDIAGPU iterates over PCI devices that are NVIDIA GPUs
-// (vendor 0x10de + 3D-controller class), invoking fn with each device's
-// sysfs entry name. Walking stops if fn returns false.
-func forEachNVIDIAGPU(fn func(entryName string) bool) error {
-	const pciPath = "/sys/bus/pci/devices"
-	entries, err := os.ReadDir(pciPath)
-	if err != nil {
-		return fmt.Errorf("reading PCI devices: %w", err)
-	}
-	for _, entry := range entries {
-		vendor, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "vendor"))
-		if err != nil || strings.TrimSpace(string(vendor)) != nvidiaVendorID {
-			continue
-		}
-		class, err := os.ReadFile(filepath.Join(pciPath, entry.Name(), "class"))
-		if err != nil || strings.TrimSpace(string(class)) != nvidiaGPUClass {
-			continue
-		}
-		if !fn(entry.Name()) {
-			return nil
-		}
-	}
-	return nil
-}
+var (
+	commandContext              = exec.CommandContext
+	generateGPUAttestationNonce = newGPUAttestationNonce
+	enableVerifiedGPUs          = enableGPUsForIdentities
+	disableGPUs                 = func() error { return setGPUReadyState(false) }
+	gpuEvidenceTempDir          = "/run/tinfoil"
+	initializeNVML              = nvml.Init
+	shutdownNVML                = nvml.Shutdown
+	snapshotLiveGPUIdentities   = liveGPUIdentities
+	setGPUReadyStateValue       = nvml.SystemSetConfComputeGpusReadyState
+)
 
-// detectGPUArch returns "h100", "h200", "b200", "b300", or "" from the first GPU.
-func detectGPUArch() (string, error) {
-	const pciPath = "/sys/bus/pci/devices"
-	var arch string
-	err := forEachNVIDIAGPU(func(entryName string) bool {
-		device, err := os.ReadFile(filepath.Join(pciPath, entryName, "device"))
-		if err != nil {
-			return true
-		}
-		switch strings.TrimSpace(string(device)) {
-		case gpuDeviceIDH100:
-			arch = "h100"
-		case gpuDeviceIDH200:
-			arch = "h200"
-		case gpuDeviceIDB200:
-			arch = "b200"
-		case gpuDeviceIDB300:
-			arch = "b300"
-		default:
-			return true
-		}
-		return false
-	})
-	return arch, err
-}
-
-func runNvattest(device string) error {
-	log.Printf("Running nvattest attest for %s", device)
-	ctx, cancel := context.WithTimeout(context.Background(), nvattestTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "nvattest", "attest", "--device", device, "--verifier", "local")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		if ctx.Err() == context.DeadlineExceeded {
-			return fmt.Errorf("nvattest %s timed out after %s", device, nvattestTimeout)
-		}
-		return fmt.Errorf("nvattest %s attestation failed: %w", device, err)
-	}
-	return nil
+type nvattestEvidenceEntry struct {
+	Arch        string `json:"arch"`
+	Certificate string `json:"certificate"`
+	Evidence    string `json:"evidence"`
+	Nonce       string `json:"nonce"`
 }
 
 type nvattestEvidenceOutput struct {
-	Evidences []struct {
-		Evidence    string `json:"evidence"`
-		Certificate string `json:"certificate"`
-	} `json:"evidences"`
+	Evidences     json.RawMessage `json:"evidences"`
+	ResultCode    int             `json:"result_code"`
+	ResultMessage string          `json:"result_message"`
+}
+
+type nvattestAppraisalOutput struct {
 	ResultCode    int    `json:"result_code"`
 	ResultMessage string `json:"result_message"`
 }
 
-func collectEvidence(device string) ([][]byte, json.RawMessage, error) {
+type verifiedEvidence struct {
+	raw            json.RawMessage
+	appraisalInput json.RawMessage
+	reports        [][]byte
+	identities     []string
+	arches         []string
+}
+
+func newGPUAttestationNonce() ([32]byte, error) {
+	var nonce [32]byte
+	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+		return nonce, fmt.Errorf("generating GPU attestation nonce: %w", err)
+	}
+	return nonce, nil
+}
+
+func collectAndAppraiseEvidence(device string, nonce [32]byte) (*verifiedEvidence, error) {
+	raw, err := collectEvidence(device, nonce)
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := parseEvidence(device, nonce, raw)
+	if err != nil {
+		return nil, err
+	}
+	if err := appraiseEvidence(device, nonce, parsed.appraisalInput); err != nil {
+		return nil, err
+	}
+	return parsed, nil
+}
+
+func collectEvidence(device string, nonce [32]byte) (json.RawMessage, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), nvattestTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "nvattest", "collect-evidence", "--device", device, "--format", "json")
+	nonceHex := hex.EncodeToString(nonce[:])
+	cmd := commandContext(ctx, "nvattest", "collect-evidence",
+		"--device", device,
+		"--nonce", nonceHex,
+		"--format", "json",
+	)
 	out, err := cmd.Output()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return nil, nil, fmt.Errorf("nvattest collect-evidence %s timed out after %s", device, nvattestTimeout)
+			return nil, fmt.Errorf("nvattest collect-evidence %s timed out after %s", device, nvattestTimeout)
 		}
-		return nil, nil, fmt.Errorf("nvattest collect-evidence %s: %w", device, err)
+		return nil, fmt.Errorf("nvattest collect-evidence %s: %w", device, err)
 	}
-
-	var parsed nvattestEvidenceOutput
-	if err := json.Unmarshal(out, &parsed); err != nil {
-		return nil, nil, fmt.Errorf("parsing collect-evidence %s JSON: %w", device, err)
-	}
-	if parsed.ResultCode != 0 {
-		return nil, nil, fmt.Errorf("collect-evidence %s failed: %s (code %d)", device, parsed.ResultMessage, parsed.ResultCode)
-	}
-
-	reports := make([][]byte, 0, len(parsed.Evidences))
-	for i, ev := range parsed.Evidences {
-		raw, err := base64.StdEncoding.DecodeString(ev.Evidence)
-		if err != nil {
-			return nil, nil, fmt.Errorf("decoding evidence[%d]: %w", i, err)
-		}
-		reports = append(reports, raw)
-	}
-	return reports, json.RawMessage(out), nil
+	return json.RawMessage(out), nil
 }
 
-func setGPUReadyState(accepting bool) error {
-	ret := nvml.Init()
+func parseEvidence(device string, nonce [32]byte, raw json.RawMessage) (*verifiedEvidence, error) {
+	var parsed nvattestEvidenceOutput
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing collect-evidence %s JSON: %w", device, err)
+	}
+	if parsed.ResultCode != 0 {
+		return nil, fmt.Errorf("collect-evidence %s failed: %s (code %d)", device, parsed.ResultMessage, parsed.ResultCode)
+	}
+	var entries []nvattestEvidenceEntry
+	if err := json.Unmarshal(parsed.Evidences, &entries); err != nil {
+		return nil, fmt.Errorf("parsing collect-evidence %s entries: %w", device, err)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("collect-evidence %s returned no evidence", device)
+	}
+
+	expectedNonce := hex.EncodeToString(nonce[:])
+	verified := &verifiedEvidence{
+		raw:            append(json.RawMessage(nil), raw...),
+		appraisalInput: append(json.RawMessage(nil), parsed.Evidences...),
+		reports:        make([][]byte, 0, len(entries)),
+		identities:     make([]string, 0, len(entries)),
+		arches:         make([]string, 0, len(entries)),
+	}
+	for index, evidence := range entries {
+		if evidence.Nonce != expectedNonce {
+			return nil, fmt.Errorf("%s evidence[%d] nonce does not match the requested nonce", device, index)
+		}
+		report, err := base64.StdEncoding.DecodeString(evidence.Evidence)
+		if err != nil {
+			return nil, fmt.Errorf("decoding %s evidence[%d] report: %w", device, index, err)
+		}
+		if len(report) == 0 {
+			return nil, fmt.Errorf("%s evidence[%d] report is empty", device, index)
+		}
+		certificate, err := base64.StdEncoding.DecodeString(evidence.Certificate)
+		if err != nil {
+			return nil, fmt.Errorf("decoding %s evidence[%d] certificate: %w", device, index, err)
+		}
+		if len(certificate) == 0 {
+			return nil, fmt.Errorf("%s evidence[%d] certificate is empty", device, index)
+		}
+		identity := certificateIdentity(certificate)
+		verified.reports = append(verified.reports, report)
+		verified.identities = append(verified.identities, identity)
+		verified.arches = append(verified.arches, strings.ToUpper(evidence.Arch))
+	}
+	normalizedIdentities, err := sortedUniqueIdentities(device+" evidence", verified.identities)
+	if err != nil {
+		return nil, err
+	}
+	verified.identities = normalizedIdentities
+	return verified, nil
+}
+
+func appraiseEvidence(device string, nonce [32]byte, raw json.RawMessage) error {
+	if err := os.MkdirAll(gpuEvidenceTempDir, 0755); err != nil {
+		return fmt.Errorf("creating GPU evidence directory: %w", err)
+	}
+	file, err := os.CreateTemp(gpuEvidenceTempDir, "nvattest-evidence-*.json")
+	if err != nil {
+		return fmt.Errorf("creating %s evidence file: %w", device, err)
+	}
+	path := file.Name()
+	defer file.Close()
+	defer func() {
+		if path != "" {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := file.Write(raw); err != nil {
+		return fmt.Errorf("writing %s evidence file: %w", device, err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewinding %s evidence file: %w", device, err)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("unlinking %s evidence file: %w", device, err)
+	}
+	path = ""
+
+	args := []string{
+		"attest",
+		"--device", device,
+		"--verifier", "local",
+		"--nonce", hex.EncodeToString(nonce[:]),
+		"--format", "json",
+	}
+	if device == "gpu" {
+		args = append(args, "--gpu-evidence-source", "file", "--gpu-evidence-file", "/proc/self/fd/3")
+	} else if device == "nvswitch" {
+		args = append(args, "--nvswitch-evidence-source", "file", "--nvswitch-evidence-file", "/proc/self/fd/3")
+	} else {
+		return fmt.Errorf("unsupported nvattest device %q", device)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), nvattestTimeout)
+	defer cancel()
+	cmd := commandContext(ctx, "nvattest", args...)
+	cmd.ExtraFiles = []*os.File{file}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("nvattest %s appraisal timed out after %s", device, nvattestTimeout)
+		}
+		return fmt.Errorf("nvattest %s appraisal failed: %w: %s", device, err, strings.TrimSpace(stderr.String()))
+	}
+	var result nvattestAppraisalOutput
+	if err := json.Unmarshal(out, &result); err != nil {
+		return fmt.Errorf("parsing nvattest %s appraisal: %w", device, err)
+	}
+	if result.ResultCode != 0 {
+		return fmt.Errorf("nvattest %s appraisal failed: %s (code %d)", device, result.ResultMessage, result.ResultCode)
+	}
+	return nil
+}
+
+func certificateIdentity(certificate []byte) string {
+	digest := sha256.Sum256(certificate)
+	return hex.EncodeToString(digest[:])
+}
+
+func sortedUniqueIdentities(source string, identities []string) ([]string, error) {
+	normalized := slices.Clone(identities)
+	slices.Sort(normalized)
+	for index := 1; index < len(normalized); index++ {
+		if normalized[index] == normalized[index-1] {
+			return nil, fmt.Errorf("%s contains duplicate device identity %s", source, normalized[index])
+		}
+	}
+	return normalized, nil
+}
+
+func liveGPUIdentities() ([]string, error) {
+	count, ret := nvml.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("DeviceGetCount: %s", nvml.ErrorString(ret))
+	}
+	identities := make([]string, 0, count)
+	for index := 0; index < count; index++ {
+		device, ret := nvml.DeviceGetHandleByIndex(index)
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("DeviceGetHandleByIndex(%d): %s", index, nvml.ErrorString(ret))
+		}
+		certificate, ret := device.GetConfComputeGpuCertificate()
+		if ret != nvml.SUCCESS {
+			return nil, fmt.Errorf("GetConfComputeGpuCertificate(%d): %s", index, nvml.ErrorString(ret))
+		}
+		if certificate.AttestationCertChainSize == 0 || certificate.AttestationCertChainSize > uint32(len(certificate.AttestationCertChain)) {
+			return nil, fmt.Errorf("GPU %d returned invalid attestation certificate size %d", index, certificate.AttestationCertChainSize)
+		}
+		identity := certificateIdentity(certificate.AttestationCertChain[:certificate.AttestationCertChainSize])
+		identities = append(identities, identity)
+	}
+	return sortedUniqueIdentities("live GPU set", identities)
+}
+
+func sameIdentities(expected, actual []string) bool {
+	return slices.Equal(expected, actual)
+}
+
+func identitySetDifference(expected, actual []string) (missing, unexpected []string) {
+	actualSet := make(map[string]struct{}, len(actual))
+	for _, identity := range actual {
+		actualSet[identity] = struct{}{}
+	}
+	for _, identity := range expected {
+		if _, exists := actualSet[identity]; !exists {
+			missing = append(missing, identity)
+		}
+	}
+	expectedSet := make(map[string]struct{}, len(expected))
+	for _, identity := range expected {
+		expectedSet[identity] = struct{}{}
+	}
+	for _, identity := range actual {
+		if _, exists := expectedSet[identity]; !exists {
+			unexpected = append(unexpected, identity)
+		}
+	}
+	return missing, unexpected
+}
+
+func setGPUReadyStateWithRetry(state uint32) error {
+	var failures []error
+	for attempt := 1; attempt <= gpuReadyStateAttempts; attempt++ {
+		ret := setGPUReadyStateValue(state)
+		if ret == nvml.SUCCESS {
+			return nil
+		}
+		failures = append(failures, fmt.Errorf("attempt %d: %s", attempt, nvml.ErrorString(ret)))
+		if attempt < gpuReadyStateAttempts {
+			time.Sleep(gpuReadyStateRetryBackoff)
+		}
+	}
+	return errors.Join(failures...)
+}
+
+func withNVML(operation func() error) error {
+	ret := initializeNVML()
 	if ret != nvml.SUCCESS {
 		return fmt.Errorf("nvml.Init: %s", nvml.ErrorString(ret))
 	}
-	defer nvml.Shutdown()
+	defer shutdownNVML()
+	return operation()
+}
 
-	var state uint32 = nvml.CC_ACCEPTING_CLIENT_REQUESTS_FALSE
-	if accepting {
-		state = nvml.CC_ACCEPTING_CLIENT_REQUESTS_TRUE
+func rollbackGPUReadiness(cause error) error {
+	if err := setGPUReadyStateWithRetry(nvml.CC_ACCEPTING_CLIENT_REQUESTS_FALSE); err != nil {
+		return errors.Join(cause, fmt.Errorf("disabling GPU readiness after identity verification failure: %w", err))
 	}
+	return cause
+}
 
-	ret = nvml.SystemSetConfComputeGpusReadyState(state)
-	if ret != nvml.SUCCESS {
-		return fmt.Errorf("SystemSetConfComputeGpusReadyState: %s", nvml.ErrorString(ret))
-	}
-	log.Printf("GPU ready state set to %v", accepting)
-	return nil
+func enableGPUsForIdentities(expected []string) error {
+	return withNVML(func() error {
+		before, err := snapshotLiveGPUIdentities()
+		if err != nil {
+			return err
+		}
+		if !sameIdentities(expected, before) {
+			missing, unexpected := identitySetDifference(expected, before)
+			return fmt.Errorf("live GPU identities changed before readiness: missing=%v unexpected=%v", missing, unexpected)
+		}
+		if err := setGPUReadyStateWithRetry(nvml.CC_ACCEPTING_CLIENT_REQUESTS_TRUE); err != nil {
+			return fmt.Errorf("enabling GPU readiness: %w", err)
+		}
+		after, err := snapshotLiveGPUIdentities()
+		if err != nil {
+			return rollbackGPUReadiness(fmt.Errorf("checking GPU identities after readiness: %w", err))
+		}
+		if !sameIdentities(expected, after) {
+			missing, unexpected := identitySetDifference(expected, after)
+			return rollbackGPUReadiness(fmt.Errorf("live GPU identities changed during readiness: missing=%v unexpected=%v", missing, unexpected))
+		}
+		log.Printf("GPU ready state set to true for %d verified device(s)", len(expected))
+		return nil
+	})
+}
+
+func setGPUReadyState(accepting bool) error {
+	return withNVML(func() error {
+		var state uint32 = nvml.CC_ACCEPTING_CLIENT_REQUESTS_FALSE
+		if accepting {
+			state = nvml.CC_ACCEPTING_CLIENT_REQUESTS_TRUE
+		}
+
+		if err := setGPUReadyStateWithRetry(state); err != nil {
+			return fmt.Errorf("setting GPU ready state to %v: %w", accepting, err)
+		}
+		log.Printf("GPU ready state set to %v", accepting)
+		return nil
+	})
 }
 
 // GPURawEvidence holds the raw nvattest collect-evidence JSON output.
@@ -161,99 +373,95 @@ type GPURawEvidence struct {
 	Switch json.RawMessage `json:"nvswitch,omitempty"`
 }
 
-type dummyEvidenceEntry struct {
-	Arch        string `json:"arch"`
-	Certificate string `json:"certificate"`
-	Evidence    string `json:"evidence"`
-	Nonce       string `json:"nonce"`
-}
-
-type dummyEvidenceOutput struct {
-	Evidences     []dummyEvidenceEntry `json:"evidences"`
-	ResultCode    int                  `json:"result_code"`
-	ResultMessage string               `json:"result_message"`
-}
-
 // dummyGPUEvidence returns mock GPU evidence matching the nvattest JSON format.
 func dummyGPUEvidence(gpuCount int) *GPURawEvidence {
-	gpuOut := dummyEvidenceOutput{ResultCode: 0, ResultMessage: "dummy-attestation"}
-	for range gpuCount {
-		gpuOut.Evidences = append(gpuOut.Evidences, dummyEvidenceEntry{Arch: "DUMMY"})
-	}
-	gpuRaw, _ := json.Marshal(gpuOut)
+	gpuRaw := dummyEvidenceJSON(gpuCount)
 	evidence := &GPURawEvidence{GPU: json.RawMessage(gpuRaw)}
 
 	if gpuCount > 1 {
-		switchOut := dummyEvidenceOutput{ResultCode: 0, ResultMessage: "dummy-attestation"}
-		for range 4 {
-			switchOut.Evidences = append(switchOut.Evidences, dummyEvidenceEntry{Arch: "DUMMY"})
-		}
-		switchRaw, _ := json.Marshal(switchOut)
+		switchRaw := dummyEvidenceJSON(4)
 		evidence.Switch = json.RawMessage(switchRaw)
 	}
 	return evidence
 }
 
-// verifyGPUAttestation runs attestation for the expected number of GPUs (1 or 8).
-// Returns the raw evidence for inclusion in the attestation envelope.
+func dummyEvidenceJSON(count int) []byte {
+	entries := make([]nvattestEvidenceEntry, count)
+	for index := range entries {
+		entries[index].Arch = "DUMMY"
+	}
+	encodedEntries, _ := json.Marshal(entries)
+	encodedOutput, _ := json.Marshal(nvattestEvidenceOutput{
+		Evidences:     encodedEntries,
+		ResultCode:    0,
+		ResultMessage: "dummy-attestation",
+	})
+	return encodedOutput
+}
+
+func multiGPUArchitecture(arches []string) (string, error) {
+	architecture := arches[0]
+	for _, candidate := range arches[1:] {
+		if candidate != architecture {
+			return "", fmt.Errorf("GPU evidence contains mixed architectures %q and %q", architecture, candidate)
+		}
+	}
+	return architecture, nil
+}
+
+// verifyGPUAttestation appraises one nonced evidence transaction and binds
+// topology validation and readiness to the identities in that transaction.
 func verifyGPUAttestation(expectedGPUs int) (*GPURawEvidence, error) {
 	ok := false
 	defer func() {
 		if !ok {
-			if err := setGPUReadyState(false); err != nil {
+			if err := disableGPUs(); err != nil {
 				log.Printf("WARNING: failed to disable GPU ready state: %v", err)
 			}
 		}
 	}()
 
-	if err := runNvattest("gpu"); err != nil {
+	nonce, err := generateGPUAttestationNonce()
+	if err != nil {
 		return nil, err
 	}
 
-	evidence := &GPURawEvidence{}
-
-	log.Println("Collecting GPU evidence")
-	gpuReports, gpuRaw, err := collectEvidence("gpu")
+	log.Println("Collecting and appraising GPU evidence")
+	gpuEvidence, err := collectAndAppraiseEvidence("gpu", nonce)
 	if err != nil {
-		return nil, fmt.Errorf("collecting GPU evidence: %w", err)
+		return nil, fmt.Errorf("verifying GPU evidence: %w", err)
 	}
-	if len(gpuReports) != expectedGPUs {
-		return nil, fmt.Errorf("expected %d GPU reports, got %d", expectedGPUs, len(gpuReports))
+	if len(gpuEvidence.reports) != expectedGPUs {
+		return nil, fmt.Errorf("expected %d GPU reports, got %d", expectedGPUs, len(gpuEvidence.reports))
 	}
-	evidence.GPU = gpuRaw
+	evidence := &GPURawEvidence{GPU: gpuEvidence.raw}
 
 	if expectedGPUs > 1 {
-		arch, err := detectGPUArch()
+		architecture, err := multiGPUArchitecture(gpuEvidence.arches)
 		if err != nil {
-			return nil, fmt.Errorf("detecting GPU arch: %w", err)
+			return nil, err
 		}
-		switch arch {
-		case "b200", "b300":
-			// Blackwell MPT: NVSwitches are not exposed to the guest.
+		switch architecture {
+		case gpuattestation.GPUArchBlackwell:
 			log.Printf("HGX Blackwell MPT: no in-guest NVSwitch evidence")
-
-		case "h100", "h200", "":
-			if err := runNvattest("nvswitch"); err != nil {
-				return nil, err
-			}
-			log.Println("Collecting NVSwitch evidence for topology validation")
-			switchReports, switchRaw, err := collectEvidence("nvswitch")
+		case gpuattestation.GPUArchHopper:
+			log.Println("Collecting and appraising NVSwitch evidence for topology validation")
+			switchEvidence, err := collectAndAppraiseEvidence("nvswitch", nonce)
 			if err != nil {
-				return nil, fmt.Errorf("collecting switch evidence: %w", err)
+				return nil, fmt.Errorf("verifying switch evidence: %w", err)
 			}
-			evidence.Switch = switchRaw
+			evidence.Switch = switchEvidence.raw
 			log.Printf("Validating Hopper PPCIe topology (%d GPUs, %d switches)", expectedGPUs, hopperSwitchCount)
-			if err := validateTopology(gpuReports, switchReports, expectedGPUs, hopperSwitchCount); err != nil {
+			if err := validateTopology(gpuEvidence.reports, switchEvidence.reports, expectedGPUs, hopperSwitchCount); err != nil {
 				return nil, fmt.Errorf("topology validation failed: %w", err)
 			}
-
 		default:
-			return nil, fmt.Errorf("unsupported multi-GPU arch %q for in-guest attestation", arch)
+			return nil, fmt.Errorf("unsupported multi-GPU architecture %q", architecture)
 		}
 	}
 
-	if err := setGPUReadyState(true); err != nil {
-		return nil, fmt.Errorf("enabling GPU ready state: %w", err)
+	if err := enableVerifiedGPUs(gpuEvidence.identities); err != nil {
+		return nil, fmt.Errorf("enabling verified GPUs: %w", err)
 	}
 
 	ok = true

--- a/tinfoil/cmd/boot/gpuattest_transaction_test.go
+++ b/tinfoil/cmd/boot/gpuattest_transaction_test.go
@@ -1,0 +1,267 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"tinfoil/internal/nvml"
+)
+
+func fixedGPUAttestationNonce() [32]byte {
+	var nonce [32]byte
+	for index := range nonce {
+		nonce[index] = byte(index + 1)
+	}
+	return nonce
+}
+
+func installFakeNvattest(t *testing.T, appraisalCode int) (string, string) {
+	t.Helper()
+	directory := t.TempDir()
+	callsPath := filepath.Join(directory, "calls")
+	appraisedPath := filepath.Join(directory, "appraised")
+	noncePath := filepath.Join(directory, "nonce")
+	scriptPath := filepath.Join(directory, "nvattest")
+	script := `#!/bin/sh
+set -eu
+printf '%s\n' "$1" >> "$NVATTEST_CALLS"
+command="$1"
+shift
+nonce=""
+evidence_file=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --nonce) nonce="$2"; shift 2 ;;
+    --gpu-evidence-file|--nvswitch-evidence-file) evidence_file="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [ "$command" = "collect-evidence" ]; then
+  printf '%s' "$nonce" > "$NVATTEST_NONCE"
+  printf '{"evidences":[{"arch":"HOPPER","certificate":"Y2VydGlmaWNhdGU=","evidence":"AQID","nonce":"%s"}],"result_code":0,"result_message":"ok"}\n' "$nonce"
+  exit 0
+fi
+if [ -f "$NVATTEST_NONCE" ]; then
+  test "$nonce" = "$(cat "$NVATTEST_NONCE")"
+fi
+cat "$evidence_file" > "$NVATTEST_APPRAISED"
+printf '{"result_code":%s,"result_message":"appraisal"}\n' "$NVATTEST_APPRAISAL_CODE"
+`
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", directory+":"+os.Getenv("PATH"))
+	t.Setenv("NVATTEST_CALLS", callsPath)
+	t.Setenv("NVATTEST_APPRAISED", appraisedPath)
+	t.Setenv("NVATTEST_NONCE", noncePath)
+	t.Setenv("NVATTEST_APPRAISAL_CODE", fmt.Sprintf("%d", appraisalCode))
+	oldTempDir := gpuEvidenceTempDir
+	gpuEvidenceTempDir = directory
+	t.Cleanup(func() { gpuEvidenceTempDir = oldTempDir })
+	return callsPath, appraisedPath
+}
+
+func TestCollectAndAppraiseEvidenceUsesOneNoncedTransaction(t *testing.T) {
+	callsPath, appraisedPath := installFakeNvattest(t, 0)
+	nonce := fixedGPUAttestationNonce()
+
+	verified, err := collectAndAppraiseEvidence("gpu", nonce)
+	if err != nil {
+		t.Fatalf("collectAndAppraiseEvidence: %v", err)
+	}
+	if len(verified.reports) != 1 || !slices.Equal(verified.reports[0], []byte{1, 2, 3}) {
+		t.Fatalf("reports = %#v", verified.reports)
+	}
+	wantIdentity := sha256.Sum256([]byte("certificate"))
+	if len(verified.identities) != 1 || verified.identities[0] != hex.EncodeToString(wantIdentity[:]) {
+		t.Fatalf("identities = %#v", verified.identities)
+	}
+	appraised, err := os.ReadFile(appraisedPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(appraised) != string(verified.appraisalInput) {
+		t.Fatal("appraiser did not consume the exact collected evidence bytes")
+	}
+	calls, err := os.ReadFile(callsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.Fields(string(calls)); !slices.Equal(got, []string{"collect-evidence", "attest"}) {
+		t.Fatalf("nvattest calls = %#v", got)
+	}
+}
+
+func TestParseEvidenceRejectsWrongNonce(t *testing.T) {
+	nonce := fixedGPUAttestationNonce()
+	entries, err := json.Marshal([]nvattestEvidenceEntry{{
+		Arch:        "HOPPER",
+		Certificate: base64.StdEncoding.EncodeToString([]byte("certificate")),
+		Evidence:    base64.StdEncoding.EncodeToString([]byte("report")),
+		Nonce:       strings.Repeat("00", 32),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(nvattestEvidenceOutput{Evidences: entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseEvidence("gpu", nonce, raw); err == nil || !strings.Contains(err.Error(), "nonce") {
+		t.Fatalf("parseEvidence error = %v", err)
+	}
+}
+
+func TestParseEvidenceRejectsDuplicateIdentity(t *testing.T) {
+	nonce := fixedGPUAttestationNonce()
+	nonceHex := hex.EncodeToString(nonce[:])
+	entry := nvattestEvidenceEntry{
+		Arch:        "HOPPER",
+		Certificate: base64.StdEncoding.EncodeToString([]byte("certificate")),
+		Evidence:    base64.StdEncoding.EncodeToString([]byte("report")),
+		Nonce:       nonceHex,
+	}
+	entries, err := json.Marshal([]nvattestEvidenceEntry{entry, entry})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(nvattestEvidenceOutput{Evidences: entries})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := parseEvidence("gpu", nonce, raw); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("parseEvidence error = %v", err)
+	}
+}
+
+func TestAppraiseEvidenceRejectsFailedResult(t *testing.T) {
+	installFakeNvattest(t, 7)
+	nonce := fixedGPUAttestationNonce()
+	raw := json.RawMessage(`{"evidences":[]}`)
+	if err := appraiseEvidence("gpu", nonce, raw); err == nil || !strings.Contains(err.Error(), "code 7") {
+		t.Fatalf("appraiseEvidence error = %v", err)
+	}
+}
+
+func TestVerifyGPUAttestationBindsReadinessToEvidenceIdentity(t *testing.T) {
+	installFakeNvattest(t, 0)
+	nonce := fixedGPUAttestationNonce()
+	oldNonceGenerator := generateGPUAttestationNonce
+	oldEnable := enableVerifiedGPUs
+	oldDisable := disableGPUs
+	t.Cleanup(func() {
+		generateGPUAttestationNonce = oldNonceGenerator
+		enableVerifiedGPUs = oldEnable
+		disableGPUs = oldDisable
+	})
+	generateGPUAttestationNonce = func() ([32]byte, error) { return nonce, nil }
+	disableGPUs = func() error { return nil }
+	var readinessIdentities []string
+	enableVerifiedGPUs = func(identities []string) error {
+		readinessIdentities = slices.Clone(identities)
+		return nil
+	}
+
+	if _, err := verifyGPUAttestation(1); err != nil {
+		t.Fatalf("verifyGPUAttestation: %v", err)
+	}
+	wantIdentity := sha256.Sum256([]byte("certificate"))
+	if !slices.Equal(readinessIdentities, []string{hex.EncodeToString(wantIdentity[:])}) {
+		t.Fatalf("readiness identities = %#v", readinessIdentities)
+	}
+}
+
+func TestVerifyGPUAttestationFailsWhenIdentityGateDetectsReplacement(t *testing.T) {
+	installFakeNvattest(t, 0)
+	nonce := fixedGPUAttestationNonce()
+	oldNonceGenerator := generateGPUAttestationNonce
+	oldEnable := enableVerifiedGPUs
+	oldDisable := disableGPUs
+	t.Cleanup(func() {
+		generateGPUAttestationNonce = oldNonceGenerator
+		enableVerifiedGPUs = oldEnable
+		disableGPUs = oldDisable
+	})
+	generateGPUAttestationNonce = func() ([32]byte, error) { return nonce, nil }
+	enableVerifiedGPUs = func([]string) error { return errors.New("live GPU identities changed before readiness") }
+	disabled := false
+	disableGPUs = func() error {
+		disabled = true
+		return nil
+	}
+
+	if _, err := verifyGPUAttestation(1); err == nil || !strings.Contains(err.Error(), "identities changed") {
+		t.Fatalf("verifyGPUAttestation error = %v", err)
+	}
+	if !disabled {
+		t.Fatal("failed verification did not force GPU readiness off")
+	}
+}
+
+func TestIdentitySetComparisonDetectsReplacement(t *testing.T) {
+	if sameIdentities([]string{"a", "b"}, []string{"a", "c"}) {
+		t.Fatal("replacement passed identity comparison")
+	}
+}
+
+func TestIdentitySetDifferenceReportsReplacement(t *testing.T) {
+	missing, unexpected := identitySetDifference([]string{"a", "b"}, []string{"b", "c"})
+	if !slices.Equal(missing, []string{"a"}) || !slices.Equal(unexpected, []string{"c"}) {
+		t.Fatalf("missing=%v unexpected=%v", missing, unexpected)
+	}
+}
+
+func TestEnableGPUsForIdentitiesRollsBackMidTransitionReplacement(t *testing.T) {
+	oldInitialize := initializeNVML
+	oldShutdown := shutdownNVML
+	oldSnapshot := snapshotLiveGPUIdentities
+	oldSetReady := setGPUReadyStateValue
+	t.Cleanup(func() {
+		initializeNVML = oldInitialize
+		shutdownNVML = oldShutdown
+		snapshotLiveGPUIdentities = oldSnapshot
+		setGPUReadyStateValue = oldSetReady
+	})
+
+	initializeNVML = func() nvml.Return { return nvml.SUCCESS }
+	shutdownCalled := false
+	shutdownNVML = func() nvml.Return {
+		shutdownCalled = true
+		return nvml.SUCCESS
+	}
+	snapshots := [][]string{{"verified"}, {"replacement"}}
+	snapshotLiveGPUIdentities = func() ([]string, error) {
+		identity := snapshots[0]
+		snapshots = snapshots[1:]
+		return identity, nil
+	}
+	var states []uint32
+	setGPUReadyStateValue = func(state uint32) nvml.Return {
+		states = append(states, state)
+		return nvml.SUCCESS
+	}
+
+	err := enableGPUsForIdentities([]string{"verified"})
+	if err == nil || !strings.Contains(err.Error(), "unexpected=[replacement]") {
+		t.Fatalf("enableGPUsForIdentities error = %v", err)
+	}
+	wantStates := []uint32{
+		nvml.CC_ACCEPTING_CLIENT_REQUESTS_TRUE,
+		nvml.CC_ACCEPTING_CLIENT_REQUESTS_FALSE,
+	}
+	if !slices.Equal(states, wantStates) {
+		t.Fatalf("ready states = %v, want %v", states, wantStates)
+	}
+	if !shutdownCalled {
+		t.Fatal("NVML was not shut down")
+	}
+}


### PR DESCRIPTION
## Summary
- collect each GPU evidence set with a boot-generated nonce
- appraise the exact collected evidence before using its architecture or topology data
- bind the readiness transition to the appraised device certificate identities
- recheck the live identity set before and after enabling client requests

## Validation
- `GOTOOLCHAIN=go1.26.5 go test ./... -count=1`
- `GOTOOLCHAIN=go1.26.5 go vet ./...`
- `nix-build --no-out-link -I . -A checks -A runtime-go`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind GPU readiness to appraised evidence using a nonce-based transaction. Readiness is gated by appraised device certificate identities and rechecked before and after enabling client requests.

- **New Features**
  - Collect GPU/NVSwitch evidence with a boot-generated nonce; appraise the exact collected bytes via FD and enforce nonce match.
  - Derive identities from attestation certificates; sort, reject duplicates, and bind readiness to this set.
  - Re-verify live identities via `nvml` before and after readiness; retry ready-state with backoff and rollback if identities change.
  - Detect multi-GPU architecture from evidence; reject mixed architectures.
  - Validate Hopper topology with appraised NVSwitch evidence; skip in-guest NVSwitch for Blackwell MPT.

- **Refactors**
  - Replaced PCI-based arch detection and split attestation into small units (collection, parsing, appraisal, identity gating).
  - Added tests in `tinfoil/cmd/boot/gpuattest_transaction_test.go` for nonce handling, exact appraisal input, identity checks, readiness binding, and rollback on identity changes.

<sup>Written for commit a3fb1038b26f76dfd904a56b1b3aa6e840da62c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

