### PR TITLE
Stop attaching a console device to the debug toolbox

### DIFF
--- a/tinfoil/cmd/boot/debug_policy.go
+++ b/tinfoil/cmd/boot/debug_policy.go
@@ -8,6 +8,5 @@ const (
 	reservedDebugContainerName = runtimeconfig.ReservedDebugContainerName
 	reservedDebugPort          = runtimeconfig.ReservedDebugPort
 	reservedDebugHostPort      = runtimeconfig.ReservedDebugHostPort
-	reservedDebugSerialDevice  = runtimeconfig.ReservedDebugSerialDevice
 	debugDockerSocketBind      = "/run/docker.sock:/var/run/docker.sock"
 )

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -561,11 +561,6 @@ func applyReservedDebugRuntime(containerConfig *container.Config, hostConfig *co
 	hostConfig.PortBindings[port] = []dockernetwork.PortBinding{{
 		HostPort: fmt.Sprintf("%d", reservedDebugHostPort),
 	}}
-	hostConfig.Devices = append(hostConfig.Devices, container.DeviceMapping{
-		PathOnHost:        reservedDebugSerialDevice,
-		PathInContainer:   reservedDebugSerialDevice,
-		CgroupPermissions: "rw",
-	})
 }
 
 func endpointSettings(name string, gwPriority int) *dockernetwork.EndpointSettings {

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -238,11 +238,8 @@ func TestBuildContainerCreateSpec_DebugInstallerGetsFixedRuntime(t *testing.T) {
 	if len(bindings) != 1 || bindings[0].HostPort != "2222" {
 		t.Fatalf("PortBindings[%s] = %v, want host port 2222", port, bindings)
 	}
-	if len(hostConfig.Devices) != 1 {
-		t.Fatalf("Devices = %v, want one synthesized serial mapping", hostConfig.Devices)
-	}
-	if got := hostConfig.Devices[0]; got.PathOnHost != reservedDebugSerialDevice || got.PathInContainer != reservedDebugSerialDevice || got.CgroupPermissions != "rw" {
-		t.Fatalf("Devices[0] = %+v, want exact /dev/hvc1 rw mapping", got)
+	if len(hostConfig.Devices) != 0 {
+		t.Fatalf("Devices = %v, want no synthesized device mappings", hostConfig.Devices)
 	}
 }
 
@@ -263,9 +260,7 @@ func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testi
 	if len(hostConfig.PortBindings) != 0 {
 		t.Fatalf("PortBindings = %v, want none in production", hostConfig.PortBindings)
 	}
-	for _, dev := range hostConfig.Devices {
-		if dev.PathOnHost == reservedDebugSerialDevice || dev.PathInContainer == reservedDebugSerialDevice {
-			t.Fatalf("Devices = %v, want no synthesized serial device in production", hostConfig.Devices)
-		}
+	if len(hostConfig.Devices) != 0 {
+		t.Fatalf("Devices = %v, want no synthesized device mappings", hostConfig.Devices)
 	}
 }

--- a/tinfoil/internal/containers/types.go
+++ b/tinfoil/internal/containers/types.go
@@ -13,6 +13,5 @@ const (
 	reservedDebugContainerName = runtimeconfig.ReservedDebugContainerName
 	reservedDebugPort          = runtimeconfig.ReservedDebugPort
 	reservedDebugHostPort      = runtimeconfig.ReservedDebugHostPort
-	reservedDebugSerialDevice  = runtimeconfig.ReservedDebugSerialDevice
 	debugDockerSocketBind      = "/run/docker.sock:/var/run/docker.sock"
 )

--- a/tinfoil/internal/runtimeconfig/types.go
+++ b/tinfoil/internal/runtimeconfig/types.go
@@ -15,7 +15,6 @@ const (
 	ReservedDebugContainerName = "tinfoil-debug-toolbox"
 	ReservedDebugPort          = "2222/tcp"
 	ReservedDebugHostPort      = 2222
-	ReservedDebugSerialDevice  = "/dev/hvc1"
 )
 
 type Config struct {


### PR DESCRIPTION
## Summary
- keep the reserved toolbox runtime on its fixed SSH port
- stop synthesizing a guest character-device mapping for the toolbox
- update container runtime tests for the SSH-only contract

## Validation
- `go test ./...` from `tinfoil/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the debug toolbox SSH-only by removing the synthesized console device mapping. Keep the reserved runtime on port 2222 and update tests to assert no device mappings.

- **Refactors**
  - Removed the `/dev/hvc1` mapping and the `ReservedDebugSerialDevice` constant.
  - Updated container tests to expect only the fixed SSH `PortBindings` and zero `Devices`.

<sup>Written for commit dbe5f322cf2d51826325371dbf076a0aef6a56ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

