### PR TITLE
Bill authenticated requests sent directly to inference endpoints (cvmimage side)

### DIFF
--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -230,6 +230,11 @@ func NewShimServer(
 			req.Header.Set("Host", "localhost")
 			req.Host = "localhost"
 			req.Header.Del(ehbpProtocol.EncapsulatedKeyHeader)
+			if billingRequired {
+				// Token extraction must see the upstream representation, so do not
+				// negotiate a content coding that would hide JSON or SSE framing.
+				req.Header.Set("Accept-Encoding", "identity")
+			}
 
 			// Forward original host and protocol to the upstream
 			req.Header.Del("Forwarded")

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -91,6 +91,14 @@ func (v *metricsValidator) Validate(req key.Request) error {
 
 // extractBearerToken returns the token portion of an Authorization header,
 // accepting any capitalization of the "Bearer" scheme.
+//
+// This must produce byte-identical output to the confidential-model-router's
+// manager.BearerToken: the router signs usage-context APIKeyHash with
+// HashAPIKey(BearerToken(...)) and the shim verifies with
+// VerifyAPIKeyHash(extractBearerToken(...), ctx.APIKeyHash). Any divergence
+// in parsing (scheme casing, trimming) silently breaks billing suppression
+// (fail-closed to double-billing). The two functions are intentionally
+// identical and must not drift.
 func extractBearerToken(header string) string {
 	const scheme = "bearer "
 	if len(header) < len(scheme) || !strings.EqualFold(header[:len(scheme)], scheme) {
@@ -196,9 +204,10 @@ func NewShimServer(
 	externalConfig *config.ExternalConfig,
 	upstreamAddr string,
 	billingCollector *billing.Collector,
+	usageContextSecret string,
 ) http.Handler {
 	billingRequired := config.BillingRequired()
-	if err := validateShimBillingInvariant(config, billingCollector); err != nil {
+	if err := validateShimBillingInvariant(config, billingCollector, usageContextSecret); err != nil {
 		panic(err)
 	}
 	ehbpMiddleware := ehbpIdentity.Middleware()
@@ -285,6 +294,10 @@ func NewShimServer(
 				writeJSONError(w, errMsgRateLimited, errTypeInvalidRequest, http.StatusTooManyRequests)
 				return
 			}
+		}
+
+		if billingRequired {
+			prepareBillingSuppression(r, apiKey, usageContextSecret)
 		}
 
 		if r.Body != nil && r.Body != http.NoBody {

--- a/tinfoil/cmd/shim/api.go
+++ b/tinfoil/cmd/shim/api.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	tinfoilattestation "tinfoil/internal/attestation"
+	"tinfoil/internal/billing"
 	"tinfoil/internal/boot"
 	"tinfoil/internal/config"
 	"tinfoil/internal/key"
@@ -24,6 +25,8 @@ import (
 	ehbpProtocol "github.com/tinfoilsh/encrypted-http-body-protocol/protocol"
 	"github.com/tinfoilsh/tinfoil-go/verifier/attestation"
 )
+
+const maxRequestBodySize int64 = 64 * 1024 * 1024
 
 // pathMatchesPattern checks if a request path matches a pattern.
 // Patterns can be exact matches or use a trailing * for segment-boundary prefix matching.
@@ -192,9 +195,22 @@ func NewShimServer(
 	config *config.Config,
 	externalConfig *config.ExternalConfig,
 	upstreamAddr string,
+	billingCollector *billing.Collector,
 ) http.Handler {
+	billingRequired := config.BillingRequired()
+	if err := validateShimBillingInvariant(config, billingCollector); err != nil {
+		panic(err)
+	}
 	ehbpMiddleware := ehbpIdentity.Middleware()
 	mux := http.NewServeMux()
+
+	// The enclave host identifies which enclave served the request in billing
+	// events. DOMAIN is the enclave's public domain, provisioned in the
+	// external config env alongside other shim secrets.
+	enclaveHost := externalConfig.Env["DOMAIN"]
+	if enclaveHost == "" {
+		enclaveHost = externalConfig.Metadata.Domain
+	}
 
 	proxy := httputil.ReverseProxy{
 		Director: func(req *http.Request) {
@@ -220,9 +236,18 @@ func NewShimServer(
 		ModifyResponse: func(res *http.Response) error {
 			res.Header.Del("Access-Control-Allow-Origin")
 			res.Header.Del(ehbpProtocol.ResponseNonceHeader)
+
+			if billingRequired {
+				applyBillingToResponse(res, billingCollector, config.ModelName, enclaveHost)
+			}
 			return nil
 		},
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			var tooLarge *http.MaxBytesError
+			if errors.As(err, &tooLarge) {
+				writeJSONError(w, "Request body is too large.", errTypeInvalidRequest, http.StatusRequestEntityTooLarge)
+				return
+			}
 			log.Printf("proxy error: %v", err)
 			writeJSONError(w, errMsgServerError, errTypeServer, http.StatusBadGateway)
 		},
@@ -258,6 +283,30 @@ func NewShimServer(
 			limiter := rateLimiter.Limit(apiKey)
 			if !limiter.Allow() {
 				writeJSONError(w, errMsgRateLimited, errTypeInvalidRequest, http.StatusTooManyRequests)
+				return
+			}
+		}
+
+		if r.Body != nil && r.Body != http.NoBody {
+			if r.ContentLength > maxRequestBodySize {
+				writeJSONError(w, "Request body is too large.", errTypeInvalidRequest, http.StatusRequestEntityTooLarge)
+				return
+			}
+			r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
+		}
+
+		if billingRequired {
+			// The configured model is authoritative. JSON inspection only forces
+			// streaming usage emission needed by the billing token extractor.
+			_, err := prepareBillingRequest(r)
+			if err != nil {
+				var tooLarge *http.MaxBytesError
+				if errors.As(err, &tooLarge) {
+					writeJSONError(w, "Request body is too large.", errTypeInvalidRequest, http.StatusRequestEntityTooLarge)
+					return
+				}
+				log.Printf("Warning: rejecting invalid billing request metadata: %v", err)
+				writeJSONError(w, "Invalid request body: "+err.Error()+".", errTypeInvalidRequest, http.StatusBadRequest)
 				return
 			}
 		}

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -55,7 +55,7 @@ func testAuthServer(t *testing.T, validator key.Validator, authenticatedEndpoint
 		Body:   "deadbeef",
 	}
 
-	return NewShimServer(validator, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, "127.0.0.1:9999", nil)
+	return NewShimServer(validator, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, "127.0.0.1:9999", nil, "")
 }
 
 func testServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
@@ -82,7 +82,7 @@ func testFullServer(t *testing.T, paths []string, upstreamPort int) http.Handler
 	}
 	upstreamAddr := fmt.Sprintf("127.0.0.1:%d", upstreamPort)
 
-	return NewShimServer(nil, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, upstreamAddr, nil)
+	return NewShimServer(nil, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, upstreamAddr, nil, "")
 }
 
 func testObservabilityServer(t *testing.T, paths []string) http.Handler {

--- a/tinfoil/cmd/shim/api_test.go
+++ b/tinfoil/cmd/shim/api_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,15 @@ import (
 	"tinfoil/internal/config"
 	"tinfoil/internal/key"
 )
+
+type repeatingByteReader struct{}
+
+func (repeatingByteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
+}
 
 type fakeValidator struct {
 	err   error
@@ -45,7 +55,7 @@ func testAuthServer(t *testing.T, validator key.Validator, authenticatedEndpoint
 		Body:   "deadbeef",
 	}
 
-	return NewShimServer(validator, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, "127.0.0.1:9999")
+	return NewShimServer(validator, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, "127.0.0.1:9999", nil)
 }
 
 func testServer(t *testing.T, paths []string, upstreamPort int) http.Handler {
@@ -72,7 +82,7 @@ func testFullServer(t *testing.T, paths []string, upstreamPort int) http.Handler
 	}
 	upstreamAddr := fmt.Sprintf("127.0.0.1:%d", upstreamPort)
 
-	return NewShimServer(nil, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, upstreamAddr)
+	return NewShimServer(nil, nil, att, tinfoilattestation.BodyV2{}, 0, id, nil, cfg, extCfg, upstreamAddr, nil)
 }
 
 func testObservabilityServer(t *testing.T, paths []string) http.Handler {
@@ -113,6 +123,39 @@ func TestPathNotAllowed_Returns404(t *testing.T) {
 	}
 	if typ := body["error"]["type"]; typ != "invalid_request_error" {
 		t.Errorf("expected error type %q, got %q", "invalid_request_error", typ)
+	}
+}
+
+func TestOversizedRequestBodyKnownLengthReturns413(t *testing.T) {
+	handler := testServer(t, nil, 9999)
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", repeatingByteReader{})
+	req.ContentLength = maxRequestBodySize + 1
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
+	}
+}
+
+func TestOversizedChunkedRequestBodyReturns413(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+	port := upstream.Listener.Addr().(*net.TCPAddr).Port
+	handler := testServer(t, nil, port)
+	body := io.NopCloser(io.LimitReader(repeatingByteReader{}, maxRequestBodySize+1))
+	req := httptest.NewRequest(http.MethodPost, "/v1/audio/transcriptions", body)
+	req.ContentLength = -1
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("status = %d, want %d: %s", rec.Code, http.StatusRequestEntityTooLarge, rec.Body.String())
 	}
 }
 

--- a/tinfoil/cmd/shim/billing.go
+++ b/tinfoil/cmd/shim/billing.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mime"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"tinfoil/internal/billing"
+	"tinfoil/internal/tokencount"
+)
+
+// Billing request/response headers shared with the confidential-model-router.
+const (
+	// clientRequestedUsageHeader is set by ensureStreamingUsageOptions when the
+	// client explicitly asked for usage stats. The response extractor reads it
+	// to decide whether to keep or filter usage-only SSE chunks.
+	clientRequestedUsageHeader = "X-Tinfoil-Client-Requested-Usage"
+)
+
+type billingEventCollector interface {
+	AddEvent(billing.Event)
+}
+
+// ensureStreamingUsageOptions forces upstream streaming requests to include
+// usage and continuous usage stats so billing can extract token counts. If the
+// client explicitly asked for usage stats, it marks that in a header so the
+// response extractor preserves usage-only chunks instead of filtering them.
+// Ported from confidential-model-router/main.go.
+func ensureStreamingUsageOptions(body map[string]any, headers http.Header) error {
+	// Clear any client-supplied value so it cannot spoof the filtering
+	// decision in applyBillingToResponse. Only the parsed body options
+	// determine whether usage-only chunks are preserved.
+	headers.Del(clientRequestedUsageHeader)
+
+	clientRequestedUsage := false
+
+	streamOptions := map[string]any{}
+	if raw, present := body["stream_options"]; present {
+		var ok bool
+		streamOptions, ok = raw.(map[string]any)
+		if !ok {
+			return fmt.Errorf("'stream_options' must be an object")
+		}
+	} else {
+		streamOptions = map[string]any{}
+		body["stream_options"] = streamOptions
+	}
+
+	if raw, present := streamOptions["include_usage"]; present {
+		includeUsage, ok := raw.(bool)
+		if !ok {
+			return fmt.Errorf("'stream_options.include_usage' must be a boolean")
+		}
+		clientRequestedUsage = includeUsage
+	}
+	if raw, present := streamOptions["continuous_usage_stats"]; present {
+		continuousUsage, ok := raw.(bool)
+		if !ok {
+			return fmt.Errorf("'stream_options.continuous_usage_stats' must be a boolean")
+		}
+		clientRequestedUsage = clientRequestedUsage || continuousUsage
+	}
+
+	streamOptions["include_usage"] = true
+	streamOptions["continuous_usage_stats"] = true
+
+	if clientRequestedUsage {
+		headers.Set(clientRequestedUsageHeader, "true")
+	}
+	return nil
+}
+
+func hasJSONContentType(header string) bool {
+	mediaType, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		return false
+	}
+	mediaType = strings.ToLower(mediaType)
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+// prepareBillingRequest inspects every JSON POST body, independent of path, so
+// the generic shim supports the same OpenAI-compatible API surface as the
+// router. It forces streaming usage options when requested. Billing attribution
+// always comes from the shim's measured model-name, never from this untrusted
+// request body.
+//
+// For non-streaming requests, the original body bytes are restored unchanged
+// so inference traffic is not modified. For streaming requests, stream_options
+// are injected and the body is re-marshalled using json.Number to preserve
+// integer precision (e.g. large seed values) that float64 unmarshalling
+// would lose. Key order may change (alphabetical) but this does not affect
+// the upstream's JSON parsing.
+//
+// Non-JSON bodies pass through unchanged. Read errors, malformed JSON,
+// trailing JSON values, and invalid stream_options are rejected rather than
+// forwarding a partial or destructively rewritten request.
+func prepareBillingRequest(r *http.Request) (streaming bool, err error) {
+	r.Header.Del(clientRequestedUsageHeader)
+	if r.Method != http.MethodPost || r.Body == nil || r.Body == http.NoBody || !hasJSONContentType(r.Header.Get("Content-Type")) {
+		return false, nil
+	}
+
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		_ = r.Body.Close()
+		return false, fmt.Errorf("read request body: %w", err)
+	}
+	_ = r.Body.Close()
+
+	// Use json.Decoder with UseNumber to preserve integer precision.
+	// json.Unmarshal into map[string]any coerces all numbers to float64,
+	// which can lose precision for large values (e.g. seed) and alter
+	// upstream inference behavior on re-marshal.
+	dec := json.NewDecoder(bytes.NewReader(bodyBytes))
+	dec.UseNumber()
+	var body map[string]any
+	if err := dec.Decode(&body); err != nil {
+		return false, fmt.Errorf("decode request JSON: %w", err)
+	}
+	var trailing any
+	if err := dec.Decode(&trailing); err != io.EOF {
+		if err == nil {
+			return false, fmt.Errorf("decode request JSON: multiple JSON values")
+		}
+		return false, fmt.Errorf("decode request JSON: trailing data: %w", err)
+	}
+	if body == nil {
+		return false, fmt.Errorf("decode request JSON: body must be an object")
+	}
+
+	if stream, ok := body["stream"].(bool); ok && stream {
+		streaming = true
+		if err := ensureStreamingUsageOptions(body, r.Header); err != nil {
+			return false, err
+		}
+	}
+
+	// Only re-marshal when the body was mutated (streaming requests may have
+	// had stream_options injected). For non-streaming requests, restore the
+	// original bytes to avoid changing whitespace and key order.
+	if streaming {
+		remarshalled, err := json.Marshal(body)
+		if err != nil {
+			return false, fmt.Errorf("encode request JSON: %w", err)
+		}
+		r.Body = io.NopCloser(bytes.NewReader(remarshalled))
+		r.Header.Set("Content-Length", strconv.Itoa(len(remarshalled)))
+		r.ContentLength = int64(len(remarshalled))
+	} else {
+		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
+		r.ContentLength = int64(len(bodyBytes))
+	}
+	return streaming, nil
+}
+
+// billingCloser wraps a response body and emits a zero-token billing event
+// on Close() if the usageHandler was never called. This ensures per-request
+// models (e.g. tokenize, whisper) that don't return usage fields still
+// generate billing events. Ported from confidential-model-router/manager/proxy.go.
+type billingCloser struct {
+	io.ReadCloser
+	handlerCalled *atomic.Bool
+	emitEvent     func()
+	once          sync.Once
+}
+
+func (b *billingCloser) Close() error {
+	err := b.ReadCloser.Close()
+	b.once.Do(func() {
+		if !b.handlerCalled.Load() {
+			b.emitEvent()
+		}
+	})
+	return err
+}
+
+// applyBillingToResponse wraps the proxied response body to extract token
+// usage and emits a billing event via the collector. It mirrors the
+// confidential-model-router proxy's ModifyResponse billing chokepoint:
+//
+//   - Streaming responses are processed through the SSE token extractor, which
+//     invokes the usage handler on the terminal usage chunk and filters
+//     usage-only chunks when the client did not request usage. The handler is
+//     always invoked (even with zero usage) so a billing event is emitted
+//     even if the stream was truncated or the client disconnected early.
+//   - Non-streaming JSON 200 responses are teed so usage is extracted on
+//     Close() without buffering the whole body up front.
+//   - A billingCloser guarantees a zero-token event for usage-less 200 paths.
+//   - WebSocket/protocol upgrades emit a zero-token event immediately.
+//
+// When collector is nil or the request carried no API key, this is a no-op
+// (the body still passes through the token extractor unchanged so streaming
+// usage-only chunk filtering behaves consistently, but no event is emitted).
+func applyBillingToResponse(resp *http.Response, collector billingEventCollector, modelName, enclaveHost string) {
+	req := resp.Request
+
+	apiKey := extractBearerToken(req.Header.Get("Authorization"))
+	clientRequestedUsage := req.Header.Get(clientRequestedUsageHeader) == "true"
+	requestPath := req.URL.Path
+	streaming := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
+
+	requestID := resp.Header.Get("X-Request-Id")
+	if requestID == "" {
+		requestID = resp.Header.Get("X-Request-ID")
+	}
+
+	emitZeroTokenEvent := func() {
+		if collector == nil || apiKey == "" {
+			return
+		}
+		collector.AddEvent(billing.Event{
+			Timestamp:   time.Now(),
+			UserID:      "authenticated_user",
+			APIKey:      apiKey,
+			Model:       modelName,
+			RequestID:   requestID,
+			Enclave:     enclaveHost,
+			RequestPath: requestPath,
+			Streaming:   streaming,
+		})
+	}
+
+	// WebSocket/protocol upgrade: the reverse proxy hijacks both connections
+	// and copies bidirectionally after this callback returns. We must not
+	// touch or wrap the body, but still emit a billing event.
+	if resp.StatusCode == http.StatusSwitchingProtocols {
+		emitZeroTokenEvent()
+		return
+	}
+
+	var handlerCalled atomic.Bool
+
+	usageHandler := func(usage *tokencount.Usage) {
+		handlerCalled.Store(true)
+		if usage == nil {
+			return
+		}
+		if collector == nil || apiKey == "" {
+			return
+		}
+		cachedPromptTokens := 0
+		if value, ok := usage.CachedPromptTokens(); ok {
+			cachedPromptTokens = value
+		}
+		collector.AddEvent(billing.Event{
+			Timestamp:          time.Now(),
+			UserID:             "authenticated_user",
+			APIKey:             apiKey,
+			Model:              modelName,
+			PromptTokens:       usage.PromptTokens,
+			CachedPromptTokens: cachedPromptTokens,
+			CompletionTokens:   usage.CompletionTokens,
+			TotalTokens:        usage.TotalTokens,
+			RequestID:          requestID,
+			Enclave:            enclaveHost,
+			RequestPath:        requestPath,
+			Streaming:          streaming,
+		})
+	}
+
+	newBody, err := tokencount.ExtractTokensFromResponseWithHandler(resp, modelName, usageHandler, clientRequestedUsage)
+	if err != nil {
+		// Don't fail the request; leave the body untouched.
+		log.Printf("billing token extraction failed: %v", err)
+		return
+	}
+	resp.Body = newBody
+
+	// For non-streaming successful responses, wrap the body so a billing
+	// event is emitted on Close() even when the response has no usage field
+	// (e.g. tokenize, metrics). The billingCloser only fires if the
+	// usageHandler was never called, preventing double-billing for models
+	// that do include usage.
+	if !streaming && collector != nil && apiKey != "" && resp.StatusCode == http.StatusOK {
+		resp.Body = &billingCloser{
+			ReadCloser:    resp.Body,
+			handlerCalled: &handlerCalled,
+			emitEvent:     emitZeroTokenEvent,
+		}
+	}
+
+	if streaming {
+		resp.Header.Del("Content-Length")
+	}
+}

--- a/tinfoil/cmd/shim/billing.go
+++ b/tinfoil/cmd/shim/billing.go
@@ -107,6 +107,24 @@ func ensureStreamingUsageOptions(body map[string]any, headers http.Header) error
 	return nil
 }
 
+func prepareStreamingRequest(body map[string]any, headers http.Header) (bool, error) {
+	raw, present := body["stream"]
+	if !present {
+		return false, nil
+	}
+	stream, ok := raw.(bool)
+	if !ok {
+		return false, fmt.Errorf("'stream' must be a boolean")
+	}
+	if !stream {
+		return false, nil
+	}
+	if err := ensureStreamingUsageOptions(body, headers); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func hasJSONContentType(header string) bool {
 	mediaType, _, err := mime.ParseMediaType(header)
 	if err != nil {
@@ -175,11 +193,9 @@ func prepareBillingRequest(r *http.Request) (streaming bool, err error) {
 		return false, fmt.Errorf("decode request JSON: body must be an object")
 	}
 
-	if stream, ok := body["stream"].(bool); ok && stream {
-		streaming = true
-		if err := ensureStreamingUsageOptions(body, r.Header); err != nil {
-			return false, err
-		}
+	streaming, err = prepareStreamingRequest(body, r.Header)
+	if err != nil {
+		return false, err
 	}
 
 	// Only re-marshal when the body was mutated (streaming requests may have
@@ -407,7 +423,13 @@ func applyBillingToResponse(resp *http.Response, collector billingEventCollector
 		})
 	}
 
-	resp.Body = tokencount.ExtractTokensFromResponseWithHandler(resp, usageHandler, clientRequestedUsage)
+	newBody, err := tokencount.ExtractTokensFromResponseWithHandler(resp, usageHandler, clientRequestedUsage)
+	if err != nil {
+		log.Printf("billing token extraction failed: %v", err)
+		emitZeroTokenEvent()
+		return
+	}
+	resp.Body = newBody
 
 	// For non-streaming successful responses, wrap the body so a billing
 	// event is emitted on Close() even when the response has no usage field

--- a/tinfoil/cmd/shim/billing.go
+++ b/tinfoil/cmd/shim/billing.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -115,6 +116,11 @@ func hasJSONContentType(header string) bool {
 	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
 }
 
+func hasMediaType(header, want string) bool {
+	mediaType, _, err := mime.ParseMediaType(header)
+	return err == nil && strings.EqualFold(mediaType, want)
+}
+
 // prepareBillingRequest inspects every JSON POST body, independent of path, so
 // the generic shim supports the same OpenAI-compatible API surface as the
 // router. It forces streaming usage options when requested. Billing attribution
@@ -137,12 +143,16 @@ func prepareBillingRequest(r *http.Request) (streaming bool, err error) {
 		return false, nil
 	}
 
-	bodyBytes, err := io.ReadAll(r.Body)
+	originalBody, err := io.ReadAll(r.Body)
 	if err != nil {
 		_ = r.Body.Close()
 		return false, fmt.Errorf("read request body: %w", err)
 	}
 	_ = r.Body.Close()
+	bodyBytes, contentEncoding, err := decodeBillingRequestBody(originalBody, r.Header.Get("Content-Encoding"))
+	if err != nil {
+		return false, err
+	}
 
 	// Use json.Decoder with UseNumber to preserve integer precision.
 	// json.Unmarshal into map[string]any coerces all numbers to float64,
@@ -175,20 +185,67 @@ func prepareBillingRequest(r *http.Request) (streaming bool, err error) {
 	// Only re-marshal when the body was mutated (streaming requests may have
 	// had stream_options injected). For non-streaming requests, restore the
 	// original bytes to avoid changing whitespace and key order.
+	payload := originalBody
 	if streaming {
-		remarshalled, err := json.Marshal(body)
+		payload, err = json.Marshal(body)
 		if err != nil {
 			return false, fmt.Errorf("encode request JSON: %w", err)
 		}
-		r.Body = io.NopCloser(bytes.NewReader(remarshalled))
-		r.Header.Set("Content-Length", strconv.Itoa(len(remarshalled)))
-		r.ContentLength = int64(len(remarshalled))
-	} else {
-		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-		r.Header.Set("Content-Length", strconv.Itoa(len(bodyBytes)))
-		r.ContentLength = int64(len(bodyBytes))
+		payload, err = encodeBillingRequestBody(payload, contentEncoding)
+		if err != nil {
+			return false, err
+		}
 	}
+	setRequestBody(r, payload)
 	return streaming, nil
+}
+
+func decodeBillingRequestBody(encoded []byte, contentEncoding string) ([]byte, string, error) {
+	encoding := strings.ToLower(strings.TrimSpace(contentEncoding))
+	switch encoding {
+	case "":
+		return encoded, "", nil
+	case "gzip":
+		zr, err := gzip.NewReader(bytes.NewReader(encoded))
+		if err != nil {
+			return nil, "", fmt.Errorf("decode gzip request body: %w", err)
+		}
+		decompressed, readErr := io.ReadAll(io.LimitReader(zr, maxRequestBodySize+1))
+		closeErr := zr.Close()
+		if readErr != nil {
+			return nil, "", fmt.Errorf("read gzip request body: %w", readErr)
+		}
+		if closeErr != nil {
+			return nil, "", fmt.Errorf("close gzip request body: %w", closeErr)
+		}
+		if int64(len(decompressed)) > maxRequestBodySize {
+			return nil, "", &http.MaxBytesError{Limit: maxRequestBodySize}
+		}
+		return decompressed, encoding, nil
+	default:
+		return nil, "", fmt.Errorf("unsupported content encoding %q", contentEncoding)
+	}
+}
+
+func encodeBillingRequestBody(plain []byte, contentEncoding string) ([]byte, error) {
+	if contentEncoding == "" {
+		return plain, nil
+	}
+	var encoded bytes.Buffer
+	zw := gzip.NewWriter(&encoded)
+	if _, err := zw.Write(plain); err != nil {
+		return nil, fmt.Errorf("encode gzip request body: %w", err)
+	}
+	if err := zw.Close(); err != nil {
+		return nil, fmt.Errorf("close gzip request body: %w", err)
+	}
+	return encoded.Bytes(), nil
+}
+
+func setRequestBody(r *http.Request, payload []byte) {
+	r.Body = io.NopCloser(bytes.NewReader(payload))
+	r.Header.Set("Content-Length", strconv.Itoa(len(payload)))
+	r.ContentLength = int64(len(payload))
 }
 
 // billingCloser wraps a response body and emits a zero-token billing event
@@ -282,7 +339,7 @@ func applyBillingToResponse(resp *http.Response, collector billingEventCollector
 	apiKey := extractBearerToken(req.Header.Get("Authorization"))
 	clientRequestedUsage := req.Header.Get(clientRequestedUsageHeader) == "true"
 	requestPath := req.URL.Path
-	streaming := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream")
+	streaming := hasMediaType(resp.Header.Get("Content-Type"), "text/event-stream")
 
 	requestID := resp.Header.Get("X-Request-Id")
 	if requestID == "" {
@@ -350,13 +407,7 @@ func applyBillingToResponse(resp *http.Response, collector billingEventCollector
 		})
 	}
 
-	newBody, err := tokencount.ExtractTokensFromResponseWithHandler(resp, modelName, usageHandler, clientRequestedUsage)
-	if err != nil {
-		// Don't fail the request; leave the body untouched.
-		log.Printf("billing token extraction failed: %v", err)
-		return
-	}
-	resp.Body = newBody
+	resp.Body = tokencount.ExtractTokensFromResponseWithHandler(resp, usageHandler, clientRequestedUsage)
 
 	// For non-streaming successful responses, wrap the body so a billing
 	// event is emitted on Close() even when the response has no usage field

--- a/tinfoil/cmd/shim/billing.go
+++ b/tinfoil/cmd/shim/billing.go
@@ -152,9 +152,10 @@ func hasMediaType(header, want string) bool {
 // would lose. Key order may change (alphabetical) but this does not affect
 // the upstream's JSON parsing.
 //
-// Non-JSON bodies pass through unchanged. Read errors, malformed JSON,
-// trailing JSON values, and invalid stream_options are rejected rather than
-// forwarding a partial or destructively rewritten request.
+// Non-JSON bodies and valid non-object JSON values pass through unchanged.
+// Read errors, malformed JSON, trailing JSON values, and invalid streaming
+// options are rejected rather than forwarding a partial or destructively
+// rewritten request.
 func prepareBillingRequest(r *http.Request) (streaming bool, err error) {
 	r.Header.Del(clientRequestedUsageHeader)
 	if r.Method != http.MethodPost || r.Body == nil || r.Body == http.NoBody || !hasJSONContentType(r.Header.Get("Content-Type")) {
@@ -178,8 +179,8 @@ func prepareBillingRequest(r *http.Request) (streaming bool, err error) {
 	// upstream inference behavior on re-marshal.
 	dec := json.NewDecoder(bytes.NewReader(bodyBytes))
 	dec.UseNumber()
-	var body map[string]any
-	if err := dec.Decode(&body); err != nil {
+	var decoded any
+	if err := dec.Decode(&decoded); err != nil {
 		return false, fmt.Errorf("decode request JSON: %w", err)
 	}
 	var trailing any
@@ -189,8 +190,13 @@ func prepareBillingRequest(r *http.Request) (streaming bool, err error) {
 		}
 		return false, fmt.Errorf("decode request JSON: trailing data: %w", err)
 	}
-	if body == nil {
-		return false, fmt.Errorf("decode request JSON: body must be an object")
+	body, isObject := decoded.(map[string]any)
+	if !isObject {
+		// The generic shim may proxy valid non-OpenAI JSON endpoints. There is
+		// no top-level stream flag to modify outside a JSON object, so preserve
+		// valid non-object bodies exactly as received.
+		setRequestBody(r, originalBody)
+		return false, nil
 	}
 
 	streaming, err = prepareStreamingRequest(body, r.Header)

--- a/tinfoil/cmd/shim/billing.go
+++ b/tinfoil/cmd/shim/billing.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	usagereporting "github.com/tinfoilsh/usage-reporting-go"
+
 	"tinfoil/internal/billing"
 	"tinfoil/internal/tokencount"
 )
@@ -24,10 +27,34 @@ const (
 	// client explicitly asked for usage stats. The response extractor reads it
 	// to decide whether to keep or filter usage-only SSE chunks.
 	clientRequestedUsageHeader = "X-Tinfoil-Client-Requested-Usage"
+
+	// usageContextMaxSkew bounds how old a signed usage-context header may be
+	// before the shim rejects it as stale (and bills normally). Mirrors the
+	// router's tool-runtime skew window.
+	usageContextMaxSkew = time.Minute
 )
+
+// billingSuppressedKey carries the authenticated ingress decision through the
+// reverse proxy after the untrusted usage-context headers have been removed.
+type billingSuppressedKey struct{}
 
 type billingEventCollector interface {
 	AddEvent(billing.Event)
+}
+
+func billingSuppressedFromContext(ctx context.Context) bool {
+	suppressed, _ := ctx.Value(billingSuppressedKey{}).(bool)
+	return suppressed
+}
+
+// prepareBillingSuppression validates the router context while its one-minute
+// freshness window is still measured at request ingress, then strips both
+// headers so they are not exposed to the workload container.
+func prepareBillingSuppression(r *http.Request, apiKey, usageContextSecret string) {
+	suppressed := alreadyBilledByRouter(r.Header, apiKey, usageContextSecret)
+	r.Header.Del(usagereporting.HeaderContext)
+	r.Header.Del(usagereporting.HeaderUsageContextSignature)
+	*r = *r.WithContext(context.WithValue(r.Context(), billingSuppressedKey{}, suppressed))
 }
 
 // ensureStreamingUsageOptions forces upstream streaming requests to include
@@ -185,6 +212,53 @@ func (b *billingCloser) Close() error {
 	return err
 }
 
+// alreadyBilledByRouter reports whether the request carries a validly-signed
+// usage-context header from the confidential-model-router declaring that the
+// router has already counted this customer request (BillCustomerRequest ==
+// false). The shim suppresses its own billing event in that case to prevent
+// double-billing on the cloud path (teep → router → shim).
+//
+// Fail closed toward billing accuracy: a missing context (direct-path client
+// with no signing secret) returns false, and an invalid context (bad
+// signature, expired IssuedAt, missing half of the header pair, or API key
+// mismatch) also returns false with a warning log. The only path that
+// suppresses is a validly-signed, in-skew, BillCustomerRequest == false
+// context whose APIKeyHash matches the request's bearer token.
+func alreadyBilledByRouter(header http.Header, apiKey, usageContextSecret string) bool {
+	if usageContextSecret == "" || apiKey == "" {
+		return false
+	}
+	ctx, present, err := usagereporting.FromHeaders(header, usageContextSecret, time.Now(), usageContextMaxSkew)
+	switch {
+	case !present:
+		// Direct-path client (teep): no signed context. Bill normally.
+		return false
+	case err != nil:
+		// Bad signature, expired, or malformed: bill normally and warn.
+		log.Printf("warning: invalid usage-context signature from upstream: %v", err)
+		return false
+	case ctx.BillCustomerRequest:
+		// Downstream is explicitly told to bill its own line item
+		// (the tool-runtime semantics). Not the router→shim case; bill.
+		return false
+	}
+
+	// Suppression is only valid for the immediate router -> shim hop. Requiring
+	// all three fields prevents a correctly signed but semantically unrelated
+	// context (or an empty API-key hash) from becoming a billing wildcard.
+	if ctx.ParentService != usagereporting.ServiceRouter || ctx.Depth != 1 || strings.TrimSpace(ctx.APIKeyHash) == "" {
+		log.Printf("warning: refusing billing suppression for unexpected usage context (parent_service=%q depth=%d api_key_hash_present=%t)",
+			ctx.ParentService, ctx.Depth, strings.TrimSpace(ctx.APIKeyHash) != "")
+		return false
+	}
+	if !usagereporting.VerifyAPIKeyHash(apiKey, ctx.APIKeyHash) {
+		log.Printf("warning: refusing billing suppression because usage context does not match request API key")
+		return false
+	}
+
+	return true
+}
+
 // applyBillingToResponse wraps the proxied response body to extract token
 // usage and emits a billing event via the collector. It mirrors the
 // confidential-model-router proxy's ModifyResponse billing chokepoint:
@@ -215,8 +289,15 @@ func applyBillingToResponse(resp *http.Response, collector billingEventCollector
 		requestID = resp.Header.Get("X-Request-ID")
 	}
 
+	// Suppress this enclave's billing event when the router has already
+	// counted the request (cloud path). The response body still passes
+	// through the token extractor unchanged so streaming usage-only chunk
+	// filtering behaves identically for router-path and direct-path traffic
+	// — only the event emission is suppressed, never the body transformation.
+	alreadyBilled := billingSuppressedFromContext(req.Context())
+
 	emitZeroTokenEvent := func() {
-		if collector == nil || apiKey == "" {
+		if collector == nil || apiKey == "" || alreadyBilled {
 			return
 		}
 		collector.AddEvent(billing.Event{
@@ -246,7 +327,7 @@ func applyBillingToResponse(resp *http.Response, collector billingEventCollector
 		if usage == nil {
 			return
 		}
-		if collector == nil || apiKey == "" {
+		if collector == nil || apiKey == "" || alreadyBilled {
 			return
 		}
 		cachedPromptTokens := 0
@@ -282,7 +363,7 @@ func applyBillingToResponse(resp *http.Response, collector billingEventCollector
 	// (e.g. tokenize, metrics). The billingCloser only fires if the
 	// usageHandler was never called, preventing double-billing for models
 	// that do include usage.
-	if !streaming && collector != nil && apiKey != "" && resp.StatusCode == http.StatusOK {
+	if !streaming && collector != nil && apiKey != "" && !alreadyBilled && resp.StatusCode == http.StatusOK {
 		resp.Body = &billingCloser{
 			ReadCloser:    resp.Body,
 			handlerCalled: &handlerCalled,

--- a/tinfoil/cmd/shim/billing_init_test.go
+++ b/tinfoil/cmd/shim/billing_init_test.go
@@ -13,8 +13,10 @@ func TestNewShimBillingIsMandatoryForModelShim(t *testing.T) {
 	}
 	for _, secrets := range []map[string]string{
 		nil,
+		{config.SecretUsageReporter: "reporter-secret"},
+		{config.SecretUsageContext: "context-secret"},
 	} {
-		collector, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
+		collector, _, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
 		if err == nil || collector != nil {
 			t.Fatalf("newShimBilling accepted incomplete secrets: %v", secrets)
 		}
@@ -22,13 +24,17 @@ func TestNewShimBillingIsMandatoryForModelShim(t *testing.T) {
 
 	secrets := map[string]string{
 		config.SecretUsageReporter: "reporter-secret",
+		config.SecretUsageContext:  "context-secret",
 	}
-	collector, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
+	collector, usageContextSecret, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !collector.Enabled() {
 		t.Fatal("newShimBilling returned a disabled collector")
+	}
+	if usageContextSecret != "context-secret" {
+		t.Fatalf("usage context secret = %q", usageContextSecret)
 	}
 	collector.Stop()
 }
@@ -37,26 +43,27 @@ func TestNewShimBillingRejectsInvalidControlPlane(t *testing.T) {
 	modelConfig := &config.Config{ControlPlane: "http://api.tinfoil.test", ModelName: "glm-5-2"}
 	secrets := map[string]string{
 		config.SecretUsageReporter: "reporter-secret",
+		config.SecretUsageContext:  "context-secret",
 	}
-	collector, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
+	collector, _, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
 	if err == nil || collector != nil {
 		t.Fatalf("newShimBilling() = (%v, %v), want nil collector and error", collector, err)
 	}
 }
 
 func TestNewShimBillingSkipsNonModelShim(t *testing.T) {
-	collector, err := newShimBilling(&config.Config{}, &config.ExternalConfig{})
-	if err != nil || collector != nil {
-		t.Fatalf("newShimBilling non-model result = (%v, %v)", collector, err)
+	collector, secret, err := newShimBilling(&config.Config{}, &config.ExternalConfig{})
+	if err != nil || collector != nil || secret != "" {
+		t.Fatalf("newShimBilling non-model result = (%v, %q, %v)", collector, secret, err)
 	}
 }
 
 func TestValidateShimBillingInvariant(t *testing.T) {
 	modelConfig := &config.Config{ModelName: "test-model"}
-	if err := validateShimBillingInvariant(modelConfig, nil); err == nil {
+	if err := validateShimBillingInvariant(modelConfig, nil, "context-secret"); err == nil {
 		t.Fatal("model shim accepted a nil billing collector")
 	}
-	if err := validateShimBillingInvariant(&config.Config{}, nil); err != nil {
+	if err := validateShimBillingInvariant(&config.Config{}, nil, ""); err != nil {
 		t.Fatalf("non-model shim unexpectedly required billing: %v", err)
 	}
 }

--- a/tinfoil/cmd/shim/billing_init_test.go
+++ b/tinfoil/cmd/shim/billing_init_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	"tinfoil/internal/config"
+)
+
+func TestNewShimBillingIsMandatoryForModelShim(t *testing.T) {
+	modelConfig := &config.Config{
+		ControlPlane: "https://api.tinfoil.test",
+		ModelName:    "glm-5-2",
+	}
+	for _, secrets := range []map[string]string{
+		nil,
+	} {
+		collector, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
+		if err == nil || collector != nil {
+			t.Fatalf("newShimBilling accepted incomplete secrets: %v", secrets)
+		}
+	}
+
+	secrets := map[string]string{
+		config.SecretUsageReporter: "reporter-secret",
+	}
+	collector, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !collector.Enabled() {
+		t.Fatal("newShimBilling returned a disabled collector")
+	}
+	collector.Stop()
+}
+
+func TestNewShimBillingRejectsInvalidControlPlane(t *testing.T) {
+	modelConfig := &config.Config{ControlPlane: "http://api.tinfoil.test", ModelName: "glm-5-2"}
+	secrets := map[string]string{
+		config.SecretUsageReporter: "reporter-secret",
+	}
+	collector, err := newShimBilling(modelConfig, &config.ExternalConfig{Secrets: secrets})
+	if err == nil || collector != nil {
+		t.Fatalf("newShimBilling() = (%v, %v), want nil collector and error", collector, err)
+	}
+}
+
+func TestNewShimBillingSkipsNonModelShim(t *testing.T) {
+	collector, err := newShimBilling(&config.Config{}, &config.ExternalConfig{})
+	if err != nil || collector != nil {
+		t.Fatalf("newShimBilling non-model result = (%v, %v)", collector, err)
+	}
+}
+
+func TestValidateShimBillingInvariant(t *testing.T) {
+	modelConfig := &config.Config{ModelName: "test-model"}
+	if err := validateShimBillingInvariant(modelConfig, nil); err == nil {
+		t.Fatal("model shim accepted a nil billing collector")
+	}
+	if err := validateShimBillingInvariant(&config.Config{}, nil); err != nil {
+		t.Fatalf("non-model shim unexpectedly required billing: %v", err)
+	}
+}

--- a/tinfoil/cmd/shim/billing_test.go
+++ b/tinfoil/cmd/shim/billing_test.go
@@ -215,10 +215,29 @@ func TestPrepareBillingRequest_FullJSONAPICoverage(t *testing.T) {
 	}
 }
 
+func TestPrepareBillingRequest_PreservesValidNonObjectJSON(t *testing.T) {
+	for _, body := range []string{`null`, `[]`, `"value"`, `42`} {
+		req := httptest.NewRequest(http.MethodPost, "/custom/model/api", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		streaming, err := prepareBillingRequest(req)
+		if err != nil {
+			t.Fatalf("prepareBillingRequest(%q) error = %v", body, err)
+		}
+		if streaming {
+			t.Fatalf("prepareBillingRequest(%q) reported streaming", body)
+		}
+		got, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Fatalf("read preserved body: %v", err)
+		}
+		if string(got) != body {
+			t.Fatalf("preserved body = %q, want %q", got, body)
+		}
+	}
+}
+
 func TestPrepareBillingRequest_RejectsMalformedOrTrailingJSON(t *testing.T) {
 	for _, body := range []string{
-		`null`,
-		`[]`,
 		`{"model":"m","stream":true`,
 		`{"model":"m","stream":true}{"second":true}`,
 		`{"model":"m","stream":true} trailing`,
@@ -286,7 +305,7 @@ func TestEnsureStreamingUsageOptions_ClearsSpoofedHeader(t *testing.T) {
 
 func TestEnsureStreamingUsageOptions_SetsHeaderWhenRequested(t *testing.T) {
 	headers := http.Header{}
-	headers.Set(clientRequestedUsageHeader, "true") // spoofed
+	headers.Set(clientRequestedUsageHeader, "false") // spoofed
 
 	body := map[string]any{
 		"stream":         true,

--- a/tinfoil/cmd/shim/billing_test.go
+++ b/tinfoil/cmd/shim/billing_test.go
@@ -1,0 +1,422 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"testing/iotest"
+
+	"tinfoil/internal/billing"
+)
+
+func TestPrepareBillingRequest_JSONRequest(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/tokenize", strings.NewReader(`{"model":"x"}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	streaming, err := prepareBillingRequest(req)
+	if err != nil {
+		t.Fatalf("prepareBillingRequest() error = %v", err)
+	}
+	if streaming {
+		t.Errorf("streaming = true, want false")
+	}
+}
+
+func TestPrepareBillingRequest_NonJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("plain text"))
+	req.Header.Set("Content-Type", "text/plain")
+
+	streaming, err := prepareBillingRequest(req)
+	if err != nil {
+		t.Fatalf("prepareBillingRequest() error = %v", err)
+	}
+	if streaming {
+		t.Errorf("streaming = true, want false for non-JSON")
+	}
+}
+
+func TestPrepareBillingRequest_GetMethod(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/v1/chat/completions", nil)
+
+	streaming, err := prepareBillingRequest(req)
+	if err != nil {
+		t.Fatalf("prepareBillingRequest() error = %v", err)
+	}
+	if streaming {
+		t.Errorf("streaming = true, want false for GET")
+	}
+}
+
+func TestPrepareBillingRequest_ForceStreamingUsageOptions(t *testing.T) {
+	body := `{"model":"gpt-4","stream":true,"messages":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	streaming, err := prepareBillingRequest(req)
+	if err != nil {
+		t.Fatalf("prepareBillingRequest() error = %v", err)
+	}
+	if !streaming {
+		t.Fatalf("streaming = false, want true")
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading restored body: %v", err)
+	}
+	if !strings.Contains(string(bodyBytes), `"include_usage":true`) {
+		t.Errorf("stream_options.include_usage not forced: %s", bodyBytes)
+	}
+	if !strings.Contains(string(bodyBytes), `"continuous_usage_stats":true`) {
+		t.Errorf("stream_options.continuous_usage_stats not forced: %s", bodyBytes)
+	}
+}
+
+func TestPrepareBillingRequest_PreservesIntegerPrecision(t *testing.T) {
+	// Large integer values (e.g. seed) must not lose precision through
+	// float64 coercion during unmarshal/re-marshal. json.Number preserves
+	// the original representation.
+	body := `{"model":"gpt-4","stream":true,"seed":12345678901234567890,"messages":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	streaming, err := prepareBillingRequest(req)
+	if err != nil {
+		t.Fatalf("prepareBillingRequest() error = %v", err)
+	}
+	if !streaming {
+		t.Fatalf("streaming = false, want true")
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading restored body: %v", err)
+	}
+	// The large integer must appear exactly as the original, not as a
+	// float64 approximation (e.g. 12345678901234568000).
+	if !strings.Contains(string(bodyBytes), `"seed":12345678901234567890`) {
+		t.Errorf("integer precision lost in re-marshalled body: %s", bodyBytes)
+	}
+}
+
+func TestPrepareBillingRequest_NonStreamingPreservesOriginalBytes(t *testing.T) {
+	// Non-streaming requests must not be re-marshalled; the original bytes
+	// (including whitespace and key order) must be preserved.
+	body := `{"model":"gpt-4","seed":12345678901234567890,"messages":[{"role":"user","content":"hi"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	streaming, err := prepareBillingRequest(req)
+	if err != nil {
+		t.Fatalf("prepareBillingRequest() error = %v", err)
+	}
+	if streaming {
+		t.Errorf("streaming = true, want false for non-streaming request")
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("reading restored body: %v", err)
+	}
+	if string(bodyBytes) != body {
+		t.Errorf("non-streaming body was modified:\ngot:  %s\nwant: %s", bodyBytes, body)
+	}
+}
+
+func TestPrepareBillingRequest_PreservesClientRequestedUsage(t *testing.T) {
+	body := `{"model":"gpt-4","stream":true,"stream_options":{"include_usage":true},"messages":[]}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	streaming, err := prepareBillingRequest(req)
+	if err != nil {
+		t.Fatalf("prepareBillingRequest() error = %v", err)
+	}
+	if !streaming {
+		t.Fatalf("streaming = false, want true")
+	}
+	if req.Header.Get(clientRequestedUsageHeader) != "true" {
+		t.Errorf("clientRequestedUsageHeader not set when client requested usage")
+	}
+}
+
+func TestPrepareBillingRequest_FullJSONAPICoverage(t *testing.T) {
+	paths := []string{
+		"/v1/chat/completions",
+		"/v1/completions",
+		"/v1/responses",
+		"/v1/embeddings",
+		"/v1/audio/speech",
+		"/v1/rerank",
+		"/custom/model/api",
+	}
+	for _, path := range paths {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(`{"model":"client-alias","stream":true}`))
+			req.Header.Set("Content-Type", "application/vnd.openai+json; charset=utf-8")
+			streaming, err := prepareBillingRequest(req)
+			if err != nil {
+				t.Fatalf("prepareBillingRequest() error = %v", err)
+			}
+			if !streaming {
+				t.Fatal("streaming = false, want true")
+			}
+			body, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Fatalf("read prepared body: %v", err)
+			}
+			if !bytes.Contains(body, []byte(`"include_usage":true`)) {
+				t.Fatalf("prepared body did not request usage: %s", body)
+			}
+		})
+	}
+}
+
+func TestPrepareBillingRequest_RejectsMalformedOrTrailingJSON(t *testing.T) {
+	for _, body := range []string{
+		`null`,
+		`[]`,
+		`{"model":"m","stream":true`,
+		`{"model":"m","stream":true}{"second":true}`,
+		`{"model":"m","stream":true} trailing`,
+	} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/completions", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		if _, err := prepareBillingRequest(req); err == nil {
+			t.Fatalf("prepareBillingRequest(%q) succeeded, want error", body)
+		}
+	}
+}
+
+func TestPrepareBillingRequest_RejectsReadError(t *testing.T) {
+	readErr := errors.New("synthetic body failure")
+	req := httptest.NewRequest(http.MethodPost, "/v1/completions", nil)
+	req.Body = io.NopCloser(io.MultiReader(strings.NewReader(`{"model":"m",`), iotest.ErrReader(readErr)))
+	req.ContentLength = -1
+	req.Header.Set("Content-Type", "application/json")
+	if _, err := prepareBillingRequest(req); !errors.Is(err, readErr) {
+		t.Fatalf("prepareBillingRequest() error = %v, want wrapped %v", err, readErr)
+	}
+}
+
+func TestEnsureStreamingUsageOptions_RejectsInvalidValues(t *testing.T) {
+	tests := []map[string]any{
+		{"stream_options": nil},
+		{"stream_options": "invalid"},
+		{"stream_options": map[string]any{"include_usage": "true"}},
+		{"stream_options": map[string]any{"continuous_usage_stats": 1}},
+	}
+	for _, body := range tests {
+		headers := http.Header{clientRequestedUsageHeader: []string{"true"}}
+		if err := ensureStreamingUsageOptions(body, headers); err == nil {
+			t.Fatalf("ensureStreamingUsageOptions(%v) succeeded, want error", body)
+		}
+		if got := headers.Get(clientRequestedUsageHeader); got != "" {
+			t.Fatalf("internal usage header survived invalid request: %q", got)
+		}
+	}
+}
+
+func TestEnsureStreamingUsageOptions_ClearsSpoofedHeader(t *testing.T) {
+	headers := http.Header{}
+	headers.Set(clientRequestedUsageHeader, "true")
+
+	body := map[string]any{
+		"stream": true,
+		// No stream_options.include_usage — client did not request usage
+	}
+	if err := ensureStreamingUsageOptions(body, headers); err != nil {
+		t.Fatalf("ensureStreamingUsageOptions() error = %v", err)
+	}
+
+	if headers.Get(clientRequestedUsageHeader) == "true" {
+		t.Errorf("spoofed clientRequestedUsageHeader was not cleared")
+	}
+}
+
+func TestEnsureStreamingUsageOptions_SetsHeaderWhenRequested(t *testing.T) {
+	headers := http.Header{}
+	headers.Set(clientRequestedUsageHeader, "true") // spoofed
+
+	body := map[string]any{
+		"stream":         true,
+		"stream_options": map[string]any{"include_usage": true},
+	}
+	if err := ensureStreamingUsageOptions(body, headers); err != nil {
+		t.Fatalf("ensureStreamingUsageOptions() error = %v", err)
+	}
+
+	if headers.Get(clientRequestedUsageHeader) != "true" {
+		t.Errorf("clientRequestedUsageHeader should be set when client requested usage")
+	}
+}
+
+func TestApplyBillingToResponse_NoOpWithoutAPIKey(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"id":"x","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`))),
+		Request:    httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil),
+	}
+	// No Authorization header → no API key
+
+	applyBillingToResponse(resp, nil, "test-model", "test-enclave")
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	resp.Body.Close()
+	if !strings.Contains(string(body), "usage") {
+		t.Errorf("body should be unchanged (pass-through), got: %s", body)
+	}
+}
+
+func TestApplyBillingToResponse_ZeroTokenFallbackNonStreaming(t *testing.T) {
+	collector, events := newRecordingBillingCollector()
+
+	// Non-streaming 200 response with no usage field — billingCloser should
+	// emit a zero-token event on Close.
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"id":"x","choices":[]}`))),
+		Request:    httptest.NewRequest(http.MethodPost, "/tokenize", nil),
+	}
+	resp.Request.Header.Set("Authorization", "Bearer sk-test-key-1234567890")
+
+	applyBillingToResponse(resp, collector, "test-model", "test-enclave")
+
+	// Read and close to trigger billingCloser
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+	select {
+	case event := <-events:
+		if event.Model != "test-model" || event.TotalTokens != 0 {
+			t.Fatalf("unexpected fallback event: %+v", event)
+		}
+	default:
+		t.Fatal("zero-token fallback did not emit an event")
+	}
+}
+
+func TestApplyBillingToResponse_StreamingDeletesContentLength(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":   []string{"text/event-stream"},
+			"Content-Length": []string{"123"},
+		},
+		Body:    io.NopCloser(strings.NewReader("data: {}\n\ndata: [DONE]\n\n")),
+		Request: httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil),
+	}
+	resp.Request.Header.Set("Authorization", "Bearer sk-test-key-1234567890")
+
+	applyBillingToResponse(resp, nil, "test-model", "test-enclave")
+
+	if resp.Header.Get("Content-Length") != "" {
+		t.Errorf("Content-Length should be deleted for streaming, got %q", resp.Header.Get("Content-Length"))
+	}
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+}
+
+func TestApplyBillingToResponse_NilCollectorIsNoOp(t *testing.T) {
+	body := `{"id":"x","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+		Request:    httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil),
+	}
+	resp.Request.Header.Set("Authorization", "Bearer sk-test-key-1234567890")
+
+	applyBillingToResponse(resp, nil, "test-model", "test-enclave")
+
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	resp.Body.Close()
+	if string(out) != body {
+		t.Errorf("body changed with nil collector: got %s", out)
+	}
+}
+
+func TestBillingCloser_EmitsOnce(t *testing.T) {
+	calls := 0
+	emit := func() { calls++ }
+	var called atomic.Bool
+	closer := &billingCloser{
+		ReadCloser:    io.NopCloser(bytes.NewReader([]byte{})),
+		handlerCalled: &called,
+		emitEvent:     emit,
+	}
+	closer.Close()
+	closer.Close()
+	if calls != 1 {
+		t.Errorf("emitEvent called %d times, want 1", calls)
+	}
+}
+
+func TestBillingCloser_SkipsWhenHandlerCalled(t *testing.T) {
+	calls := 0
+	emit := func() { calls++ }
+	var called atomic.Bool
+	called.Store(true)
+	closer := &billingCloser{
+		ReadCloser:    io.NopCloser(bytes.NewReader([]byte{})),
+		handlerCalled: &called,
+		emitEvent:     emit,
+	}
+	closer.Close()
+	if calls != 0 {
+		t.Errorf("emitEvent called %d times, want 0 when handler was called", calls)
+	}
+}
+
+type recordingBillingCollector struct {
+	events chan billing.Event
+}
+
+func newRecordingBillingCollector() (*recordingBillingCollector, <-chan billing.Event) {
+	events := make(chan billing.Event, 2)
+	return &recordingBillingCollector{events: events}, events
+}
+
+func (c *recordingBillingCollector) AddEvent(event billing.Event) {
+	c.events <- event
+}
+
+func TestApplyBillingToResponse_BillsDirectPath(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"id":"x","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`))),
+		Request:    httptest.NewRequest(http.MethodPost, "/tokenize", nil),
+	}
+	resp.Request.Header.Set("Authorization", "Bearer sk-test-key-1234567890")
+	collector, events := newRecordingBillingCollector()
+
+	applyBillingToResponse(resp, collector, "test-model", "test-enclave")
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("closing body: %v", err)
+	}
+
+	select {
+	case event := <-events:
+		if event.PromptTokens != 5 || event.CompletionTokens != 3 {
+			t.Fatalf("unexpected direct-path event: %+v", event)
+		}
+	default:
+		t.Fatal("direct-path billing event was not emitted")
+	}
+}

--- a/tinfoil/cmd/shim/billing_test.go
+++ b/tinfoil/cmd/shim/billing_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"compress/gzip"
 	"errors"
 	"io"
 	"net/http"
@@ -104,6 +105,40 @@ func TestPrepareBillingRequest_PreservesIntegerPrecision(t *testing.T) {
 	// float64 approximation (e.g. 12345678901234568000).
 	if !strings.Contains(string(bodyBytes), `"seed":12345678901234567890`) {
 		t.Errorf("integer precision lost in re-marshalled body: %s", bodyBytes)
+	}
+}
+
+func TestPrepareBillingRequest_GzipStreaming(t *testing.T) {
+	plain := []byte(`{"model":"gpt-4","stream":true,"messages":[]}`)
+	var compressed bytes.Buffer
+	zw := gzip.NewWriter(&compressed)
+	if _, err := zw.Write(plain); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(compressed.Bytes()))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+
+	streaming, err := prepareBillingRequest(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !streaming {
+		t.Fatal("streaming = false, want true")
+	}
+	zr, err := gzip.NewReader(req.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(got, []byte(`"include_usage":true`)) {
+		t.Fatalf("gzip body did not request usage: %s", got)
 	}
 }
 

--- a/tinfoil/cmd/shim/billing_test.go
+++ b/tinfoil/cmd/shim/billing_test.go
@@ -260,6 +260,13 @@ func TestEnsureStreamingUsageOptions_RejectsInvalidValues(t *testing.T) {
 	}
 }
 
+func TestPrepareStreamingRequestRejectsInvalidStream(t *testing.T) {
+	headers := make(http.Header)
+	if _, err := prepareStreamingRequest(map[string]any{"stream": "true"}, headers); err == nil {
+		t.Fatal("prepareStreamingRequest() accepted non-boolean stream")
+	}
+}
+
 func TestEnsureStreamingUsageOptions_ClearsSpoofedHeader(t *testing.T) {
 	headers := http.Header{}
 	headers.Set(clientRequestedUsageHeader, "true")
@@ -340,6 +347,63 @@ func TestApplyBillingToResponse_ZeroTokenFallbackNonStreaming(t *testing.T) {
 		}
 	default:
 		t.Fatal("zero-token fallback did not emit an event")
+	}
+}
+
+func TestApplyBillingToResponse_OversizedResponseFallback(t *testing.T) {
+	collector, events := newRecordingBillingCollector()
+	body := strings.Repeat("x", (10<<20)+1)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil),
+	}
+	resp.Request.Header.Set("Authorization", "Bearer sk-test-key-1234567890")
+	applyBillingToResponse(resp, collector, "test-model", "test-enclave")
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(body) {
+		t.Fatalf("pass-through body length = %d, want %d", len(got), len(body))
+	}
+	select {
+	case event := <-events:
+		if event.TotalTokens != 0 {
+			t.Fatalf("fallback event = %+v", event)
+		}
+	default:
+		t.Fatal("oversized response did not emit fallback event")
+	}
+}
+
+func TestApplyBillingToResponse_NonSSEMediaTypePassesThrough(t *testing.T) {
+	collector, events := newRecordingBillingCollector()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header: http.Header{
+			"Content-Type":   []string{"text/event-streaming"},
+			"Content-Length": []string{"4"},
+		},
+		Body:    io.NopCloser(strings.NewReader("data")),
+		Request: httptest.NewRequest(http.MethodPost, "/custom", nil),
+	}
+	resp.Request.Header.Set("Authorization", "Bearer sk-test-key-1234567890")
+	applyBillingToResponse(resp, collector, "test-model", "test-enclave")
+	if got := resp.Header.Get("Content-Length"); got != "4" {
+		t.Fatalf("Content-Length = %q, want pass-through", got)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-events:
+	default:
+		t.Fatal("non-SSE response did not emit fallback event")
 	}
 }
 

--- a/tinfoil/cmd/shim/billing_test.go
+++ b/tinfoil/cmd/shim/billing_test.go
@@ -10,6 +10,9 @@ import (
 	"sync/atomic"
 	"testing"
 	"testing/iotest"
+	"time"
+
+	usagereporting "github.com/tinfoilsh/usage-reporting-go"
 
 	"tinfoil/internal/billing"
 )
@@ -380,6 +383,231 @@ func TestBillingCloser_SkipsWhenHandlerCalled(t *testing.T) {
 	}
 }
 
+// --- alreadyBilledByRouter tests ---
+
+const testUsageContextSecret = "test-usage-context-secret-32-bytes!"
+
+const testAPIKey = "sk-test-key-1234567890"
+
+// TestExtractBearerToken_MatchesHashAPIKeyRoundTrip verifies that the
+// shim's extractBearerToken produces the exact string the router would
+// hash with usagereporting.HashAPIKey, so the VerifyAPIKeyHash check in
+// alreadyBilledByRouter succeeds. The router's manager.BearerToken and
+// the shim's extractBearerToken are intentionally identical duplicates in
+// separate modules; this test guards against drift in the shim's copy.
+func TestExtractBearerToken_MatchesHashAPIKeyRoundTrip(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"standard", "Bearer " + testAPIKey, testAPIKey},
+		{"lowercase scheme", "bearer " + testAPIKey, testAPIKey},
+		{"mixed case", "BeArEr " + testAPIKey, testAPIKey},
+		{"trailing whitespace", "Bearer " + testAPIKey + "  ", testAPIKey},
+		{"no space after scheme", "Bearer" + testAPIKey, ""},
+		{"empty", "", ""},
+		{"wrong scheme", "Basic " + testAPIKey, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractBearerToken(tc.header)
+			if got != tc.want {
+				t.Fatalf("extractBearerToken(%q) = %q, want %q", tc.header, got, tc.want)
+			}
+			// When extraction succeeds, the extracted key must verify
+			// against a hash of the same key — the exact round-trip the
+			// router→shim billing-suppression path depends on.
+			if got != "" {
+				hash := usagereporting.HashAPIKey(got)
+				if !usagereporting.VerifyAPIKeyHash(got, hash) {
+					t.Fatalf("VerifyAPIKeyHash mismatch: extracted token does not verify against its own hash")
+				}
+			}
+		})
+	}
+}
+
+// signUsageContext sets a validly-signed usage-context header on the
+// request for the given context fields.
+func signUsageContext(t *testing.T, header http.Header, apiKey string, billCustomerRequest bool) {
+	t.Helper()
+	ctx := usagereporting.Context{
+		ParentService:       usagereporting.ServiceRouter,
+		APIKeyHash:          usagereporting.HashAPIKey(apiKey),
+		BillCustomerRequest: billCustomerRequest,
+		Depth:               1,
+		IssuedAt:            time.Now().UTC(),
+	}
+	signExactUsageContext(t, header, ctx)
+}
+
+func signExactUsageContext(t *testing.T, header http.Header, ctx usagereporting.Context) {
+	t.Helper()
+	if err := usagereporting.SetHeaders(header, ctx, testUsageContextSecret); err != nil {
+		t.Fatalf("SetHeaders: %v", err)
+	}
+}
+
+func TestAlreadyBilledByRouter_NoContext_DirectPath(t *testing.T) {
+	header := http.Header{}
+	// No usage-context header set — direct-path client.
+	got := alreadyBilledByRouter(header, testAPIKey, testUsageContextSecret)
+	if got {
+		t.Errorf("alreadyBilledByRouter = true, want false for direct-path (no context)")
+	}
+}
+
+func TestAlreadyBilledByRouter_NoSecret(t *testing.T) {
+	header := http.Header{}
+	signUsageContext(t, header, testAPIKey, false)
+	// Shim booted without USAGE_CONTEXT_SECRET — cannot verify, must bill.
+	got := alreadyBilledByRouter(header, testAPIKey, "")
+	if got {
+		t.Errorf("alreadyBilledByRouter = true, want false when secret is empty")
+	}
+}
+
+func TestAlreadyBilledByRouter_NoAPIKey(t *testing.T) {
+	header := http.Header{}
+	signUsageContext(t, header, testAPIKey, false)
+	// No API key on the request — cannot bind, must bill.
+	got := alreadyBilledByRouter(header, "", testUsageContextSecret)
+	if got {
+		t.Errorf("alreadyBilledByRouter = true, want false when apiKey is empty")
+	}
+}
+
+func TestAlreadyBilledByRouter_ValidSuppression(t *testing.T) {
+	header := http.Header{}
+	signUsageContext(t, header, testAPIKey, false)
+	got := alreadyBilledByRouter(header, testAPIKey, testUsageContextSecret)
+	if !got {
+		t.Errorf("alreadyBilledByRouter = false, want true for valid signed context with BillCustomerRequest=false and matching API key")
+	}
+}
+
+func TestAlreadyBilledByRouter_BillCustomerRequestTrue(t *testing.T) {
+	header := http.Header{}
+	// Tool-runtime semantics: BillCustomerRequest=true means the downstream
+	// should bill its own line item, not suppress.
+	signUsageContext(t, header, testAPIKey, true)
+	got := alreadyBilledByRouter(header, testAPIKey, testUsageContextSecret)
+	if got {
+		t.Errorf("alreadyBilledByRouter = true, want false when BillCustomerRequest=true")
+	}
+}
+
+func TestAlreadyBilledByRouter_BadSignature(t *testing.T) {
+	header := http.Header{}
+	signUsageContext(t, header, testAPIKey, false)
+	// Tamper with the signature.
+	header.Set(usagereporting.HeaderUsageContextSignature, "deadbeef")
+	got := alreadyBilledByRouter(header, testAPIKey, testUsageContextSecret)
+	if got {
+		t.Errorf("alreadyBilledByRouter = true, want false for bad signature")
+	}
+}
+
+func TestAlreadyBilledByRouter_ExpiredContext(t *testing.T) {
+	header := http.Header{}
+	// Sign with an IssuedAt well outside the skew window.
+	ctx := usagereporting.Context{
+		ParentService:       usagereporting.ServiceRouter,
+		APIKeyHash:          usagereporting.HashAPIKey(testAPIKey),
+		BillCustomerRequest: false,
+		Depth:               1,
+		IssuedAt:            time.Now().UTC().Add(-10 * time.Minute),
+	}
+	if err := usagereporting.SetHeaders(header, ctx, testUsageContextSecret); err != nil {
+		t.Fatalf("SetHeaders: %v", err)
+	}
+	got := alreadyBilledByRouter(header, testAPIKey, testUsageContextSecret)
+	if got {
+		t.Errorf("alreadyBilledByRouter = true, want false for expired context")
+	}
+}
+
+func TestAlreadyBilledByRouter_APIKeyMismatch(t *testing.T) {
+	header := http.Header{}
+	// Context signed for a different API key.
+	signUsageContext(t, header, "sk-other-key-9999999999", false)
+	got := alreadyBilledByRouter(header, testAPIKey, testUsageContextSecret)
+	if got {
+		t.Errorf("alreadyBilledByRouter = true, want false when API key does not match")
+	}
+}
+
+func TestAlreadyBilledByRouter_RejectsUnexpectedContextSemantics(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*usagereporting.Context)
+	}{
+		{
+			name: "empty API key hash",
+			mutate: func(ctx *usagereporting.Context) {
+				ctx.APIKeyHash = ""
+			},
+		},
+		{
+			name: "unexpected parent service",
+			mutate: func(ctx *usagereporting.Context) {
+				ctx.ParentService = "tool-runtime"
+			},
+		},
+		{
+			name: "unexpected depth",
+			mutate: func(ctx *usagereporting.Context) {
+				ctx.Depth = 2
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := usagereporting.Context{
+				ParentService:       usagereporting.ServiceRouter,
+				APIKeyHash:          usagereporting.HashAPIKey(testAPIKey),
+				BillCustomerRequest: false,
+				Depth:               1,
+				IssuedAt:            time.Now().UTC(),
+			}
+			tc.mutate(&ctx)
+			header := http.Header{}
+			signExactUsageContext(t, header, ctx)
+			if alreadyBilledByRouter(header, testAPIKey, testUsageContextSecret) {
+				t.Fatal("alreadyBilledByRouter = true, want false")
+			}
+		})
+	}
+}
+
+func TestAlreadyBilledByRouter_HalfHeader(t *testing.T) {
+	header := http.Header{}
+	// Only the context header, no signature.
+	header.Set(usagereporting.HeaderContext, "eyJiaWxsX2N1c3RvbWVyX3JlcXVlc3QiOmZhbHNlfQ")
+	got := alreadyBilledByRouter(header, testAPIKey, testUsageContextSecret)
+	if got {
+		t.Errorf("alreadyBilledByRouter = true, want false when only one half of the header pair is present")
+	}
+}
+
+func TestPrepareBillingSuppressionValidatesAtIngressAndStripsHeaders(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	signUsageContext(t, req.Header, testAPIKey, false)
+
+	prepareBillingSuppression(req, testAPIKey, testUsageContextSecret)
+
+	if !billingSuppressedFromContext(req.Context()) {
+		t.Fatal("valid ingress context did not suppress downstream billing")
+	}
+	if req.Header.Get(usagereporting.HeaderContext) != "" || req.Header.Get(usagereporting.HeaderUsageContextSignature) != "" {
+		t.Fatal("usage-context credentials were forwarded toward the workload")
+	}
+}
+
+// --- applyBillingToResponse suppression integration tests ---
+
 type recordingBillingCollector struct {
 	events chan billing.Event
 }
@@ -393,17 +621,55 @@ func (c *recordingBillingCollector) AddEvent(event billing.Event) {
 	c.events <- event
 }
 
+func TestApplyBillingToResponse_SuppressesWhenAlreadyBilled(t *testing.T) {
+	// Non-streaming 200 with a usage field. With a valid suppression context,
+	// the billingCloser must NOT be wrapped (alreadyBilled gates it), and the
+	// body must still pass through the token extractor unchanged.
+	body := `{"id":"x","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(body))),
+		Request:    httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil),
+	}
+	resp.Request.Header.Set("Authorization", "Bearer "+testAPIKey)
+	signUsageContext(t, resp.Request.Header, testAPIKey, false)
+
+	collector, events := newRecordingBillingCollector()
+
+	prepareBillingSuppression(resp.Request, testAPIKey, testUsageContextSecret)
+	applyBillingToResponse(resp, collector, "test-model", "test-enclave")
+
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+	resp.Body.Close()
+	if string(out) != body {
+		t.Errorf("body changed when billing suppressed: got %s", out)
+	}
+	select {
+	case event := <-events:
+		t.Fatalf("suppressed request emitted billing event: %+v", event)
+	default:
+	}
+}
+
 func TestApplyBillingToResponse_BillsDirectPath(t *testing.T) {
+	// Direct-path: no usage-context header. Exactly one event must be delivered.
 	resp := &http.Response{
 		StatusCode: http.StatusOK,
 		Header:     http.Header{"Content-Type": []string{"application/json"}},
 		Body:       io.NopCloser(bytes.NewReader([]byte(`{"id":"x","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":3,"total_tokens":8}}`))),
 		Request:    httptest.NewRequest(http.MethodPost, "/tokenize", nil),
 	}
-	resp.Request.Header.Set("Authorization", "Bearer sk-test-key-1234567890")
+	resp.Request.Header.Set("Authorization", "Bearer "+testAPIKey)
+
 	collector, events := newRecordingBillingCollector()
 
+	prepareBillingSuppression(resp.Request, testAPIKey, testUsageContextSecret)
 	applyBillingToResponse(resp, collector, "test-model", "test-enclave")
+
 	if _, err := io.ReadAll(resp.Body); err != nil {
 		t.Fatalf("reading body: %v", err)
 	}
@@ -411,12 +677,43 @@ func TestApplyBillingToResponse_BillsDirectPath(t *testing.T) {
 		t.Fatalf("closing body: %v", err)
 	}
 
+	var event billing.Event
 	select {
-	case event := <-events:
-		if event.PromptTokens != 5 || event.CompletionTokens != 3 {
-			t.Fatalf("unexpected direct-path event: %+v", event)
-		}
+	case event = <-events:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for direct-path billing event")
+	}
+	if event.PromptTokens != 5 || event.CompletionTokens != 3 {
+		t.Fatalf("unexpected direct-path event: %+v", event)
+	}
+	select {
+	case extra := <-events:
+		t.Fatalf("direct request emitted a second event: %+v", extra)
 	default:
-		t.Fatal("direct-path billing event was not emitted")
+	}
+}
+
+func TestApplyBillingToResponse_DirectPathNoSecret(t *testing.T) {
+	// Shim booted without USAGE_CONTEXT_SECRET. Even if a context header
+	// were present (it shouldn't be on the direct path), suppression cannot
+	// occur. The billingCloser must be wrapped.
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader([]byte(`{"id":"x","choices":[]}`))),
+		Request:    httptest.NewRequest(http.MethodPost, "/tokenize", nil),
+	}
+	resp.Request.Header.Set("Authorization", "Bearer "+testAPIKey)
+
+	collector, events := newRecordingBillingCollector()
+
+	applyBillingToResponse(resp, collector, "test-model", "test-enclave")
+
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+	select {
+	case <-events:
+	default:
+		t.Fatal("direct path without a context secret did not bill")
 	}
 }

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -13,7 +14,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/signal"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"log"
@@ -23,6 +26,7 @@ import (
 	"golang.org/x/time/rate"
 
 	tinfoilattestation "tinfoil/internal/attestation"
+	"tinfoil/internal/billing"
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/key"
@@ -39,6 +43,7 @@ var (
 const (
 	shimReadHeaderTimeout = 10 * time.Second
 	shimIdleTimeout       = 2 * time.Minute
+	shimShutdownTimeout   = 10 * time.Second
 )
 
 func main() {
@@ -47,6 +52,7 @@ func main() {
 
 	var handler atomic.Value
 	var cert atomic.Pointer[tls.Certificate]
+	var billingCollector atomic.Pointer[billing.Collector]
 
 	// Start with an ephemeral self-signed cert and a minimal handler that
 	// serves only boot-stages. This lets the backend poll boot progress before
@@ -80,10 +86,35 @@ func main() {
 	}
 
 	// Wait for boot to provision artifacts, then upgrade to the full handler.
-	go upgradeWhenReady(&handler, &cert)
+	go upgradeWhenReady(&handler, &cert, &billingCollector)
+
+	// Stop accepting requests and drain active handlers before flushing pending
+	// billing events. Flushing first can lose events produced by handlers that
+	// complete during shutdown.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		<-sigCh
+		ctx, cancel := context.WithTimeout(context.Background(), shimShutdownTimeout)
+		defer cancel()
+		if err := srv.Shutdown(ctx); err != nil {
+			log.Printf("warning: graceful shim shutdown failed: %v", err)
+			if closeErr := srv.Close(); closeErr != nil {
+				log.Printf("warning: forced shim shutdown failed: %v", closeErr)
+			}
+		}
+		if c := billingCollector.Load(); c != nil {
+			c.Stop()
+		}
+	}()
 
 	log.Printf("Starting tinfoil shim (waiting for boot)")
-	log.Fatal(srv.ListenAndServeTLS("", ""))
+	if err := srv.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("Server failed: %v", err)
+	}
+	<-shutdownDone
 }
 
 // bootStagesHandler returns a minimal handler that only serves the
@@ -109,7 +140,7 @@ const artifactPollInterval = 1 * time.Second
 
 // upgradeWhenReady advances the public handler through three explicit phases:
 // boot stages only, observability only, and finally workload proxying.
-func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificate]) {
+func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificate], billingCollector *atomic.Pointer[billing.Collector]) {
 	start := time.Now()
 
 	err := func() error {
@@ -231,7 +262,16 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 		upstreamAddr := fmt.Sprintf("%s:%d", upstreamHost, config.UpstreamPort)
 		log.Printf("Shim upstream resolved: %s → %s", config.UpstreamContainer, upstreamAddr)
 
-		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, expectedGPUs, serverIdentity, realCertParsed, config, externalConfig, upstreamAddr)
+		collector, err := newShimBilling(config, externalConfig)
+		if err != nil {
+			return err
+		}
+		if collector != nil {
+			billingCollector.Store(collector)
+			log.Printf("Billing collector enabled (reporter=%s, control_plane=%s)", config.ModelName, config.ControlPlane)
+		}
+
+		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, expectedGPUs, serverIdentity, realCertParsed, config, externalConfig, upstreamAddr, collector)
 		handler.Store(http.HandlerFunc(fullHandler.ServeHTTP))
 
 		log.Println("Shim fully operational")
@@ -245,6 +285,37 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 		boot.RecordStage(boot.StageShim, boot.StatusOK, time.Since(start), "")
 	}
 	boot.Complete()
+}
+
+// newShimBilling initializes mandatory accounting for model-serving shims.
+// ModelName is the reporter identity, so deployment configuration cannot point
+// a model at another reporter by independently changing a duplicate field.
+func newShimBilling(config *shimconfig.Config, externalConfig *shimconfig.ExternalConfig) (*billing.Collector, error) {
+	if !config.BillingRequired() {
+		return nil, nil
+	}
+	reporterSecret := externalConfig.GetSecret(shimconfig.SecretUsageReporter)
+	if reporterSecret == "" {
+		return nil, fmt.Errorf("required shim billing secret %s is unavailable", shimconfig.SecretUsageReporter)
+	}
+	collector, err := billing.NewCollector(config.ControlPlane, config.ModelName, reporterSecret)
+	if err != nil {
+		return nil, fmt.Errorf("initialize billing collector for model %q: %w", config.ModelName, err)
+	}
+	return collector, nil
+}
+
+// validateShimBillingInvariant makes billing optional only for non-model
+// shims. Reaching handler construction for a model shim without a usable
+// collector is an internal invariant violation: startup must have failed first.
+func validateShimBillingInvariant(config *shimconfig.Config, collector *billing.Collector) error {
+	if !config.BillingRequired() {
+		return nil
+	}
+	if collector == nil || !collector.Enabled() {
+		return fmt.Errorf("model shim %q requires an initialized billing collector", config.ModelName)
+	}
+	return nil
 }
 
 // waitForArtifact polls load until it succeeds or boot fails.

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -262,7 +262,7 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 		upstreamAddr := fmt.Sprintf("%s:%d", upstreamHost, config.UpstreamPort)
 		log.Printf("Shim upstream resolved: %s → %s", config.UpstreamContainer, upstreamAddr)
 
-		collector, err := newShimBilling(config, externalConfig)
+		collector, usageContextSecret, err := newShimBilling(config, externalConfig)
 		if err != nil {
 			return err
 		}
@@ -271,7 +271,7 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 			log.Printf("Billing collector enabled (reporter=%s, control_plane=%s)", config.ModelName, config.ControlPlane)
 		}
 
-		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, expectedGPUs, serverIdentity, realCertParsed, config, externalConfig, upstreamAddr, collector)
+		fullHandler := NewShimServer(validator, rateLimiter, att, identityBody, expectedGPUs, serverIdentity, realCertParsed, config, externalConfig, upstreamAddr, collector, usageContextSecret)
 		handler.Store(http.HandlerFunc(fullHandler.ServeHTTP))
 
 		log.Println("Shim fully operational")
@@ -290,30 +290,37 @@ func upgradeWhenReady(handler *atomic.Value, cert *atomic.Pointer[tls.Certificat
 // newShimBilling initializes mandatory accounting for model-serving shims.
 // ModelName is the reporter identity, so deployment configuration cannot point
 // a model at another reporter by independently changing a duplicate field.
-func newShimBilling(config *shimconfig.Config, externalConfig *shimconfig.ExternalConfig) (*billing.Collector, error) {
+func newShimBilling(config *shimconfig.Config, externalConfig *shimconfig.ExternalConfig) (*billing.Collector, string, error) {
 	if !config.BillingRequired() {
-		return nil, nil
+		return nil, "", nil
 	}
 	reporterSecret := externalConfig.GetSecret(shimconfig.SecretUsageReporter)
 	if reporterSecret == "" {
-		return nil, fmt.Errorf("required shim billing secret %s is unavailable", shimconfig.SecretUsageReporter)
+		return nil, "", fmt.Errorf("required shim billing secret %s is unavailable", shimconfig.SecretUsageReporter)
+	}
+	usageContextSecret := externalConfig.GetSecret(shimconfig.SecretUsageContext)
+	if usageContextSecret == "" {
+		return nil, "", fmt.Errorf("required shim billing secret %s is unavailable", shimconfig.SecretUsageContext)
 	}
 	collector, err := billing.NewCollector(config.ControlPlane, config.ModelName, reporterSecret)
 	if err != nil {
-		return nil, fmt.Errorf("initialize billing collector for model %q: %w", config.ModelName, err)
+		return nil, "", fmt.Errorf("initialize billing collector for model %q: %w", config.ModelName, err)
 	}
-	return collector, nil
+	return collector, usageContextSecret, nil
 }
 
 // validateShimBillingInvariant makes billing optional only for non-model
 // shims. Reaching handler construction for a model shim without a usable
 // collector is an internal invariant violation: startup must have failed first.
-func validateShimBillingInvariant(config *shimconfig.Config, collector *billing.Collector) error {
+func validateShimBillingInvariant(config *shimconfig.Config, collector *billing.Collector, usageContextSecret string) error {
 	if !config.BillingRequired() {
 		return nil
 	}
 	if collector == nil || !collector.Enabled() {
 		return fmt.Errorf("model shim %q requires an initialized billing collector", config.ModelName)
+	}
+	if usageContextSecret == "" {
+		return fmt.Errorf("model shim %q requires %s", config.ModelName, shimconfig.SecretUsageContext)
 	}
 	return nil
 }

--- a/tinfoil/cmd/shim/main.go
+++ b/tinfoil/cmd/shim/main.go
@@ -106,7 +106,7 @@ func main() {
 			}
 		}
 		if c := billingCollector.Load(); c != nil {
-			c.Stop()
+			c.StopContext(ctx)
 		}
 	}()
 

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -17,10 +17,12 @@ require (
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
 	github.com/prometheus/client_golang v1.24.1
+	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.1
 	github.com/tinfoilsh/modelwrap v0.2.1
 	github.com/tinfoilsh/tinfoil-go/verifier v0.12.0
+	github.com/tinfoilsh/usage-reporting-go v0.1.3
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0
@@ -57,7 +59,6 @@ require (
 	github.com/secure-systems-lab/go-securesystemslib v0.11.0 // indirect
 	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/sigstore v1.10.8 // indirect
-	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/theupdateframework/go-tuf/v2 v2.4.2 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -107,6 +107,8 @@ github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgX
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
 github.com/tinfoilsh/tinfoil-go/verifier v0.12.0 h1:xg0/euV/uEGDhKXgxD6L5UpN4LCR6jcUIpEak9/WAbQ=
 github.com/tinfoilsh/tinfoil-go/verifier v0.12.0/go.mod h1:1iPX7k1r9To22RBdod/UdaA0mXR1THjl/f7RpReZ2PE=
+github.com/tinfoilsh/usage-reporting-go v0.1.3 h1:q3WJK1auo65BFDxQ+hkSRXF6B+jKhii3RUxeU18hvkA=
+github.com/tinfoilsh/usage-reporting-go v0.1.3/go.mod h1:1lXVGmDbEmlAdUo+0YPsUYuFVtr74xycCs0K4fSnwYs=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/internal/billing/billing.go
+++ b/tinfoil/internal/billing/billing.go
@@ -1,0 +1,182 @@
+// Package billing records per-request usage events and ships them to the
+// control plane via the signed usage-reporting client. It is a port of the
+// confidential-model-router's billing collector so that direct (routerless)
+// inference paths record usage identically to the relayed path.
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	usagereporting "github.com/tinfoilsh/usage-reporting-go"
+	usageclient "github.com/tinfoilsh/usage-reporting-go/client"
+)
+
+// Event represents a billing event with token usage. CachedPromptTokens is the
+// subset of PromptTokens that the model served from its prompt cache; the
+// uncached portion is derived downstream.
+type Event struct {
+	Timestamp          time.Time `json:"timestamp"`
+	UserID             string    `json:"user_id"`
+	Model              string    `json:"model"`
+	PromptTokens       int       `json:"prompt_tokens"`
+	CachedPromptTokens int       `json:"cached_prompt_tokens"`
+	CompletionTokens   int       `json:"completion_tokens"`
+	TotalTokens        int       `json:"total_tokens"`
+	RequestID          string    `json:"request_id"`
+	Enclave            string    `json:"enclave"`
+	RequestPath        string    `json:"request_path"`
+	Streaming          bool      `json:"streaming"`
+	APIKey             string    `json:"api_key"`
+}
+
+// Collector ships billing events to the control plane via the usage reporter.
+type Collector struct {
+	reporter *usageclient.ReporterClient
+	stopOnce sync.Once
+}
+
+// maskAPIKey masks an API key for safe logging
+// Shows first 3 and last 4 characters, masking the rest
+func maskAPIKey(apiKey string) string {
+	if len(apiKey) <= 10 {
+		// Too short to mask safely
+		return "***"
+	}
+	return apiKey[:3] + strings.Repeat("*", len(apiKey)-7) + apiKey[len(apiKey)-4:]
+}
+
+// NewCollector creates a billing event collector. Callers that are not
+// accounting boundaries must explicitly avoid constructing one; incomplete
+// collector configuration is an error rather than an implicit disabled mode.
+func NewCollector(controlPlaneURL, reporterID, reporterSecret string) (*Collector, error) {
+	return newCollector(controlPlaneURL, reporterID, reporterSecret, nil)
+}
+
+func newCollector(controlPlaneURL, reporterID, reporterSecret string, httpClient *http.Client) (*Collector, error) {
+	endpoint, err := ingestionEndpoint(controlPlaneURL)
+	if err != nil {
+		return nil, err
+	}
+	if reporterID == "" {
+		return nil, fmt.Errorf("usage reporter ID is required")
+	}
+	if reporterID != strings.TrimSpace(reporterID) {
+		return nil, fmt.Errorf("usage reporter ID must not have leading or trailing whitespace")
+	}
+	if reporterSecret == "" {
+		return nil, fmt.Errorf("usage reporter secret is required")
+	}
+
+	c := &Collector{
+		reporter: usageclient.New(usageclient.Config{
+			Endpoint:   endpoint,
+			ReporterID: reporterID,
+			Secret:     reporterSecret,
+			HTTPClient: httpClient,
+		}),
+	}
+	if !c.reporter.Enabled() {
+		return nil, fmt.Errorf("usage reporter initialization returned a disabled client")
+	}
+	return c, nil
+}
+
+func ingestionEndpoint(controlPlaneURL string) (string, error) {
+	u, err := url.Parse(controlPlaneURL)
+	if err != nil {
+		return "", fmt.Errorf("parse control plane URL: %w", err)
+	}
+	if u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("control plane URL must be an absolute https URL without credentials, query, or fragment")
+	}
+	return strings.TrimRight(controlPlaneURL, "/") + usagereporting.IngestionPath, nil
+}
+
+// Enabled reports whether the collector has a configured reporter.
+func (c *Collector) Enabled() bool {
+	return c != nil && c.reporter != nil && c.reporter.Enabled()
+}
+
+// AddEvent forwards a billing event to the usage reporter and writes a masked
+// log line for local observability.
+func (c *Collector) AddEvent(event Event) {
+	if !c.Enabled() {
+		panic("billing: AddEvent called on an uninitialized collector")
+	}
+
+	// Create a safe version for logging with masked API key
+	safeEvent := event
+	safeEvent.APIKey = maskAPIKey(event.APIKey)
+
+	eventJSON, err := json.Marshal(safeEvent)
+	if err != nil {
+		log.WithError(err).Error("Failed to marshal billing event")
+		return
+	}
+
+	inputTokens := int64(event.PromptTokens)
+	outputTokens := int64(event.CompletionTokens)
+	if inputTokens == 0 && outputTokens == 0 && event.TotalTokens > 0 {
+		inputTokens = int64(event.TotalTokens)
+	}
+
+	cachedInputTokens := int64(event.CachedPromptTokens)
+	if cachedInputTokens > inputTokens {
+		cachedInputTokens = inputTokens
+	}
+
+	meters := []usagereporting.Meter{
+		{Name: usagereporting.MeterInputTokens, Quantity: inputTokens},
+		{Name: usagereporting.MeterOutputTokens, Quantity: outputTokens},
+	}
+	if cachedInputTokens > 0 {
+		meters = append(meters, usagereporting.Meter{
+			Name:     usagereporting.MeterCachedInputTokens,
+			Quantity: cachedInputTokens,
+		})
+	}
+
+	c.reporter.AddEvent(usagereporting.Event{
+		RequestID:  event.RequestID,
+		OccurredAt: event.Timestamp,
+		APIKey:     event.APIKey,
+		Operation: usagereporting.Operation{
+			Service: usagereporting.ServiceRouter,
+			Name:    usagereporting.OperationRouterModelRequest,
+		},
+		CustomerRequests: 1,
+		Meters:           meters,
+		Attributes: map[string]string{
+			"model":     event.Model,
+			"route":     event.RequestPath,
+			"streaming": fmt.Sprintf("%t", event.Streaming),
+			"enclave":   event.Enclave,
+		},
+	})
+
+	log.WithFields(log.Fields{
+		"type": "billing_event",
+		"data": string(eventJSON),
+	}).Info("Billing event collected")
+}
+
+// Stop gracefully shuts down the collector, flushing pending events with a
+// bounded timeout so a network stall cannot block shim shutdown indefinitely.
+func (c *Collector) Stop() {
+	c.stopOnce.Do(func() {
+		if c.reporter != nil {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			c.reporter.Stop(ctx)
+		}
+	})
+}

--- a/tinfoil/internal/billing/billing.go
+++ b/tinfoil/internal/billing/billing.go
@@ -44,14 +44,19 @@ type Collector struct {
 	stopOnce sync.Once
 }
 
-// maskAPIKey masks an API key for safe logging
-// Shows first 3 and last 4 characters, masking the rest
+const (
+	apiKeyVisiblePrefix = 3
+	apiKeyVisibleSuffix = 4
+	apiKeyMinimumLength = apiKeyVisiblePrefix + apiKeyVisibleSuffix + 4
+)
+
 func maskAPIKey(apiKey string) string {
-	if len(apiKey) <= 10 {
-		// Too short to mask safely
+	if len(apiKey) < apiKeyMinimumLength {
 		return "***"
 	}
-	return apiKey[:3] + strings.Repeat("*", len(apiKey)-7) + apiKey[len(apiKey)-4:]
+	return apiKey[:apiKeyVisiblePrefix] +
+		strings.Repeat("*", len(apiKey)-apiKeyVisiblePrefix-apiKeyVisibleSuffix) +
+		apiKey[len(apiKey)-apiKeyVisibleSuffix:]
 }
 
 // NewCollector creates a billing event collector. Callers that are not
@@ -72,8 +77,11 @@ func newCollector(controlPlaneURL, reporterID, reporterSecret string, httpClient
 	if reporterID != strings.TrimSpace(reporterID) {
 		return nil, fmt.Errorf("usage reporter ID must not have leading or trailing whitespace")
 	}
-	if reporterSecret == "" {
+	if strings.TrimSpace(reporterSecret) == "" {
 		return nil, fmt.Errorf("usage reporter secret is required")
+	}
+	if reporterSecret != strings.TrimSpace(reporterSecret) {
+		return nil, fmt.Errorf("usage reporter secret must not have leading or trailing whitespace")
 	}
 
 	c := &Collector{
@@ -91,11 +99,14 @@ func newCollector(controlPlaneURL, reporterID, reporterSecret string, httpClient
 }
 
 func ingestionEndpoint(controlPlaneURL string) (string, error) {
+	if strings.TrimSpace(controlPlaneURL) == "" {
+		return "", fmt.Errorf("control plane URL is required")
+	}
 	u, err := url.Parse(controlPlaneURL)
 	if err != nil {
 		return "", fmt.Errorf("parse control plane URL: %w", err)
 	}
-	if u.Scheme != "https" || u.Host == "" || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+	if u.Scheme != "https" || u.Hostname() == "" || u.User != nil || u.ForceQuery || u.RawQuery != "" || strings.Contains(controlPlaneURL, "#") {
 		return "", fmt.Errorf("control plane URL must be an absolute https URL without credentials, query, or fragment")
 	}
 	return strings.TrimRight(controlPlaneURL, "/") + usagereporting.IngestionPath, nil
@@ -106,14 +117,12 @@ func (c *Collector) Enabled() bool {
 	return c != nil && c.reporter != nil && c.reporter.Enabled()
 }
 
-// AddEvent forwards a billing event to the usage reporter and writes a masked
-// log line for local observability.
+// AddEvent converts the normalized token fields into canonical usage meters.
 func (c *Collector) AddEvent(event Event) {
 	if !c.Enabled() {
 		panic("billing: AddEvent called on an uninitialized collector")
 	}
 
-	// Create a safe version for logging with masked API key
 	safeEvent := event
 	safeEvent.APIKey = maskAPIKey(event.APIKey)
 
@@ -172,10 +181,15 @@ func (c *Collector) AddEvent(event Event) {
 // Stop gracefully shuts down the collector, flushing pending events with a
 // bounded timeout so a network stall cannot block shim shutdown indefinitely.
 func (c *Collector) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	c.StopContext(ctx)
+}
+
+// StopContext flushes pending events within the caller's shutdown budget.
+func (c *Collector) StopContext(ctx context.Context) {
 	c.stopOnce.Do(func() {
 		if c.reporter != nil {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
 			c.reporter.Stop(ctx)
 		}
 	})

--- a/tinfoil/internal/billing/billing_test.go
+++ b/tinfoil/internal/billing/billing_test.go
@@ -1,0 +1,216 @@
+package billing
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	usagereporting "github.com/tinfoilsh/usage-reporting-go"
+)
+
+func setupCollectorTest(t *testing.T) (*Collector, func() usagereporting.Batch) {
+	t.Helper()
+
+	bodies := make(chan []byte, 1)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+		}
+		bodies <- buf
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := newCollector(server.URL, "shim-test", "test-secret", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(c.Stop)
+
+	readBatch := func() usagereporting.Batch {
+		t.Helper()
+		c.reporter.Flush(context.Background())
+
+		var body []byte
+		select {
+		case body = <-bodies:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for billing event delivery")
+		}
+
+		var batch usagereporting.Batch
+		if err := json.Unmarshal(body, &batch); err != nil {
+			t.Fatalf("decode batch: %v", err)
+		}
+		if len(batch.Events) != 1 {
+			t.Fatalf("expected 1 event, got %d", len(batch.Events))
+		}
+		return batch
+	}
+
+	return c, readBatch
+}
+
+// TestCollectorEmitsCustomerRequestAndTokenMeters verifies that a billing
+// event flushed through the reporter carries CustomerRequests=1 and exactly
+// the canonical input/output token meters (no requests meter).
+func TestCollectorEmitsCustomerRequestAndTokenMeters(t *testing.T) {
+	c, readBatch := setupCollectorTest(t)
+
+	c.AddEvent(Event{
+		Timestamp:        time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Model:            "glm-5-2",
+		PromptTokens:     11,
+		CompletionTokens: 7,
+		TotalTokens:      18,
+		RequestID:        "req-1",
+		Enclave:          "glm-5-2.inference.tinfoil.sh",
+		RequestPath:      "/v1/chat/completions",
+		Streaming:        true,
+		APIKey:           "sk-test-1234567890",
+	})
+
+	batch := readBatch()
+	got := batch.Events[0]
+
+	if got.Operation.Service != usagereporting.ServiceRouter {
+		t.Errorf("service mismatch: got %q want %q", got.Operation.Service, usagereporting.ServiceRouter)
+	}
+	if got.Operation.Name != usagereporting.OperationRouterModelRequest {
+		t.Errorf("operation mismatch: got %q want %q", got.Operation.Name, usagereporting.OperationRouterModelRequest)
+	}
+	if got.CustomerRequests != 1 {
+		t.Errorf("customer requests mismatch: got %d want 1", got.CustomerRequests)
+	}
+
+	meters := make(map[string]int64)
+	for _, m := range got.Meters {
+		meters[m.Name] = m.Quantity
+	}
+	if meters[usagereporting.MeterInputTokens] != 11 {
+		t.Errorf("input_tokens mismatch: got %d want 11", meters[usagereporting.MeterInputTokens])
+	}
+	if meters[usagereporting.MeterOutputTokens] != 7 {
+		t.Errorf("output_tokens mismatch: got %d want 7", meters[usagereporting.MeterOutputTokens])
+	}
+	if _, hasRequestsMeter := meters["requests"]; hasRequestsMeter {
+		t.Errorf("billing event should not emit a requests meter; got %+v", meters)
+	}
+
+	if got.Attributes["model"] != "glm-5-2" {
+		t.Errorf("model attribute mismatch: got %q", got.Attributes["model"])
+	}
+	if got.Attributes["streaming"] != "true" {
+		t.Errorf("streaming attribute mismatch: got %q", got.Attributes["streaming"])
+	}
+	if got.Attributes["enclave"] != "glm-5-2.inference.tinfoil.sh" {
+		t.Errorf("enclave attribute mismatch: got %q", got.Attributes["enclave"])
+	}
+	if got.Attributes["route"] != "/v1/chat/completions" {
+		t.Errorf("route attribute mismatch: got %q", got.Attributes["route"])
+	}
+}
+
+func TestCollectorEmitsCachedInputTokensMeterWhenPresent(t *testing.T) {
+	c, readBatch := setupCollectorTest(t)
+
+	c.AddEvent(Event{
+		Timestamp:          time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Model:              "glm-5-2",
+		PromptTokens:       100,
+		CachedPromptTokens: 64,
+		CompletionTokens:   7,
+		TotalTokens:        107,
+		RequestID:          "req-1",
+		APIKey:             "tk_test",
+	})
+
+	batch := readBatch()
+
+	meters := make(map[string]int64)
+	for _, m := range batch.Events[0].Meters {
+		meters[m.Name] = m.Quantity
+	}
+	if meters[usagereporting.MeterInputTokens] != 100 {
+		t.Errorf("input_tokens mismatch: got %d want 100", meters[usagereporting.MeterInputTokens])
+	}
+	if meters[usagereporting.MeterCachedInputTokens] != 64 {
+		t.Errorf("cached_input_tokens mismatch: got %d want 64", meters[usagereporting.MeterCachedInputTokens])
+	}
+	if meters[usagereporting.MeterOutputTokens] != 7 {
+		t.Errorf("output_tokens mismatch: got %d want 7", meters[usagereporting.MeterOutputTokens])
+	}
+}
+
+func TestCollectorOmitsCachedMeterWhenZero(t *testing.T) {
+	c, readBatch := setupCollectorTest(t)
+
+	c.AddEvent(Event{
+		Timestamp:    time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Model:        "glm-5-2",
+		PromptTokens: 100,
+		APIKey:       "tk_test",
+	})
+
+	batch := readBatch()
+	for _, m := range batch.Events[0].Meters {
+		if m.Name == usagereporting.MeterCachedInputTokens {
+			t.Fatalf("cached_input_tokens meter should be omitted when zero, got %+v", batch.Events[0].Meters)
+		}
+	}
+}
+
+func TestCollectorFallsBackToTotalTokensWhenSplitMissing(t *testing.T) {
+	c, readBatch := setupCollectorTest(t)
+
+	c.AddEvent(Event{
+		Timestamp:   time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC),
+		Model:       "glm-5-2",
+		TotalTokens: 18,
+		RequestID:   "req-1",
+		APIKey:      "tk_test",
+	})
+
+	batch := readBatch()
+
+	meters := make(map[string]int64)
+	for _, m := range batch.Events[0].Meters {
+		meters[m.Name] = m.Quantity
+	}
+	if meters[usagereporting.MeterInputTokens] != 18 {
+		t.Errorf("input_tokens mismatch: got %d want 18", meters[usagereporting.MeterInputTokens])
+	}
+	if meters[usagereporting.MeterOutputTokens] != 0 {
+		t.Errorf("output_tokens mismatch: got %d want 0", meters[usagereporting.MeterOutputTokens])
+	}
+}
+
+func TestNewCollectorRejectsInvalidConfiguration(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		endpoint string
+		id       string
+		secret   string
+	}{
+		{name: "missing endpoint", id: "model", secret: "secret"},
+		{name: "plaintext endpoint", endpoint: "http://api.example", id: "model", secret: "secret"},
+		{name: "missing endpoint host", endpoint: "https://", id: "model", secret: "secret"},
+		{name: "endpoint credentials", endpoint: "https://user@api.example", id: "model", secret: "secret"},
+		{name: "endpoint query", endpoint: "https://api.example?target=other", id: "model", secret: "secret"},
+		{name: "missing reporter ID", endpoint: "https://api.example", secret: "secret"},
+		{name: "padded reporter ID", endpoint: "https://api.example", id: " model", secret: "secret"},
+		{name: "missing reporter secret", endpoint: "https://api.example", id: "model"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			collector, err := NewCollector(test.endpoint, test.id, test.secret)
+			if err == nil || collector != nil {
+				t.Fatalf("NewCollector() = (%v, %v), want nil collector and error", collector, err)
+			}
+		})
+	}
+}

--- a/tinfoil/internal/billing/billing_test.go
+++ b/tinfoil/internal/billing/billing_test.go
@@ -200,11 +200,15 @@ func TestNewCollectorRejectsInvalidConfiguration(t *testing.T) {
 		{name: "missing endpoint", id: "model", secret: "secret"},
 		{name: "plaintext endpoint", endpoint: "http://api.example", id: "model", secret: "secret"},
 		{name: "missing endpoint host", endpoint: "https://", id: "model", secret: "secret"},
+		{name: "empty endpoint hostname", endpoint: "https://:443", id: "model", secret: "secret"},
 		{name: "endpoint credentials", endpoint: "https://user@api.example", id: "model", secret: "secret"},
 		{name: "endpoint query", endpoint: "https://api.example?target=other", id: "model", secret: "secret"},
+		{name: "endpoint empty query", endpoint: "https://api.example?", id: "model", secret: "secret"},
+		{name: "endpoint empty fragment", endpoint: "https://api.example#", id: "model", secret: "secret"},
 		{name: "missing reporter ID", endpoint: "https://api.example", secret: "secret"},
 		{name: "padded reporter ID", endpoint: "https://api.example", id: " model", secret: "secret"},
 		{name: "missing reporter secret", endpoint: "https://api.example", id: "model"},
+		{name: "whitespace reporter secret", endpoint: "https://api.example", id: "model", secret: "   "},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			collector, err := NewCollector(test.endpoint, test.id, test.secret)

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strings"
 
 	"github.com/creasty/defaults"
 	"gopkg.in/yaml.v3"
@@ -39,6 +40,12 @@ type Config struct {
 	RateBurst int     `yaml:"rate-burst"`
 	Email     string  `yaml:"email" default:"tls@tinfoil.sh"`
 
+	// ModelName is the authoritative served-model and billing reporter identity.
+	// A non-empty value makes direct billing mandatory: shim startup fails unless
+	// reporter credentials are available. Request-controlled model fields never
+	// override it.
+	ModelName string `yaml:"model-name"`
+
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
 	DummyAttestation   bool `yaml:"dummy-attestation" default:"false"`
 
@@ -47,7 +54,17 @@ type Config struct {
 	ExpectedGPUs int `yaml:"expected-gpus" default:"0"`
 }
 
-const SecretMetricsAPIKey = "METRICS_API_KEY"
+const (
+	SecretMetricsAPIKey = "METRICS_API_KEY"
+	SecretUsageReporter = "USAGE_REPORTER_SECRET"
+)
+
+// BillingRequired reports whether this shim is a model accounting boundary.
+// ModelName is also the reporter ID, preventing independent configuration from
+// drifting and attributing usage to the wrong model.
+func (c *Config) BillingRequired() bool {
+	return c != nil && c.ModelName != ""
+}
 
 type Metadata struct {
 	ID     string `yaml:"id"`
@@ -156,6 +173,9 @@ func (c *Config) Validate() error {
 	}
 	if c.TLSWildcard && c.TLSChallengeMode != "dns" {
 		return fmt.Errorf("tls-wildcard requires tls-challenge: dns (wildcard certs cannot use %s challenge)", c.TLSChallengeMode)
+	}
+	if c.ModelName != strings.TrimSpace(c.ModelName) {
+		return fmt.Errorf("model-name must not have leading or trailing whitespace")
 	}
 	return nil
 }

--- a/tinfoil/internal/config/config.go
+++ b/tinfoil/internal/config/config.go
@@ -42,8 +42,8 @@ type Config struct {
 
 	// ModelName is the authoritative served-model and billing reporter identity.
 	// A non-empty value makes direct billing mandatory: shim startup fails unless
-	// reporter credentials are available. Request-controlled model fields never
-	// override it.
+	// both declared billing secrets are available. Request-controlled model
+	// fields never override it.
 	ModelName string `yaml:"model-name"`
 
 	PublishAttestation bool `yaml:"publish-attestation" default:"true"`
@@ -57,6 +57,7 @@ type Config struct {
 const (
 	SecretMetricsAPIKey = "METRICS_API_KEY"
 	SecretUsageReporter = "USAGE_REPORTER_SECRET"
+	SecretUsageContext  = "USAGE_CONTEXT_SECRET"
 )
 
 // BillingRequired reports whether this shim is a model accounting boundary.

--- a/tinfoil/internal/config/config_test.go
+++ b/tinfoil/internal/config/config_test.go
@@ -1,8 +1,31 @@
 package config
 
-import (
-	"testing"
-)
+import "testing"
+
+func TestBillingRequiredUsesModelName(t *testing.T) {
+	var nilConfig *Config
+	if nilConfig.BillingRequired() {
+		t.Fatal("nil config unexpectedly requires billing")
+	}
+
+	config := &Config{ModelName: "glm-5-2"}
+	if !config.BillingRequired() {
+		t.Fatal("model-name did not activate billing")
+	}
+}
+
+func TestValidateRejectsModelNameWhitespace(t *testing.T) {
+	config := &Config{
+		UpstreamPort:     8001,
+		TLSMode:          "self-signed",
+		TLSEnv:           "production",
+		TLSChallengeMode: "tls",
+		ModelName:        " glm-5-2",
+	}
+	if err := config.Validate(); err == nil {
+		t.Fatal("Validate accepted model-name with leading whitespace")
+	}
+}
 
 func TestGetSecret(t *testing.T) {
 	tests := []struct {

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -127,10 +127,12 @@ func TestBuildEnvNilConfig(t *testing.T) {
 func TestBuildEnvInjectsDeclaredBillingSecrets(t *testing.T) {
 	ext := &shimconfig.ExternalConfig{Secrets: map[string]string{
 		shimconfig.SecretUsageReporter: "reporter-secret",
+		shimconfig.SecretUsageContext:  "context-secret",
 	}}
-	env := buildEnv(nil, []string{shimconfig.SecretUsageReporter}, ext)
+	env := buildEnv(nil, []string{shimconfig.SecretUsageReporter, shimconfig.SecretUsageContext}, ext)
 	want := map[string]bool{
 		shimconfig.SecretUsageReporter + "=reporter-secret": true,
+		shimconfig.SecretUsageContext + "=context-secret":   true,
 	}
 	for _, entry := range env {
 		delete(want, entry)

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -124,6 +124,22 @@ func TestBuildEnvNilConfig(t *testing.T) {
 	}
 }
 
+func TestBuildEnvInjectsDeclaredBillingSecrets(t *testing.T) {
+	ext := &shimconfig.ExternalConfig{Secrets: map[string]string{
+		shimconfig.SecretUsageReporter: "reporter-secret",
+	}}
+	env := buildEnv(nil, []string{shimconfig.SecretUsageReporter}, ext)
+	want := map[string]bool{
+		shimconfig.SecretUsageReporter + "=reporter-secret": true,
+	}
+	for _, entry := range env {
+		delete(want, entry)
+	}
+	if len(want) != 0 {
+		t.Fatalf("declared billing secrets missing from container env: %v", want)
+	}
+}
+
 func TestContainerMemoryBytes(t *testing.T) {
 	const mib = int64(1024 * 1024)
 	tests := []struct {

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -42,6 +42,9 @@ func Validate(config *Config, debug bool) error {
 	if len(config.Models) > device.MaxModelDisks {
 		return fmt.Errorf("models must contain at most %d entries (got %d)", device.MaxModelDisks, len(config.Models))
 	}
+	if len(config.Models) > 0 && (config.ShimCfg == nil || config.ShimCfg.ModelName == "") {
+		return fmt.Errorf("shim.model-name is required when models are configured")
+	}
 	if err := validateShape(config, debug); err != nil {
 		return err
 	}

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -42,6 +42,8 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		want  string
 	}{
 		{name: "valid", yaml: validConfig},
+		{name: "model missing model-name", yaml: validConfig + "models:\n  - repo: example/model\n", want: "shim.model-name is required"},
+		{name: "model with model-name", yaml: strings.Replace(validConfig, "shim:\n", "shim:\n  model-name: app-model\n", 1) + "models:\n  - repo: example/model\n"},
 		{name: "unknown field", yaml: validConfig + "unknown: true\n", want: "field unknown not found"},
 		{name: "unknown container field", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    typo: true", 1), want: "unknown container field"},
 		{name: "duplicate container field", yaml: strings.Replace(validConfig, "networks: [app]", "image: duplicate\n    networks: [app]", 1), want: "duplicate container field"},

--- a/tinfoil/internal/tokencount/tokencount.go
+++ b/tinfoil/internal/tokencount/tokencount.go
@@ -10,6 +10,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log"
 	"mime"
@@ -148,7 +149,7 @@ func (t *teeReaderCloser) Close() error {
 // receives bytes without delay; usage is extracted on Close() or, for
 // streaming, as the stream is processed. Usage is delivered via the
 // usageHandler callback, not a return value.
-func ExtractTokensFromResponse(resp *http.Response) io.ReadCloser {
+func ExtractTokensFromResponse(resp *http.Response) (io.ReadCloser, error) {
 	return ExtractTokensFromResponseWithHandler(resp, nil, false)
 }
 
@@ -158,7 +159,10 @@ func ExtractTokensFromResponse(resp *http.Response) io.ReadCloser {
 // responses it is invoked on Close(). clientRequestedUsage indicates if the
 // client explicitly requested usage stats in their request (controls
 // usage-only SSE chunk filtering).
-func ExtractTokensFromResponseWithHandler(resp *http.Response, usageHandler func(*Usage), clientRequestedUsage bool) io.ReadCloser {
+func ExtractTokensFromResponseWithHandler(resp *http.Response, usageHandler func(*Usage), clientRequestedUsage bool) (io.ReadCloser, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, fmt.Errorf("tokencount: response and response body are required")
+	}
 	contentType := resp.Header.Get("Content-Type")
 
 	// For streaming responses, use the streaming extractor
@@ -168,12 +172,12 @@ func ExtractTokensFromResponseWithHandler(resp *http.Response, usageHandler func
 		extractor.usageHandler = usageHandler
 		extractor.clientRequestedUsage = clientRequestedUsage
 		go extractor.processStream()
-		return &streamReadCloser{PipeReader: pr, upstream: resp.Body}
+		return &streamReadCloser{PipeReader: pr, upstream: resp.Body}, nil
 	}
 
 	// For non-JSON or non-200 responses, pass through unchanged
 	if resp.StatusCode != http.StatusOK || !hasJSONMediaType(contentType) {
-		return resp.Body
+		return resp.Body, nil
 	}
 
 	// For JSON responses, tee the body to the client while accumulating a copy
@@ -191,7 +195,7 @@ func ExtractTokensFromResponseWithHandler(resp *http.Response, usageHandler func
 		origBody:     resp.Body,
 		extractor:    extractor,
 		usageHandler: usageHandler,
-	}
+	}, nil
 }
 
 type streamReadCloser struct {

--- a/tinfoil/internal/tokencount/tokencount.go
+++ b/tinfoil/internal/tokencount/tokencount.go
@@ -180,9 +180,8 @@ func ExtractTokensFromResponseWithHandler(resp *http.Response, usageHandler func
 		return resp.Body, nil
 	}
 
-	// For JSON responses, tee the body to the client while accumulating a copy
-	// for usage extraction on Close(). This retains the full response in memory,
-	// matching the router extractor's existing behavior.
+	// For JSON responses, tee the body to the client while accumulating a
+	// bounded prefix for usage extraction on Close().
 	extractor := &JSONTokenExtractor{}
 
 	// TeeReader copies data to the extractor while passing it through to

--- a/tinfoil/internal/tokencount/tokencount.go
+++ b/tinfoil/internal/tokencount/tokencount.go
@@ -1,0 +1,365 @@
+// Package tokencount extracts OpenAI-compatible token usage from inference
+// responses (streaming and non-streaming). Streaming responses are processed
+// line-by-line without buffering the full body; non-streaming JSON responses
+// are teed to the client while being accumulated for usage extraction on
+// Close(). It is a port of the confidential-model-router's tokencount package
+// so the direct (routerless) path can bill identically.
+package tokencount
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// Usage represents token usage information from inference responses.
+// Supports both Chat Completions (prompt_tokens/completion_tokens) and
+// Responses API (input_tokens/output_tokens) field names.
+type Usage struct {
+	PromptTokens        int                  `json:"prompt_tokens"`
+	CompletionTokens    int                  `json:"completion_tokens"`
+	TotalTokens         int                  `json:"total_tokens"`
+	InputTokens         int                  `json:"input_tokens"`
+	OutputTokens        int                  `json:"output_tokens"`
+	PromptTokensDetails *PromptTokensDetails `json:"prompt_tokens_details,omitempty"`
+	InputTokensDetails  *PromptTokensDetails `json:"input_tokens_details,omitempty"`
+}
+
+type PromptTokensDetails struct {
+	CachedTokens int `json:"cached_tokens"`
+}
+
+// Normalize maps Responses API fields (input_tokens/output_tokens) into
+// Chat Completions fields (prompt_tokens/completion_tokens) so billing
+// works uniformly regardless of which API produced the usage data. It also
+// derives TotalTokens when the upstream omits it, so non-streaming and
+// streaming billing events are consistent.
+func (u *Usage) Normalize() {
+	if u.PromptTokens == 0 && u.InputTokens > 0 {
+		u.PromptTokens = u.InputTokens
+	}
+	if u.CompletionTokens == 0 && u.OutputTokens > 0 {
+		u.CompletionTokens = u.OutputTokens
+	}
+	if u.PromptTokensDetails == nil && u.InputTokensDetails != nil {
+		u.PromptTokensDetails = u.InputTokensDetails
+	}
+	if u.TotalTokens == 0 {
+		u.TotalTokens = u.PromptTokens + u.CompletionTokens
+	}
+}
+
+func (u *Usage) CachedPromptTokens() (int, bool) {
+	if u == nil || u.PromptTokensDetails == nil {
+		return 0, false
+	}
+
+	cached := min(u.PromptTokens, max(0, u.PromptTokensDetails.CachedTokens))
+	return cached, true
+}
+
+// OpenAIResponse represents a standard OpenAI-compatible response
+type OpenAIResponse struct {
+	Usage *Usage `json:"usage,omitempty"`
+}
+
+// JSONTokenExtractor accumulates JSON response data and extracts tokens
+type JSONTokenExtractor struct {
+	buffer bytes.Buffer
+	model  string
+	usage  *Usage
+	mu     sync.Mutex
+}
+
+// Write implements io.Writer, accumulating data
+func (j *JSONTokenExtractor) Write(p []byte) (n int, err error) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.buffer.Write(p)
+}
+
+// ExtractUsage parses the accumulated JSON and extracts token usage
+func (j *JSONTokenExtractor) ExtractUsage() {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	var resp OpenAIResponse
+	if err := json.Unmarshal(j.buffer.Bytes(), &resp); err == nil && resp.Usage != nil {
+		resp.Usage.Normalize()
+		j.usage = resp.Usage
+	}
+}
+
+// teeReaderCloser wraps a TeeReader and extracts tokens on close
+type teeReaderCloser struct {
+	io.Reader
+	origBody     io.ReadCloser
+	extractor    *JSONTokenExtractor
+	usageHandler func(*Usage)
+}
+
+// Close extracts usage from the data accumulated so far and closes the
+// original body. If the caller closes early (e.g. client disconnect), the
+// buffered JSON may be incomplete and usage extraction will silently fail,
+// leading to under-billing for that request. This matches the
+// confidential-model-router's behavior; draining the remaining upstream
+// body on early close would waste bandwidth on a disconnected client.
+func (t *teeReaderCloser) Close() error {
+	// Extract usage from accumulated data
+	t.extractor.ExtractUsage()
+
+	// Call usage handler if provided
+	if t.usageHandler != nil && t.extractor.usage != nil {
+		t.usageHandler(t.extractor.usage)
+	}
+
+	// Close original body
+	return t.origBody.Close()
+}
+
+// ExtractTokensFromResponse extracts token counts from HTTP response.
+// The response body is returned as a pass-through reader so the client
+// receives bytes without delay; usage is extracted on Close() or, for
+// streaming, as the stream is processed. Usage is delivered via the
+// usageHandler callback, not a return value.
+func ExtractTokensFromResponse(resp *http.Response, model string) (io.ReadCloser, error) {
+	return ExtractTokensFromResponseWithHandler(resp, model, nil, false)
+}
+
+// ExtractTokensFromResponseWithHandler wraps the response body to extract
+// token usage with an optional usage handler. For streaming responses the
+// handler is invoked on the terminal usage chunk; for non-streaming JSON
+// responses it is invoked on Close(). clientRequestedUsage indicates if the
+// client explicitly requested usage stats in their request (controls
+// usage-only SSE chunk filtering).
+func ExtractTokensFromResponseWithHandler(resp *http.Response, model string, usageHandler func(*Usage), clientRequestedUsage bool) (io.ReadCloser, error) {
+	contentType := resp.Header.Get("Content-Type")
+
+	// For streaming responses, use the streaming extractor
+	if strings.Contains(contentType, "text/event-stream") {
+		pr, pw := io.Pipe()
+		extractor := NewStreamingTokenExtractor(resp.Body, pw, model)
+		extractor.usageHandler = usageHandler
+		extractor.clientRequestedUsage = clientRequestedUsage
+		go extractor.processStream()
+		return pr, nil
+	}
+
+	// For non-JSON or non-200 responses, pass through unchanged
+	if resp.StatusCode != http.StatusOK || !strings.Contains(contentType, "application/json") {
+		return resp.Body, nil
+	}
+
+	// For JSON responses, tee the body to the client while accumulating a copy
+	// for usage extraction on Close(). This retains the full response in memory,
+	// matching the router extractor's existing behavior.
+	extractor := &JSONTokenExtractor{
+		model: model,
+	}
+
+	// TeeReader copies data to the extractor while passing it through to
+	// the client unchanged.
+	teeReader := io.TeeReader(resp.Body, extractor)
+
+	// Return a custom closer that logs tokens when closed
+	return &teeReaderCloser{
+		Reader:       teeReader,
+		origBody:     resp.Body,
+		extractor:    extractor,
+		usageHandler: usageHandler,
+	}, nil
+}
+
+// maxSSELineBytes bounds a single SSE line; mirrors the tool runtime's
+// sseReader limit so large frames survive both parsers.
+const maxSSELineBytes = 1 << 22 // 4 MiB
+
+// StreamingTokenExtractor handles token extraction for streaming responses
+type StreamingTokenExtractor struct {
+	reader               io.ReadCloser
+	writer               io.WriteCloser
+	model                string
+	usage                *Usage
+	buffer               bytes.Buffer
+	scanner              *bufio.Scanner
+	completed            bool
+	usageHandler         func(*Usage) // Callback for when usage is extracted
+	clientRequestedUsage bool         // Whether client explicitly requested usage stats
+}
+
+// NewStreamingTokenExtractor creates a new streaming token extractor that intercepts SSE chunks
+func NewStreamingTokenExtractor(reader io.ReadCloser, writer io.WriteCloser, model string) *StreamingTokenExtractor {
+	s := &StreamingTokenExtractor{
+		reader: reader,
+		writer: writer,
+		model:  model,
+		usage:  &Usage{},
+	}
+	s.scanner = bufio.NewScanner(reader)
+	// Single SSE lines can exceed bufio's 64KiB default (for example a large
+	// tool-call argument blob in one chunk), which would abort the stream
+	// with ErrTooLong and surface as a silent truncation to the client.
+	s.scanner.Buffer(make([]byte, 0, 64*1024), maxSSELineBytes)
+	return s
+}
+
+// processStream processes the SSE stream, extracting token usage. It reads
+// lines from the upstream, writes them to the downstream pipe, and parses
+// usage data from SSE chunks. The usage handler is always invoked when the
+// stream ends (normally, on client disconnect, or on scanner error) so that
+// a billing event is emitted even if no usage data was collected — this
+// prevents billing bypass via early disconnect.
+func (s *StreamingTokenExtractor) processStream() {
+	defer s.writer.Close()
+	defer s.reader.Close()
+
+	lastLineWasFiltered := false
+	terminalEventPending := false
+	terminalResponseEvent := false
+	eventHasData := false
+
+	for s.scanner.Scan() {
+		line := s.scanner.Text()
+		shouldWrite := true
+		if strings.HasPrefix(line, "event:") {
+			eventType := strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			terminalResponseEvent = isTerminalResponseEvent(eventType)
+		}
+
+		// If the previous line was filtered and this is an empty line, skip it
+		// to avoid consecutive empty lines in the output
+		if lastLineWasFiltered && line == "" {
+			lastLineWasFiltered = false
+			terminalEventPending = false
+			terminalResponseEvent = false
+			eventHasData = false
+			continue
+		}
+
+		lastLineWasFiltered = false
+
+		// Parse SSE data lines
+		if strings.HasPrefix(line, "data:") {
+			eventHasData = true
+			data := strings.TrimPrefix(line, "data:")
+			data = strings.TrimPrefix(data, " ")
+			if data == "[DONE]" {
+				terminalEventPending = true
+			} else {
+				// Try to parse the chunk
+				var chunk map[string]interface{}
+				if err := json.Unmarshal([]byte(data), &chunk); err == nil {
+					if eventType, ok := chunk["type"].(string); ok && isTerminalResponseEvent(eventType) {
+						terminalEventPending = true
+					}
+					// Check for usage in the chunk (Chat Completions API)
+					// or nested under "response" (Responses API streaming)
+					usageData, ok := chunk["usage"]
+					if !ok || usageData == nil {
+						if respObj, rOk := chunk["response"].(map[string]interface{}); rOk {
+							usageData, ok = respObj["usage"]
+						}
+					}
+					if ok && usageData != nil {
+						usageBytes, _ := json.Marshal(usageData)
+						var usage Usage
+						if err := json.Unmarshal(usageBytes, &usage); err == nil {
+							usage.Normalize()
+							// Update usage data (continuous stats may send incremental updates)
+							if usage.PromptTokens > 0 {
+								s.usage.PromptTokens = usage.PromptTokens
+							}
+							if usage.CompletionTokens > 0 {
+								s.usage.CompletionTokens = usage.CompletionTokens
+							}
+							if usage.TotalTokens > 0 {
+								s.usage.TotalTokens = usage.TotalTokens
+							}
+							if usage.PromptTokensDetails != nil {
+								s.usage.PromptTokensDetails = usage.PromptTokensDetails
+							}
+						}
+
+						// Check if this is a usage-only chunk that should be filtered
+						if !s.clientRequestedUsage {
+							// Check if choices array exists and is empty
+							if choices, hasChoices := chunk["choices"].([]interface{}); hasChoices && len(choices) == 0 {
+								// This is a usage-only chunk with empty choices array
+								// Filter it out since client didn't request usage
+								shouldWrite = false
+								lastLineWasFiltered = true
+							}
+						}
+					}
+				}
+			}
+		}
+
+		// Write the line to output if we should. If the downstream client
+		// has closed the connection, stop reading the upstream so the
+		// deferred reader.Close() runs promptly.
+		if shouldWrite {
+			var writeErr error
+			if line == "" {
+				_, writeErr = s.writer.Write([]byte("\n"))
+			} else {
+				_, writeErr = s.writer.Write([]byte(line + "\n"))
+			}
+			if writeErr != nil {
+				break
+			}
+		}
+
+		if line == "" {
+			if (terminalEventPending || terminalResponseEvent) && eventHasData {
+				break
+			}
+			terminalEventPending = false
+			terminalResponseEvent = false
+			eventHasData = false
+		}
+	}
+
+	// Surface scanner errors (e.g. bufio.ErrTooLong) so they are not
+	// silently swallowed. The downstream client already received whatever
+	// was written before the error; the pipe closes cleanly via the
+	// deferred writer.Close().
+	if err := s.scanner.Err(); err != nil {
+		log.Printf("tokencount: streaming scanner error (truncated response): %v", err)
+	}
+
+	// Always invoke the usage handler so a billing event is emitted even
+	// when the stream was truncated or the client disconnected before any
+	// usage chunk arrived. Without this, a client could avoid billing by
+	// disconnecting early. The handler receives zero values when no usage
+	// data was collected, which the billing layer records as a zero-token
+	// event (equivalent to the billingCloser fallback for non-streaming).
+	if s.usageHandler != nil {
+		if s.usage.TotalTokens == 0 {
+			s.usage.TotalTokens = s.usage.PromptTokens + s.usage.CompletionTokens
+		}
+		s.usageHandler(s.usage)
+	}
+
+	s.completed = true
+}
+
+func isTerminalResponseEvent(eventType string) bool {
+	switch eventType {
+	case "response.completed", "response.failed", "response.incomplete", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+// Read implements io.Reader for compatibility
+func (s *StreamingTokenExtractor) Read(p []byte) (n int, err error) {
+	// This is mainly for compatibility - actual processing happens in processStream
+	return s.buffer.Read(p)
+}

--- a/tinfoil/internal/tokencount/tokencount.go
+++ b/tinfoil/internal/tokencount/tokencount.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"io"
 	"log"
+	"mime"
 	"net/http"
 	"strings"
 	"sync"
@@ -70,26 +71,46 @@ type OpenAIResponse struct {
 
 // JSONTokenExtractor accumulates JSON response data and extracts tokens
 type JSONTokenExtractor struct {
-	buffer bytes.Buffer
-	model  string
-	usage  *Usage
-	mu     sync.Mutex
+	buffer   bytes.Buffer
+	usage    *Usage
+	overflow bool
+	mu       sync.Mutex
 }
+
+const maxJSONResponseBytes = 10 << 20
 
 // Write implements io.Writer, accumulating data
 func (j *JSONTokenExtractor) Write(p []byte) (n int, err error) {
 	j.mu.Lock()
 	defer j.mu.Unlock()
-	return j.buffer.Write(p)
+	if j.overflow {
+		return len(p), nil
+	}
+	remaining := maxJSONResponseBytes - j.buffer.Len()
+	if len(p) > remaining {
+		_, _ = j.buffer.Write(p[:max(0, remaining)])
+		j.overflow = true
+		return len(p), nil
+	}
+	_, _ = j.buffer.Write(p)
+	return len(p), nil
 }
 
 // ExtractUsage parses the accumulated JSON and extracts token usage
 func (j *JSONTokenExtractor) ExtractUsage() {
 	j.mu.Lock()
 	defer j.mu.Unlock()
+	if j.overflow {
+		log.Printf("tokencount: non-streaming response exceeded %d-byte extraction limit", maxJSONResponseBytes)
+		return
+	}
 
 	var resp OpenAIResponse
-	if err := json.Unmarshal(j.buffer.Bytes(), &resp); err == nil && resp.Usage != nil {
+	if err := json.Unmarshal(j.buffer.Bytes(), &resp); err != nil {
+		log.Printf("tokencount: failed to parse non-streaming usage response: %v", err)
+		return
+	}
+	if resp.Usage != nil {
 		resp.Usage.Normalize()
 		j.usage = resp.Usage
 	}
@@ -127,8 +148,8 @@ func (t *teeReaderCloser) Close() error {
 // receives bytes without delay; usage is extracted on Close() or, for
 // streaming, as the stream is processed. Usage is delivered via the
 // usageHandler callback, not a return value.
-func ExtractTokensFromResponse(resp *http.Response, model string) (io.ReadCloser, error) {
-	return ExtractTokensFromResponseWithHandler(resp, model, nil, false)
+func ExtractTokensFromResponse(resp *http.Response) io.ReadCloser {
+	return ExtractTokensFromResponseWithHandler(resp, nil, false)
 }
 
 // ExtractTokensFromResponseWithHandler wraps the response body to extract
@@ -137,30 +158,28 @@ func ExtractTokensFromResponse(resp *http.Response, model string) (io.ReadCloser
 // responses it is invoked on Close(). clientRequestedUsage indicates if the
 // client explicitly requested usage stats in their request (controls
 // usage-only SSE chunk filtering).
-func ExtractTokensFromResponseWithHandler(resp *http.Response, model string, usageHandler func(*Usage), clientRequestedUsage bool) (io.ReadCloser, error) {
+func ExtractTokensFromResponseWithHandler(resp *http.Response, usageHandler func(*Usage), clientRequestedUsage bool) io.ReadCloser {
 	contentType := resp.Header.Get("Content-Type")
 
 	// For streaming responses, use the streaming extractor
-	if strings.Contains(contentType, "text/event-stream") {
+	if hasMediaType(contentType, "text/event-stream") {
 		pr, pw := io.Pipe()
-		extractor := NewStreamingTokenExtractor(resp.Body, pw, model)
+		extractor := NewStreamingTokenExtractor(resp.Body, pw)
 		extractor.usageHandler = usageHandler
 		extractor.clientRequestedUsage = clientRequestedUsage
 		go extractor.processStream()
-		return pr, nil
+		return &streamReadCloser{PipeReader: pr, upstream: resp.Body}
 	}
 
 	// For non-JSON or non-200 responses, pass through unchanged
-	if resp.StatusCode != http.StatusOK || !strings.Contains(contentType, "application/json") {
-		return resp.Body, nil
+	if resp.StatusCode != http.StatusOK || !hasJSONMediaType(contentType) {
+		return resp.Body
 	}
 
 	// For JSON responses, tee the body to the client while accumulating a copy
 	// for usage extraction on Close(). This retains the full response in memory,
 	// matching the router extractor's existing behavior.
-	extractor := &JSONTokenExtractor{
-		model: model,
-	}
+	extractor := &JSONTokenExtractor{}
 
 	// TeeReader copies data to the extractor while passing it through to
 	// the client unchanged.
@@ -172,7 +191,35 @@ func ExtractTokensFromResponseWithHandler(resp *http.Response, model string, usa
 		origBody:     resp.Body,
 		extractor:    extractor,
 		usageHandler: usageHandler,
-	}, nil
+	}
+}
+
+type streamReadCloser struct {
+	*io.PipeReader
+	upstream io.Closer
+}
+
+func (s *streamReadCloser) Close() error {
+	pipeErr := s.PipeReader.Close()
+	upstreamErr := s.upstream.Close()
+	if pipeErr != nil {
+		return pipeErr
+	}
+	return upstreamErr
+}
+
+func hasMediaType(header, want string) bool {
+	mediaType, _, err := mime.ParseMediaType(header)
+	return err == nil && strings.EqualFold(mediaType, want)
+}
+
+func hasJSONMediaType(header string) bool {
+	mediaType, _, err := mime.ParseMediaType(header)
+	if err != nil {
+		return false
+	}
+	mediaType = strings.ToLower(mediaType)
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
 }
 
 // maxSSELineBytes bounds a single SSE line; mirrors the tool runtime's
@@ -183,9 +230,7 @@ const maxSSELineBytes = 1 << 22 // 4 MiB
 type StreamingTokenExtractor struct {
 	reader               io.ReadCloser
 	writer               io.WriteCloser
-	model                string
 	usage                *Usage
-	buffer               bytes.Buffer
 	scanner              *bufio.Scanner
 	completed            bool
 	usageHandler         func(*Usage) // Callback for when usage is extracted
@@ -193,11 +238,10 @@ type StreamingTokenExtractor struct {
 }
 
 // NewStreamingTokenExtractor creates a new streaming token extractor that intercepts SSE chunks
-func NewStreamingTokenExtractor(reader io.ReadCloser, writer io.WriteCloser, model string) *StreamingTokenExtractor {
+func NewStreamingTokenExtractor(reader io.ReadCloser, writer io.WriteCloser) *StreamingTokenExtractor {
 	s := &StreamingTokenExtractor{
 		reader: reader,
 		writer: writer,
-		model:  model,
 		usage:  &Usage{},
 	}
 	s.scanner = bufio.NewScanner(reader)
@@ -340,9 +384,7 @@ func (s *StreamingTokenExtractor) processStream() {
 	// data was collected, which the billing layer records as a zero-token
 	// event (equivalent to the billingCloser fallback for non-streaming).
 	if s.usageHandler != nil {
-		if s.usage.TotalTokens == 0 {
-			s.usage.TotalTokens = s.usage.PromptTokens + s.usage.CompletionTokens
-		}
+		s.usage.Normalize()
 		s.usageHandler(s.usage)
 	}
 
@@ -356,10 +398,4 @@ func isTerminalResponseEvent(eventType string) bool {
 	default:
 		return false
 	}
-}
-
-// Read implements io.Reader for compatibility
-func (s *StreamingTokenExtractor) Read(p []byte) (n int, err error) {
-	// This is mainly for compatibility - actual processing happens in processStream
-	return s.buffer.Read(p)
 }

--- a/tinfoil/internal/tokencount/tokencount_test.go
+++ b/tinfoil/internal/tokencount/tokencount_test.go
@@ -101,7 +101,10 @@ func TestExtractTokensFromResponse(t *testing.T) {
 			}
 
 			// Extract tokens with handler
-			newBody := ExtractTokensFromResponseWithHandler(resp, usageHandler, false)
+			newBody, err := ExtractTokensFromResponseWithHandler(resp, usageHandler, false)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			// Verify we can still read the response body
 			bodyBytes, err := io.ReadAll(newBody)
@@ -137,7 +140,10 @@ func TestNonStreamingExtractionIsBounded(t *testing.T) {
 		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 	called := false
-	wrapped := ExtractTokensFromResponseWithHandler(resp, func(*Usage) { called = true }, false)
+	wrapped, err := ExtractTokensFromResponseWithHandler(resp, func(*Usage) { called = true }, false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	got, err := io.ReadAll(wrapped)
 	if err != nil {
 		t.Fatal(err)
@@ -175,7 +181,10 @@ func TestClosingStreamingBodyClosesUpstream(t *testing.T) {
 		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
 		Body:       upstream,
 	}
-	body := ExtractTokensFromResponse(resp)
+	body, err := ExtractTokensFromResponse(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if err := body.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -183,6 +192,12 @@ func TestClosingStreamingBodyClosesUpstream(t *testing.T) {
 	case <-upstream.closed:
 	case <-time.After(time.Second):
 		t.Fatal("closing downstream body did not close upstream")
+	}
+}
+
+func TestExtractTokensRejectsNilResponseBody(t *testing.T) {
+	if _, err := ExtractTokensFromResponseWithHandler(&http.Response{}, nil, false); err == nil {
+		t.Fatal("nil response body accepted")
 	}
 }
 
@@ -264,7 +279,10 @@ data: [DONE]
 			}
 
 			// Extract tokens
-			newBody := ExtractTokensFromResponseWithHandler(resp, usageHandler, false)
+			newBody, err := ExtractTokensFromResponseWithHandler(resp, usageHandler, false)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			// Read the entire response to trigger processing. io.Copy blocks
 			// until the pipe writer closes (EOF), which only happens after
@@ -327,7 +345,10 @@ data: [DONE]
 			}
 
 			// Should handle errors gracefully
-			newBody := ExtractTokensFromResponse(resp)
+			newBody, err := ExtractTokensFromResponse(resp)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			// Should still pass through the entire stream
 			output := &bytes.Buffer{}
@@ -386,7 +407,10 @@ data: [DONE]
 				Body:       io.NopCloser(strings.NewReader(streamWithUsageOnlyChunk)),
 			}
 
-			newBody := ExtractTokensFromResponseWithHandler(resp, nil, tt.clientRequestedUsage)
+			newBody, err := ExtractTokensFromResponseWithHandler(resp, nil, tt.clientRequestedUsage)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			output := &bytes.Buffer{}
 			io.Copy(output, newBody)
@@ -425,7 +449,10 @@ data: [DONE]
 		callbackCalled = true
 	}
 
-	newBody := ExtractTokensFromResponseWithHandler(resp, usageHandler, true)
+	newBody, err := ExtractTokensFromResponseWithHandler(resp, usageHandler, true)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	io.Copy(io.Discard, newBody)
 	newBody.Close()

--- a/tinfoil/internal/tokencount/tokencount_test.go
+++ b/tinfoil/internal/tokencount/tokencount_test.go
@@ -1,0 +1,431 @@
+package tokencount
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestExtractTokensFromResponse(t *testing.T) {
+	tests := []struct {
+		name         string
+		responseBody string
+		contentType  string
+		statusCode   int
+		wantUsage    *Usage
+		wantErr      bool
+	}{
+		{
+			name: "valid OpenAI response",
+			responseBody: `{
+				"id": "chatcmpl-123",
+				"object": "chat.completion",
+				"created": 1677652288,
+				"choices": [{
+					"index": 0,
+					"message": {"role": "assistant", "content": "Hello!"},
+					"finish_reason": "stop"
+				}],
+				"usage": {
+					"prompt_tokens": 10,
+					"completion_tokens": 20,
+					"total_tokens": 30
+				}
+			}`,
+			contentType: "application/json",
+			statusCode:  http.StatusOK,
+			wantUsage: &Usage{
+				PromptTokens:     10,
+				CompletionTokens: 20,
+				TotalTokens:      30,
+			},
+		},
+		{
+			name: "response without usage",
+			responseBody: `{
+				"id": "chatcmpl-123",
+				"object": "chat.completion",
+				"created": 1677652288,
+				"choices": [{
+					"index": 0,
+					"message": {"role": "assistant", "content": "Hello!"},
+					"finish_reason": "stop"
+				}]
+			}`,
+			contentType: "application/json",
+			statusCode:  http.StatusOK,
+			wantUsage:   nil,
+		},
+		{
+			name:         "non-JSON response",
+			responseBody: `Hello, this is plain text`,
+			contentType:  "text/plain",
+			statusCode:   http.StatusOK,
+			wantUsage:    nil,
+		},
+		{
+			name:         "error response",
+			responseBody: `{"error": "Invalid request"}`,
+			contentType:  "application/json",
+			statusCode:   http.StatusBadRequest,
+			wantUsage:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock response
+			resp := &http.Response{
+				StatusCode: tt.statusCode,
+				Header:     http.Header{"Content-Type": []string{tt.contentType}},
+				Body:       io.NopCloser(bytes.NewReader([]byte(tt.responseBody))),
+			}
+
+			var capturedUsage *Usage
+			usageHandler := func(usage *Usage) {
+				capturedUsage = usage
+			}
+
+			// Extract tokens with handler
+			newBody, err := ExtractTokensFromResponseWithHandler(resp, "test-model", usageHandler, false)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ExtractTokensFromResponseWithHandler() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Verify we can still read the response body
+			bodyBytes, err := io.ReadAll(newBody)
+			if err != nil {
+				t.Errorf("Failed to read new body: %v", err)
+			}
+			if string(bodyBytes) != tt.responseBody {
+				t.Errorf("Body content changed: got %s, want %s", string(bodyBytes), tt.responseBody)
+			}
+
+			// Close to trigger token extraction
+			newBody.Close()
+
+			// Verify usage was captured correctly
+			if tt.wantUsage != nil {
+				if capturedUsage == nil {
+					t.Errorf("Expected usage to be captured, but it wasn't")
+				} else if *capturedUsage != *tt.wantUsage {
+					t.Errorf("Usage mismatch: got %+v, want %+v", capturedUsage, tt.wantUsage)
+				}
+			}
+		})
+	}
+}
+
+func TestStreamingTokenExtraction(t *testing.T) {
+	tests := []struct {
+		name           string
+		streamData     string
+		expectedUsage  *Usage
+		expectCallback bool
+	}{
+		{
+			name: "OpenAI streaming with usage in final chunk",
+			streamData: `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}
+
+data: [DONE]
+
+`,
+			expectedUsage: &Usage{
+				PromptTokens:     10,
+				CompletionTokens: 2,
+				TotalTokens:      12,
+			},
+			expectCallback: true,
+		},
+		{
+			name: "Streaming with continuous usage stats",
+			streamData: `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}],"usage":{"prompt_tokens":5,"completion_tokens":0,"total_tokens":5}}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}
+
+data: [DONE]
+
+`,
+			expectedUsage: &Usage{
+				PromptTokens:     5,
+				CompletionTokens: 1,
+				TotalTokens:      6,
+			},
+			expectCallback: true,
+		},
+		{
+			name: "Streaming without explicit usage (zero-token callback for billing fallback)",
+			streamData: `data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":"This is a test"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}
+
+data: [DONE]
+
+`,
+			expectedUsage:  &Usage{}, // Zero usage: callback fires as billing fallback
+			expectCallback: true,     // Always called to prevent billing bypass
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a mock streaming response
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(tt.streamData)),
+			}
+
+			var capturedUsage *Usage
+			callbackCalled := false
+			usageHandler := func(usage *Usage) {
+				capturedUsage = usage
+				callbackCalled = true
+			}
+
+			// Extract tokens
+			newBody, err := ExtractTokensFromResponseWithHandler(resp, "test-model", usageHandler, false)
+			if err != nil {
+				t.Errorf("ExtractTokensFromResponseWithHandler() error = %v", err)
+				return
+			}
+
+			// Read the entire response to trigger processing. io.Copy blocks
+			// until the pipe writer closes (EOF), which only happens after
+			// the background goroutine completes, so no sleep is needed.
+			output := &bytes.Buffer{}
+			io.Copy(output, newBody)
+			newBody.Close()
+
+			// Verify output matches input
+			if output.String() != tt.streamData {
+				t.Errorf("Stream output doesn't match input.\nGot:\n%s\nWant:\n%s", output.String(), tt.streamData)
+			}
+
+			// Verify callback was called if expected
+			if tt.expectCallback && !callbackCalled {
+				t.Errorf("Expected usage callback to be called, but it wasn't")
+			}
+
+			// Verify usage matches expected
+			if tt.expectedUsage != nil && capturedUsage != nil {
+				if capturedUsage.PromptTokens != tt.expectedUsage.PromptTokens ||
+					capturedUsage.CompletionTokens != tt.expectedUsage.CompletionTokens ||
+					capturedUsage.TotalTokens != tt.expectedUsage.TotalTokens {
+					t.Errorf("Usage mismatch: got %+v, want %+v", capturedUsage, tt.expectedUsage)
+				}
+			}
+		})
+	}
+}
+
+func TestStreamingErrorCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		streamData string
+	}{
+		{
+			name: "Malformed JSON in stream",
+			streamData: `data: {"id":"chatcmpl-123","malformed json
+
+data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}
+
+data: [DONE]
+
+`,
+		},
+		{
+			name: "Empty data lines",
+			streamData: "data: \n\n" +
+				`data: {"id":"chatcmpl-123","object":"chat.completion.chunk","created":1677652288,"model":"gpt-3.5-turbo","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}` +
+				"\n\ndata: \n\ndata: [DONE]\n\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(tt.streamData)),
+			}
+
+			// Should handle errors gracefully
+			newBody, err := ExtractTokensFromResponse(resp, "test-model")
+			if err != nil {
+				t.Errorf("ExtractTokensFromResponse() unexpected error = %v", err)
+				return
+			}
+
+			// Should still pass through the entire stream
+			output := &bytes.Buffer{}
+			io.Copy(output, newBody)
+			newBody.Close()
+
+			if output.String() != tt.streamData {
+				t.Errorf("Stream output doesn't match input despite errors")
+			}
+		})
+	}
+}
+
+func TestStreamingUsageOnlyChunkFiltering(t *testing.T) {
+	// A usage-only chunk has an empty choices array. When the client did
+	// NOT request usage, it should be filtered from the output. When the
+	// client DID request usage, it should be preserved.
+	streamWithUsageOnlyChunk := `data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":5,"completion_tokens":1,"total_tokens":6}}
+
+data: [DONE]
+
+`
+
+	// Expected output when usage-only chunks are filtered: the usage-only
+	// chunk and its trailing blank line are removed.
+	filteredOutput := `data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}
+
+data: [DONE]
+
+`
+
+	tests := []struct {
+		name                 string
+		clientRequestedUsage bool
+		wantOutput           string
+	}{
+		{
+			name:                 "usage-only chunk filtered when client did not request usage",
+			clientRequestedUsage: false,
+			wantOutput:           filteredOutput,
+		},
+		{
+			name:                 "usage-only chunk preserved when client requested usage",
+			clientRequestedUsage: true,
+			wantOutput:           streamWithUsageOnlyChunk,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+				Body:       io.NopCloser(strings.NewReader(streamWithUsageOnlyChunk)),
+			}
+
+			newBody, err := ExtractTokensFromResponseWithHandler(resp, "test-model", nil, tt.clientRequestedUsage)
+			if err != nil {
+				t.Fatalf("ExtractTokensFromResponseWithHandler() error = %v", err)
+			}
+
+			output := &bytes.Buffer{}
+			io.Copy(output, newBody)
+			newBody.Close()
+
+			if output.String() != tt.wantOutput {
+				t.Errorf("Stream output mismatch.\nGot:\n%s\nWant:\n%s", output.String(), tt.wantOutput)
+			}
+		})
+	}
+}
+
+func TestStreamingPromptOnlyUsage(t *testing.T) {
+	// A stream that sends prompt_tokens but no completion_tokens or
+	// total_tokens. The usage handler should still fire so billing is
+	// recorded (regression: previously the handler only fired when
+	// TotalTokens > 0 or CompletionTokens > 0).
+	streamData := `data: {"id":"chatcmpl-1","choices":[{"index":0,"delta":{"content":"Hi"},"finish_reason":null}]}
+
+data: {"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":42,"completion_tokens":0,"total_tokens":0}}
+
+data: [DONE]
+
+`
+
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(streamData)),
+	}
+
+	var capturedUsage *Usage
+	callbackCalled := false
+	usageHandler := func(usage *Usage) {
+		capturedUsage = usage
+		callbackCalled = true
+	}
+
+	newBody, err := ExtractTokensFromResponseWithHandler(resp, "test-model", usageHandler, true)
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+
+	io.Copy(io.Discard, newBody)
+	newBody.Close()
+
+	if !callbackCalled {
+		t.Fatal("usage handler should fire when prompt_tokens > 0 even if completion/total are 0")
+	}
+	if capturedUsage.PromptTokens != 42 {
+		t.Errorf("prompt_tokens = %d, want 42", capturedUsage.PromptTokens)
+	}
+	if capturedUsage.TotalTokens != 42 {
+		t.Errorf("total_tokens should be derived = %d, want 42", capturedUsage.TotalTokens)
+	}
+}
+
+func TestNormalizeDerivesTotalTokens(t *testing.T) {
+	// When the upstream omits total_tokens, Normalize should derive it
+	// from prompt + completion, so non-streaming billing is consistent
+	// with streaming (which also derives total).
+	tests := []struct {
+		name      string
+		usage     Usage
+		wantTotal int
+	}{
+		{
+			name:      "derives total from prompt + completion",
+			usage:     Usage{PromptTokens: 10, CompletionTokens: 5},
+			wantTotal: 15,
+		},
+		{
+			name:      "preserves explicit total",
+			usage:     Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 99},
+			wantTotal: 99,
+		},
+		{
+			name:      "derives total from responses API input/output",
+			usage:     Usage{InputTokens: 8, OutputTokens: 3},
+			wantTotal: 11,
+		},
+		{
+			name:      "zero usage stays zero",
+			usage:     Usage{},
+			wantTotal: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u := tt.usage
+			u.Normalize()
+			if u.TotalTokens != tt.wantTotal {
+				t.Errorf("TotalTokens = %d, want %d", u.TotalTokens, tt.wantTotal)
+			}
+		})
+	}
+}

--- a/tinfoil/internal/tokencount/tokencount_test.go
+++ b/tinfoil/internal/tokencount/tokencount_test.go
@@ -5,7 +5,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestExtractTokensFromResponse(t *testing.T) {
@@ -15,7 +17,6 @@ func TestExtractTokensFromResponse(t *testing.T) {
 		contentType  string
 		statusCode   int
 		wantUsage    *Usage
-		wantErr      bool
 	}{
 		{
 			name: "valid OpenAI response",
@@ -40,6 +41,17 @@ func TestExtractTokensFromResponse(t *testing.T) {
 				PromptTokens:     10,
 				CompletionTokens: 20,
 				TotalTokens:      30,
+			},
+		},
+		{
+			name:         "vendor JSON response",
+			responseBody: `{"usage":{"prompt_tokens":3,"completion_tokens":4,"total_tokens":7}}`,
+			contentType:  "application/vnd.openai+json; charset=utf-8",
+			statusCode:   http.StatusOK,
+			wantUsage: &Usage{
+				PromptTokens:     3,
+				CompletionTokens: 4,
+				TotalTokens:      7,
 			},
 		},
 		{
@@ -89,11 +101,7 @@ func TestExtractTokensFromResponse(t *testing.T) {
 			}
 
 			// Extract tokens with handler
-			newBody, err := ExtractTokensFromResponseWithHandler(resp, "test-model", usageHandler, false)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ExtractTokensFromResponseWithHandler() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			newBody := ExtractTokensFromResponseWithHandler(resp, usageHandler, false)
 
 			// Verify we can still read the response body
 			bodyBytes, err := io.ReadAll(newBody)
@@ -114,8 +122,67 @@ func TestExtractTokensFromResponse(t *testing.T) {
 				} else if *capturedUsage != *tt.wantUsage {
 					t.Errorf("Usage mismatch: got %+v, want %+v", capturedUsage, tt.wantUsage)
 				}
+			} else if capturedUsage != nil {
+				t.Errorf("Expected no usage to be captured, got %+v", capturedUsage)
 			}
 		})
+	}
+}
+
+func TestNonStreamingExtractionIsBounded(t *testing.T) {
+	body := strings.Repeat("x", maxJSONResponseBytes+1)
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	called := false
+	wrapped := ExtractTokensFromResponseWithHandler(resp, func(*Usage) { called = true }, false)
+	got, err := io.ReadAll(wrapped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := wrapped.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != len(body) {
+		t.Fatalf("pass-through body length = %d, want %d", len(got), len(body))
+	}
+	if called {
+		t.Fatal("usage handler called for oversized response")
+	}
+}
+
+type blockingReadCloser struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (b *blockingReadCloser) Read([]byte) (int, error) {
+	<-b.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (b *blockingReadCloser) Close() error {
+	b.once.Do(func() { close(b.closed) })
+	return nil
+}
+
+func TestClosingStreamingBodyClosesUpstream(t *testing.T) {
+	upstream := &blockingReadCloser{closed: make(chan struct{})}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       upstream,
+	}
+	body := ExtractTokensFromResponse(resp)
+	if err := body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-upstream.closed:
+	case <-time.After(time.Second):
+		t.Fatal("closing downstream body did not close upstream")
 	}
 }
 
@@ -197,11 +264,7 @@ data: [DONE]
 			}
 
 			// Extract tokens
-			newBody, err := ExtractTokensFromResponseWithHandler(resp, "test-model", usageHandler, false)
-			if err != nil {
-				t.Errorf("ExtractTokensFromResponseWithHandler() error = %v", err)
-				return
-			}
+			newBody := ExtractTokensFromResponseWithHandler(resp, usageHandler, false)
 
 			// Read the entire response to trigger processing. io.Copy blocks
 			// until the pipe writer closes (EOF), which only happens after
@@ -264,11 +327,7 @@ data: [DONE]
 			}
 
 			// Should handle errors gracefully
-			newBody, err := ExtractTokensFromResponse(resp, "test-model")
-			if err != nil {
-				t.Errorf("ExtractTokensFromResponse() unexpected error = %v", err)
-				return
-			}
+			newBody := ExtractTokensFromResponse(resp)
 
 			// Should still pass through the entire stream
 			output := &bytes.Buffer{}
@@ -327,10 +386,7 @@ data: [DONE]
 				Body:       io.NopCloser(strings.NewReader(streamWithUsageOnlyChunk)),
 			}
 
-			newBody, err := ExtractTokensFromResponseWithHandler(resp, "test-model", nil, tt.clientRequestedUsage)
-			if err != nil {
-				t.Fatalf("ExtractTokensFromResponseWithHandler() error = %v", err)
-			}
+			newBody := ExtractTokensFromResponseWithHandler(resp, nil, tt.clientRequestedUsage)
 
 			output := &bytes.Buffer{}
 			io.Copy(output, newBody)
@@ -369,10 +425,7 @@ data: [DONE]
 		callbackCalled = true
 	}
 
-	newBody, err := ExtractTokensFromResponseWithHandler(resp, "test-model", usageHandler, true)
-	if err != nil {
-		t.Fatalf("error = %v", err)
-	}
+	newBody := ExtractTokensFromResponseWithHandler(resp, usageHandler, true)
 
 	io.Copy(io.Discard, newBody)
 	newBody.Close()


### PR DESCRIPTION
This is the cvmimage and shim side of a fix that ensures that direct usage of tinfoil inference endpoints bills properly. 

Commits correspond to commits in the confidential-model-router PR for ease of review.

Issue filed as https://github.com/tinfoilsh/cvmimage/issues/337. See the issue for the design doc and upgrade details.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fail-closed billing collector to the shim so direct, authenticated calls to inference endpoints are billed the same as router-mediated requests. For model workloads, the shim now requires `shim.model-name` and both billing secrets at startup.

- New Features
  - Added `tinfoil/internal/billing` with signed usage reporting via `github.com/tinfoilsh/usage-reporting-go`; suppresses duplicates using a router-signed usage context (±1-minute skew) bound to the bearer token’s API key hash; flushes on shutdown.
  - Added `tinfoil/internal/tokencount` to extract token usage from JSON and SSE responses without buffering; supports gzip and vendor field names; usage-only SSE chunks are forwarded only when requested.
  - Enforced direct billing: setting `shim.model-name` makes billing mandatory; startup fails without `USAGE_REPORTER_SECRET` and `USAGE_CONTEXT_SECRET`; validates `model-name` (rejects leading/trailing whitespace) and requires it when `models` are configured.
  - Capped request body size at 64 MiB and injected declared billing secrets into the container env.

- Migration
  - Set `shim.model-name` to the served model ID in the shim config.
  - Provide `USAGE_REPORTER_SECRET` and `USAGE_CONTEXT_SECRET` via external secrets; the shim will not start without both.
  - No client API changes; streaming usage chunks are included only when usage is requested.

<sup>Written for commit 6c3fc13a8c773d0424f73b15b23b5897943fa6f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



