### PR TITLE
Fix v3 attestation under hardened shim runtime

### DIFF
--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -27,7 +27,6 @@ import (
 const (
 	containerdReadyLimit = 30 * time.Second
 	dockerReadyLimit     = 60 * time.Second
-	containersReadyLimit = 30 * time.Minute
 	shimReadyLimit       = 30 * time.Second
 	oneShotStopGrace     = 2 * time.Second
 	serviceTermGrace     = 10 * time.Second
@@ -257,7 +256,7 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 		Name: containersName, Required: true, Restart: true,
 		Command: hardenedCommand(hardening.ServiceContainers, boot.ContainersBinary,
 			fmt.Sprintf("--debug=%t", deps.cmdline.Debug)),
-		Ready: fileReady(boot.ContainersReadyPath, containersReadyLimit),
+		Ready: fileReady(boot.ContainersReadyPath),
 	}); err != nil {
 		return err
 	}
@@ -613,7 +612,9 @@ func annotateOneShotFailure(
 
 func endpointReady(network, address string, limit time.Duration) func(context.Context) error {
 	return func(parent context.Context) error {
-		return waitForEndpoint(parent, limit, func(ctx context.Context) error {
+		ctx, cancel := context.WithTimeout(parent, limit)
+		defer cancel()
+		return waitForReadiness(ctx, func(ctx context.Context) error {
 			connection, err := (&net.Dialer{}).DialContext(ctx, network, address)
 			if err == nil {
 				_ = connection.Close()
@@ -623,18 +624,16 @@ func endpointReady(network, address string, limit time.Duration) func(context.Co
 	}
 }
 
-func fileReady(path string, limit time.Duration) func(context.Context) error {
+func fileReady(path string) func(context.Context) error {
 	return func(parent context.Context) error {
-		return waitForEndpoint(parent, limit, func(context.Context) error {
+		return waitForReadiness(parent, func(context.Context) error {
 			_, err := os.Stat(path)
 			return err
 		})
 	}
 }
 
-func waitForEndpoint(parent context.Context, limit time.Duration, probe func(context.Context) error) error {
-	ctx, cancel := context.WithTimeout(parent, limit)
-	defer cancel()
+func waitForReadiness(ctx context.Context, probe func(context.Context) error) error {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	var lastErr error

--- a/tinfoil/cmd/pid1/main_test.go
+++ b/tinfoil/cmd/pid1/main_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -753,6 +754,44 @@ func TestReadinessPublicationAllowsTransientRecovery(t *testing.T) {
 	readiness.Update(supervisor.State{Name: "second", Required: true, Ready: true})
 	if got := fmt.Sprint(states); got != "[false true]" {
 		t.Fatalf("published readiness states = %s, want [false true]", got)
+	}
+}
+
+func TestFileReadyWaitsForTheServiceLifecycle(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "containers.ready")
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		result <- fileReady(path)(ctx)
+	}()
+
+	select {
+	case err := <-result:
+		t.Fatalf("fileReady returned before readiness or cancellation: %v", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	cancel()
+	if err := <-result; !errors.Is(err, context.Canceled) {
+		t.Fatalf("fileReady cancellation error = %v, want context canceled", err)
+	}
+}
+
+func TestFileReadyReturnsWhenReadinessIsPublished(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "containers.ready")
+	writeResult := make(chan error, 1)
+	go func() {
+		time.Sleep(150 * time.Millisecond)
+		writeResult <- os.WriteFile(path, nil, 0o600)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := fileReady(path)(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := <-writeResult; err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/tinfoil/internal/nvidia/services.go
+++ b/tinfoil/internal/nvidia/services.go
@@ -150,23 +150,26 @@ func (s *Services) waitForService(ctx context.Context, name, pidPath, socketPath
 
 	var lastErr error
 	for {
-		if pidPath != "" {
-			if err := validateLivePID(pidPath); err != nil {
-				lastErr = fmt.Errorf("validate %s PID: %w", name, err)
-			} else if err := validateUnixSocket(socketPath); err != nil {
-				lastErr = fmt.Errorf("validate %s socket: %w", name, err)
-			} else {
-				return nil
-			}
-		} else if err := validateUnixSocket(socketPath); err != nil {
-			lastErr = fmt.Errorf("validate %s socket: %w", name, err)
-		} else {
+		lastErr = validateServiceReadiness(name, pidPath, socketPath)
+		if lastErr == nil {
 			return nil
 		}
 		if err := waitPoll(waitCtx, s.pollInterval); err != nil {
 			return fmt.Errorf("%s readiness failed (%v): %w", name, lastErr, err)
 		}
 	}
+}
+
+func validateServiceReadiness(name, pidPath, socketPath string) error {
+	if pidPath != "" {
+		if err := validateLivePID(pidPath); err != nil {
+			return fmt.Errorf("validate %s PID: %w", name, err)
+		}
+	}
+	if err := validateUnixSocket(socketPath); err != nil {
+		return fmt.Errorf("validate %s socket: %w", name, err)
+	}
+	return nil
 }
 
 // WaitForNVML polls go-nvml directly until it reports exactly expected GPUs.

--- a/tinfoil/internal/nvidia/services.go
+++ b/tinfoil/internal/nvidia/services.go
@@ -19,7 +19,7 @@ import (
 const (
 	persistencedUID     = 143
 	persistencedGID     = 143
-	serviceReadyWait    = 15 * time.Second
+	serviceReadyWait    = 30 * time.Second
 	servicePollInterval = 500 * time.Millisecond
 	maxPIDFileSize      = 32
 )
@@ -137,10 +137,11 @@ func (s *Services) WaitForPersistenced(ctx context.Context) error {
 	return s.waitForService(ctx, "nvidia-persistenced", s.paths.persistencedPID, s.paths.persistencedSock)
 }
 
-// WaitForFabricManager waits for a regular, nonempty bounded PID file and the
-// fixed Fabric Manager Unix socket.
+// WaitForFabricManager waits for the fixed Fabric Manager Unix socket. Fabric
+// Manager runs in the foreground under the PID1 supervisor, so it does not
+// publish a PID file.
 func (s *Services) WaitForFabricManager(ctx context.Context) error {
-	return s.waitForService(ctx, "NVIDIA Fabric Manager", s.paths.fabricPID, s.paths.fabricSock)
+	return s.waitForService(ctx, "NVIDIA Fabric Manager", "", s.paths.fabricSock)
 }
 
 func (s *Services) waitForService(ctx context.Context, name, pidPath, socketPath string) error {
@@ -149,8 +150,14 @@ func (s *Services) waitForService(ctx context.Context, name, pidPath, socketPath
 
 	var lastErr error
 	for {
-		if err := validateLivePID(pidPath); err != nil {
-			lastErr = fmt.Errorf("validate %s PID: %w", name, err)
+		if pidPath != "" {
+			if err := validateLivePID(pidPath); err != nil {
+				lastErr = fmt.Errorf("validate %s PID: %w", name, err)
+			} else if err := validateUnixSocket(socketPath); err != nil {
+				lastErr = fmt.Errorf("validate %s socket: %w", name, err)
+			} else {
+				return nil
+			}
 		} else if err := validateUnixSocket(socketPath); err != nil {
 			lastErr = fmt.Errorf("validate %s socket: %w", name, err)
 		} else {

--- a/tinfoil/internal/nvidia/services_test.go
+++ b/tinfoil/internal/nvidia/services_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -73,6 +72,12 @@ func testServices(t *testing.T, api nvmlAPI) *Services {
 	services.readyWait = 100 * time.Millisecond
 	services.pollInterval = time.Millisecond
 	return services
+}
+
+func TestProductionReadinessWindowCoversMultiGPUInitialization(t *testing.T) {
+	if serviceReadyWait < 30*time.Second {
+		t.Fatalf("serviceReadyWait = %s, want at least 30s for multi-GPU initialization", serviceReadyWait)
+	}
 }
 
 func writeServiceFile(t *testing.T, path, contents string) {
@@ -258,42 +263,30 @@ func TestWaitForPersistencedRequiresUnixSocket(t *testing.T) {
 	}
 }
 
-func TestWaitForFabricManagerRequiresPIDAndSocket(t *testing.T) {
+func TestWaitForFabricManagerRequiresSocketOnly(t *testing.T) {
 	services := testServices(t, nil)
-	writeServiceFile(t, services.paths.fabricPID, "")
-	listenUnix(t, services.paths.fabricSock)
+	writeServiceFile(t, services.paths.fabricSock, "not a socket")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer cancel()
 	if err := services.WaitForFabricManager(ctx); err == nil {
-		t.Fatal("WaitForFabricManager accepted empty PID file")
+		t.Fatal("WaitForFabricManager accepted regular file")
 	}
 
-	writeServiceFile(t, services.paths.fabricPID, strconv.Itoa(os.Getpid())+"\n")
+	if err := os.Remove(services.paths.fabricSock); err != nil {
+		t.Fatal(err)
+	}
+	listenUnix(t, services.paths.fabricSock)
 	if err := services.WaitForFabricManager(context.Background()); err != nil {
 		t.Fatalf("WaitForFabricManager: %v", err)
 	}
 }
 
-func TestWaitForFabricManagerRejectsPIDLinksAndOversize(t *testing.T) {
+func TestWaitForFabricManagerIgnoresStalePIDState(t *testing.T) {
 	services := testServices(t, nil)
-	writeServiceFile(t, services.paths.fabricPID+".target", strconv.Itoa(os.Getpid())+"\n")
-	if err := os.Symlink(services.paths.fabricPID+".target", services.paths.fabricPID); err != nil {
-		t.Fatal(err)
-	}
+	writeServiceFile(t, services.paths.fabricPID, "stale")
 	listenUnix(t, services.paths.fabricSock)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
-	defer cancel()
-	if err := services.WaitForFabricManager(ctx); err == nil {
-		t.Fatal("WaitForFabricManager followed PID symlink")
-	}
-	if err := os.Remove(services.paths.fabricPID); err != nil {
-		t.Fatal(err)
-	}
-	writeServiceFile(t, services.paths.fabricPID, strings.Repeat("1", maxPIDFileSize+1))
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Millisecond)
-	defer cancel()
-	if err := services.WaitForFabricManager(ctx); err == nil {
-		t.Fatal("WaitForFabricManager accepted oversized PID file")
+	if err := services.WaitForFabricManager(context.Background()); err != nil {
+		t.Fatalf("WaitForFabricManager: %v", err)
 	}
 }
 

--- a/tinfoil/internal/pid1/hardening/filesystems_linux.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux.go
@@ -1,18 +1,31 @@
 package hardening
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
 
-func (linuxServiceKernel) restrictFilesystems() error {
-	return restrictServiceFilesystems(linuxFilesystemKernel{})
+const (
+	attestationDeviceSource = "/run/tinfoil-attestation-devices"
+	attestationSysSource    = "/run/tinfoil-attestation-sys"
+	tdxReportSource         = "/sys/kernel/config/tsm"
+)
+
+func (linuxServiceKernel) restrictFilesystems(exposeAttestation bool) error {
+	return restrictServiceFilesystems(linuxFilesystemKernel{}, exposeAttestation)
 }
 
 type filesystemKernel interface {
 	unshare(int) error
 	mount(string, string, string, uintptr, string) error
+	unmount(string, int) error
+	pathKind(string) (devicePathKind, error)
+	makeTarget(string, devicePathKind) error
+	remove(string) error
 }
 
 type linuxFilesystemKernel struct{}
@@ -25,7 +38,55 @@ func (linuxFilesystemKernel) mount(source, target, filesystemType string, flags 
 	return unix.Mount(source, target, filesystemType, flags, data)
 }
 
-func restrictServiceFilesystems(kernel filesystemKernel) error {
+func (linuxFilesystemKernel) unmount(target string, flags int) error {
+	return unix.Unmount(target, flags)
+}
+
+type devicePathKind uint8
+
+const (
+	devicePathMissing devicePathKind = iota
+	devicePathNode
+	devicePathDirectory
+)
+
+func (linuxFilesystemKernel) pathKind(path string) (devicePathKind, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return devicePathMissing, nil
+	}
+	if err != nil {
+		return devicePathMissing, err
+	}
+	if info.IsDir() {
+		return devicePathDirectory, nil
+	}
+	if info.Mode()&os.ModeCharDevice != 0 {
+		return devicePathNode, nil
+	}
+	return devicePathMissing, fmt.Errorf("unexpected attestation device path type %s", info.Mode())
+}
+
+func (linuxFilesystemKernel) makeTarget(path string, kind devicePathKind) error {
+	switch kind {
+	case devicePathDirectory:
+		return os.MkdirAll(path, 0555)
+	case devicePathNode:
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL, 0000)
+		if err != nil {
+			return err
+		}
+		return file.Close()
+	default:
+		return fmt.Errorf("invalid attestation device path kind %d", kind)
+	}
+}
+
+func (linuxFilesystemKernel) remove(path string) error {
+	return os.RemoveAll(path)
+}
+
+func restrictServiceFilesystems(kernel filesystemKernel, exposeAttestation bool) error {
 	if err := kernel.unshare(unix.CLONE_NEWNS); err != nil {
 		return fmt.Errorf("unshare mount namespace: %w", err)
 	}
@@ -35,12 +96,128 @@ func restrictServiceFilesystems(kernel filesystemKernel) error {
 	if err := mountRestrictedProc(kernel); err != nil {
 		return err
 	}
-	for _, target := range []string{"/dev", "/sys"} {
-		if err := mountEmptyReadOnly(kernel, target); err != nil {
+	if exposeAttestation {
+		if err := mountAttestationDeviceView(kernel); err != nil {
 			return err
 		}
+	} else if err := mountEmptyReadOnly(kernel, "/dev"); err != nil {
+		return err
+	}
+	if exposeAttestation {
+		if err := mountAttestationSysView(kernel); err != nil {
+			return err
+		}
+	} else if err := mountEmptyReadOnly(kernel, "/sys"); err != nil {
+		return err
 	}
 	return nil
+}
+
+func mountAttestationSysView(kernel filesystemKernel) (result error) {
+	kind, err := kernel.pathKind(tdxReportSource)
+	if err != nil {
+		return fmt.Errorf("inspect TDX report interface: %w", err)
+	}
+	if kind == devicePathMissing {
+		return mountEmptyReadOnly(kernel, "/sys")
+	}
+	if kind != devicePathDirectory {
+		return fmt.Errorf("TDX report interface is not a directory")
+	}
+	if err := kernel.makeTarget(attestationSysSource, devicePathDirectory); err != nil {
+		return fmt.Errorf("create attestation sys source: %w", err)
+	}
+	defer func() {
+		result = errors.Join(result, kernel.remove(attestationSysSource))
+	}()
+	if err := kernel.mount(tdxReportSource, attestationSysSource, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+		return fmt.Errorf("preserve TDX report interface: %w", err)
+	}
+	defer func() {
+		if err := kernel.unmount(attestationSysSource, unix.MNT_DETACH); err != nil {
+			result = errors.Join(result, fmt.Errorf("unmount attestation sys source: %w", err))
+		}
+	}()
+
+	flags := uintptr(unix.MS_NOSUID | unix.MS_NODEV | unix.MS_NOEXEC)
+	if err := kernel.mount("tmpfs", "/sys", "tmpfs", flags, "size=16k,nr_inodes=16,mode=0755"); err != nil {
+		return fmt.Errorf("mount restricted attestation /sys: %w", err)
+	}
+	if err := kernel.makeTarget(tdxReportSource, devicePathDirectory); err != nil {
+		return fmt.Errorf("create TDX report target: %w", err)
+	}
+	if err := kernel.mount(attestationSysSource, tdxReportSource, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+		return fmt.Errorf("bind TDX report interface: %w", err)
+	}
+	if err := kernel.mount("", "/sys", "", flags|unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("remount restricted attestation /sys read-only: %w", err)
+	}
+	return nil
+}
+
+func mountAttestationDeviceView(kernel filesystemKernel) (result error) {
+	if err := kernel.makeTarget(attestationDeviceSource, devicePathDirectory); err != nil {
+		return fmt.Errorf("create attestation device source: %w", err)
+	}
+	defer func() {
+		result = errors.Join(result, kernel.remove(attestationDeviceSource))
+	}()
+	if err := kernel.mount("/dev", attestationDeviceSource, "", unix.MS_BIND|unix.MS_REC, ""); err != nil {
+		return fmt.Errorf("preserve attestation device source: %w", err)
+	}
+	defer func() {
+		if err := kernel.unmount(attestationDeviceSource, unix.MNT_DETACH); err != nil {
+			result = errors.Join(result, fmt.Errorf("unmount attestation device source: %w", err))
+		}
+	}()
+
+	flags := uintptr(unix.MS_NOSUID | unix.MS_NOEXEC)
+	if err := kernel.mount("tmpfs", "/dev", "tmpfs", flags, "size=64k,nr_inodes=128,mode=0755"); err != nil {
+		return fmt.Errorf("mount restricted attestation /dev: %w", err)
+	}
+	for _, relative := range attestationDevicePaths() {
+		source := filepath.Join(attestationDeviceSource, relative)
+		kind, err := kernel.pathKind(source)
+		if err != nil {
+			return fmt.Errorf("inspect attestation device %s: %w", relative, err)
+		}
+		if kind == devicePathMissing {
+			continue
+		}
+		target := filepath.Join("/dev", relative)
+		if err := kernel.makeTarget(target, kind); err != nil {
+			return fmt.Errorf("create attestation device target %s: %w", relative, err)
+		}
+		bindFlags := uintptr(unix.MS_BIND)
+		if kind == devicePathDirectory {
+			bindFlags |= unix.MS_REC
+		}
+		if err := kernel.mount(source, target, "", bindFlags, ""); err != nil {
+			return fmt.Errorf("bind attestation device %s: %w", relative, err)
+		}
+	}
+	if err := kernel.mount("", "/dev", "", flags|unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
+		return fmt.Errorf("remount restricted attestation /dev read-only: %w", err)
+	}
+	return nil
+}
+
+func attestationDevicePaths() []string {
+	paths := []string{
+		"null",
+		"tdx_guest",
+		"sev-guest",
+		"nvidiactl",
+		"nvidia-uvm",
+		"nvidia-uvm-tools",
+		"nvidia-caps",
+		"nvidia-nvswitchctl",
+		"nvidia-nvlink",
+	}
+	for index := 0; index < 16; index++ {
+		paths = append(paths, fmt.Sprintf("nvidia%d", index), fmt.Sprintf("nvidia-nvswitch%d", index))
+	}
+	return paths
 }
 
 func mountRestrictedProc(kernel filesystemKernel) error {

--- a/tinfoil/internal/pid1/hardening/filesystems_linux.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux.go
@@ -124,8 +124,8 @@ func mountAttestationSysView(kernel filesystemKernel) (result error) {
 	if kind != devicePathDirectory {
 		return fmt.Errorf("TDX report interface is not a directory")
 	}
-	if err := kernel.makeTarget(attestationSysSource, devicePathDirectory); err != nil {
-		return fmt.Errorf("create attestation sys source: %w", err)
+	if err := resetStagingDirectory(kernel, attestationSysSource); err != nil {
+		return fmt.Errorf("reset attestation sys source: %w", err)
 	}
 	defer func() {
 		result = errors.Join(result, kernel.remove(attestationSysSource))
@@ -156,8 +156,8 @@ func mountAttestationSysView(kernel filesystemKernel) (result error) {
 }
 
 func mountAttestationDeviceView(kernel filesystemKernel) (result error) {
-	if err := kernel.makeTarget(attestationDeviceSource, devicePathDirectory); err != nil {
-		return fmt.Errorf("create attestation device source: %w", err)
+	if err := resetStagingDirectory(kernel, attestationDeviceSource); err != nil {
+		return fmt.Errorf("reset attestation device source: %w", err)
 	}
 	defer func() {
 		result = errors.Join(result, kernel.remove(attestationDeviceSource))
@@ -198,6 +198,16 @@ func mountAttestationDeviceView(kernel filesystemKernel) (result error) {
 	}
 	if err := kernel.mount("", "/dev", "", flags|unix.MS_REMOUNT|unix.MS_RDONLY, ""); err != nil {
 		return fmt.Errorf("remount restricted attestation /dev read-only: %w", err)
+	}
+	return nil
+}
+
+func resetStagingDirectory(kernel filesystemKernel, path string) error {
+	if err := kernel.remove(path); err != nil {
+		return fmt.Errorf("remove stale path: %w", err)
+	}
+	if err := kernel.makeTarget(path, devicePathDirectory); err != nil {
+		return fmt.Errorf("create clean directory: %w", err)
 	}
 	return nil
 }

--- a/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
@@ -24,6 +24,7 @@ type fakeFilesystemKernel struct {
 	err    error
 	calls  []mountCall
 	kinds  map[string]devicePathKind
+	paths  []string
 }
 
 func (kernel *fakeFilesystemKernel) unshare(flags int) error {
@@ -52,8 +53,14 @@ func (kernel *fakeFilesystemKernel) unmount(target string, flags int) error { re
 func (kernel *fakeFilesystemKernel) pathKind(path string) (devicePathKind, error) {
 	return kernel.kinds[path], nil
 }
-func (kernel *fakeFilesystemKernel) makeTarget(string, devicePathKind) error { return nil }
-func (kernel *fakeFilesystemKernel) remove(string) error                     { return nil }
+func (kernel *fakeFilesystemKernel) makeTarget(path string, _ devicePathKind) error {
+	kernel.paths = append(kernel.paths, "create:"+path)
+	return nil
+}
+func (kernel *fakeFilesystemKernel) remove(path string) error {
+	kernel.paths = append(kernel.paths, "remove:"+path)
+	return nil
+}
 
 func TestRestrictServiceFilesystemsUsesFixedPrivateReadOnlyLayout(t *testing.T) {
 	kernel := &fakeFilesystemKernel{}
@@ -135,5 +142,34 @@ func TestRestrictShimFilesystemsBindsOnlyAttestationDevices(t *testing.T) {
 	}
 	if !foundTDXReport {
 		t.Fatalf("TDX report interface was not bound: %#v", kernel.calls)
+	}
+}
+
+func TestRestrictShimFilesystemsResetsReservedStagingDirectories(t *testing.T) {
+	kernel := &fakeFilesystemKernel{kinds: map[string]devicePathKind{
+		tdxReportSource: devicePathDirectory,
+	}}
+	if err := restrictServiceFilesystems(kernel, true); err != nil {
+		t.Fatalf("restrictServiceFilesystems: %v", err)
+	}
+
+	for _, path := range []string{attestationDeviceSource, attestationSysSource} {
+		remove := -1
+		create := -1
+		for index, operation := range kernel.paths {
+			switch operation {
+			case "remove:" + path:
+				if remove == -1 {
+					remove = index
+				}
+			case "create:" + path:
+				if create == -1 {
+					create = index
+				}
+			}
+		}
+		if remove == -1 || create == -1 || remove > create {
+			t.Fatalf("staging operations for %s = %v, want remove before create", path, kernel.paths)
+		}
 	}
 }

--- a/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
@@ -106,10 +106,13 @@ func TestRestrictServiceFilesystemsFailsClosedAtEveryStep(t *testing.T) {
 }
 
 func TestRestrictShimFilesystemsFailsClosedAtEveryStep(t *testing.T) {
-	kinds := map[string]devicePathKind{
-		tdxReportSource: devicePathDirectory,
-		filepath.Join(attestationDeviceSource, "nvidia0"):     devicePathNode,
-		filepath.Join(attestationDeviceSource, "nvidia-caps"): devicePathDirectory,
+	kinds := map[string]devicePathKind{tdxReportSource: devicePathDirectory}
+	for _, relative := range attestationDevicePaths() {
+		kind := devicePathNode
+		if relative == "nvidia-caps" {
+			kind = devicePathDirectory
+		}
+		kinds[filepath.Join(attestationDeviceSource, relative)] = kind
 	}
 	baseline := &fakeFilesystemKernel{kinds: kinds}
 	if err := restrictServiceFilesystems(baseline, true); err != nil {

--- a/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
@@ -22,17 +22,23 @@ type mountCall struct {
 type fakeFilesystemKernel struct {
 	failAt int
 	err    error
+	steps  int
 	calls  []mountCall
 	kinds  map[string]devicePathKind
 	paths  []string
 }
 
-func (kernel *fakeFilesystemKernel) unshare(flags int) error {
-	kernel.calls = append(kernel.calls, mountCall{source: "unshare", flags: uintptr(flags)})
-	if kernel.failAt == len(kernel.calls) {
+func (kernel *fakeFilesystemKernel) step() error {
+	kernel.steps++
+	if kernel.failAt == kernel.steps {
 		return kernel.err
 	}
 	return nil
+}
+
+func (kernel *fakeFilesystemKernel) unshare(flags int) error {
+	kernel.calls = append(kernel.calls, mountCall{source: "unshare", flags: uintptr(flags)})
+	return kernel.step()
 }
 
 func (kernel *fakeFilesystemKernel) mount(source, target, filesystemType string, flags uintptr, data string) error {
@@ -43,23 +49,22 @@ func (kernel *fakeFilesystemKernel) mount(source, target, filesystemType string,
 		flags:          flags,
 		data:           data,
 	})
-	if kernel.failAt == len(kernel.calls) {
-		return kernel.err
-	}
-	return nil
+	return kernel.step()
 }
 
-func (kernel *fakeFilesystemKernel) unmount(target string, flags int) error { return nil }
+func (kernel *fakeFilesystemKernel) unmount(target string, flags int) error {
+	return kernel.step()
+}
 func (kernel *fakeFilesystemKernel) pathKind(path string) (devicePathKind, error) {
-	return kernel.kinds[path], nil
+	return kernel.kinds[path], kernel.step()
 }
 func (kernel *fakeFilesystemKernel) makeTarget(path string, _ devicePathKind) error {
 	kernel.paths = append(kernel.paths, "create:"+path)
-	return nil
+	return kernel.step()
 }
 func (kernel *fakeFilesystemKernel) remove(path string) error {
 	kernel.paths = append(kernel.paths, "remove:"+path)
-	return nil
+	return kernel.step()
 }
 
 func TestRestrictServiceFilesystemsUsesFixedPrivateReadOnlyLayout(t *testing.T) {
@@ -95,6 +100,29 @@ func TestRestrictServiceFilesystemsFailsClosedAtEveryStep(t *testing.T) {
 			}
 			if len(kernel.calls) != failAt {
 				t.Fatalf("calls = %d, want %d", len(kernel.calls), failAt)
+			}
+		})
+	}
+}
+
+func TestRestrictShimFilesystemsFailsClosedAtEveryStep(t *testing.T) {
+	kinds := map[string]devicePathKind{
+		tdxReportSource: devicePathDirectory,
+		filepath.Join(attestationDeviceSource, "nvidia0"):     devicePathNode,
+		filepath.Join(attestationDeviceSource, "nvidia-caps"): devicePathDirectory,
+	}
+	baseline := &fakeFilesystemKernel{kinds: kinds}
+	if err := restrictServiceFilesystems(baseline, true); err != nil {
+		t.Fatalf("baseline restrictServiceFilesystems: %v", err)
+	}
+
+	for failAt := 1; failAt <= baseline.steps; failAt++ {
+		t.Run(fmt.Sprint(failAt), func(t *testing.T) {
+			stepErr := errors.New("step failed")
+			kernel := &fakeFilesystemKernel{failAt: failAt, err: stepErr, kinds: kinds}
+			err := restrictServiceFilesystems(kernel, true)
+			if !errors.Is(err, stepErr) {
+				t.Fatalf("error = %v, want %v", err, stepErr)
 			}
 		})
 	}

--- a/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
+++ b/tinfoil/internal/pid1/hardening/filesystems_linux_test.go
@@ -3,7 +3,9 @@ package hardening
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -21,6 +23,7 @@ type fakeFilesystemKernel struct {
 	failAt int
 	err    error
 	calls  []mountCall
+	kinds  map[string]devicePathKind
 }
 
 func (kernel *fakeFilesystemKernel) unshare(flags int) error {
@@ -45,9 +48,16 @@ func (kernel *fakeFilesystemKernel) mount(source, target, filesystemType string,
 	return nil
 }
 
+func (kernel *fakeFilesystemKernel) unmount(target string, flags int) error { return nil }
+func (kernel *fakeFilesystemKernel) pathKind(path string) (devicePathKind, error) {
+	return kernel.kinds[path], nil
+}
+func (kernel *fakeFilesystemKernel) makeTarget(string, devicePathKind) error { return nil }
+func (kernel *fakeFilesystemKernel) remove(string) error                     { return nil }
+
 func TestRestrictServiceFilesystemsUsesFixedPrivateReadOnlyLayout(t *testing.T) {
 	kernel := &fakeFilesystemKernel{}
-	if err := restrictServiceFilesystems(kernel); err != nil {
+	if err := restrictServiceFilesystems(kernel, false); err != nil {
 		t.Fatalf("restrictServiceFilesystems: %v", err)
 	}
 
@@ -72,7 +82,7 @@ func TestRestrictServiceFilesystemsFailsClosedAtEveryStep(t *testing.T) {
 		t.Run(fmt.Sprint(failAt), func(t *testing.T) {
 			stepErr := errors.New("step failed")
 			kernel := &fakeFilesystemKernel{failAt: failAt, err: stepErr}
-			err := restrictServiceFilesystems(kernel)
+			err := restrictServiceFilesystems(kernel, false)
 			if !errors.Is(err, stepErr) {
 				t.Fatalf("error = %v, want %v", err, stepErr)
 			}
@@ -80,5 +90,50 @@ func TestRestrictServiceFilesystemsFailsClosedAtEveryStep(t *testing.T) {
 				t.Fatalf("calls = %d, want %d", len(kernel.calls), failAt)
 			}
 		})
+	}
+}
+
+func TestRestrictShimFilesystemsBindsOnlyAttestationDevices(t *testing.T) {
+	kernel := &fakeFilesystemKernel{kinds: map[string]devicePathKind{
+		tdxReportSource: devicePathDirectory,
+		filepath.Join(attestationDeviceSource, "null"):               devicePathNode,
+		filepath.Join(attestationDeviceSource, "tdx_guest"):          devicePathNode,
+		filepath.Join(attestationDeviceSource, "nvidiactl"):          devicePathNode,
+		filepath.Join(attestationDeviceSource, "nvidia0"):            devicePathNode,
+		filepath.Join(attestationDeviceSource, "nvidia-caps"):        devicePathDirectory,
+		filepath.Join(attestationDeviceSource, "nvidia-nvswitchctl"): devicePathNode,
+		filepath.Join(attestationDeviceSource, "nvidia-nvlink"):      devicePathNode,
+	}}
+	if err := restrictServiceFilesystems(kernel, true); err != nil {
+		t.Fatalf("restrictServiceFilesystems: %v", err)
+	}
+
+	var bindings []mountCall
+	for _, call := range kernel.calls {
+		if strings.HasPrefix(call.source, attestationDeviceSource+"/") {
+			bindings = append(bindings, call)
+		}
+	}
+	want := []mountCall{
+		{source: filepath.Join(attestationDeviceSource, "null"), target: "/dev/null", flags: unix.MS_BIND},
+		{source: filepath.Join(attestationDeviceSource, "tdx_guest"), target: "/dev/tdx_guest", flags: unix.MS_BIND},
+		{source: filepath.Join(attestationDeviceSource, "nvidiactl"), target: "/dev/nvidiactl", flags: unix.MS_BIND},
+		{source: filepath.Join(attestationDeviceSource, "nvidia-caps"), target: "/dev/nvidia-caps", flags: unix.MS_BIND | unix.MS_REC},
+		{source: filepath.Join(attestationDeviceSource, "nvidia-nvswitchctl"), target: "/dev/nvidia-nvswitchctl", flags: unix.MS_BIND},
+		{source: filepath.Join(attestationDeviceSource, "nvidia-nvlink"), target: "/dev/nvidia-nvlink", flags: unix.MS_BIND},
+		{source: filepath.Join(attestationDeviceSource, "nvidia0"), target: "/dev/nvidia0", flags: unix.MS_BIND},
+	}
+	if !reflect.DeepEqual(bindings, want) {
+		t.Fatalf("attestation bindings = %#v, want %#v", bindings, want)
+	}
+
+	var foundTDXReport bool
+	for _, call := range kernel.calls {
+		if call.source == attestationSysSource && call.target == tdxReportSource && call.flags == unix.MS_BIND|unix.MS_REC {
+			foundTDXReport = true
+		}
+	}
+	if !foundTDXReport {
+		t.Fatalf("TDX report interface was not bound: %#v", kernel.calls)
 	}
 }

--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -27,12 +27,13 @@ const (
 )
 
 type servicePolicy struct {
-	noNewPrivileges      bool
-	boundCapabilities    []int
-	restrictFilesystems  bool
-	deniedSyscalls       []uint32
-	restrictNamespaceOps bool
-	allowedSocketDomains []uint32
+	noNewPrivileges          bool
+	boundCapabilities        []int
+	restrictFilesystems      bool
+	exposeAttestationDevices bool
+	deniedSyscalls           []uint32
+	restrictNamespaceOps     bool
+	allowedSocketDomains     []uint32
 }
 
 // kernelManagementSyscalls are denied for every hardened service, including
@@ -119,10 +120,12 @@ func policyFor(service Service) (servicePolicy, bool) {
 			[]uint32{unix.AF_INET, unix.AF_INET6, unix.AF_NETLINK},
 		), true
 	case ServiceShim:
-		return restrictedServicePolicy(
+		policy := restrictedServicePolicy(
 			[]int{unix.CAP_NET_BIND_SERVICE},
 			[]uint32{unix.AF_INET, unix.AF_INET6},
-		), true
+		)
+		policy.exposeAttestationDevices = true
+		return policy, true
 	default:
 		return servicePolicy{}, false
 	}
@@ -147,7 +150,7 @@ func ApplyService(service Service) error {
 }
 
 type serviceKernel interface {
-	restrictFilesystems() error
+	restrictFilesystems(bool) error
 	dropBoundingCapability(int) error
 	setCapabilities([2]unix.CapUserData) error
 	setNoNewPrivileges() error
@@ -161,7 +164,7 @@ func applyService(kernel serviceKernel, service Service) error {
 	}
 
 	if policy.restrictFilesystems {
-		if err := kernel.restrictFilesystems(); err != nil {
+		if err := kernel.restrictFilesystems(policy.exposeAttestationDevices); err != nil {
 			return fmt.Errorf("restrict filesystems for %s: %w", service, err)
 		}
 	}

--- a/tinfoil/internal/pid1/hardening/hardening_test.go
+++ b/tinfoil/internal/pid1/hardening/hardening_test.go
@@ -34,12 +34,13 @@ func TestServicePoliciesAreExact(t *testing.T) {
 			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6, unix.AF_NETLINK},
 		},
 		ServiceShim: {
-			noNewPrivileges:      true,
-			boundCapabilities:    []int{unix.CAP_NET_BIND_SERVICE},
-			restrictFilesystems:  true,
-			deniedSyscalls:       restrictedServiceSyscalls,
-			restrictNamespaceOps: true,
-			allowedSocketDomains: []uint32{unix.AF_INET, unix.AF_INET6},
+			noNewPrivileges:          true,
+			boundCapabilities:        []int{unix.CAP_NET_BIND_SERVICE},
+			restrictFilesystems:      true,
+			exposeAttestationDevices: true,
+			deniedSyscalls:           restrictedServiceSyscalls,
+			restrictNamespaceOps:     true,
+			allowedSocketDomains:     []uint32{unix.AF_INET, unix.AF_INET6},
 		},
 	}
 	for service, wantPolicy := range want {
@@ -316,8 +317,11 @@ type fakeServiceKernel struct {
 	socketDomains        []uint32
 }
 
-func (kernel *fakeServiceKernel) restrictFilesystems() error {
+func (kernel *fakeServiceKernel) restrictFilesystems(exposeAttestation bool) error {
 	kernel.calls = append(kernel.calls, "restrict-filesystems")
+	if exposeAttestation {
+		kernel.calls = append(kernel.calls, "expose-attestation-devices")
+	}
 	return kernel.restrictFilesystemsErr
 }
 


### PR DESCRIPTION
## Summary
- wait for foreground Fabric Manager via its supervised Unix socket instead of a PID file it never creates
- extend the multi-GPU NVIDIA readiness window to 30 seconds
- preserve a narrowly scoped shim mount view for CPU attestation, NVIDIA GPU/NVSwitch evidence, TDX configfs reports, and `/dev/null`
- keep the rest of `/dev` and `/sys` hidden by the existing hardening policy

## Qualification
- `go test ./...`
- local Nix shipping-image build
- TDX CPU attestation: ~1.0s on INF7 and INF15
- 1× H200 boot GPU attestation: ~1.6s
- 1× B200 boot GPU attestation: ~4.5s
- 8× H200 boot GPU attestation: ~35s
- fresh nonce-bound v3 evidence succeeds on H200 and B200
- fresh 8× H200 evidence succeeds with NVSwitch evidence
- eight concurrent H200 fresh-attestation requests all returned 200

No diagnostic response instrumentation is included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix v3 attestation under the hardened shim by exposing only the minimal `/dev` and `/sys` needed for CPU (TDX/SEV) and NVIDIA GPU/NVSwitch evidence, waiting on Fabric Manager’s Unix socket, and letting workload health policy govern container startup timing. Restores fresh GPU attestations (incl. multi‑GPU) while keeping the rest of the system hidden.

- **Bug Fixes**
  - Fabric Manager readiness now waits on its supervised Unix socket; no PID file is required.
  - Extended readiness: `serviceReadyWait` 30s for multi‑GPU init; container startup now waits on the supervisor/workload health context (no fixed `containersReadyLimit`).
  - Added a narrow, read‑only mount view for attestation: binds `/dev/null`, CPU TDX/SEV, NVIDIA GPU/NVSwitch/NVLink devices, and the TDX configfs into `/sys`; all other `/dev` and `/sys` remain hidden.
  - Reset attestation staging directories before binding to prevent stale paths and ensure a clean device/sys view.
  - Updated `ServiceShim` policy to `exposeAttestationDevices`, and expanded tests for socket‑only Fabric Manager, readiness behavior, the device/sys view, staging resets, shim filesystem failure paths, and every attestation device bind.

<sup>Written for commit cc91510d1ed3e3465b667115aad2b1f19c4ad80b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

