### PR TITLE
Restore fast TDX quote polling

### DIFF
--- a/nix/kernel.nix
+++ b/nix/kernel.nix
@@ -47,7 +47,10 @@ let
   patchedSource = pkgs.applyPatches {
     name = "linux-source-${version}-tinfoil";
     src = source;
-    patches = [ ./patches/kernel-disable-virtio-pci-admin-legacy.patch ];
+    patches = [
+      ./patches/kernel-disable-virtio-pci-admin-legacy.patch
+      ./patches/kernel-tdx-fast-quote-polling.patch
+    ];
   };
 
   configFile = pkgs.stdenv.mkDerivation {

--- a/nix/patches/kernel-tdx-fast-quote-polling.patch
+++ b/nix/patches/kernel-tdx-fast-quote-polling.patch
@@ -1,0 +1,28 @@
+Reduce the TDX guest quote-completion polling interval from one second to
+10 milliseconds. Keep the overall timeout at approximately 30 seconds by
+scaling the iteration limit accordingly.
+
+The VMM normally completes quote requests far faster than one second. The
+stock polling interval therefore adds almost a full second of avoidable
+latency to every live attestation request.
+
+--- a/drivers/virt/coco/tdx-guest/tdx-guest.c
++++ b/drivers/virt/coco/tdx-guest/tdx-guest.c
+@@ -202,7 +202,7 @@ static DEFINE_MUTEX(quote_lock);
+  * GetQuote request timeout in seconds. Expect that 30 seconds
+  * is enough time for QE to respond to any Quote requests.
+  */
+-static u32 getquote_timeout = 30;
++static u32 getquote_timeout = 3000;
+ 
+ static long tdx_get_report0(struct tdx_report_req __user *req)
+ {
+@@ -259,7 +259,7 @@ static int wait_for_quote_completion(struct tdx_quote_buf *quote_buf, u32 timeout
+ 	 * once per second to recheck the status is fine for this use case.
+ 	 */
+ 	while (quote_buf->status == GET_QUOTE_IN_FLIGHT && i++ < timeout) {
+-		if (msleep_interruptible(MSEC_PER_SEC))
++		if (msleep_interruptible(10))
+ 			return -EINTR;
+ 	}
+ 


### PR DESCRIPTION
## Summary

- restore the 10 ms TDX guest quote-completion polling used by cvmimage v0.10.8
- preserve the existing approximately 30 second overall quote timeout
- apply the change while building the measured Nix kernel, rather than replacing `tdx-guest.ko` after package installation

## Why

The Nix image migration dropped the historical `tdx-fast-quote` patch. The stock kernel polls quote completion once per second, adding about one second to every fresh TDX attestation even though the host quote is normally ready within milliseconds.

## Qualification

Tested on INF7 with one H200 using local debug artifacts only; no release, tag, uploaded artifact, or production deployment was created.

| Image | Boot CPU attestation | Warm enclave work | Warm end-to-end |
|---|---:|---:|---:|
| exact v0.10.8 | 11.6 ms | 85.4 ms | 216.3 ms |
| current v3 before patch | 1056.7 ms | about 1.21 s | about 1.30 s |
| current v3 with patch | 11 ms | 86.1 ms | 285.6 ms |

The v3 response is about 99 KB versus 20 KB in v0.10.8, accounting for most of the remaining wall-clock difference. A zero-GPU control measured 50.7 ms of warm enclave work, so fresh H200 evidence adds about 35 ms. A 20-request burst at concurrency five returned 20/20 HTTP 200 responses, with 312 ms mean and 380 ms maximum end-to-end latency.

The first request remains intentionally colder because the lazy collateral cache fills and NVML initializes; subsequent requests are stable.

## Validation

- `nix-build -I . -A debug-image -o result-debug-test`
- local-artifact debug launch with `--skip-manifest`
- 12 sequential fresh nonce attestations with one H200
- 12 sequential fresh nonce attestations with zero GPUs
- 20 fresh nonce attestations at concurrency five


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores 10 ms TDX quote polling to remove ~1s of latency from fresh attestations while keeping the ~30s overall timeout. The patch is now applied during the Nix kernel build so the measured kernel includes it.

- **Bug Fixes**
  - Added `kernel-tdx-fast-quote-polling.patch` to `nix/kernel.nix`.
  - Updated `tdx-guest.c` to sleep 10 ms per poll and set `getquote_timeout` to 3000 iterations (~30s).
  - Applies within the measured kernel instead of replacing `tdx-guest.ko` post-install.

<sup>Written for commit 42e954e998525a7308497f16d194e459e5454226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

