### PR TITLE
Fetch vault secrets in the containers runtime

### DIFF
--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -146,20 +146,7 @@ func run(ctx context.Context, invocation invocation) error {
 	}
 	tracker.Record("certificate", boot.StatusOK, time.Since(start), "")
 
-	// 7. Fetch any external vault secrets.
-	start = time.Now()
-	if config.VaultURL == "" {
-		tracker.Record(boot.StageVaultSecrets, boot.StatusSkipped, time.Since(start), "no vault configured")
-	} else {
-		log.Println("Fetching vault secrets")
-		if err := fetchVaultSecrets(config, externalConfig); err != nil {
-			tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
-			return fmt.Errorf("vault secret fetch failed: %w", err)
-		}
-		tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), config.VaultURL)
-	}
-
-	// 8. Registry auth
+	// 7. Registry auth
 	start = time.Now()
 	log.Println("Setting up registry authentication")
 	if err := setupRegistryAuth(externalConfig); err != nil {
@@ -168,7 +155,7 @@ func run(ctx context.Context, invocation invocation) error {
 	}
 	tracker.Record("registry-auth", boot.StatusOK, time.Since(start), "")
 
-	// 9. Models
+	// 8. Models
 	start = time.Now()
 	log.Println("Mounting models")
 	if err := mountModels(config, externalConfig); err != nil {

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -21,6 +21,7 @@ import (
 	"tinfoil/internal/containers"
 	"tinfoil/internal/firewall"
 	"tinfoil/internal/runtimeconfig"
+	"tinfoil/internal/vault"
 )
 
 const bootPath = "/v1/boot"
@@ -189,6 +190,24 @@ func (m *manager) boot(override []byte) (result error) {
 		}
 		preserved[runtimeconfig.ReservedDebugContainerName] = true
 	}
+	tracker, err := boot.ResumeTracker()
+	if err != nil {
+		return err
+	}
+	// Fetch vault secrets here, in the process that builds container
+	// environments, so released values stay in memory and are never persisted.
+	// Runs before any teardown so a vault failure leaves running containers up.
+	start := time.Now()
+	if config.VaultURL == "" {
+		tracker.Record(boot.StageVaultSecrets, boot.StatusSkipped, time.Since(start), "no vault configured")
+	} else {
+		log.Println("Fetching vault secrets")
+		if err := vault.FetchSecrets(config, external); err != nil {
+			tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
+			return fmt.Errorf("vault secret fetch failed: %w", err)
+		}
+		tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), config.VaultURL)
+	}
 	frozenEgress, err := freezeFromPIDFile(boot.EgressPIDPath)
 	if err != nil {
 		return fmt.Errorf("freezing current egress policy: %w", err)
@@ -209,11 +228,7 @@ func (m *manager) boot(override []byte) (result error) {
 	if err := writeRuntimeArtifacts(config, source); err != nil {
 		return err
 	}
-	tracker, err := boot.ResumeTracker()
-	if err != nil {
-		return err
-	}
-	start := time.Now()
+	start = time.Now()
 	if err := firewall.ApplyInbound(config.CVMNetwork.InboundPorts); err != nil {
 		tracker.Record(boot.StageFirewall, boot.StatusFailed, time.Since(start), err.Error())
 		return err

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -194,18 +194,18 @@ func (m *manager) boot(override []byte) (result error) {
 	if err != nil {
 		return err
 	}
-	// Fetch vault secrets here, in the process that builds container
-	// environments, so released values stay in memory and are never persisted.
-	// Runs before any teardown so a vault failure leaves running containers up.
+	// Resolve declared container secrets here, in the process that builds
+	// container environments, so released values stay in memory and are never
+	// persisted. Runs before any teardown so a failure leaves running
+	// containers up, and fails closed on secrets nothing can resolve.
 	start := time.Now()
+	if err := vault.FetchSecrets(config, external); err != nil {
+		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
+		return fmt.Errorf("resolving container secrets: %w", err)
+	}
 	if config.VaultURL == "" {
 		tracker.Record(boot.StageVaultSecrets, boot.StatusSkipped, time.Since(start), "no vault configured")
 	} else {
-		log.Println("Fetching vault secrets")
-		if err := vault.FetchSecrets(config, external); err != nil {
-			tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
-			return fmt.Errorf("vault secret fetch failed: %w", err)
-		}
 		tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), config.VaultURL)
 	}
 	frozenEgress, err := freezeFromPIDFile(boot.EgressPIDPath)

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -57,7 +57,7 @@ const (
 // Both boot and shim use this as the starting point.
 var InitialStages = []string{
 	StageConfig, StageNetwork, StageIdentity, StageCPUAttestation, StageGPUAttestation, StageCertificate,
-	StageVaultSecrets, StageRegistryAuth, StageFirewall, StageModels, StageContainers, StageShim,
+	StageRegistryAuth, StageModels, StageVaultSecrets, StageFirewall, StageContainers, StageShim,
 }
 
 // Tracker records boot stages as they complete.

--- a/tinfoil/internal/vault/vault.go
+++ b/tinfoil/internal/vault/vault.go
@@ -1,4 +1,7 @@
-package main
+// Package vault fetches declared container secrets from the customer's
+// attested-release vault. It runs in tinfoil-containers so released values
+// reach container environments without ever being persisted to disk.
+package vault
 
 import (
 	"bytes"
@@ -17,20 +20,21 @@ import (
 
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/runtimeconfig"
 )
 
-const vaultFetchTimeout = 60 * time.Second
+const fetchTimeout = 60 * time.Second
 
-type vaultFetchRequest struct {
+type fetchRequest struct {
 	Repo       string           `json:"repo"`
 	SecretRefs []string         `json:"secret_refs"`
 	Bundle     *verifier.Bundle `json:"bundle"`
 	Token      string           `json:"token"`
 }
 
-// fetchVaultSecrets asks the vault for the declared secrets the external
-// config did not populate.
-func fetchVaultSecrets(config *Config, ext *shimconfig.ExternalConfig) error {
+// FetchSecrets asks the vault for the declared secrets the external config
+// did not populate, merging released values into ext.
+func FetchSecrets(config *runtimeconfig.Config, ext *shimconfig.ExternalConfig) error {
 	names := missingSecretValues(config, ext)
 	if len(names) == 0 {
 		log.Println("All declared secrets populated by external config, nothing to fetch")
@@ -53,7 +57,7 @@ func fetchVaultSecrets(config *Config, ext *shimconfig.ExternalConfig) error {
 		return fmt.Errorf("loading boot attestation document: %w", err)
 	}
 
-	req := vaultFetchRequest{
+	req := fetchRequest{
 		Repo:       ext.Metadata.Repo,
 		SecretRefs: names,
 		Bundle: &verifier.Bundle{
@@ -63,7 +67,7 @@ func fetchVaultSecrets(config *Config, ext *shimconfig.ExternalConfig) error {
 		Token: ext.VaultToken,
 	}
 
-	secrets, err := vaultFetch(vaultClient(cert), config.VaultURL, req)
+	secrets, err := fetch(client(cert), config.VaultURL, req)
 	if err != nil {
 		return err
 	}
@@ -80,7 +84,7 @@ func fetchVaultSecrets(config *Config, ext *shimconfig.ExternalConfig) error {
 
 // missingSecretValues returns the deduplicated, sorted names of the
 // containers' secrets whose values the external config did not populate
-func missingSecretValues(config *Config, ext *shimconfig.ExternalConfig) []string {
+func missingSecretValues(config *runtimeconfig.Config, ext *shimconfig.ExternalConfig) []string {
 	seen := map[string]struct{}{}
 	var names []string
 	for _, c := range config.Containers {
@@ -99,14 +103,14 @@ func missingSecretValues(config *Config, ext *shimconfig.ExternalConfig) []strin
 	return names
 }
 
-// vaultClient returns an HTTP client that presents the enclave's TLS
-// certificate for mutual TLS. The vault authenticates the connection by
-// pinning the certificate's key fingerprint to the attested REPORTDATA, so no
-// separate client credential is needed. The vault's own server certificate is
-// verified against the system roots (its host is fixed in the measured config).
-func vaultClient(cert tls.Certificate) *http.Client {
+// client returns an HTTP client that presents the enclave's TLS certificate
+// for mutual TLS. The vault authenticates the connection by pinning the
+// certificate's key fingerprint to the attested REPORTDATA, so no separate
+// client credential is needed. The vault's own server certificate is verified
+// against the system roots (its host is fixed in the measured config).
+func client(cert tls.Certificate) *http.Client {
 	return &http.Client{
-		Timeout: vaultFetchTimeout,
+		Timeout: fetchTimeout,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				Certificates: []tls.Certificate{cert},
@@ -116,8 +120,8 @@ func vaultClient(cert tls.Certificate) *http.Client {
 	}
 }
 
-// vaultFetch POSTs to /fetch and decodes the released secrets. Fails fast.
-func vaultFetch(client *http.Client, base string, req vaultFetchRequest) (map[string]string, error) {
+// fetch POSTs to /fetch and decodes the released secrets. Fails fast.
+func fetch(client *http.Client, base string, req fetchRequest) (map[string]string, error) {
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, err

--- a/tinfoil/internal/vault/vault.go
+++ b/tinfoil/internal/vault/vault.go
@@ -33,12 +33,17 @@ type fetchRequest struct {
 }
 
 // FetchSecrets asks the vault for the declared secrets the external config
-// did not populate, merging released values into ext.
+// did not populate, merging released values into ext. Declared secrets that
+// nothing can resolve are an error, so misconfigured containers never launch
+// with a variable silently missing.
 func FetchSecrets(config *runtimeconfig.Config, ext *shimconfig.ExternalConfig) error {
 	names := missingSecretValues(config, ext)
 	if len(names) == 0 {
 		log.Println("All declared secrets populated by external config, nothing to fetch")
 		return nil
+	}
+	if config.VaultURL == "" {
+		return fmt.Errorf("%d declared secret(s) missing from external config and no vault-url configured", len(names))
 	}
 	if ext.VaultToken == "" {
 		return fmt.Errorf("%d secret(s) need the vault but external config has no vault-token", len(names))

--- a/tinfoil/internal/vault/vault_test.go
+++ b/tinfoil/internal/vault/vault_test.go
@@ -38,9 +38,18 @@ func TestMissingSecretValues(t *testing.T) {
 
 func TestFetchSecretsAllPopulated(t *testing.T) {
 	config := configWithSecrets([]string{"API_KEY"})
+	config.VaultURL = ""
 	ext := &shimconfig.ExternalConfig{Secrets: map[string]string{"API_KEY": "populated"}}
 	if err := FetchSecrets(config, ext); err != nil {
 		t.Fatalf("FetchSecrets with populated secrets: %v", err)
+	}
+}
+
+func TestFetchSecretsUnresolvedWithoutVault(t *testing.T) {
+	config := configWithSecrets([]string{"API_KEY"})
+	config.VaultURL = ""
+	if err := FetchSecrets(config, &shimconfig.ExternalConfig{}); err == nil {
+		t.Fatal("FetchSecrets with unresolved secret and no vault succeeded")
 	}
 }
 

--- a/tinfoil/internal/vault/vault_test.go
+++ b/tinfoil/internal/vault/vault_test.go
@@ -1,0 +1,104 @@
+package vault
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/runtimeconfig"
+)
+
+func configWithSecrets(secrets ...[]string) *runtimeconfig.Config {
+	config := &runtimeconfig.Config{VaultURL: "https://vault.example.com"}
+	for i, names := range secrets {
+		config.Containers = append(config.Containers, runtimeconfig.Container{
+			Name:    "c" + string(rune('a'+i)),
+			Secrets: names,
+		})
+	}
+	return config
+}
+
+func TestMissingSecretValues(t *testing.T) {
+	config := configWithSecrets(
+		[]string{"DB_PASSWORD", "API_KEY", "DB_PASSWORD"},
+		[]string{"API_KEY", "STRIPE_KEY"},
+	)
+	ext := &shimconfig.ExternalConfig{Secrets: map[string]string{"API_KEY": "populated"}}
+
+	got := missingSecretValues(config, ext)
+	want := []string{"DB_PASSWORD", "STRIPE_KEY"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("missingSecretValues = %v, want %v", got, want)
+	}
+}
+
+func TestFetchSecretsAllPopulated(t *testing.T) {
+	config := configWithSecrets([]string{"API_KEY"})
+	ext := &shimconfig.ExternalConfig{Secrets: map[string]string{"API_KEY": "populated"}}
+	if err := FetchSecrets(config, ext); err != nil {
+		t.Fatalf("FetchSecrets with populated secrets: %v", err)
+	}
+}
+
+func TestFetchSecretsRequiresToken(t *testing.T) {
+	config := configWithSecrets([]string{"API_KEY"})
+	if err := FetchSecrets(config, &shimconfig.ExternalConfig{}); err == nil {
+		t.Fatal("FetchSecrets without vault-token succeeded")
+	}
+}
+
+func TestFetchSecretsRequiresHTTPS(t *testing.T) {
+	config := configWithSecrets([]string{"API_KEY"})
+	config.VaultURL = "http://vault.example.com"
+	ext := &shimconfig.ExternalConfig{VaultToken: "token"}
+	if err := FetchSecrets(config, ext); err == nil {
+		t.Fatal("FetchSecrets with http vault-url succeeded")
+	}
+}
+
+func TestFetch(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/fetch" {
+			t.Errorf("path = %q, want /fetch", r.URL.Path)
+		}
+		var req fetchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decoding request: %v", err)
+		}
+		if req.Repo != "org/repo" || req.Token != "token" {
+			t.Errorf("request repo=%q token=%q", req.Repo, req.Token)
+		}
+		if !reflect.DeepEqual(req.SecretRefs, []string{"DB_PASSWORD"}) {
+			t.Errorf("secret_refs = %v", req.SecretRefs)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"DB_PASSWORD": "hunter2"})
+	}))
+	defer server.Close()
+
+	secrets, err := fetch(server.Client(), server.URL+"/", fetchRequest{
+		Repo:       "org/repo",
+		SecretRefs: []string{"DB_PASSWORD"},
+		Token:      "token",
+	})
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if secrets["DB_PASSWORD"] != "hunter2" {
+		t.Fatalf("secrets = %v", secrets)
+	}
+}
+
+func TestFetchNonOK(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "measurement not in policy", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	if _, err := fetch(server.Client(), server.URL, fetchRequest{}); err == nil {
+		t.Fatal("fetch with 403 response succeeded")
+	}
+}


### PR DESCRIPTION
Vault-released container secrets silently stopped reaching container environments when runtime boot was centralized in tinfoil-containers (#305): the fetched values intentionally never touch disk, so they were lost when container launch moved out of the process that fetched them, and affected containers now start with those variables missing. This moves the vault fetch into tinfoil-containers itself — the process that builds container environments — which keeps released values memory-only, keeps the launch fail-closed before any running containers are torn down, and gives the debug re-boot path fresh values on every launch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetches vault-backed container secrets in the containers runtime so released values reach container environments and never touch disk. Previously boot fetched them in another process and containers launched without those variables; now the containers process resolves secrets before any teardown and fails closed when a declared secret cannot be resolved.

- Moves secret resolution from `tinfoil/cmd/boot` to `tinfoil/cmd/containers` via `tinfoil/internal/vault.FetchSecrets`; records `StageVaultSecrets` after models and before firewall with the boot tracker.
- Adds `tinfoil/internal/vault` (mTLS HTTPS client, 60s timeout) and unit tests; renames helpers to `client` and `fetch`.
- If all declared secrets are present, the stage is skipped; if any are missing and no `VaultURL` is set, boot fails closed without tearing down running containers; when using a vault, `VaultToken` is required and `VaultURL` must be HTTPS.

<sup>Written for commit aceb82d978d28576d52d8cbd15c277115d3262a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

