### PR TITLE
Fetch Vault secrets during boot and hand off in memory

### DIFF
--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -13,7 +13,6 @@ import (
 
 	"tinfoil/internal/boot"
 	"tinfoil/internal/nvidia"
-	"tinfoil/internal/secretstore"
 )
 
 func init() {
@@ -157,38 +156,12 @@ func run(ctx context.Context, invocation invocation) error {
 
 	// 7. Resolve declared secrets and hand workload values to the container manager.
 	start = time.Now()
-	fetched := 0
-	if config.VaultURL != "" {
-		log.Println("Fetching vault secrets")
-		fetched, err = fetchVaultSecrets(config, externalConfig)
-		if err != nil {
-			tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
-			return fmt.Errorf("vault secret fetch failed: %w", err)
-		}
-	}
-	if missing := secretstore.MissingReferences(config, externalConfig); len(missing) != 0 {
-		err := fmt.Errorf("%d declared secret(s) remain unresolved", len(missing))
-		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
-		return err
-	}
-	workloadSecrets, err := secretstore.WorkloadStore(config, externalConfig)
+	secretDetail, err := prepareSecretHandoff(config, externalConfig, secretHandoff, invocation.configHash)
 	if err != nil {
 		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
 		return err
 	}
-	if err := secretstore.WriteHandoff(secretHandoff, invocation.configHash, workloadSecrets); err != nil {
-		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
-		return err
-	}
-	if fetched == 0 {
-		detail := "no vault configured"
-		if config.VaultURL != "" {
-			detail = "all declared secrets already populated"
-		}
-		tracker.Record(boot.StageVaultSecrets, boot.StatusSkipped, time.Since(start), detail)
-	} else {
-		tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), fmt.Sprintf("fetched %d secret(s)", fetched))
-	}
+	tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), secretDetail)
 
 	// 8. Registry auth
 	start = time.Now()

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -70,9 +70,6 @@ func run(ctx context.Context, invocation invocation) error {
 		return fmt.Errorf("container-secret handoff descriptor is required")
 	}
 	secretHandoff := os.NewFile(uintptr(invocation.secretsFD), "tinfoil-container-secrets")
-	if secretHandoff == nil {
-		return fmt.Errorf("opening container-secret handoff descriptor")
-	}
 	defer secretHandoff.Close()
 
 	tracker := boot.NewTracker(boot.InitialStages)

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -13,6 +13,7 @@ import (
 
 	"tinfoil/internal/boot"
 	"tinfoil/internal/nvidia"
+	"tinfoil/internal/secretstore"
 )
 
 func init() {
@@ -42,6 +43,7 @@ func main() {
 type invocation struct {
 	configHash string
 	debug      bool
+	secretsFD  int
 }
 
 func parseInvocation(args []string) (invocation, error) {
@@ -53,6 +55,7 @@ func parseInvocation(args []string) (invocation, error) {
 	flags.SetOutput(io.Discard)
 	flags.StringVar(&parsed.configHash, "config-hash", "", "verified config hash from the kernel command line")
 	flags.BoolVar(&parsed.debug, "debug", false, "enable the measured debug policy")
+	flags.IntVar(&parsed.secretsFD, "secrets-fd", -1, "sealed container-secret handoff descriptor")
 	if err := flags.Parse(args[1:]); err != nil {
 		return invocation{}, err
 	}
@@ -63,6 +66,15 @@ func parseInvocation(args []string) (invocation, error) {
 }
 
 func run(ctx context.Context, invocation invocation) error {
+	if invocation.secretsFD < 0 {
+		return fmt.Errorf("container-secret handoff descriptor is required")
+	}
+	secretHandoff := os.NewFile(uintptr(invocation.secretsFD), "tinfoil-container-secrets")
+	if secretHandoff == nil {
+		return fmt.Errorf("opening container-secret handoff descriptor")
+	}
+	defer secretHandoff.Close()
+
 	tracker := boot.NewTracker(boot.InitialStages)
 
 	// 1. Config
@@ -146,17 +158,39 @@ func run(ctx context.Context, invocation invocation) error {
 	}
 	tracker.Record("certificate", boot.StatusOK, time.Since(start), "")
 
-	// 7. Fetch any external vault secrets.
+	// 7. Resolve declared secrets and hand workload values to the container manager.
 	start = time.Now()
-	if config.VaultURL == "" {
-		tracker.Record(boot.StageVaultSecrets, boot.StatusSkipped, time.Since(start), "no vault configured")
-	} else {
+	fetched := 0
+	if config.VaultURL != "" {
 		log.Println("Fetching vault secrets")
-		if err := fetchVaultSecrets(config, externalConfig); err != nil {
+		fetched, err = fetchVaultSecrets(config, externalConfig)
+		if err != nil {
 			tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
 			return fmt.Errorf("vault secret fetch failed: %w", err)
 		}
-		tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), config.VaultURL)
+	}
+	if missing := secretstore.MissingReferences(config, externalConfig); len(missing) != 0 {
+		err := fmt.Errorf("%d declared secret(s) remain unresolved", len(missing))
+		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
+		return err
+	}
+	workloadSecrets, err := secretstore.WorkloadStore(config, externalConfig)
+	if err != nil {
+		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
+		return err
+	}
+	if err := secretstore.WriteHandoff(secretHandoff, invocation.configHash, workloadSecrets); err != nil {
+		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
+		return err
+	}
+	if fetched == 0 {
+		detail := "no vault configured"
+		if config.VaultURL != "" {
+			detail = "all declared secrets already populated"
+		}
+		tracker.Record(boot.StageVaultSecrets, boot.StatusSkipped, time.Since(start), detail)
+	} else {
+		tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), fmt.Sprintf("fetched %d secret(s)", fetched))
 	}
 
 	// 8. Registry auth

--- a/tinfoil/cmd/boot/main_test.go
+++ b/tinfoil/cmd/boot/main_test.go
@@ -5,11 +5,11 @@ import (
 )
 
 func TestParseInvocation(t *testing.T) {
-	invocation, err := parseInvocation([]string{"tinfoil-boot", "--config-hash=abc", "--debug=true"})
+	invocation, err := parseInvocation([]string{"tinfoil-boot", "--config-hash=abc", "--debug=true", "--secrets-fd=3"})
 	if err != nil {
 		t.Fatalf("normal boot invocation failed: %v", err)
 	}
-	if invocation.configHash != "abc" || !invocation.debug {
+	if invocation.configHash != "abc" || !invocation.debug || invocation.secretsFD != 3 {
 		t.Fatalf("invocation = %#v", invocation)
 	}
 

--- a/tinfoil/cmd/boot/secrets.go
+++ b/tinfoil/cmd/boot/secrets.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/secretstore"
+)
+
+func prepareSecretHandoff(config *Config, externalConfig *shimconfig.ExternalConfig, handoff *os.File, configDigest string) (string, error) {
+	fetched := 0
+	if config.VaultURL != "" {
+		log.Println("Fetching vault secrets")
+		var err error
+		fetched, err = fetchVaultSecrets(config, externalConfig)
+		if err != nil {
+			return "", fmt.Errorf("vault secret fetch failed: %w", err)
+		}
+	}
+
+	if missing := secretstore.MissingReferences(config, externalConfig); len(missing) != 0 {
+		return "", fmt.Errorf("%d declared secret(s) remain unresolved", len(missing))
+	}
+	workloadSecrets, err := secretstore.WorkloadStore(config, externalConfig)
+	if err != nil {
+		return "", err
+	}
+	if err := secretstore.WriteHandoff(handoff, configDigest, workloadSecrets); err != nil {
+		return "", err
+	}
+
+	detail := fmt.Sprintf("handed off %d workload secret(s)", len(workloadSecrets))
+	if fetched != 0 {
+		return fmt.Sprintf("%s; fetched %d from vault", detail, fetched), nil
+	}
+	if config.VaultURL != "" {
+		return detail + "; all declared secrets already populated", nil
+	}
+	return detail + "; vault not configured", nil
+}

--- a/tinfoil/cmd/boot/secrets.go
+++ b/tinfoil/cmd/boot/secrets.go
@@ -25,10 +25,10 @@ func prepareSecretHandoff(config *Config, externalConfig *shimconfig.ExternalCon
 	}
 	workloadSecrets, err := secretstore.WorkloadStore(config, externalConfig)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("resolving workload secrets: %w", err)
 	}
 	if err := secretstore.WriteHandoff(handoff, configDigest, workloadSecrets); err != nil {
-		return "", err
+		return "", fmt.Errorf("creating sealed secret handoff: %w", err)
 	}
 
 	detail := fmt.Sprintf("handed off %d workload secret(s)", len(workloadSecrets))

--- a/tinfoil/cmd/boot/secrets_test.go
+++ b/tinfoil/cmd/boot/secrets_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/secretstore"
+)
+
+func TestPrepareSecretHandoff(t *testing.T) {
+	config := &Config{
+		Containers: []Container{{Secrets: []string{"API_KEY"}}},
+	}
+	externalConfig := &shimconfig.ExternalConfig{
+		Secrets: map[string]string{"API_KEY": "secret"},
+	}
+	handoff, err := secretstore.NewHandoffFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handoff.Close()
+
+	detail, err := prepareSecretHandoff(config, externalConfig, handoff, "config-digest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail != "handed off 1 workload secret(s); vault not configured" {
+		t.Fatalf("detail = %q", detail)
+	}
+	store, err := secretstore.ReadHandoff(handoff, "config-digest", []string{"API_KEY"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store["API_KEY"] != "secret" {
+		t.Fatalf("secret handoff = %#v", store)
+	}
+}
+
+func TestPrepareSecretHandoffRejectsUnresolvedSecrets(t *testing.T) {
+	config := &Config{
+		Containers: []Container{{Secrets: []string{"API_KEY"}}},
+	}
+	handoff, err := secretstore.NewHandoffFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer handoff.Close()
+
+	_, err = prepareSecretHandoff(config, &shimconfig.ExternalConfig{}, handoff, "config-digest")
+	if err == nil || !strings.Contains(err.Error(), "1 declared secret(s) remain unresolved") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/tinfoil/cmd/boot/secrets_test.go
+++ b/tinfoil/cmd/boot/secrets_test.go
@@ -52,3 +52,10 @@ func TestPrepareSecretHandoffRejectsUnresolvedSecrets(t *testing.T) {
 		t.Fatalf("error = %v", err)
 	}
 }
+
+func TestPrepareSecretHandoffReportsHandoffFailure(t *testing.T) {
+	_, err := prepareSecretHandoff(&Config{}, &shimconfig.ExternalConfig{}, nil, "config-digest")
+	if err == nil || !strings.Contains(err.Error(), "creating sealed secret handoff") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/tinfoil/cmd/boot/vault.go
+++ b/tinfoil/cmd/boot/vault.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"net/url"
-	"slices"
 	"strings"
 	"time"
 
@@ -17,6 +16,7 @@ import (
 
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/secretstore"
 )
 
 const vaultFetchTimeout = 60 * time.Second
@@ -30,27 +30,27 @@ type vaultFetchRequest struct {
 
 // fetchVaultSecrets asks the vault for the declared secrets the external
 // config did not populate.
-func fetchVaultSecrets(config *Config, ext *shimconfig.ExternalConfig) error {
-	names := missingSecretValues(config, ext)
+func fetchVaultSecrets(config *Config, ext *shimconfig.ExternalConfig) (int, error) {
+	names := secretstore.MissingReferences(config, ext)
 	if len(names) == 0 {
 		log.Println("All declared secrets populated by external config, nothing to fetch")
-		return nil
+		return 0, nil
 	}
 	if ext.VaultToken == "" {
-		return fmt.Errorf("%d secret(s) need the vault but external config has no vault-token", len(names))
+		return 0, fmt.Errorf("%d secret(s) need the vault but external config has no vault-token", len(names))
 	}
 	// TLS required
 	if u, err := url.Parse(config.VaultURL); err != nil || u.Scheme != "https" || u.Host == "" {
-		return fmt.Errorf("vault-url must be an https URL, got %q", config.VaultURL)
+		return 0, fmt.Errorf("vault-url must be an https URL, got %q", config.VaultURL)
 	}
 
 	cert, err := tls.LoadX509KeyPair(boot.TLSCertPath, boot.TLSKeyPath)
 	if err != nil {
-		return fmt.Errorf("loading enclave TLS certificate: %w", err)
+		return 0, fmt.Errorf("loading enclave TLS certificate: %w", err)
 	}
 	attDoc, err := verifier.FromFile(boot.AttestationPath)
 	if err != nil {
-		return fmt.Errorf("loading boot attestation document: %w", err)
+		return 0, fmt.Errorf("loading boot attestation document: %w", err)
 	}
 
 	req := vaultFetchRequest{
@@ -65,7 +65,24 @@ func fetchVaultSecrets(config *Config, ext *shimconfig.ExternalConfig) error {
 
 	secrets, err := vaultFetch(vaultClient(cert), config.VaultURL, req)
 	if err != nil {
-		return err
+		return 0, err
+	}
+	if err := mergeVaultSecrets(names, secrets, ext); err != nil {
+		return 0, err
+	}
+	log.Printf("Vault released %d secret(s) for %s", len(secrets), ext.Metadata.Repo)
+	return len(secrets), nil
+}
+
+func mergeVaultSecrets(names []string, secrets map[string]string, ext *shimconfig.ExternalConfig) error {
+	if len(secrets) != len(names) {
+		return fmt.Errorf("vault returned %d secret(s), expected %d", len(secrets), len(names))
+	}
+	for _, name := range names {
+		value, ok := secrets[name]
+		if !ok || value == "" || value == "null" {
+			return fmt.Errorf("vault did not return declared secret %q", name)
+		}
 	}
 
 	if ext.Secrets == nil {
@@ -74,29 +91,7 @@ func fetchVaultSecrets(config *Config, ext *shimconfig.ExternalConfig) error {
 	for name, value := range secrets {
 		ext.Secrets[name] = value
 	}
-	log.Printf("Vault released %d secret(s) for %s", len(secrets), ext.Metadata.Repo)
 	return nil
-}
-
-// missingSecretValues returns the deduplicated, sorted names of the
-// containers' secrets whose values the external config did not populate
-func missingSecretValues(config *Config, ext *shimconfig.ExternalConfig) []string {
-	seen := map[string]struct{}{}
-	var names []string
-	for _, c := range config.Containers {
-		for _, n := range c.Secrets {
-			if _, ok := seen[n]; ok {
-				continue
-			}
-			seen[n] = struct{}{}
-			if ext.GetSecret(n) != "" {
-				continue
-			}
-			names = append(names, n)
-		}
-	}
-	slices.Sort(names)
-	return names
 }
 
 // vaultClient returns an HTTP client that presents the enclave's TLS

--- a/tinfoil/cmd/boot/vault_test.go
+++ b/tinfoil/cmd/boot/vault_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+)
+
+func TestMergeVaultSecretsRequiresExactResponse(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		secrets map[string]string
+	}{
+		{name: "missing", secrets: map[string]string{}},
+		{name: "empty", secrets: map[string]string{"API_KEY": ""}},
+		{name: "null", secrets: map[string]string{"API_KEY": "null"}},
+		{name: "wrong name", secrets: map[string]string{"OTHER": "value"}},
+		{name: "extra", secrets: map[string]string{"API_KEY": "value", "OTHER": "value"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := mergeVaultSecrets([]string{"API_KEY"}, test.secrets, &shimconfig.ExternalConfig{}); err == nil {
+				t.Fatal("invalid Vault response accepted")
+			}
+		})
+	}
+}
+
+func TestMergeVaultSecrets(t *testing.T) {
+	external := &shimconfig.ExternalConfig{Secrets: map[string]string{"EXISTING": "value"}}
+	if err := mergeVaultSecrets([]string{"API_KEY"}, map[string]string{"API_KEY": "secret"}, external); err != nil {
+		t.Fatal(err)
+	}
+	if external.Secrets["API_KEY"] != "secret" || external.Secrets["EXISTING"] != "value" {
+		t.Fatalf("external secrets = %#v", external.Secrets)
+	}
+}

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -203,8 +203,10 @@ func (m *manager) boot(override []byte) (result error) {
 	if err != nil {
 		return err
 	}
-	if err := secretstore.RequireWorkloadSecrets(config, m.secrets); err != nil {
-		return err
+	if !m.debug {
+		if err := secretstore.RequireWorkloadSecrets(config, m.secrets); err != nil {
+			return err
+		}
 	}
 	externalData, err := os.ReadFile(boot.ExternalConfigPath)
 	if err != nil {

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -214,7 +214,12 @@ func (m *manager) boot(override []byte) (result error) {
 	secretValues := m.secrets
 	if m.debug {
 		// Debug users may request any customer-supplied external secret.
-		secretValues = secretstore.Store(external.Secrets)
+		secretValues = make(secretstore.Store, len(external.Secrets))
+		for name := range external.Secrets {
+			if value := external.GetSecret(name); value != "" {
+				secretValues[name] = value
+			}
+		}
 	}
 	previous, err := loadRuntimeConfig()
 	if err != nil {

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -27,10 +27,11 @@ import (
 const bootPath = "/v1/boot"
 
 type manager struct {
-	bootMu  sync.Mutex
-	ctx     context.Context
-	debug   bool
-	secrets secretstore.Store
+	bootMu         sync.Mutex
+	ctx            context.Context
+	debug          bool
+	verifiedConfig []byte
+	secrets        secretstore.Store
 }
 
 type invocation struct {
@@ -86,9 +87,6 @@ func run(ctx context.Context, invocation invocation) error {
 		return err
 	}
 	secretHandoff := os.NewFile(uintptr(invocation.secretsFD), "tinfoil-container-secrets")
-	if secretHandoff == nil {
-		return fmt.Errorf("opening container-secret handoff descriptor")
-	}
 	secrets, err := secretstore.ReadHandoff(
 		secretHandoff,
 		secretstore.ConfigDigest(verifiedConfig),
@@ -106,7 +104,12 @@ func run(ctx context.Context, invocation invocation) error {
 	}
 	runtimeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	manager := &manager{ctx: runtimeCtx, debug: invocation.debug, secrets: secrets}
+	manager := &manager{
+		ctx:            runtimeCtx,
+		debug:          invocation.debug,
+		verifiedConfig: verifiedConfig,
+		secrets:        secrets,
+	}
 
 	var listener net.Listener
 	if invocation.debug {
@@ -195,11 +198,7 @@ func (m *manager) boot(override []byte) (result error) {
 
 	source := override
 	if len(source) == 0 {
-		var err error
-		source, err = os.ReadFile(boot.ConfigPath)
-		if err != nil {
-			return fmt.Errorf("reading verified config: %w", err)
-		}
+		source = m.verifiedConfig
 	}
 	config, err := runtimeconfig.Decode(source, m.debug)
 	if err != nil {

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -203,11 +203,6 @@ func (m *manager) boot(override []byte) (result error) {
 	if err != nil {
 		return err
 	}
-	if !m.debug {
-		if err := secretstore.RequireWorkloadSecrets(config, m.secrets); err != nil {
-			return err
-		}
-	}
 	externalData, err := os.ReadFile(boot.ExternalConfigPath)
 	if err != nil {
 		return fmt.Errorf("reading external config: %w", err)
@@ -215,6 +210,11 @@ func (m *manager) boot(override []byte) (result error) {
 	external, err := shimconfig.DecodeExternal(externalData)
 	if err != nil {
 		return err
+	}
+	secretValues := m.secrets
+	if m.debug {
+		// Debug users may request any customer-supplied external secret.
+		secretValues = secretstore.Store(external.Secrets)
 	}
 	previous, err := loadRuntimeConfig()
 	if err != nil {
@@ -265,7 +265,7 @@ func (m *manager) boot(override []byte) (result error) {
 		return fmt.Errorf("restarting egress policy: %w", err)
 	}
 	frozenEgress = nil
-	if err := containers.LaunchAndWaitHealthyExcept(m.ctx, tracker, config, external, m.secrets, m.debug, preserved); err != nil {
+	if err := containers.LaunchAndWaitHealthyExcept(m.ctx, tracker, config, external, secretValues, m.debug, preserved); err != nil {
 		return err
 	}
 	return restartRuntimeServices(m.ctx)

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -92,12 +92,11 @@ func run(ctx context.Context, invocation invocation) error {
 		secretstore.ConfigDigest(verifiedConfig),
 		secretstore.WorkloadReferences(config),
 	)
-	closeErr := secretHandoff.Close()
 	if err != nil {
 		return err
 	}
-	if closeErr != nil {
-		return fmt.Errorf("closing container-secret handoff: %w", closeErr)
+	if err := secretHandoff.Close(); err != nil {
+		return fmt.Errorf("closing container-secret handoff: %w", err)
 	}
 	if err := os.MkdirAll("/run/tinfoil", 0o700); err != nil {
 		return err

--- a/tinfoil/cmd/containers/main.go
+++ b/tinfoil/cmd/containers/main.go
@@ -21,14 +21,21 @@ import (
 	"tinfoil/internal/containers"
 	"tinfoil/internal/firewall"
 	"tinfoil/internal/runtimeconfig"
+	"tinfoil/internal/secretstore"
 )
 
 const bootPath = "/v1/boot"
 
 type manager struct {
-	bootMu sync.Mutex
-	ctx    context.Context
-	debug  bool
+	bootMu  sync.Mutex
+	ctx     context.Context
+	debug   bool
+	secrets secretstore.Store
+}
+
+type invocation struct {
+	debug     bool
+	secretsFD int
 }
 
 type errorResponse struct {
@@ -37,44 +44,72 @@ type errorResponse struct {
 
 func main() {
 	log.SetFlags(0)
-	debug, err := parseInvocation(os.Args)
+	invocation, err := parseInvocation(os.Args)
 	if err != nil {
 		log.Fatalf("tinfoil-containers: %v", err)
 	}
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	if err := run(ctx, debug); err != nil && !errors.Is(err, context.Canceled) {
+	if err := run(ctx, invocation); err != nil && !errors.Is(err, context.Canceled) {
 		log.Fatalf("tinfoil-containers: %v", err)
 	}
 }
 
-func parseInvocation(args []string) (bool, error) {
+func parseInvocation(args []string) (invocation, error) {
 	if len(args) == 0 {
-		return false, fmt.Errorf("missing argv[0]")
+		return invocation{}, fmt.Errorf("missing argv[0]")
 	}
-	var debug bool
+	var parsed invocation
 	flags := flag.NewFlagSet(args[0], flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
-	flags.BoolVar(&debug, "debug", false, "enable the debug boot API")
+	flags.BoolVar(&parsed.debug, "debug", false, "enable the debug boot API")
+	flags.IntVar(&parsed.secretsFD, "secrets-fd", -1, "sealed container-secret handoff descriptor")
 	if err := flags.Parse(args[1:]); err != nil {
-		return false, err
+		return invocation{}, err
 	}
 	if flags.NArg() != 0 {
-		return false, fmt.Errorf("unexpected arguments: %v", flags.Args())
+		return invocation{}, fmt.Errorf("unexpected arguments: %v", flags.Args())
 	}
-	return debug, nil
+	return parsed, nil
 }
 
-func run(ctx context.Context, debug bool) error {
+func run(ctx context.Context, invocation invocation) error {
+	if invocation.secretsFD < 0 {
+		return fmt.Errorf("container-secret handoff descriptor is required")
+	}
+	verifiedConfig, err := os.ReadFile(boot.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("reading verified config: %w", err)
+	}
+	config, err := runtimeconfig.Decode(verifiedConfig, invocation.debug)
+	if err != nil {
+		return err
+	}
+	secretHandoff := os.NewFile(uintptr(invocation.secretsFD), "tinfoil-container-secrets")
+	if secretHandoff == nil {
+		return fmt.Errorf("opening container-secret handoff descriptor")
+	}
+	secrets, err := secretstore.ReadHandoff(
+		secretHandoff,
+		secretstore.ConfigDigest(verifiedConfig),
+		secretstore.WorkloadReferences(config),
+	)
+	closeErr := secretHandoff.Close()
+	if err != nil {
+		return err
+	}
+	if closeErr != nil {
+		return fmt.Errorf("closing container-secret handoff: %w", closeErr)
+	}
 	if err := os.MkdirAll("/run/tinfoil", 0o700); err != nil {
 		return err
 	}
 	runtimeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	manager := &manager{ctx: runtimeCtx, debug: debug}
+	manager := &manager{ctx: runtimeCtx, debug: invocation.debug, secrets: secrets}
 
 	var listener net.Listener
-	if debug {
+	if invocation.debug {
 		var err error
 		listener, err = listenDebugSocket()
 		if err != nil {
@@ -101,7 +136,7 @@ func run(ctx context.Context, debug bool) error {
 
 	statusDone := make(chan error, 1)
 	go func() { statusDone <- containers.RunStatusPublisher(runtimeCtx) }()
-	if !debug {
+	if !invocation.debug {
 		return <-statusDone
 	}
 
@@ -170,6 +205,9 @@ func (m *manager) boot(override []byte) (result error) {
 	if err != nil {
 		return err
 	}
+	if err := secretstore.RequireWorkloadSecrets(config, m.secrets); err != nil {
+		return err
+	}
 	externalData, err := os.ReadFile(boot.ExternalConfigPath)
 	if err != nil {
 		return fmt.Errorf("reading external config: %w", err)
@@ -227,7 +265,7 @@ func (m *manager) boot(override []byte) (result error) {
 		return fmt.Errorf("restarting egress policy: %w", err)
 	}
 	frozenEgress = nil
-	if err := containers.LaunchAndWaitHealthyExcept(m.ctx, tracker, config, external, m.debug, preserved); err != nil {
+	if err := containers.LaunchAndWaitHealthyExcept(m.ctx, tracker, config, external, m.secrets, m.debug, preserved); err != nil {
 		return err
 	}
 	return restartRuntimeServices(m.ctx)

--- a/tinfoil/cmd/containers/runtime_test.go
+++ b/tinfoil/cmd/containers/runtime_test.go
@@ -7,9 +7,9 @@ import (
 )
 
 func TestParseInvocation(t *testing.T) {
-	debug, err := parseInvocation([]string{"tinfoil-containers", "--debug=true"})
-	if err != nil || !debug {
-		t.Fatalf("parseInvocation() = %t, %v", debug, err)
+	invocation, err := parseInvocation([]string{"tinfoil-containers", "--debug=true", "--secrets-fd=3"})
+	if err != nil || !invocation.debug || invocation.secretsFD != 3 {
+		t.Fatalf("parseInvocation() = %#v, %v", invocation, err)
 	}
 	if _, err := parseInvocation([]string{"tinfoil-containers", "unexpected"}); err == nil {
 		t.Fatal("unexpected positional argument accepted")

--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -22,6 +22,7 @@ import (
 	"tinfoil/internal/pid1/hardening"
 	pidruntime "tinfoil/internal/pid1/runtime"
 	"tinfoil/internal/pid1/supervisor"
+	"tinfoil/internal/secretstore"
 )
 
 const (
@@ -206,6 +207,11 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	if err := deps.limits(); err != nil {
 		return fmt.Errorf("runtime limits: %w", err)
 	}
+	secretHandoff, err := secretstore.NewHandoffFile()
+	if err != nil {
+		return err
+	}
+	defer secretHandoff.Close()
 	if err := deps.oneShot(bootCtx, command("loopback", "/usr/sbin/ip", "link", "set", "dev", "lo", "up")); err != nil {
 		return err
 	}
@@ -245,18 +251,24 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	}); err != nil {
 		return err
 	}
-	if err := deps.oneShot(bootCtx, hardenedCommand(
+	bootCommand := hardenedCommand(
 		hardening.ServiceBoot, boot.BootBinary,
 		"--config-hash="+deps.cmdline.ConfigHash,
 		fmt.Sprintf("--debug=%t", deps.cmdline.Debug),
-	)); err != nil {
+		fmt.Sprintf("--secrets-fd=%d", secretstore.HandoffFD),
+	)
+	bootCommand.ExtraFiles = []*os.File{secretHandoff}
+	if err := deps.oneShot(bootCtx, bootCommand); err != nil {
 		return err
 	}
+	containersCommand := hardenedCommand(hardening.ServiceContainers, boot.ContainersBinary,
+		fmt.Sprintf("--debug=%t", deps.cmdline.Debug),
+		fmt.Sprintf("--secrets-fd=%d", secretstore.HandoffFD))
+	containersCommand.ExtraFiles = []*os.File{secretHandoff}
 	if err := deps.services.Start(bootCtx, supervisor.Service{
 		Name: containersName, Required: true, Restart: true,
-		Command: hardenedCommand(hardening.ServiceContainers, boot.ContainersBinary,
-			fmt.Sprintf("--debug=%t", deps.cmdline.Debug)),
-		Ready: fileReady(boot.ContainersReadyPath),
+		Command: containersCommand,
+		Ready:   fileReady(boot.ContainersReadyPath),
 	}); err != nil {
 		return err
 	}

--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -255,16 +255,14 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 		hardening.ServiceBoot, boot.BootBinary,
 		"--config-hash="+deps.cmdline.ConfigHash,
 		fmt.Sprintf("--debug=%t", deps.cmdline.Debug),
-		fmt.Sprintf("--secrets-fd=%d", secretstore.HandoffFD),
 	)
-	bootCommand.ExtraFiles = []*os.File{secretHandoff}
+	bootCommand = withSecretHandoff(bootCommand, secretHandoff)
 	if err := deps.oneShot(bootCtx, bootCommand); err != nil {
 		return err
 	}
 	containersCommand := hardenedCommand(hardening.ServiceContainers, boot.ContainersBinary,
-		fmt.Sprintf("--debug=%t", deps.cmdline.Debug),
-		fmt.Sprintf("--secrets-fd=%d", secretstore.HandoffFD))
-	containersCommand.ExtraFiles = []*os.File{secretHandoff}
+		fmt.Sprintf("--debug=%t", deps.cmdline.Debug))
+	containersCommand = withSecretHandoff(containersCommand, secretHandoff)
 	if err := deps.services.Start(bootCtx, supervisor.Service{
 		Name: containersName, Required: true, Restart: true,
 		Command: containersCommand,
@@ -287,6 +285,12 @@ func runLifecycle(parent context.Context, deps lifecycleDeps, readiness *readine
 	<-parent.Done()
 	initLogf("shutdown requested")
 	return nil
+}
+
+func withSecretHandoff(command supervisor.Command, handoff *os.File) supervisor.Command {
+	childFD := command.AddExtraFile(handoff)
+	command.Args = append(command.Args, fmt.Sprintf("--secrets-fd=%d", childFD))
+	return command
 }
 
 type nvidiaBootstrapControl interface {

--- a/tinfoil/cmd/pid1/main_test.go
+++ b/tinfoil/cmd/pid1/main_test.go
@@ -132,6 +132,9 @@ func TestLifecycleCommandsCarryCapturedKernelPolicy(t *testing.T) {
 	if got := fmt.Sprint(bootCommand.Args); !strings.Contains(got, "--config-hash=abc --debug=true") {
 		t.Fatalf("boot args = %s", got)
 	}
+	if len(bootCommand.ExtraFiles) != 1 {
+		t.Fatalf("boot extra files = %d, want 1", len(bootCommand.ExtraFiles))
+	}
 	var containersCommand supervisor.Command
 	for _, service := range harness.services.started {
 		if service.Name == containersName {
@@ -139,6 +142,12 @@ func TestLifecycleCommandsCarryCapturedKernelPolicy(t *testing.T) {
 		}
 	}
 	if got := fmt.Sprint(containersCommand.Args); !strings.Contains(got, "--debug=true") {
+		t.Fatalf("containers args = %s", got)
+	}
+	if len(containersCommand.ExtraFiles) != 1 || containersCommand.ExtraFiles[0] != bootCommand.ExtraFiles[0] {
+		t.Fatal("boot and containers did not receive the same secret handoff")
+	}
+	if got := fmt.Sprint(containersCommand.Args); !strings.Contains(got, "--secrets-fd=3") {
 		t.Fatalf("containers args = %s", got)
 	}
 }

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -25,6 +25,7 @@ import (
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/containernet"
 	"tinfoil/internal/runtimeconfig"
+	"tinfoil/internal/secretstore"
 )
 
 const (
@@ -122,11 +123,11 @@ func networkCreateOptions(name string) client.NetworkCreateOptions {
 // launchContainersAndWaitHealthy launches all containers in parallel with
 // health checking. Each container is tracked as a substage of "containers"
 // with per-phase sub-substages (pull, start, healthy).
-func LaunchAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
-	return LaunchAndWaitHealthyExcept(ctx, tracker, config, extConfig, debug, nil)
+func LaunchAndWaitHealthy(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, secrets secretstore.Store, debug bool) error {
+	return LaunchAndWaitHealthyExcept(ctx, tracker, config, extConfig, secrets, debug, nil)
 }
 
-func LaunchAndWaitHealthyExcept(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, debug bool, preserved map[string]bool) error {
+func LaunchAndWaitHealthyExcept(ctx context.Context, tracker *boot.Tracker, config *Config, extConfig *shimconfig.ExternalConfig, secrets secretstore.Store, debug bool, preserved map[string]bool) error {
 	if len(config.Containers) == 0 {
 		log.Println("No containers to launch")
 		tracker.Record(boot.StageContainers, boot.StatusSkipped, 0, "no containers")
@@ -177,7 +178,7 @@ func LaunchAndWaitHealthyExcept(ctx context.Context, tracker *boot.Tracker, conf
 		wg.Add(1)
 		go func(i int, c Container) {
 			defer wg.Done()
-			errs[i] = runContainer(ctx, cli, c, config, extConfig, &substages, &mu, flush, debug)
+			errs[i] = runContainer(ctx, cli, c, config, extConfig, secrets, &substages, &mu, flush, debug)
 		}(i, c)
 	}
 	wg.Wait()
@@ -241,6 +242,7 @@ func runContainer(
 	c Container,
 	cfg *Config,
 	extConfig *shimconfig.ExternalConfig,
+	secrets secretstore.Store,
 	substages *[]boot.Stage,
 	mu *sync.Mutex,
 	flush func(),
@@ -274,7 +276,7 @@ func runContainer(
 
 	// Create + start
 	startPhase := time.Now()
-	if err := createAndStartContainer(ctx, cli, c, cfg, extConfig, debug); err != nil {
+	if err := createAndStartContainer(ctx, cli, c, cfg, extConfig, secrets, debug); err != nil {
 		detail := fmt.Sprintf("starting: %v", err)
 		record("start", boot.StatusFailed, time.Since(startPhase), detail)
 		finish(boot.StatusFailed, detail)
@@ -390,8 +392,8 @@ func attachOrder(c Container, cfg *Config) (first string, rest []string) {
 	return first, rest
 }
 
-func createAndStartContainer(ctx context.Context, cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, debug bool) error {
-	containerConfig, hostConfig, networkingConfig, rest, err := buildContainerCreateSpec(c, cfg, extConfig, debug)
+func createAndStartContainer(ctx context.Context, cli *client.Client, c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, secrets secretstore.Store, debug bool) error {
+	containerConfig, hostConfig, networkingConfig, rest, err := buildContainerCreateSpec(c, cfg, extConfig, secrets, debug)
 	if err != nil {
 		return err
 	}
@@ -426,13 +428,13 @@ func createAndStartContainer(ctx context.Context, cli *client.Client, c Containe
 	return nil
 }
 
-func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, debug bool) (*container.Config, *container.HostConfig, *dockernetwork.NetworkingConfig, []string, error) {
+func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.ExternalConfig, secrets secretstore.Store, debug bool) (*container.Config, *container.HostConfig, *dockernetwork.NetworkingConfig, []string, error) {
 	if c.Image == "" {
 		return nil, nil, nil, nil, fmt.Errorf("no image specified for container %s", c.Name)
 	}
 
 	// Build environment variables
-	env := buildEnv(c.Env, c.Secrets, extConfig)
+	env := buildEnv(c.Env, c.Secrets, extConfig, secrets)
 
 	// Container configuration
 	containerConfig := &container.Config{
@@ -658,7 +660,7 @@ func containerMemoryBytes(c *Container, cfg *Config) int64 {
 }
 
 // buildEnv parses env entries and secrets from external config
-func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.ExternalConfig) []string {
+func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.ExternalConfig, secretValues secretstore.Store) []string {
 	var env []string
 
 	// Process env items
@@ -683,12 +685,12 @@ func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.Ex
 		}
 	}
 
-	// Process secrets (lookup from external-config secrets section)
+	// Process secrets resolved by tinfoil-boot and held by tinfoil-containers.
 	for _, key := range secrets {
-		if v := extConfig.GetSecret(key); v != "" {
+		if v := secretValues[key]; v != "" {
 			env = append(env, key+"="+v)
 		} else {
-			log.Printf("Warning: secret key %s not found in external config", key)
+			log.Printf("Warning: secret key %s not found in secret store", key)
 		}
 	}
 

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -434,7 +434,7 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 	}
 
 	// Build environment variables
-	env := buildEnv(c.Env, c.Secrets, extConfig, secrets)
+	env := buildEnv(c.Env, c.Secrets, extConfig, secrets, debug)
 
 	// Container configuration
 	containerConfig := &container.Config{
@@ -660,7 +660,7 @@ func containerMemoryBytes(c *Container, cfg *Config) int64 {
 }
 
 // buildEnv parses env entries and secrets from external config
-func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.ExternalConfig, secretValues secretstore.Store) []string {
+func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.ExternalConfig, secretValues secretstore.Store, debug bool) []string {
 	var env []string
 
 	// Process env items
@@ -685,12 +685,18 @@ func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.Ex
 		}
 	}
 
-	// Process secrets resolved by tinfoil-boot and held by tinfoil-containers.
+	// Debug workloads may use customer-supplied external secrets; production only uses the sealed store.
 	for _, key := range secrets {
-		if v := secretValues[key]; v != "" {
-			env = append(env, key+"="+v)
+		value := secretValues[key]
+		if debug && extConfig != nil {
+			if externalValue := extConfig.GetSecret(key); externalValue != "" {
+				value = externalValue
+			}
+		}
+		if value != "" {
+			env = append(env, key+"="+value)
 		} else {
-			log.Printf("Warning: secret key %s not found in secret store", key)
+			log.Printf("Warning: secret key %s not found", key)
 		}
 	}
 

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -659,7 +659,7 @@ func containerMemoryBytes(c *Container, cfg *Config) int64 {
 	return 0
 }
 
-// buildEnv parses env entries and secrets from external config
+// buildEnv combines external-config environment entries with resolved secret values.
 func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.ExternalConfig, secretValues secretstore.Store) []string {
 	var env []string
 

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -434,7 +434,7 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 	}
 
 	// Build environment variables
-	env := buildEnv(c.Env, c.Secrets, extConfig, secrets, debug)
+	env := buildEnv(c.Env, c.Secrets, extConfig, secrets)
 
 	// Container configuration
 	containerConfig := &container.Config{
@@ -660,7 +660,7 @@ func containerMemoryBytes(c *Container, cfg *Config) int64 {
 }
 
 // buildEnv parses env entries and secrets from external config
-func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.ExternalConfig, secretValues secretstore.Store, debug bool) []string {
+func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.ExternalConfig, secretValues secretstore.Store) []string {
 	var env []string
 
 	// Process env items
@@ -685,18 +685,12 @@ func buildEnv(envItems []interface{}, secrets []string, extConfig *shimconfig.Ex
 		}
 	}
 
-	// Debug workloads may use customer-supplied external secrets; production only uses the sealed store.
+	// Process secrets resolved by tinfoil-boot and held by tinfoil-containers.
 	for _, key := range secrets {
-		value := secretValues[key]
-		if debug && extConfig != nil {
-			if externalValue := extConfig.GetSecret(key); externalValue != "" {
-				value = externalValue
-			}
-		}
-		if value != "" {
-			env = append(env, key+"="+value)
+		if v := secretValues[key]; v != "" {
+			env = append(env, key+"="+v)
 		} else {
-			log.Printf("Warning: secret key %s not found", key)
+			log.Printf("Warning: secret key %s not found in secret store", key)
 		}
 	}
 

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -10,6 +10,7 @@ import (
 
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/containernet"
+	"tinfoil/internal/secretstore"
 )
 
 func TestParseGPUs(t *testing.T) {
@@ -98,6 +99,7 @@ func TestBuildEnv(t *testing.T) {
 		},
 		[]string{"API_KEY", "MISSING_SECRET"},
 		ext,
+		secretstore.Store{"API_KEY": "sk-123"},
 	)
 
 	want := map[string]bool{
@@ -118,7 +120,7 @@ func TestBuildEnv(t *testing.T) {
 
 func TestBuildEnvNilConfig(t *testing.T) {
 	ext := &shimconfig.ExternalConfig{}
-	env := buildEnv([]interface{}{"FOO"}, []string{"BAR"}, ext)
+	env := buildEnv([]interface{}{"FOO"}, []string{"BAR"}, ext, nil)
 	if len(env) != 0 {
 		t.Errorf("expected empty env with nil maps, got %v", env)
 	}
@@ -204,7 +206,7 @@ func TestBuildContainerCreateSpec_DebugInstallerGetsFixedRuntime(t *testing.T) {
 		Volumes: []string{debugDockerSocketBind},
 	}
 
-	containerConfig, hostConfig, networkingConfig, rest, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, true)
+	containerConfig, hostConfig, networkingConfig, rest, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, nil, true)
 	if err != nil {
 		t.Fatalf("buildContainerCreateSpec: %v", err)
 	}
@@ -250,7 +252,7 @@ func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testi
 		Image: "example.invalid/installer",
 	}
 
-	containerConfig, hostConfig, _, _, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, false)
+	containerConfig, hostConfig, _, _, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, nil, false)
 	if err != nil {
 		t.Fatalf("buildContainerCreateSpec: %v", err)
 	}

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -99,13 +99,13 @@ func TestBuildEnv(t *testing.T) {
 		},
 		[]string{"API_KEY", "MISSING_SECRET"},
 		ext,
-		secretstore.Store{"API_KEY": "sk-123"},
+		secretstore.Store{"API_KEY": "from-handoff"},
 	)
 
 	want := map[string]bool{
 		"DOMAIN=test.example.com": true,
 		"STATIC=value":            true,
-		"API_KEY=sk-123":          true,
+		"API_KEY=from-handoff":    true,
 	}
 	for _, e := range env {
 		if !want[e] {

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -100,6 +100,7 @@ func TestBuildEnv(t *testing.T) {
 		[]string{"API_KEY", "MISSING_SECRET"},
 		ext,
 		secretstore.Store{"API_KEY": "from-handoff"},
+		false,
 	)
 
 	want := map[string]bool{
@@ -120,9 +121,38 @@ func TestBuildEnv(t *testing.T) {
 
 func TestBuildEnvNilConfig(t *testing.T) {
 	ext := &shimconfig.ExternalConfig{}
-	env := buildEnv([]interface{}{"FOO"}, []string{"BAR"}, ext, nil)
+	env := buildEnv([]interface{}{"FOO"}, []string{"BAR"}, ext, nil, false)
 	if len(env) != 0 {
 		t.Errorf("expected empty env with nil maps, got %v", env)
+	}
+}
+
+func TestBuildEnvDebugUsesExternalSecrets(t *testing.T) {
+	external := &shimconfig.ExternalConfig{Secrets: map[string]string{
+		"API_KEY":    "from-external",
+		"DEBUG_ONLY": "debug-secret",
+	}}
+	env := buildEnv(
+		nil,
+		[]string{"API_KEY", "DEBUG_ONLY", "VAULT_ONLY"},
+		external,
+		secretstore.Store{"API_KEY": "from-handoff", "VAULT_ONLY": "vault-secret"},
+		true,
+	)
+
+	want := map[string]bool{
+		"API_KEY=from-external":   true,
+		"DEBUG_ONLY=debug-secret": true,
+		"VAULT_ONLY=vault-secret": true,
+	}
+	for _, value := range env {
+		if !want[value] {
+			t.Fatalf("unexpected environment entry %q", value)
+		}
+		delete(want, value)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing environment entries: %v", want)
 	}
 }
 

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -100,7 +100,6 @@ func TestBuildEnv(t *testing.T) {
 		[]string{"API_KEY", "MISSING_SECRET"},
 		ext,
 		secretstore.Store{"API_KEY": "from-handoff"},
-		false,
 	)
 
 	want := map[string]bool{
@@ -121,38 +120,9 @@ func TestBuildEnv(t *testing.T) {
 
 func TestBuildEnvNilConfig(t *testing.T) {
 	ext := &shimconfig.ExternalConfig{}
-	env := buildEnv([]interface{}{"FOO"}, []string{"BAR"}, ext, nil, false)
+	env := buildEnv([]interface{}{"FOO"}, []string{"BAR"}, ext, nil)
 	if len(env) != 0 {
 		t.Errorf("expected empty env with nil maps, got %v", env)
-	}
-}
-
-func TestBuildEnvDebugUsesExternalSecrets(t *testing.T) {
-	external := &shimconfig.ExternalConfig{Secrets: map[string]string{
-		"API_KEY":    "from-external",
-		"DEBUG_ONLY": "debug-secret",
-	}}
-	env := buildEnv(
-		nil,
-		[]string{"API_KEY", "DEBUG_ONLY", "VAULT_ONLY"},
-		external,
-		secretstore.Store{"API_KEY": "from-handoff", "VAULT_ONLY": "vault-secret"},
-		true,
-	)
-
-	want := map[string]bool{
-		"API_KEY=from-external":   true,
-		"DEBUG_ONLY=debug-secret": true,
-		"VAULT_ONLY=vault-secret": true,
-	}
-	for _, value := range env {
-		if !want[value] {
-			t.Fatalf("unexpected environment entry %q", value)
-		}
-		delete(want, value)
-	}
-	if len(want) != 0 {
-		t.Fatalf("missing environment entries: %v", want)
 	}
 }
 

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64.go
@@ -14,6 +14,9 @@ func (m *Manager) StartConsole(command Command, console *os.File) (*Process, err
 	if console == nil {
 		return nil, errors.New("console is required")
 	}
+	if len(command.ExtraFiles) != 0 {
+		return nil, errors.New("console commands do not support extra files")
+	}
 	return m.start(command, "", startOptions{
 		files:   []*os.File{console, console, console},
 		console: true,

--- a/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
+++ b/tinfoil/internal/pid1/supervisor/debug_console_linux_amd64_test.go
@@ -36,3 +36,19 @@ func TestStartConsoleUsesManagedEphemeralScope(t *testing.T) {
 		}
 	}
 }
+
+func TestStartConsoleRejectsExtraFiles(t *testing.T) {
+	sigchld := make(chan os.Signal, 1)
+	manager := newManager(newFakeBackend(sigchld), sigchld, nil)
+	console, err := os.CreateTemp(t.TempDir(), "console")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer console.Close()
+
+	command := Command{Name: "debug-console", Path: "/bin/sh"}
+	command.AddExtraFile(console)
+	if _, err := manager.StartConsole(command, console); err == nil {
+		t.Fatal("StartConsole accepted an extra file")
+	}
+}

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -27,11 +27,12 @@ const (
 
 // Command describes a direct child of PID 1.
 type Command struct {
-	Name string
-	Path string
-	Args []string
-	Env  []string
-	Dir  string
+	Name       string
+	Path       string
+	Args       []string
+	Env        []string
+	Dir        string
+	ExtraFiles []*os.File
 }
 
 // Exit is the wait status collected for a child.
@@ -266,7 +267,7 @@ func (b *osBackend) start(command Command, scope string, options startOptions) (
 	defer cgroupFD.Close()
 	files := options.files
 	if files == nil {
-		files = []*os.File{os.Stdin, os.Stdout, os.Stderr}
+		files = append([]*os.File{os.Stdin, os.Stdout, os.Stderr}, command.ExtraFiles...)
 	}
 	system := &syscall.SysProcAttr{
 		UseCgroupFD: true,

--- a/tinfoil/internal/pid1/supervisor/supervisor.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor.go
@@ -19,10 +19,11 @@ import (
 )
 
 const (
-	childCgroupRoot     = "/sys/fs/cgroup/tinfoil-pid1"
-	cgroupEventsLimit   = 4096
-	cgroupPollInterval  = 10 * time.Millisecond
-	initialCleanupGrace = 5 * time.Second
+	childStandardFileCount = 3
+	childCgroupRoot        = "/sys/fs/cgroup/tinfoil-pid1"
+	cgroupEventsLimit      = 4096
+	cgroupPollInterval     = 10 * time.Millisecond
+	initialCleanupGrace    = 5 * time.Second
 )
 
 // Command describes a direct child of PID 1.
@@ -33,6 +34,12 @@ type Command struct {
 	Env        []string
 	Dir        string
 	ExtraFiles []*os.File
+}
+
+func (c *Command) AddExtraFile(file *os.File) int {
+	childFD := childStandardFileCount + len(c.ExtraFiles)
+	c.ExtraFiles = append(c.ExtraFiles, file)
+	return childFD
 }
 
 // Exit is the wait status collected for a child.
@@ -267,7 +274,8 @@ func (b *osBackend) start(command Command, scope string, options startOptions) (
 	defer cgroupFD.Close()
 	files := options.files
 	if files == nil {
-		files = append([]*os.File{os.Stdin, os.Stdout, os.Stderr}, command.ExtraFiles...)
+		standardFiles := [childStandardFileCount]*os.File{os.Stdin, os.Stdout, os.Stderr}
+		files = append(standardFiles[:], command.ExtraFiles...)
 	}
 	system := &syscall.SysProcAttr{
 		UseCgroupFD: true,

--- a/tinfoil/internal/pid1/supervisor/supervisor_test.go
+++ b/tinfoil/internal/pid1/supervisor/supervisor_test.go
@@ -147,6 +147,20 @@ func (p *fakeProcess) killCgroup() error {
 
 func (p *fakeProcess) removeCgroup() error { return nil }
 
+func TestCommandAddExtraFileUsesChildPosition(t *testing.T) {
+	first, second := &os.File{}, &os.File{}
+	command := Command{}
+	if fd := command.AddExtraFile(first); fd != 3 {
+		t.Fatalf("first child fd = %d, want 3", fd)
+	}
+	if fd := command.AddExtraFile(second); fd != 4 {
+		t.Fatalf("second child fd = %d, want 4", fd)
+	}
+	if len(command.ExtraFiles) != 2 || command.ExtraFiles[0] != first || command.ExtraFiles[1] != second {
+		t.Fatalf("extra files = %v", command.ExtraFiles)
+	}
+}
+
 func TestManagerOwnsDirectWaitsAndReapsOrphans(t *testing.T) {
 	sigchld := make(chan os.Signal, 8)
 	backend := newFakeBackend(sigchld)

--- a/tinfoil/internal/runtimeconfig/validation.go
+++ b/tinfoil/internal/runtimeconfig/validation.go
@@ -67,6 +67,16 @@ func validateShape(config *Config, debug bool) error {
 		}
 	}
 	seen := map[string]int{}
+	modelKeys := map[string]int{}
+	for index, model := range config.Models {
+		if model.KeySecret == "" {
+			continue
+		}
+		if !validEnvironmentName(model.KeySecret) {
+			return fmt.Errorf("models[%d].key-secret has invalid secret name %q", index, model.KeySecret)
+		}
+		modelKeys[model.KeySecret] = index
+	}
 	for index := range config.Containers {
 		container := &config.Containers[index]
 		if prior, found := seen[container.Name]; found {
@@ -75,6 +85,11 @@ func validateShape(config *Config, debug bool) error {
 		seen[container.Name] = index
 		if err := validateContainer(index, container, config.GPUs, debug); err != nil {
 			return err
+		}
+		for secretIndex, secret := range container.Secrets {
+			if modelIndex, found := modelKeys[secret]; found {
+				return fmt.Errorf("containers[%d].secrets[%d] %q exposes models[%d].key-secret", index, secretIndex, secret, modelIndex)
+			}
 		}
 	}
 	return nil

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -61,6 +61,7 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		{name: "gpu selection without runtime", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    gpus: all", 1), want: "declares no GPUs"},
 		{name: "valid top-level gpu count", yaml: strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1) + "\n", want: ""},
 		{name: "unsupported capability", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    cap_add: [SETUID]", 1), want: "capability"},
+		{name: "model key exposed to container", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    secrets: [MODEL_KEY]", 1) + "\nmodels:\n  - name: private\n    key-secret: MODEL_KEY\n", want: "exposes models[0].key-secret"},
 		{name: "invalid allowlist", yaml: strings.Replace(validConfig, "egress: closed", "egress: allowlist\n    allow: ['*.example.com']", 1), want: "wildcards"},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/tinfoil/internal/secretstore/handoff.go
+++ b/tinfoil/internal/secretstore/handoff.go
@@ -1,0 +1,189 @@
+package secretstore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+
+	"golang.org/x/sys/unix"
+
+	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/runtimeconfig"
+)
+
+const (
+	HandoffFD       = 3
+	handoffVersion  = 1
+	maxHandoffBytes = 1 << 20
+	requiredSeals   = unix.F_SEAL_SEAL | unix.F_SEAL_SHRINK | unix.F_SEAL_GROW | unix.F_SEAL_WRITE
+)
+
+type Store map[string]string
+
+type handoff struct {
+	Version      int               `json:"version"`
+	ConfigDigest string            `json:"config_digest"`
+	Secrets      map[string]string `json:"secrets"`
+}
+
+func NewHandoffFile() (*os.File, error) {
+	fd, err := unix.MemfdCreate("tinfoil-container-secrets", unix.MFD_CLOEXEC|unix.MFD_ALLOW_SEALING)
+	if err != nil {
+		return nil, fmt.Errorf("creating secret handoff: %w", err)
+	}
+	return os.NewFile(uintptr(fd), "tinfoil-container-secrets"), nil
+}
+
+func ConfigDigest(source []byte) string {
+	digest := sha256.Sum256(source)
+	return hex.EncodeToString(digest[:])
+}
+
+func AllReferences(config *runtimeconfig.Config) []string {
+	seen := map[string]struct{}{}
+	for _, model := range config.Models {
+		if model.KeySecret != "" {
+			seen[model.KeySecret] = struct{}{}
+		}
+	}
+	for _, name := range WorkloadReferences(config) {
+		seen[name] = struct{}{}
+	}
+	return sortedKeys(seen)
+}
+
+func WorkloadReferences(config *runtimeconfig.Config) []string {
+	seen := map[string]struct{}{}
+	for _, container := range config.Containers {
+		for _, name := range container.Secrets {
+			seen[name] = struct{}{}
+		}
+	}
+	return sortedKeys(seen)
+}
+
+func MissingReferences(config *runtimeconfig.Config, external *shimconfig.ExternalConfig) []string {
+	var missing []string
+	for _, name := range AllReferences(config) {
+		if external.GetSecret(name) == "" {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+func WorkloadStore(config *runtimeconfig.Config, external *shimconfig.ExternalConfig) (Store, error) {
+	store := make(Store)
+	for _, name := range WorkloadReferences(config) {
+		value := external.GetSecret(name)
+		if value == "" {
+			return nil, fmt.Errorf("declared container secret %q is unresolved", name)
+		}
+		store[name] = value
+	}
+	return store, nil
+}
+
+func RequireWorkloadSecrets(config *runtimeconfig.Config, store Store) error {
+	for _, name := range WorkloadReferences(config) {
+		if store[name] == "" {
+			return fmt.Errorf("declared container secret %q is unavailable", name)
+		}
+	}
+	return nil
+}
+
+func WriteHandoff(file *os.File, configDigest string, store Store) error {
+	if file == nil {
+		return fmt.Errorf("secret handoff file is required")
+	}
+	for name, value := range store {
+		if name == "" || value == "" || value == "null" {
+			return fmt.Errorf("secret handoff contains unresolved secret %q", name)
+		}
+	}
+	payload, err := json.Marshal(handoff{
+		Version:      handoffVersion,
+		ConfigDigest: configDigest,
+		Secrets:      store,
+	})
+	if err != nil {
+		return fmt.Errorf("encoding secret handoff: %w", err)
+	}
+	if len(payload) > maxHandoffBytes {
+		return fmt.Errorf("secret handoff exceeds %d bytes", maxHandoffBytes)
+	}
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("truncating secret handoff: %w", err)
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seeking secret handoff: %w", err)
+	}
+	if _, err := file.Write(payload); err != nil {
+		return fmt.Errorf("writing secret handoff: %w", err)
+	}
+	if _, err := unix.FcntlInt(file.Fd(), unix.F_ADD_SEALS, requiredSeals); err != nil {
+		return fmt.Errorf("sealing secret handoff: %w", err)
+	}
+	return nil
+}
+
+func ReadHandoff(file *os.File, configDigest string, expected []string) (Store, error) {
+	if file == nil {
+		return nil, fmt.Errorf("secret handoff file is required")
+	}
+	seals, err := unix.FcntlInt(file.Fd(), unix.F_GET_SEALS, 0)
+	if err != nil {
+		return nil, fmt.Errorf("reading secret handoff seals: %w", err)
+	}
+	if seals&requiredSeals != requiredSeals {
+		return nil, fmt.Errorf("secret handoff is not sealed")
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seeking secret handoff: %w", err)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxHandoffBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("reading secret handoff: %w", err)
+	}
+	if len(data) > maxHandoffBytes {
+		return nil, fmt.Errorf("secret handoff exceeds %d bytes", maxHandoffBytes)
+	}
+	var payload handoff
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return nil, fmt.Errorf("decoding secret handoff: %w", err)
+	}
+	if payload.Version != handoffVersion {
+		return nil, fmt.Errorf("unsupported secret handoff version %d", payload.Version)
+	}
+	if payload.ConfigDigest != configDigest {
+		return nil, fmt.Errorf("secret handoff config digest mismatch")
+	}
+	want := slices.Clone(expected)
+	slices.Sort(want)
+	got := make([]string, 0, len(payload.Secrets))
+	for name, value := range payload.Secrets {
+		if value == "" || value == "null" {
+			return nil, fmt.Errorf("secret handoff contains unresolved secret %q", name)
+		}
+		got = append(got, name)
+	}
+	slices.Sort(got)
+	if !slices.Equal(got, want) {
+		return nil, fmt.Errorf("secret handoff names do not match verified config")
+	}
+	return Store(payload.Secrets), nil
+}
+
+func sortedKeys(values map[string]struct{}) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+	return keys
+}

--- a/tinfoil/internal/secretstore/handoff.go
+++ b/tinfoil/internal/secretstore/handoff.go
@@ -87,15 +87,6 @@ func WorkloadStore(config *runtimeconfig.Config, external *shimconfig.ExternalCo
 	return store, nil
 }
 
-func RequireWorkloadSecrets(config *runtimeconfig.Config, store Store) error {
-	for _, name := range WorkloadReferences(config) {
-		if store[name] == "" {
-			return fmt.Errorf("declared container secret %q is unavailable", name)
-		}
-	}
-	return nil
-}
-
 func WriteHandoff(file *os.File, configDigest string, store Store) error {
 	if file == nil {
 		return fmt.Errorf("secret handoff file is required")

--- a/tinfoil/internal/secretstore/handoff.go
+++ b/tinfoil/internal/secretstore/handoff.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-	HandoffFD       = 3
 	handoffVersion  = 1
 	maxHandoffBytes = 1 << 20
 	requiredSeals   = unix.F_SEAL_SEAL | unix.F_SEAL_SHRINK | unix.F_SEAL_GROW | unix.F_SEAL_WRITE

--- a/tinfoil/internal/secretstore/handoff_test.go
+++ b/tinfoil/internal/secretstore/handoff_test.go
@@ -1,0 +1,99 @@
+package secretstore
+
+import (
+	"os"
+	"slices"
+	"testing"
+
+	shimconfig "tinfoil/internal/config"
+	"tinfoil/internal/runtimeconfig"
+)
+
+func TestReferencesAndWorkloadStore(t *testing.T) {
+	config := &runtimeconfig.Config{
+		Models: []runtimeconfig.ModelSpec{{KeySecret: "MODEL_KEY"}},
+		Containers: []runtimeconfig.Container{
+			{Secrets: []string{"API_KEY", "SHARED"}},
+			{Secrets: []string{"SHARED"}},
+		},
+	}
+	external := &shimconfig.ExternalConfig{Secrets: map[string]string{
+		"API_KEY": "api", "SHARED": "shared",
+	}}
+	if got := AllReferences(config); !slices.Equal(got, []string{"API_KEY", "MODEL_KEY", "SHARED"}) {
+		t.Fatalf("AllReferences() = %v", got)
+	}
+	if got := MissingReferences(config, external); !slices.Equal(got, []string{"MODEL_KEY"}) {
+		t.Fatalf("MissingReferences() = %v", got)
+	}
+	store, err := WorkloadStore(config, external)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store["API_KEY"] != "api" || store["SHARED"] != "shared" || len(store) != 2 {
+		t.Fatalf("WorkloadStore() = %#v", store)
+	}
+}
+
+func TestHandoffRoundTrip(t *testing.T) {
+	file, err := NewHandoffFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	digest := ConfigDigest([]byte("config"))
+	if err := WriteHandoff(file, digest, Store{"API_KEY": "secret"}); err != nil {
+		t.Fatal(err)
+	}
+	store, err := ReadHandoff(file, digest, []string{"API_KEY"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store["API_KEY"] != "secret" {
+		t.Fatalf("ReadHandoff() = %#v", store)
+	}
+	if _, err := ReadHandoff(file, digest, []string{"API_KEY"}); err != nil {
+		t.Fatalf("second ReadHandoff() failed: %v", err)
+	}
+	if _, err := file.WriteAt([]byte("x"), 0); err == nil {
+		t.Fatal("sealed handoff remained writable")
+	}
+}
+
+func TestReadHandoffRejectsWrongContract(t *testing.T) {
+	tests := []struct {
+		name     string
+		digest   string
+		expected []string
+	}{
+		{name: "digest", digest: ConfigDigest([]byte("other")), expected: []string{"API_KEY"}},
+		{name: "missing name", digest: ConfigDigest([]byte("config")), expected: []string{"API_KEY", "OTHER"}},
+		{name: "extra name", digest: ConfigDigest([]byte("config")), expected: nil},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			file, err := NewHandoffFile()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer file.Close()
+			if err := WriteHandoff(file, ConfigDigest([]byte("config")), Store{"API_KEY": "secret"}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := ReadHandoff(file, test.digest, test.expected); err == nil {
+				t.Fatal("invalid handoff accepted")
+			}
+		})
+	}
+}
+
+func TestReadHandoffRejectsUnsealedFile(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "handoff")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if _, err := ReadHandoff(file, "digest", nil); err == nil {
+		t.Fatal("unsealed handoff accepted")
+	}
+}


### PR DESCRIPTION
## Summary

- keep the single Vault fetch in `tinfoil-boot`, including encrypted-model key references
- pass only config-declared workload secrets to `tinfoil-containers` through a sealed anonymous memfd retained by PID 1
- validate the config digest and exact secret-name set before storing values in the daemon
- inject each container's declared subset without merging Vault values into external config
- reject missing, extra, empty, or model-key-as-container-secret values

This supersedes #344. It preserves boot-time consumers such as encrypted model mounting while fixing the process-boundary regression that prevented Vault values from reaching container environments.

## Security properties

- no Vault-released value is written to a filesystem path
- the handoff is immutable after boot seals it
- model keys remain boot-only
- PID 1 retains the sealed descriptor so a supervised `tinfoil-containers` restart can recover the same in-memory handoff
- runtime config overrides can only request secrets present in the verified boot config

## Validation

- `go test ./...`
- `go test -tags tinfoil_debug_image ./...`
- `go vet ./...`
- `nix-build --no-out-link -I . -A checks -A runtime-go -A debug-pid1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hands off workload secrets in memory from `tinfoil-boot` to `tinfoil-containers` via a sealed `memfd`, replacing container-time reads from external config so Vault values reliably reach container environments.

- Adds `tinfoil/internal/secretstore` for sealed handoff (`WriteHandoff`/`ReadHandoff`), config digesting, and secret reference helpers; enforces seals, size limits, exact-name matching to the verified config, and rejects empty/"null" values.
- `pid1` creates one sealed `memfd` and passes it to both binaries via supervisor extra files with stable child-FD positions; debug console commands reject extra files; supervised restarts reuse the same in-memory data.
- `tinfoil-boot` requires `--secrets-fd`; fetches only missing declared secrets from Vault with strict response matching, fails on unresolved secrets (including model keys), writes a workload-only store, and records a concise boot detail.
- `tinfoil-containers` requires `--secrets-fd`; reads the verified config, checks its digest, and loads the sealed handoff once with the expected workload secret names. Production uses only the sealed store; debug builds secret values for boot requests from external config (normalized via `GetSecret`) and may include additional names.
- Runtime config validation now rejects using a model key secret as a container secret.
- Required migration for manual invocations: pass the same sealed descriptor via `--secrets-fd` to both `tinfoil-boot` and `tinfoil-containers`.

<sup>Written for commit 48c9262470b6533f5cfa8ab7e0722ac50e82a71b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

