### PR TITLE
Isolate private model mounts per container

### DIFF
--- a/docs/runtime-policy.md
+++ b/docs/runtime-policy.md
@@ -54,3 +54,9 @@ including in measured debug mode. The container manager pulls that exact
 reference and verifies Docker's inspected repository digests before creating
 the container; mutable tag-only references are always rejected during
 configuration validation.
+
+Encrypted models require an explicit `containers[].models` grant. Boot mounts
+granted models outside the shared public ramdisk and the container manager
+binds each model read-only at `/tinfoil/models/<name>` only in the named
+containers. Ungranted plaintext model packs retain the legacy shared layout
+for compatibility; adding a grant moves them to the isolated layout.

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-j2QA8RuJvQ1sQC+DjswIH6d9Ayckx+dt8CnEstVNRcE=";
+    vendorHash = "sha256-KTq0SxXd6KjHAzTNKinhszi/5Xtfp62qwD4PtHgU69M=";
     ldflags = [
       "-s"
       "-w"

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-KTq0SxXd6KjHAzTNKinhszi/5Xtfp62qwD4PtHgU69M=";
+    vendorHash = "sha256-Pai94mgQANx1SwSCTqfgO5xGeKmEIjxsSeRsNk3LnYk=";
     ldflags = [
       "-s"
       "-w"

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -46,6 +46,12 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 		}
 		seen[ref.mapperName()] = struct{}{}
 		mountPoint, legacyAlias := modelMountTarget(config, model, ref)
+		if !legacyAlias {
+			containerMountPoint := boot.PublicModelsDir + "/" + model.Name
+			if err := os.MkdirAll(containerMountPoint, 0755); err != nil {
+				return fmt.Errorf("creating container mount point for model %q: %w", model.Name, err)
+			}
+		}
 
 		switch kind {
 		case modelKindPlaintext:

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -16,6 +16,7 @@ import (
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/device"
 	"tinfoil/internal/devicemapper"
+	"tinfoil/internal/runtimeconfig"
 )
 
 const (
@@ -31,6 +32,9 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 	}
 
 	log.Printf("Mounting %d model packs", len(config.Models))
+	if err := os.MkdirAll(boot.PublicModelsDir, 0755); err != nil {
+		return fmt.Errorf("creating container model directory: %w", err)
+	}
 	seen := map[string]struct{}{}
 	for index, model := range config.Models {
 		ref, kind, err := modelPackRefForModel(model)
@@ -41,6 +45,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 			return fmt.Errorf("duplicate model pack root hash: %s", ref.RootHash)
 		}
 		seen[ref.mapperName()] = struct{}{}
+		mountPoint, legacyAlias := modelMountTarget(config, model, ref)
 
 		switch kind {
 		case modelKindPlaintext:
@@ -52,7 +57,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 			if err != nil {
 				return fmt.Errorf("finding model disk %d: %w", index, err)
 			}
-			if err := mountModelPack(ref, salt, sourceDevice); err != nil {
+			if err := mountModelPack(ref, salt, sourceDevice, mountPoint, legacyAlias); err != nil {
 				return fmt.Errorf("mounting model pack %s: %w", ref.raw, err)
 			}
 		case modelKindEncrypted:
@@ -60,7 +65,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 			if err != nil {
 				return fmt.Errorf("finding encrypted model partition %d: %w", index, err)
 			}
-			if err := mountEncryptedModelPack(model, externalConfig, sourceDevice); err != nil {
+			if err := mountEncryptedModelPack(model, externalConfig, sourceDevice, mountPoint); err != nil {
 				return fmt.Errorf("mounting encrypted model pack %q: %w", model.Name, err)
 			}
 		}
@@ -81,16 +86,19 @@ func modelSalt(model ModelSpec) ([]byte, error) {
 }
 
 // mountModelPack mounts a plaintext model wrap using dm-verity.
-func mountModelPack(spec *modelPackRef, salt []byte, sourceDevice string) error {
+func mountModelPack(spec *modelPackRef, salt []byte, sourceDevice, mountPoint string, legacyAlias bool) error {
 	deviceName := spec.mapperName()
-	mountPoint := spec.mountPoint()
 
 	log.Printf("Opening verity device %s (uuid=%s)", deviceName, spec.UUID)
-	if err := createLegacyModelPackAlias(spec); err != nil {
-		return err
+	if legacyAlias {
+		if err := createLegacyModelPackAlias(spec); err != nil {
+			return err
+		}
 	}
 	if err := openAndMountVerity(sourceDevice, deviceName, spec.RootHash, spec.HashOffset, salt, mountPoint); err != nil {
-		removeLegacyModelPackAlias(spec)
+		if legacyAlias {
+			removeLegacyModelPackAlias(spec)
+		}
 		return err
 	}
 
@@ -104,7 +112,7 @@ func mountModelPack(spec *modelPackRef, salt []byte, sourceDevice string) error 
 func mountEncryptedModelPack(
 	model ModelSpec,
 	externalConfig *shimconfig.ExternalConfig,
-	sourceDevice string,
+	sourceDevice, mountPoint string,
 ) error {
 	spec, err := parseModelPackRef(model.EMWP)
 	if err != nil {
@@ -123,12 +131,7 @@ func mountEncryptedModelPack(
 
 	cryptName := fmt.Sprintf("emwp-%s-crypt", spec.RootHash)
 	verityName := spec.mapperName()
-	mountPoint := spec.mountPoint()
-
 	log.Printf("Opening encrypted model pack %s (uuid=%s)", modelLogName(model.Name, spec.RootHash), spec.UUID)
-	if err := createLegacyModelPackAlias(spec); err != nil {
-		return err
-	}
 	if err := openEncryptedAndMount(
 		directModelVolumeOps{},
 		sourceDevice,
@@ -140,12 +143,18 @@ func mountEncryptedModelPack(
 		mountPoint,
 		key,
 	); err != nil {
-		removeLegacyModelPackAlias(spec)
 		return err
 	}
 
 	log.Printf("Mounted encrypted model pack %s at %s", modelLogName(model.Name, spec.RootHash), mountPoint)
 	return nil
+}
+
+func modelMountTarget(config *Config, model ModelSpec, spec *modelPackRef) (string, bool) {
+	if runtimeconfig.ModelIsIsolated(config, model.Name) {
+		return boot.PrivateModelsDir + "/" + model.Name, false
+	}
+	return spec.mountPoint(), true
 }
 
 func createLegacyModelPackAlias(spec *modelPackRef) error {

--- a/tinfoil/cmd/boot/models_integration_test.go
+++ b/tinfoil/cmd/boot/models_integration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 )
 
@@ -29,9 +30,10 @@ func TestMountEncryptedModelPackIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parsing EMWP ref: %v", err)
 	}
-	cleanupEMWPIntegration(spec)
+	mountPoint := boot.PrivateModelsDir + "/emwp-integration"
+	cleanupEMWPIntegration(spec, mountPoint)
 	t.Cleanup(func() {
-		cleanupEMWPIntegration(spec)
+		cleanupEMWPIntegration(spec, mountPoint)
 	})
 
 	err = mountEncryptedModelPack(ModelSpec{
@@ -41,23 +43,19 @@ func TestMountEncryptedModelPackIntegration(t *testing.T) {
 		KeySecret: "PRIVATE_MODEL_KEY",
 	}, &shimconfig.ExternalConfig{
 		Secrets: map[string]string{"PRIVATE_MODEL_KEY": key},
-	}, device)
+	}, device, mountPoint)
 	if err != nil {
 		t.Fatalf("mounting EMWP: %v", err)
 	}
 
-	if _, err := os.Stat(filepath.Join(spec.mountPoint(), "config.json")); err != nil {
+	if _, err := os.Stat(filepath.Join(mountPoint, "config.json")); err != nil {
 		t.Fatalf("checking mounted file: %v", err)
-	}
-	if _, err := os.Lstat(spec.legacyMountPoint()); err != nil {
-		t.Fatalf("checking legacy mount alias: %v", err)
 	}
 }
 
-func cleanupEMWPIntegration(spec *modelPackRef) {
-	_ = unix.Unmount(spec.mountPoint(), 0)
+func cleanupEMWPIntegration(spec *modelPackRef, mountPoint string) {
+	_ = unix.Unmount(mountPoint, 0)
 	ops := directModelVolumeOps{}
 	_ = ops.remove(spec.mapperName())
 	_ = ops.remove("emwp-" + spec.RootHash + "-crypt")
-	removeLegacyModelPackAlias(spec)
 }

--- a/tinfoil/cmd/boot/models_test.go
+++ b/tinfoil/cmd/boot/models_test.go
@@ -42,6 +42,22 @@ func TestModelPackRefLayout(t *testing.T) {
 	}
 }
 
+func TestModelMountTarget(t *testing.T) {
+	ref := &modelPackRef{ArtifactRef: &modelwrap.ArtifactRef{RootHash: strings.Repeat("a", 64)}}
+	model := ModelSpec{Name: "private-model"}
+
+	isolatedConfig := &Config{Containers: []Container{{Models: []string{model.Name}}}}
+	mountPoint, legacyAlias := modelMountTarget(isolatedConfig, model, ref)
+	if mountPoint != boot.PrivateModelsDir+"/"+model.Name || legacyAlias {
+		t.Fatalf("isolated target = (%q, %t)", mountPoint, legacyAlias)
+	}
+
+	mountPoint, legacyAlias = modelMountTarget(&Config{}, model, ref)
+	if mountPoint != ref.mountPoint() || !legacyAlias {
+		t.Fatalf("legacy target = (%q, %t)", mountPoint, legacyAlias)
+	}
+}
+
 func TestVerityTableUsesFixedModelwrapContract(t *testing.T) {
 	rootHash := strings.Repeat("a", 64)
 	salt := bytes.Repeat([]byte{0x5a}, veritySaltSize)

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2
 	github.com/tinfoilsh/modelwrap v0.2.1
-	github.com/tinfoilsh/tinfoil-config v0.1.3-0.20260824183327-c454347528df
+	github.com/tinfoilsh/tinfoil-config v0.1.3
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2
 	github.com/tinfoilsh/modelwrap v0.2.1
-	github.com/tinfoilsh/tinfoil-config v0.1.2
+	github.com/tinfoilsh/tinfoil-config v0.1.3-0.20260824183327-c454347528df
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -95,8 +95,8 @@ github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2 h1:yKxfC3pVJ4ORwLeHwflv
 github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2/go.mod h1:THDK0GFNny7Pcc+nO3AQi4f6Wf1cDkfLatmHAUlIn5s=
 github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgXKbq0=
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
-github.com/tinfoilsh/tinfoil-config v0.1.2 h1:d/OIAg5WpTZojRIteX94pZEXrVFbFDNXR3+XBj49vMY=
-github.com/tinfoilsh/tinfoil-config v0.1.2/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
+github.com/tinfoilsh/tinfoil-config v0.1.3-0.20260824183327-c454347528df h1:fUUndO8fR0RAfjelFtQeor2bCgo48Ev1R6kmYkTAYZs=
+github.com/tinfoilsh/tinfoil-config v0.1.3-0.20260824183327-c454347528df/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513 h1:bKenHmdOAI0zEBb8iCtSRzN5YgFNNuja29IN95fieqg=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513/go.mod h1:GPckBb5gXbgwcVYAM6UaS5hb+cuHkHJzy//vebjSRLQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -95,8 +95,8 @@ github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2 h1:yKxfC3pVJ4ORwLeHwflv
 github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2/go.mod h1:THDK0GFNny7Pcc+nO3AQi4f6Wf1cDkfLatmHAUlIn5s=
 github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgXKbq0=
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
-github.com/tinfoilsh/tinfoil-config v0.1.3-0.20260824183327-c454347528df h1:fUUndO8fR0RAfjelFtQeor2bCgo48Ev1R6kmYkTAYZs=
-github.com/tinfoilsh/tinfoil-config v0.1.3-0.20260824183327-c454347528df/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
+github.com/tinfoilsh/tinfoil-config v0.1.3 h1:A5q0aurQB+4scDUH1SlXIQhxgK0wnQ5iw0q1UMT5D1Q=
+github.com/tinfoilsh/tinfoil-config v0.1.3/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513 h1:bKenHmdOAI0zEBb8iCtSRzN5YgFNNuja29IN95fieqg=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513/go.mod h1:GPckBb5gXbgwcVYAM6UaS5hb+cuHkHJzy//vebjSRLQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/internal/boot/paths.go
+++ b/tinfoil/internal/boot/paths.go
@@ -9,11 +9,13 @@ const (
 	ConfigPath          = PublicDir + "/config.yml"
 	AttestationPath     = PublicDir + "/attestation.json"
 	ContainerStatusPath = PublicDir + "/container-status.json"
+	PublicModelsDir     = PublicDir + "/models"
 	MWPDir              = PublicDir + "/mwp"
 	MPKDir              = PublicDir + "/mpk" // Legacy alias directory for MWP mounts.
+	ContainerModelsDir  = "/tinfoil/models"
 
-	// Private — only accessible to boot, egress, and shim processes (mode 0700).
-	// Holds CVM-level secrets and material that must never reach a container.
+	// Private — not globally mounted into containers (mode 0700). Explicitly
+	// granted model directories are the only read-only container exception.
 	TLSDir                = PrivateDir + "/tls"
 	TLSCertPath           = TLSDir + "/cert.pem"
 	TLSKeyPath            = TLSDir + "/key.pem"
@@ -22,6 +24,7 @@ const (
 	ShimConfigPath        = PrivateDir + "/shim.yml"
 	EgressConfigPath      = PrivateDir + "/egress.yml"
 	ExternalConfigPath    = PrivateDir + "/external-config.yml"
+	PrivateModelsDir      = PrivateDir + "/models"
 	RuntimeConfigPath     = PrivateDir + "/runtime-config.yml"
 	RuntimeBootedPath     = PrivateDir + "/runtime-booted"
 	DockerConfigDir       = PrivateDir + "/docker-config"

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -479,6 +479,11 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 		Tmpfs:          c.Tmpfs,
 		Binds:          []string{boot.PublicDir + ":/tinfoil:ro"},
 	}
+	for _, model := range c.Models {
+		hostConfig.Binds = append(hostConfig.Binds,
+			boot.PrivateModelsDir+"/"+model+":"+boot.ContainerModelsDir+"/"+model+":ro",
+		)
+	}
 	hostConfig.Resources.PidsLimit = pidsLimit
 	if first == "" {
 		hostConfig.NetworkMode = "none"

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -277,7 +277,7 @@ func TestBuildContainerCreateSpec_BindsOnlyGrantedModels(t *testing.T) {
 		Models: []string{"private-model"},
 	}
 
-	_, hostConfig, _, _, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, false)
+	_, hostConfig, _, _, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, nil, false)
 	if err != nil {
 		t.Fatalf("buildContainerCreateSpec: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestBuildContainerCreateSpec_BindsOnlyGrantedModels(t *testing.T) {
 	_, ungrantedHostConfig, _, _, err := buildContainerCreateSpec(Container{
 		Name:  "sidecar",
 		Image: "example.invalid/sidecar",
-	}, cfg, &shimconfig.ExternalConfig{}, false)
+	}, cfg, &shimconfig.ExternalConfig{}, nil, false)
 	if err != nil {
 		t.Fatalf("buildContainerCreateSpec: %v", err)
 	}

--- a/tinfoil/internal/containers/containers_test.go
+++ b/tinfoil/internal/containers/containers_test.go
@@ -2,12 +2,14 @@ package containers
 
 import (
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/moby/moby/api/types/container"
 	dockernetwork "github.com/moby/moby/api/types/network"
 
+	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/containernet"
 	"tinfoil/internal/secretstore"
@@ -264,5 +266,36 @@ func TestBuildContainerCreateSpec_ProductionInstallerKeepsRuntimeClosed(t *testi
 	}
 	if len(hostConfig.Devices) != 0 {
 		t.Fatalf("Devices = %v, want no synthesized device mappings", hostConfig.Devices)
+	}
+}
+
+func TestBuildContainerCreateSpec_BindsOnlyGrantedModels(t *testing.T) {
+	cfg := &Config{Networks: map[string]*NetworkSpec{}}
+	c := Container{
+		Name:   "inference",
+		Image:  "example.invalid/inference",
+		Models: []string{"private-model"},
+	}
+
+	_, hostConfig, _, _, err := buildContainerCreateSpec(c, cfg, &shimconfig.ExternalConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildContainerCreateSpec: %v", err)
+	}
+	want := boot.PrivateModelsDir + "/private-model:" + boot.ContainerModelsDir + "/private-model:ro"
+	if !slices.Contains(hostConfig.Binds, want) {
+		t.Fatalf("Binds = %v, want %q", hostConfig.Binds, want)
+	}
+
+	_, ungrantedHostConfig, _, _, err := buildContainerCreateSpec(Container{
+		Name:  "sidecar",
+		Image: "example.invalid/sidecar",
+	}, cfg, &shimconfig.ExternalConfig{}, false)
+	if err != nil {
+		t.Fatalf("buildContainerCreateSpec: %v", err)
+	}
+	for _, bind := range ungrantedHostConfig.Binds {
+		if strings.HasPrefix(bind, boot.PrivateModelsDir+"/") {
+			t.Fatalf("ungranted Binds = %v", ungrantedHostConfig.Binds)
+		}
 	}
 }

--- a/tinfoil/internal/runtimeconfig/types.go
+++ b/tinfoil/internal/runtimeconfig/types.go
@@ -30,6 +30,10 @@ func Validate(config *Config, debug bool) error {
 	return sharedconfig.Validate(config, options(debug))
 }
 
+func ModelIsIsolated(config *Config, name string) bool {
+	return sharedconfig.ModelIsIsolated(config, name)
+}
+
 func ReservedDebugRuntimeEnabled(containerName string, debug bool) bool {
 	return sharedconfig.ReservedDebugRuntimeEnabled(containerName, options(debug))
 }

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -93,7 +93,7 @@ func TestDecodeValidatesModelAccess(t *testing.T) {
 		{name: "encrypted model without grant", yaml: base, want: "requires an explicit container grant"},
 		{name: "unknown model", yaml: strings.Replace(base, "networks: [app]", "networks: [app]\n    models: [unknown]", 1), want: "is not declared"},
 		{name: "duplicate grant", yaml: strings.Replace(base, "networks: [app]", "networks: [app]\n    models: [private-model, private-model]", 1), want: "is duplicated"},
-		{name: "invalid name", yaml: strings.Replace(strings.Replace(base, "private-model", "../private", 1), "networks: [app]", "networks: [app]\n    models: [../private]", 1), want: "name \"../private\" is invalid"},
+		{name: "invalid name", yaml: strings.Replace(strings.Replace(base, "private-model", "../private", 1), "networks: [app]", "networks: [app]\n    models: [../private]", 1), want: "\"../private\" is invalid"},
 		{name: "duplicate model", yaml: strings.Replace(strings.Replace(base, "containers:\n", "  - name: private-model\n    mwp: "+ref+"\ncontainers:\n", 1), "networks: [app]", "networks: [app]\n    models: [private-model]", 1), want: "duplicates"},
 	} {
 		t.Run(test.name, func(t *testing.T) {
@@ -110,6 +110,10 @@ func TestDecodeValidatesModelAccess(t *testing.T) {
 	plaintext := strings.Replace(validConfig, "containers:\n", "models:\n  - name: public-model\n    mwp: "+ref+"\ncontainers:\n", 1)
 	if _, err := Decode([]byte(plaintext), false); err != nil {
 		t.Fatalf("legacy plaintext model without grant: %v", err)
+	}
+	namelessPlaintext := strings.Replace(plaintext, "  - name: public-model\n    mwp:", "  - mwp:", 1)
+	if _, err := Decode([]byte(namelessPlaintext), false); err != nil {
+		t.Fatalf("legacy nameless plaintext model: %v", err)
 	}
 }
 

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -76,6 +76,43 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 	}
 }
 
+func TestDecodeValidatesModelAccess(t *testing.T) {
+	const ref = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_4096_0eefa619-50b7-588f-a072-d405fb439d36"
+	base := strings.Replace(validConfig,
+		"containers:\n",
+		"models:\n  - name: private-model\n    repo: org/model@revision\n    emwp: "+ref+"\n    key-secret: MODEL_KEY\ncontainers:\n",
+		1,
+	)
+
+	for _, test := range []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{name: "explicit grant", yaml: strings.Replace(base, "networks: [app]", "networks: [app]\n    models: [private-model]", 1)},
+		{name: "encrypted model without grant", yaml: base, want: "requires an explicit container grant"},
+		{name: "unknown model", yaml: strings.Replace(base, "networks: [app]", "networks: [app]\n    models: [unknown]", 1), want: "is not declared"},
+		{name: "duplicate grant", yaml: strings.Replace(base, "networks: [app]", "networks: [app]\n    models: [private-model, private-model]", 1), want: "is duplicated"},
+		{name: "invalid name", yaml: strings.Replace(strings.Replace(base, "private-model", "../private", 1), "networks: [app]", "networks: [app]\n    models: [../private]", 1), want: "name \"../private\" is invalid"},
+		{name: "duplicate model", yaml: strings.Replace(strings.Replace(base, "containers:\n", "  - name: private-model\n    mwp: "+ref+"\ncontainers:\n", 1), "networks: [app]", "networks: [app]\n    models: [private-model]", 1), want: "duplicates"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Decode([]byte(test.yaml), false)
+			if test.want == "" && err != nil {
+				t.Fatal(err)
+			}
+			if test.want != "" && (err == nil || !strings.Contains(err.Error(), test.want)) {
+				t.Fatalf("error = %v, want substring %q", err, test.want)
+			}
+		})
+	}
+
+	plaintext := strings.Replace(validConfig, "containers:\n", "models:\n  - name: public-model\n    mwp: "+ref+"\ncontainers:\n", 1)
+	if _, err := Decode([]byte(plaintext), false); err != nil {
+		t.Fatalf("legacy plaintext model without grant: %v", err)
+	}
+}
+
 func TestDecodeValidatesGPUSelections(t *testing.T) {
 	base := strings.Replace(validConfig, "cvm-version: 0.11.0", "cvm-version: 0.11.0\ngpus: 2", 1)
 	for _, test := range []struct {


### PR DESCRIPTION
## Summary
- add explicit `containers[].models` access grants
- keep ungranted plaintext `mpk`/`mwp` models on the shared legacy paths
- mount granted models privately and bind them read-only only into authorized containers
- require encrypted `emwp` models to have at least one explicit container grant

Granted models are available at `/tinfoil/models/<name>`. Legacy plaintext models remain available at `/tinfoil/mwp/<hash>` and `/tinfoil/mpk/<hash>`, preserving existing workloads while repositories migrate independently.

Uses released tinfoil-config v0.1.3.

## Validation
- `go test ./internal/runtimeconfig ./internal/containers ./cmd/boot`
- `nix-build --no-out-link -I . -A checks`
- `nix-build --no-out-link -I . -A runtime-go -A debug-pid1 -A initrd`
- prior full-image SEV-SNP qualification with `confidential-pii-cpu` remains applicable to the isolated path