### PR TITLE
Expose container restart metrics

### DIFF
--- a/tinfoil/internal/containers/status.go
+++ b/tinfoil/internal/containers/status.go
@@ -20,7 +20,12 @@ import (
 )
 
 const (
-	pollInterval = 5 * time.Second
+	pollInterval             = 5 * time.Second
+	restartReasonOOMKilled   = "oom_killed"
+	restartReasonNonzero     = "nonzero_exit"
+	restartReasonClean       = "clean_exit"
+	restartReasonReplacement = "replacement"
+	restartReasonUnknown     = "unknown"
 )
 
 type declaredContainer struct {
@@ -44,20 +49,22 @@ type containersResponse struct {
 }
 
 type containerStatus struct {
-	Name          string           `json:"name"`
-	ContainerID   string           `json:"container_id,omitempty"`
-	Image         string           `json:"image"`
-	Declared      bool             `json:"declared"`
-	Created       bool             `json:"created"`
-	Status        string           `json:"status,omitempty"`
-	RestartCount  int              `json:"restart_count"`
-	RestartPolicy string           `json:"restart_policy,omitempty"`
-	OOMKilled     bool             `json:"oom_killed"`
-	ExitCode      int              `json:"exit_code"`
-	Error         string           `json:"error,omitempty"`
-	StartedAt     string           `json:"started_at,omitempty"`
-	FinishedAt    string           `json:"finished_at,omitempty"`
-	Health        *containerHealth `json:"health,omitempty"`
+	Name              string           `json:"name"`
+	ContainerID       string           `json:"container_id,omitempty"`
+	Image             string           `json:"image"`
+	Declared          bool             `json:"declared"`
+	Created           bool             `json:"created"`
+	Status            string           `json:"status,omitempty"`
+	RestartCount      int              `json:"restart_count"`
+	RestartCounts     map[string]int   `json:"restart_counts,omitempty"`
+	LastRestartReason string           `json:"last_restart_reason,omitempty"`
+	RestartPolicy     string           `json:"restart_policy,omitempty"`
+	OOMKilled         bool             `json:"oom_killed"`
+	ExitCode          int              `json:"exit_code"`
+	Error             string           `json:"error,omitempty"`
+	StartedAt         string           `json:"started_at,omitempty"`
+	FinishedAt        string           `json:"finished_at,omitempty"`
+	Health            *containerHealth `json:"health,omitempty"`
 }
 
 type containerHealth struct {
@@ -184,17 +191,64 @@ func mergeContainerLifecycles(previous, current []containerStatus) {
 	}
 	for i := range current {
 		prior, ok := byName[current[i].Name]
-		if !ok || !prior.Created || !current[i].Created {
+		if !ok {
+			current[i].RestartCounts = restartCountsWithUnknown(nil, current[i].RestartCount)
+			if current[i].RestartCount > 0 {
+				current[i].LastRestartReason = restartReasonUnknown
+			}
 			continue
 		}
-		observedReplacement := prior.ContainerID != "" && current[i].ContainerID != "" && prior.ContainerID != current[i].ContainerID
-		observedRestart := prior.StartedAt != "" && current[i].StartedAt != "" && prior.StartedAt != current[i].StartedAt
+
+		current[i].RestartCounts = restartCountsWithUnknown(prior.RestartCounts, prior.RestartCount)
+		current[i].LastRestartReason = prior.LastRestartReason
+		observedReplacement := prior.Created && current[i].Created && prior.ContainerID != "" && current[i].ContainerID != "" && prior.ContainerID != current[i].ContainerID
+		observedRestart := prior.Created && current[i].Created && prior.StartedAt != "" && current[i].StartedAt != "" && prior.StartedAt != current[i].StartedAt
+		restartCount := max(current[i].RestartCount, prior.RestartCount)
 		if observedReplacement || observedRestart {
-			current[i].RestartCount = max(current[i].RestartCount, prior.RestartCount+1)
-		} else {
-			current[i].RestartCount = max(current[i].RestartCount, prior.RestartCount)
+			restartCount = max(restartCount, prior.RestartCount+1)
 		}
+		if delta := restartCount - prior.RestartCount; delta > 0 {
+			reason := classifyRestart(prior, current[i], observedReplacement)
+			current[i].RestartCounts[reason]++
+			if delta > 1 {
+				current[i].RestartCounts[restartReasonUnknown] += delta - 1
+			}
+			current[i].LastRestartReason = reason
+		}
+		current[i].RestartCount = restartCount
 	}
+}
+
+func restartCountsWithUnknown(counts map[string]int, total int) map[string]int {
+	out := make(map[string]int, len(counts)+1)
+	recorded := 0
+	for reason, count := range counts {
+		if count <= 0 {
+			continue
+		}
+		out[reason] = count
+		recorded += count
+	}
+	if recorded < total {
+		out[restartReasonUnknown] += total - recorded
+	}
+	return out
+}
+
+func classifyRestart(previous, current containerStatus, replacement bool) string {
+	if replacement {
+		return restartReasonReplacement
+	}
+	if current.OOMKilled || previous.OOMKilled {
+		return restartReasonOOMKilled
+	}
+	if current.ExitCode != 0 || previous.ExitCode != 0 {
+		return restartReasonNonzero
+	}
+	if current.Status == "restarting" || previous.Status == "exited" {
+		return restartReasonClean
+	}
+	return restartReasonUnknown
 }
 
 func loadDeclaredContainers(path string) ([]declaredContainer, error) {

--- a/tinfoil/internal/containers/status_test.go
+++ b/tinfoil/internal/containers/status_test.go
@@ -255,6 +255,80 @@ func TestMergeContainerLifecyclesCountsReplacement(t *testing.T) {
 	if current[0].RestartCount != 3 {
 		t.Fatalf("restart_count = %d, want 3", current[0].RestartCount)
 	}
+	if current[0].RestartCounts[restartReasonReplacement] != 1 || current[0].RestartCounts[restartReasonUnknown] != 2 {
+		t.Fatalf("restart counts = %#v", current[0].RestartCounts)
+	}
+	if current[0].LastRestartReason != restartReasonReplacement {
+		t.Fatalf("last restart reason = %q", current[0].LastRestartReason)
+	}
+}
+
+func TestMergeContainerLifecyclesTracksOOMRestart(t *testing.T) {
+	current := []containerStatus{{
+		Name:         "model",
+		ContainerID:  "container-id",
+		Created:      true,
+		Status:       "restarting",
+		RestartCount: 3,
+		OOMKilled:    true,
+		ExitCode:     137,
+		StartedAt:    "2026-07-25T01:01:00Z",
+	}}
+	mergeContainerLifecycles([]containerStatus{{
+		Name:          "model",
+		ContainerID:   "container-id",
+		Created:       true,
+		Status:        "running",
+		RestartCount:  1,
+		RestartCounts: map[string]int{restartReasonNonzero: 1},
+		StartedAt:     "2026-07-25T01:00:00Z",
+	}}, current)
+
+	if current[0].RestartCount != 3 {
+		t.Fatalf("restart_count = %d, want 3", current[0].RestartCount)
+	}
+	if current[0].RestartCounts[restartReasonNonzero] != 1 || current[0].RestartCounts[restartReasonOOMKilled] != 1 || current[0].RestartCounts[restartReasonUnknown] != 1 {
+		t.Fatalf("restart counts = %#v", current[0].RestartCounts)
+	}
+	if current[0].LastRestartReason != restartReasonOOMKilled {
+		t.Fatalf("last restart reason = %q", current[0].LastRestartReason)
+	}
+}
+
+func TestMergeContainerLifecyclesBackfillsLegacyCounts(t *testing.T) {
+	current := []containerStatus{{Name: "model", Created: false}}
+	mergeContainerLifecycles([]containerStatus{{
+		Name:         "model",
+		Created:      true,
+		RestartCount: 4,
+	}}, current)
+
+	if current[0].RestartCount != 4 || current[0].RestartCounts[restartReasonUnknown] != 4 {
+		t.Fatalf("restart state = %#v", current[0])
+	}
+}
+
+func TestClassifyRestart(t *testing.T) {
+	tests := []struct {
+		name        string
+		previous    containerStatus
+		current     containerStatus
+		replacement bool
+		want        string
+	}{
+		{name: "replacement", replacement: true, want: restartReasonReplacement},
+		{name: "oom killed", current: containerStatus{OOMKilled: true, ExitCode: 137}, want: restartReasonOOMKilled},
+		{name: "nonzero exit", current: containerStatus{ExitCode: 1}, want: restartReasonNonzero},
+		{name: "clean exit", current: containerStatus{Status: "restarting"}, want: restartReasonClean},
+		{name: "cause no longer observable", previous: containerStatus{Status: "running"}, current: containerStatus{Status: "running"}, want: restartReasonUnknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := classifyRestart(test.previous, test.current, test.replacement); got != test.want {
+				t.Fatalf("classifyRestart() = %q, want %q", got, test.want)
+			}
+		})
+	}
 }
 
 func TestPreservePreviousContainerStatusesAfterInspectFailure(t *testing.T) {

--- a/tinfoil/internal/metrics/containers.go
+++ b/tinfoil/internal/metrics/containers.go
@@ -1,0 +1,209 @@
+package metrics
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var containerRestartReasons = []string{
+	"oom_killed",
+	"nonzero_exit",
+	"clean_exit",
+	"replacement",
+	"unknown",
+}
+
+type containerStatusSnapshot struct {
+	Containers []containerMetricStatus `json:"containers"`
+}
+
+type containerMetricStatus struct {
+	Name          string                 `json:"name"`
+	Status        string                 `json:"status"`
+	RestartCount  int                    `json:"restart_count"`
+	RestartCounts map[string]int         `json:"restart_counts"`
+	OOMKilled     bool                   `json:"oom_killed"`
+	ExitCode      int                    `json:"exit_code"`
+	Health        *containerMetricHealth `json:"health"`
+}
+
+type containerMetricHealth struct {
+	Status        string `json:"status"`
+	FailingStreak int    `json:"failing_streak"`
+}
+
+type containerPrometheusSnapshot struct {
+	metrics    Metrics
+	containers []containerMetricStatus
+}
+
+type containerPrometheusCollector struct {
+	mu sync.RWMutex
+
+	snapshot containerPrometheusSnapshot
+
+	restarting          *prometheus.Desc
+	restarts            *prometheus.Desc
+	oomKilled           *prometheus.Desc
+	lastExitCode        *prometheus.Desc
+	state               *prometheus.Desc
+	healthStatus        *prometheus.Desc
+	healthFailingStreak *prometheus.Desc
+}
+
+func newContainerPrometheusCollector() *containerPrometheusCollector {
+	containerLabels := append(append([]string{}, baseLabels...), "container")
+	return &containerPrometheusCollector{
+		restarting: prometheus.NewDesc(
+			"tfshim_container_restarting",
+			"Whether the container is currently restarting (1 for restarting, 0 otherwise)",
+			containerLabels,
+			nil,
+		),
+		restarts: prometheus.NewDesc(
+			"tfshim_container_restarts_total",
+			"Cumulative container restarts observed during the enclave lifecycle, partitioned by reason",
+			append(append([]string{}, containerLabels...), "reason"),
+			nil,
+		),
+		oomKilled: prometheus.NewDesc(
+			"tfshim_container_oom_killed",
+			"Whether the container's current state reports an OOM kill (1 for OOM killed, 0 otherwise)",
+			containerLabels,
+			nil,
+		),
+		lastExitCode: prometheus.NewDesc(
+			"tfshim_container_last_exit_code",
+			"Last exit code reported by the container runtime",
+			containerLabels,
+			nil,
+		),
+		state: prometheus.NewDesc(
+			"tfshim_container_state",
+			"Current container runtime state",
+			append(append([]string{}, containerLabels...), "state"),
+			nil,
+		),
+		healthStatus: prometheus.NewDesc(
+			"tfshim_container_health_status",
+			"Current container health-check status",
+			append(append([]string{}, containerLabels...), "status"),
+			nil,
+		),
+		healthFailingStreak: prometheus.NewDesc(
+			"tfshim_container_health_failing_streak",
+			"Number of consecutive failed container health checks",
+			containerLabels,
+			nil,
+		),
+	}
+}
+
+func (c *containerPrometheusCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.restarting
+	ch <- c.restarts
+	ch <- c.oomKilled
+	ch <- c.lastExitCode
+	ch <- c.state
+	ch <- c.healthStatus
+	ch <- c.healthFailingStreak
+}
+
+func (c *containerPrometheusCollector) Collect(ch chan<- prometheus.Metric) {
+	c.mu.RLock()
+	snapshot := c.snapshot
+	c.mu.RUnlock()
+
+	for _, container := range snapshot.containers {
+		labels := containerMetricLabels(&snapshot.metrics, container.Name)
+		ch <- prometheus.MustNewConstMetric(c.restarting, prometheus.GaugeValue, boolFloat(container.Status == "restarting"), labels...)
+		ch <- prometheus.MustNewConstMetric(c.oomKilled, prometheus.GaugeValue, boolFloat(container.OOMKilled), labels...)
+		ch <- prometheus.MustNewConstMetric(c.lastExitCode, prometheus.GaugeValue, float64(container.ExitCode), labels...)
+
+		state := container.Status
+		if state == "" {
+			state = "unknown"
+		}
+		ch <- prometheus.MustNewConstMetric(c.state, prometheus.GaugeValue, 1, append(labels, state)...)
+
+		healthStatus := "none"
+		failingStreak := 0
+		if container.Health != nil {
+			healthStatus = container.Health.Status
+			if healthStatus == "" {
+				healthStatus = "unknown"
+			}
+			failingStreak = container.Health.FailingStreak
+		}
+		ch <- prometheus.MustNewConstMetric(c.healthStatus, prometheus.GaugeValue, 1, append(labels, healthStatus)...)
+		ch <- prometheus.MustNewConstMetric(c.healthFailingStreak, prometheus.GaugeValue, float64(failingStreak), labels...)
+
+		restartCounts := normalizedRestartCounts(container)
+		for _, reason := range containerRestartReasons {
+			ch <- prometheus.MustNewConstMetric(c.restarts, prometheus.CounterValue, float64(restartCounts[reason]), append(labels, reason)...)
+		}
+	}
+}
+
+func (c *containerPrometheusCollector) update(metrics *Metrics, containers []containerMetricStatus) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.snapshot.metrics = *metrics
+	c.snapshot.containers = append([]containerMetricStatus(nil), containers...)
+}
+
+func loadContainerMetricStatuses(path string) ([]containerMetricStatus, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var snapshot containerStatusSnapshot
+	if err := json.Unmarshal(data, &snapshot); err != nil {
+		return nil, err
+	}
+	return snapshot.Containers, nil
+}
+
+func normalizedRestartCounts(container containerMetricStatus) map[string]int {
+	counts := make(map[string]int, len(containerRestartReasons))
+	recorded := 0
+	for _, reason := range containerRestartReasons {
+		if count := container.RestartCounts[reason]; count > 0 {
+			counts[reason] = count
+			recorded += count
+		}
+	}
+	if recorded < container.RestartCount {
+		counts["unknown"] += container.RestartCount - recorded
+	}
+	return counts
+}
+
+func containerMetricLabels(metrics *Metrics, containerName string) []string {
+	gpuType := metrics.GPUType
+	if gpuType == "" {
+		gpuType = "none"
+	}
+	return []string{
+		metrics.ID,
+		metrics.Domain,
+		metrics.Image,
+		metrics.CPUType,
+		gpuType,
+		containerName,
+	}
+}
+
+func boolFloat(value bool) float64 {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/tinfoil/internal/metrics/containers_test.go
+++ b/tinfoil/internal/metrics/containers_test.go
@@ -1,0 +1,66 @@
+package metrics
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func TestContainerPrometheusCollector(t *testing.T) {
+	collector := newContainerPrometheusCollector()
+	collector.update(&Metrics{
+		ID:      "enclave-1",
+		Domain:  "model.example.com",
+		Image:   "example/model@v1",
+		CPUType: "AuthenticAMD",
+	}, []containerMetricStatus{{
+		Name:          "model",
+		Status:        "restarting",
+		RestartCount:  4,
+		RestartCounts: map[string]int{"oom_killed": 1, "nonzero_exit": 1},
+		OOMKilled:     true,
+		ExitCode:      137,
+		Health: &containerMetricHealth{
+			Status:        "unhealthy",
+			FailingStreak: 3,
+		},
+	}})
+
+	registry := prometheus.NewPedanticRegistry()
+	registry.MustRegister(collector)
+	recorder := httptest.NewRecorder()
+	promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(recorder, httptest.NewRequest("GET", "/metrics", nil))
+	if recorder.Code != 200 {
+		t.Fatalf("status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+	body := recorder.Body.String()
+	for _, expected := range []string{
+		`# TYPE tfshim_container_restarts_total counter`,
+		`tfshim_container_restarting{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1"} 1`,
+		`tfshim_container_restarts_total{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1",reason="nonzero_exit"} 1`,
+		`tfshim_container_restarts_total{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1",reason="oom_killed"} 1`,
+		`tfshim_container_restarts_total{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1",reason="unknown"} 2`,
+		`tfshim_container_oom_killed{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1"} 1`,
+		`tfshim_container_last_exit_code{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1"} 137`,
+		`tfshim_container_state{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1",state="restarting"} 1`,
+		`tfshim_container_health_status{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1",status="unhealthy"} 1`,
+		`tfshim_container_health_failing_streak{container="model",cpu_type="AuthenticAMD",domain="model.example.com",gpu_type="none",id="enclave-1",image="example/model@v1"} 3`,
+	} {
+		if !strings.Contains(body, expected) {
+			t.Errorf("metrics output missing %q:\n%s", expected, body)
+		}
+	}
+}
+
+func TestNormalizedRestartCountsBackfillsUnknown(t *testing.T) {
+	counts := normalizedRestartCounts(containerMetricStatus{
+		RestartCount:  5,
+		RestartCounts: map[string]int{"oom_killed": 2},
+	})
+	if counts["oom_killed"] != 2 || counts["unknown"] != 3 {
+		t.Fatalf("counts = %#v", counts)
+	}
+}

--- a/tinfoil/internal/metrics/prometheus.go
+++ b/tinfoil/internal/metrics/prometheus.go
@@ -139,9 +139,9 @@ func handlePrometheusMetrics(metadata *config.Metadata, metricsAPIKey, container
 		containers, err := loadContainerMetricStatuses(containerStatusPath)
 		if err != nil {
 			log.Printf("Warning: failed to load container metrics: %v", err)
-			containers = nil
+		} else {
+			containerCollector.update(metrics, containers)
 		}
-		containerCollector.update(metrics, containers)
 		handler.ServeHTTP(w, r)
 	}
 }

--- a/tinfoil/internal/metrics/prometheus.go
+++ b/tinfoil/internal/metrics/prometheus.go
@@ -1,11 +1,13 @@
 package metrics
 
 import (
+	"log"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"tinfoil/internal/auth"
+	"tinfoil/internal/boot"
 	"tinfoil/internal/config"
 )
 
@@ -105,7 +107,12 @@ func updatePrometheusMetrics(metrics *Metrics) {
 
 // HandlePrometheusMetrics handles the /metrics endpoint for Prometheus scraping
 func HandlePrometheusMetrics(metadata *config.Metadata, metricsAPIKey string) http.HandlerFunc {
+	return handlePrometheusMetrics(metadata, metricsAPIKey, boot.ContainerStatusPath)
+}
+
+func handlePrometheusMetrics(metadata *config.Metadata, metricsAPIKey, containerStatusPath string) http.HandlerFunc {
 	registry := prometheus.NewRegistry()
+	containerCollector := newContainerPrometheusCollector()
 	registry.MustRegister(
 		cpuUtilGauge,
 		gpuUtilGauge,
@@ -113,6 +120,7 @@ func HandlePrometheusMetrics(metadata *config.Metadata, metricsAPIKey string) ht
 		gpuMemUtilGauge,
 		cpuMemTotalGauge,
 		gpuMemTotalGauge,
+		containerCollector,
 	)
 	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 
@@ -128,6 +136,12 @@ func HandlePrometheusMetrics(metadata *config.Metadata, metricsAPIKey string) ht
 		}
 
 		updatePrometheusMetrics(metrics)
+		containers, err := loadContainerMetricStatuses(containerStatusPath)
+		if err != nil {
+			log.Printf("Warning: failed to load container metrics: %v", err)
+			containers = nil
+		}
+		containerCollector.update(metrics, containers)
 		handler.ServeHTTP(w, r)
 	}
 }


### PR DESCRIPTION
## Summary

- persist cumulative restart counts by bounded reason in the container status snapshot
- expose restart counters plus current runtime and health gauges on `/.well-known/metrics`
- preserve legacy `restart_count` values by backfilling their cause as `unknown`

## Metrics

- `tfshim_container_restarts_total{container,reason}` with `reason` values `oom_killed`, `nonzero_exit`, `clean_exit`, `replacement`, and `unknown`
- `tfshim_container_restarting`
- `tfshim_container_oom_killed`
- `tfshim_container_last_exit_code`
- `tfshim_container_state{state}`
- `tfshim_container_health_status{status}`
- `tfshim_container_health_failing_streak`

Example restart-history query:

```promql
sum by (reason) (increase(tfshim_container_restarts_total[1h]))
```

The cumulative total catches multiple restarts between Prometheus scrapes. When multiple restarts occur between the enclave’s five-second runtime observations, only the latest observable cause is attributed and the remainder are counted as `unknown`; this keeps the total exact without inventing causes.

## Compatibility and security

- existing status fields and metric authentication are unchanged
- snapshots written by older versions are accepted
- reason/state labels come from fixed or runtime-bounded values; no error text becomes a label
- counter state remains scoped to the enclave lifecycle and naturally resets when the Prometheus target restarts

## Validation

- `GOWORK=off go test ./...`
- `GOWORK=off go test -race ./internal/containers ./internal/metrics`
- `nix-build --no-out-link -I . -A checks -A runtime-go`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes per-container restart metrics and runtime/health gauges on /.well-known/metrics and persists restart counts by bounded reason in the container status snapshot. Previously we tracked only restart_count; now we track cumulative restarts by reason, export them for Prometheus, and retain the last values if the snapshot read fails.

**Metrics**
- tfshim_container_restarts_total{container,reason} with reason values oom_killed, nonzero_exit, clean_exit, replacement, unknown.
- tfshim_container_restarting; tfshim_container_oom_killed; tfshim_container_last_exit_code.
- tfshim_container_state{state}; tfshim_container_health_status{status}; tfshim_container_health_failing_streak.

**Compatibility and rollout**
- Existing status fields and metric auth are unchanged; older snapshots are accepted.
- Adds restart_counts and last_restart_reason; legacy restart_count is preserved by backfilling unclassified restarts as unknown.
- Labels use fixed or bounded values; no error text becomes a label.
- Counters reset with the enclave lifecycle; unobserved causes are counted as unknown to keep totals exact.
- If the container status file cannot be read, the exporter keeps the previous metrics and logs a warning.

<sup>Written for commit c6eb6dd4bbdf480a2b53ab44f96470a7fa046c7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

