### PR TITLE
Use Key Broker Service terminology during boot

### DIFF
--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-ILfmZFw2zSezVaw6LEONPRtsj4VJyfX1lZLTI1RrzMo=";
+    vendorHash = "sha256-3yOqGhNiZarHibZVLEEUU+Th3nTtotFGzjQAi93cpO4=";
     ldflags = [
       "-s"
       "-w"

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-Pai94mgQANx1SwSCTqfgO5xGeKmEIjxsSeRsNk3LnYk=";
+    vendorHash = "sha256-ILfmZFw2zSezVaw6LEONPRtsj4VJyfX1lZLTI1RrzMo=";
     ldflags = [
       "-s"
       "-w"

--- a/tinfoil/cmd/boot/kbs.go
+++ b/tinfoil/cmd/boot/kbs.go
@@ -25,27 +25,28 @@ import (
 )
 
 const (
-	vaultFetchTimeout     = 60 * time.Second
-	maxVaultChallengeBody = 1024
-	maxVaultResponseBody  = 8 << 20
+	kbsFetchTimeout     = 60 * time.Second
+	maxKBSChallengeBody = 1024
+	maxKBSResponseBody  = 8 << 20
 )
 
-type vaultChallengeResponse struct {
+type kbsChallengeResponse struct {
 	Nonce string `json:"nonce"`
 }
 
-type vaultFetchRequest struct {
+type kbsFetchRequest struct {
 	Repo       string          `json:"repo"`
 	SecretRefs []string        `json:"secret_refs"`
 	Nonce      string          `json:"nonce"`
 	Document   json.RawMessage `json:"document"`
 }
 
-// fetchVaultSecrets asks the vault for the declared secrets the external
-// config did not populate. The vault authenticates a fresh v3 document and
-// binds it to the mTLS certificate before releasing any value.
-func fetchVaultSecrets(
+// fetchKBSSecrets asks the KBS for the declared secrets the external config
+// did not populate. The KBS authenticates a fresh v3 document and binds it to
+// the mTLS certificate before releasing any value.
+func fetchKBSSecrets(
 	ctx context.Context,
+	baseURL string,
 	config *Config,
 	ext *shimconfig.ExternalConfig,
 	nodeID *NodeIdentity,
@@ -57,12 +58,12 @@ func fetchVaultSecrets(
 		return 0, nil
 	}
 	if ext == nil || ext.Metadata.Repo == "" {
-		return 0, fmt.Errorf("vault secret fetch requires repository metadata")
+		return 0, fmt.Errorf("KBS secret fetch requires repository metadata")
 	}
 	if nodeID == nil {
-		return 0, fmt.Errorf("vault secret fetch requires boot identity")
+		return 0, fmt.Errorf("KBS secret fetch requires boot identity")
 	}
-	if _, err := vaultBaseURL(config.VaultURL); err != nil {
+	if _, err := kbsBaseURL(baseURL); err != nil {
 		return 0, err
 	}
 
@@ -73,21 +74,21 @@ func fetchVaultSecrets(
 
 	// Fetch collateral before obtaining the short-lived challenge nonce. The
 	// final document carries this untrusted transport for offline verification.
-	collateral, err := prefetchVaultCollateral(ctx, config, collateralRequest)
+	collateral, err := prefetchKBSCollateral(ctx, config, collateralRequest)
 	if err != nil {
 		return 0, err
 	}
 
-	client := vaultClient(cert)
-	nonce, err := vaultChallenge(ctx, client, config.VaultURL)
+	client := kbsClient(cert)
+	nonce, err := kbsChallenge(ctx, client, baseURL)
 	if err != nil {
-		return 0, fmt.Errorf("requesting vault challenge: %w", err)
+		return 0, fmt.Errorf("requesting KBS challenge: %w", err)
 	}
 	var nonce32 [envelope.NonceSize]byte
 	copy(nonce32[:], nonce)
 	deviceEvidence, err := attestation.CollectDeviceEvidence(nonce32, config.GPUs)
 	if err != nil {
-		return 0, fmt.Errorf("collecting vault device evidence: %w", err)
+		return 0, fmt.Errorf("collecting KBS device evidence: %w", err)
 	}
 
 	identityBody := nodeID.attestationBody()
@@ -99,14 +100,14 @@ func fetchVaultSecrets(
 		collateral,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("building vault attestation: %w", err)
+		return 0, fmt.Errorf("building KBS attestation: %w", err)
 	}
 	documentJSON, err := json.Marshal(document)
 	if err != nil {
-		return 0, fmt.Errorf("marshaling vault attestation: %w", err)
+		return 0, fmt.Errorf("marshaling KBS attestation: %w", err)
 	}
 
-	secrets, err := vaultFetch(ctx, client, config.VaultURL, vaultFetchRequest{
+	secrets, err := kbsFetch(ctx, client, baseURL, kbsFetchRequest{
 		Repo:       ext.Metadata.Repo,
 		SecretRefs: names,
 		Nonce:      hex.EncodeToString(nonce),
@@ -115,20 +116,20 @@ func fetchVaultSecrets(
 	if err != nil {
 		return 0, err
 	}
-	if err := mergeVaultSecrets(names, secrets, ext); err != nil {
+	if err := mergeKBSSecrets(names, secrets, ext); err != nil {
 		return 0, err
 	}
-	log.Printf("Vault released %d secret(s) for %s", len(secrets), ext.Metadata.Repo)
+	log.Printf("KBS released %d secret(s) for %s", len(secrets), ext.Metadata.Repo)
 	return len(secrets), nil
 }
 
-func prefetchVaultCollateral(
+func prefetchKBSCollateral(
 	ctx context.Context,
 	config *Config,
 	request wire.Request,
 ) ([]envelope.CollateralEntry, error) {
 	if request.Repo == "" || request.Platform == "" || request.Platform == attestation.PlatformDummy || request.QuoteBase64 == "" {
-		return nil, fmt.Errorf("vault secret fetch requires raw CPU attestation")
+		return nil, fmt.Errorf("KBS secret fetch requires raw CPU attestation")
 	}
 	client, err := attestationmaterial.NewClient(config.ShimCfg.ATC, nil)
 	if err != nil {
@@ -136,19 +137,19 @@ func prefetchVaultCollateral(
 	}
 	response, err := client.Fetch(ctx, request)
 	if err != nil {
-		return nil, fmt.Errorf("prefetching vault collateral: %w", err)
+		return nil, fmt.Errorf("prefetching KBS collateral: %w", err)
 	}
 	return response.Collateral, nil
 }
 
-func mergeVaultSecrets(names []string, secrets map[string]string, ext *shimconfig.ExternalConfig) error {
+func mergeKBSSecrets(names []string, secrets map[string]string, ext *shimconfig.ExternalConfig) error {
 	if len(secrets) != len(names) {
-		return fmt.Errorf("vault returned %d secret(s), expected %d", len(secrets), len(names))
+		return fmt.Errorf("KBS returned %d secret(s), expected %d", len(secrets), len(names))
 	}
 	for _, name := range names {
 		value, ok := secrets[name]
 		if !ok || value == "" || value == "null" {
-			return fmt.Errorf("vault did not return declared secret %q", name)
+			return fmt.Errorf("KBS did not return declared secret %q", name)
 		}
 	}
 
@@ -161,11 +162,11 @@ func mergeVaultSecrets(names []string, secrets map[string]string, ext *shimconfi
 	return nil
 }
 
-// vaultClient presents the enclave certificate and refuses redirects so the
-// measured vault origin is the only peer that can request that credential.
-func vaultClient(cert tls.Certificate) *http.Client {
+// kbsClient presents the enclave certificate and refuses redirects so the
+// measured KBS origin is the only peer that can request that credential.
+func kbsClient(cert tls.Certificate) *http.Client {
 	return &http.Client{
-		Timeout: vaultFetchTimeout,
+		Timeout: kbsFetchTimeout,
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
@@ -178,8 +179,8 @@ func vaultClient(cert tls.Certificate) *http.Client {
 	}
 }
 
-func vaultChallenge(ctx context.Context, client *http.Client, base string) ([]byte, error) {
-	endpoint, err := vaultEndpoint(base, "challenge")
+func kbsChallenge(ctx context.Context, client *http.Client, base string) ([]byte, error) {
+	endpoint, err := kbsEndpoint(base, "challenge")
 	if err != nil {
 		return nil, err
 	}
@@ -192,26 +193,26 @@ func vaultChallenge(ctx context.Context, client *http.Client, base string) ([]by
 		return nil, err
 	}
 	defer resp.Body.Close()
-	var challenge vaultChallengeResponse
-	if err := decodeVaultResponse(resp, maxVaultChallengeBody, &challenge); err != nil {
+	var challenge kbsChallengeResponse
+	if err := decodeKBSResponse(resp, maxKBSChallengeBody, &challenge); err != nil {
 		return nil, err
 	}
 	if challenge.Nonce != strings.ToLower(challenge.Nonce) {
-		return nil, fmt.Errorf("vault returned a non-canonical nonce")
+		return nil, fmt.Errorf("KBS returned a non-canonical nonce")
 	}
 	nonce, err := hex.DecodeString(challenge.Nonce)
 	if err != nil || len(nonce) != envelope.NonceSize {
-		return nil, fmt.Errorf("vault returned an invalid nonce")
+		return nil, fmt.Errorf("KBS returned an invalid nonce")
 	}
 	return nonce, nil
 }
 
-func vaultFetch(ctx context.Context, client *http.Client, base string, request vaultFetchRequest) (map[string]string, error) {
+func kbsFetch(ctx context.Context, client *http.Client, base string, request kbsFetchRequest) (map[string]string, error) {
 	body, err := json.Marshal(request)
 	if err != nil {
 		return nil, err
 	}
-	endpoint, err := vaultEndpoint(base, "fetch")
+	endpoint, err := kbsEndpoint(base, "fetch")
 	if err != nil {
 		return nil, err
 	}
@@ -226,35 +227,35 @@ func vaultFetch(ctx context.Context, client *http.Client, base string, request v
 	}
 	defer resp.Body.Close()
 	var secrets map[string]string
-	if err := decodeVaultResponse(resp, maxVaultResponseBody, &secrets); err != nil {
+	if err := decodeKBSResponse(resp, maxKBSResponseBody, &secrets); err != nil {
 		return nil, err
 	}
 	return secrets, nil
 }
 
-func vaultEndpoint(base, path string) (string, error) {
-	parsed, err := vaultBaseURL(base)
+func kbsEndpoint(base, path string) (string, error) {
+	parsed, err := kbsBaseURL(base)
 	if err != nil {
 		return "", err
 	}
 	return parsed.JoinPath(path).String(), nil
 }
 
-func vaultBaseURL(base string) (*url.URL, error) {
+func kbsBaseURL(base string) (*url.URL, error) {
 	parsed, err := url.Parse(base)
 	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil {
-		return nil, fmt.Errorf("vault-url must be an https URL without userinfo, got %q", base)
+		return nil, fmt.Errorf("KBS URL must be an https URL without userinfo, got %q", base)
 	}
 	return parsed, nil
 }
 
-func decodeVaultResponse(response *http.Response, limit int64, target any) error {
+func decodeKBSResponse(response *http.Response, limit int64, target any) error {
 	body, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
 	if err != nil {
-		return fmt.Errorf("reading vault response: %w", err)
+		return fmt.Errorf("reading KBS response: %w", err)
 	}
 	if int64(len(body)) > limit {
-		return fmt.Errorf("vault response exceeds %d bytes", limit)
+		return fmt.Errorf("KBS response exceeds %d bytes", limit)
 	}
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("%s: %s", response.Status, strings.TrimSpace(string(body)))
@@ -262,10 +263,10 @@ func decodeVaultResponse(response *http.Response, limit int64, target any) error
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
-		return fmt.Errorf("decoding vault response: %w", err)
+		return fmt.Errorf("decoding KBS response: %w", err)
 	}
 	if err := decoder.Decode(new(any)); err != io.EOF {
-		return fmt.Errorf("decoding vault response: trailing JSON data")
+		return fmt.Errorf("decoding KBS response: trailing JSON data")
 	}
 	return nil
 }

--- a/tinfoil/cmd/boot/kbs_test.go
+++ b/tinfoil/cmd/boot/kbs_test.go
@@ -18,7 +18,7 @@ import (
 	shimconfig "tinfoil/internal/config"
 )
 
-func TestMergeVaultSecretsRequiresExactResponse(t *testing.T) {
+func TestMergeKBSSecretsRequiresExactResponse(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		secrets map[string]string
@@ -30,16 +30,16 @@ func TestMergeVaultSecretsRequiresExactResponse(t *testing.T) {
 		{name: "extra", secrets: map[string]string{"API_KEY": "value", "OTHER": "value"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if err := mergeVaultSecrets([]string{"API_KEY"}, test.secrets, &shimconfig.ExternalConfig{}); err == nil {
-				t.Fatal("invalid Vault response accepted")
+			if err := mergeKBSSecrets([]string{"API_KEY"}, test.secrets, &shimconfig.ExternalConfig{}); err == nil {
+				t.Fatal("invalid KBS response accepted")
 			}
 		})
 	}
 }
 
-func TestMergeVaultSecrets(t *testing.T) {
+func TestMergeKBSSecrets(t *testing.T) {
 	external := &shimconfig.ExternalConfig{Secrets: map[string]string{"EXISTING": "value"}}
-	if err := mergeVaultSecrets([]string{"API_KEY"}, map[string]string{"API_KEY": "secret"}, external); err != nil {
+	if err := mergeKBSSecrets([]string{"API_KEY"}, map[string]string{"API_KEY": "secret"}, external); err != nil {
 		t.Fatal(err)
 	}
 	if external.Secrets["API_KEY"] != "secret" || external.Secrets["EXISTING"] != "value" {
@@ -47,7 +47,7 @@ func TestMergeVaultSecrets(t *testing.T) {
 	}
 }
 
-func TestVaultChallengeAndFetchProtocol(t *testing.T) {
+func TestKBSChallengeAndFetchProtocol(t *testing.T) {
 	nonce := strings.Repeat("01", 32)
 	requests := 0
 	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
@@ -68,7 +68,7 @@ func TestVaultChallengeAndFetchProtocol(t *testing.T) {
 				t.Fatal(err)
 			}
 			if _, found := decoded["token"]; found {
-				t.Fatal("vault request carried a token")
+				t.Fatal("KBS request carried a token")
 			}
 			if string(decoded["nonce"]) != `"`+nonce+`"` ||
 				string(decoded["repo"]) != `"tinfoilsh/workload"` ||
@@ -83,11 +83,11 @@ func TestVaultChallengeAndFetchProtocol(t *testing.T) {
 		}
 	})}
 
-	challenge, err := vaultChallenge(context.Background(), client, "https://vault.example")
+	challenge, err := kbsChallenge(context.Background(), client, "https://kbs.example")
 	if err != nil {
 		t.Fatal(err)
 	}
-	secrets, err := vaultFetch(context.Background(), client, "https://vault.example", vaultFetchRequest{
+	secrets, err := kbsFetch(context.Background(), client, "https://kbs.example", kbsFetchRequest{
 		Repo:       "tinfoilsh/workload",
 		SecretRefs: []string{"API_KEY"},
 		Nonce:      nonce,
@@ -101,23 +101,23 @@ func TestVaultChallengeAndFetchProtocol(t *testing.T) {
 	}
 }
 
-func TestVaultChallengeRejectsMalformedResponse(t *testing.T) {
+func TestKBSChallengeRejectsMalformedResponse(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return jsonResponse(http.StatusOK, `{"nonce":"00","extra":true}`), nil
 	})}
-	if _, err := vaultChallenge(context.Background(), client, "https://vault.example"); err == nil {
+	if _, err := kbsChallenge(context.Background(), client, "https://kbs.example"); err == nil {
 		t.Fatal("malformed challenge accepted")
 	}
 }
 
-func TestVaultClientRejectsRedirects(t *testing.T) {
-	client := vaultClient(tls.Certificate{})
+func TestKBSClientRejectsRedirects(t *testing.T) {
+	client := kbsClient(tls.Certificate{})
 	if err := client.CheckRedirect(&http.Request{}, nil); err != http.ErrUseLastResponse {
 		t.Fatalf("redirect error = %v", err)
 	}
 }
 
-func TestPrefetchVaultCollateral(t *testing.T) {
+func TestPrefetchKBSCollateral(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.URL.Path != "/attestation-collaterals" {
 			t.Fatalf("path = %s", request.URL.Path)
@@ -159,7 +159,7 @@ func TestPrefetchVaultCollateral(t *testing.T) {
 	if persisted != collateralRequest {
 		t.Fatalf("persisted request = %#v, want %#v", persisted, collateralRequest)
 	}
-	collateral, err := prefetchVaultCollateral(context.Background(), config, collateralRequest)
+	collateral, err := prefetchKBSCollateral(context.Background(), config, collateralRequest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -163,10 +163,10 @@ func run(ctx context.Context, invocation invocation) error {
 	start = time.Now()
 	secretDetail, err := prepareSecretHandoff(ctx, config, externalConfig, secretHandoff, invocation.configHash, nodeID, collateralRequest)
 	if err != nil {
-		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
+		tracker.Record(boot.StageKBSSecrets, boot.StatusFailed, time.Since(start), err.Error())
 		return err
 	}
-	tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), secretDetail)
+	tracker.Record(boot.StageKBSSecrets, boot.StatusOK, time.Since(start), secretDetail)
 
 	// 8. Registry auth
 	start = time.Now()

--- a/tinfoil/cmd/boot/secrets.go
+++ b/tinfoil/cmd/boot/secrets.go
@@ -22,12 +22,13 @@ func prepareSecretHandoff(
 	collateralRequest wire.Request,
 ) (string, error) {
 	fetched := 0
-	if config.VaultURL != "" {
-		log.Println("Fetching vault secrets")
+	kbsURL := config.VaultURL
+	if kbsURL != "" {
+		log.Println("Fetching secrets from KBS")
 		var err error
-		fetched, err = fetchVaultSecrets(ctx, config, externalConfig, nodeID, collateralRequest)
+		fetched, err = fetchKBSSecrets(ctx, kbsURL, config, externalConfig, nodeID, collateralRequest)
 		if err != nil {
-			return "", fmt.Errorf("vault secret fetch failed: %w", err)
+			return "", fmt.Errorf("KBS secret fetch failed: %w", err)
 		}
 	}
 
@@ -44,10 +45,10 @@ func prepareSecretHandoff(
 
 	detail := fmt.Sprintf("handed off %d workload secret(s)", len(workloadSecrets))
 	if fetched != 0 {
-		return fmt.Sprintf("%s; fetched %d from vault", detail, fetched), nil
+		return fmt.Sprintf("%s; fetched %d from KBS", detail, fetched), nil
 	}
-	if config.VaultURL != "" {
+	if kbsURL != "" {
 		return detail + "; all declared secrets already populated", nil
 	}
-	return detail + "; vault not configured", nil
+	return detail + "; KBS not configured", nil
 }

--- a/tinfoil/cmd/boot/secrets.go
+++ b/tinfoil/cmd/boot/secrets.go
@@ -22,7 +22,7 @@ func prepareSecretHandoff(
 	collateralRequest wire.Request,
 ) (string, error) {
 	fetched := 0
-	kbsURL := config.VaultURL
+	kbsURL := config.KeyBrokerURL()
 	if kbsURL != "" {
 		log.Println("Fetching secrets from KBS")
 		var err error

--- a/tinfoil/cmd/boot/secrets.go
+++ b/tinfoil/cmd/boot/secrets.go
@@ -22,7 +22,7 @@ func prepareSecretHandoff(
 	collateralRequest wire.Request,
 ) (string, error) {
 	fetched := 0
-	kbsURL := config.KeyBrokerURL()
+	kbsURL := config.KBSURL
 	if kbsURL != "" {
 		log.Println("Fetching secrets from KBS")
 		var err error

--- a/tinfoil/cmd/boot/secrets_test.go
+++ b/tinfoil/cmd/boot/secrets_test.go
@@ -28,7 +28,7 @@ func TestPrepareSecretHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if detail != "handed off 1 workload secret(s); vault not configured" {
+	if detail != "handed off 1 workload secret(s); KBS not configured" {
 		t.Fatalf("detail = %q", detail)
 	}
 	store, err := secretstore.ReadHandoff(handoff, "config-digest", []string{"API_KEY"})

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2
 	github.com/tinfoilsh/modelwrap v0.2.1
-	github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828155743-1265163b30e1
+	github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828161858-94fd0bc6bb18
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2
 	github.com/tinfoilsh/modelwrap v0.2.1
-	github.com/tinfoilsh/tinfoil-config v0.1.3
+	github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828155743-1265163b30e1
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -95,8 +95,8 @@ github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2 h1:yKxfC3pVJ4ORwLeHwflv
 github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2/go.mod h1:THDK0GFNny7Pcc+nO3AQi4f6Wf1cDkfLatmHAUlIn5s=
 github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgXKbq0=
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
-github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828155743-1265163b30e1 h1:GIdcObU79CvwVZmm/jHRRq2/zxeX18eXW/qfWkWwEaw=
-github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828155743-1265163b30e1/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
+github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828161858-94fd0bc6bb18 h1:bDyAmFE5uuZcSqM7NVvPvoFP8g72mbQZURn+k2qraDg=
+github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828161858-94fd0bc6bb18/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513 h1:bKenHmdOAI0zEBb8iCtSRzN5YgFNNuja29IN95fieqg=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513/go.mod h1:GPckBb5gXbgwcVYAM6UaS5hb+cuHkHJzy//vebjSRLQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -95,8 +95,8 @@ github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2 h1:yKxfC3pVJ4ORwLeHwflv
 github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2/go.mod h1:THDK0GFNny7Pcc+nO3AQi4f6Wf1cDkfLatmHAUlIn5s=
 github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgXKbq0=
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
-github.com/tinfoilsh/tinfoil-config v0.1.3 h1:A5q0aurQB+4scDUH1SlXIQhxgK0wnQ5iw0q1UMT5D1Q=
-github.com/tinfoilsh/tinfoil-config v0.1.3/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
+github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828155743-1265163b30e1 h1:GIdcObU79CvwVZmm/jHRRq2/zxeX18eXW/qfWkWwEaw=
+github.com/tinfoilsh/tinfoil-config v0.1.4-0.20260828155743-1265163b30e1/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513 h1:bKenHmdOAI0zEBb8iCtSRzN5YgFNNuja29IN95fieqg=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513/go.mod h1:GPckBb5gXbgwcVYAM6UaS5hb+cuHkHJzy//vebjSRLQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -44,7 +44,7 @@ const (
 	StageIdentity       = "identity"
 	StageCPUAttestation = "cpu-attestation"
 	StageGPUAttestation = "gpu-attestation"
-	StageVaultSecrets   = "vault-secrets"
+	StageKBSSecrets     = "kbs-secrets"
 	StageCertificate    = "certificate"
 	StageRegistryAuth   = "registry-auth"
 	StageModels         = "models"
@@ -57,7 +57,7 @@ const (
 // Both boot and shim use this as the starting point.
 var InitialStages = []string{
 	StageConfig, StageNetwork, StageIdentity, StageCPUAttestation, StageGPUAttestation, StageCertificate,
-	StageVaultSecrets, StageRegistryAuth, StageFirewall, StageModels, StageContainers, StageShim,
+	StageKBSSecrets, StageRegistryAuth, StageFirewall, StageModels, StageContainers, StageShim,
 }
 
 // Tracker records boot stages as they complete.


### PR DESCRIPTION
## Summary
- rename the boot implementation and tests from Vault-specific names to Key Broker Service (KBS)
- introduce `kbs-url` as the sole measured KBS endpoint field
- reject the superseded `vault-url` spelling
- rename the reported boot stage from `vault-secrets` to `kbs-secrets`

## Dependency
Depends on tinfoilsh/tinfoil-config#6. This branch uses its temporary pseudo-version and must move to the released module version before merge.

## Compatibility
The KBS wire protocol, nonce handling, TLS-key binding, attestation document, and secret handoff are unchanged. Workload configurations must migrate to `kbs-url` when they adopt the CVM release containing this PR.

## Validation
- `go test ./...` from `tinfoil/`
- `go vet ./...` from `tinfoil/`
- `git diff --check`
- `nix-build --no-out-link -I . -A checks -A runtime-go -A debug-pid1 -A initrd`