### PR TITLE
fix: require authentication for metrics access

### DIFF
--- a/tinfoil/internal/auth/bearer.go
+++ b/tinfoil/internal/auth/bearer.go
@@ -24,3 +24,12 @@ func RequireBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
 	}
 	return true
 }
+
+// RequireConfiguredBearer returns 401 unless a non-empty expected token is configured and supplied.
+func RequireConfiguredBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
+	if apiKey == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return false
+	}
+	return RequireBearer(apiKey, w, r)
+}

--- a/tinfoil/internal/auth/bearer.go
+++ b/tinfoil/internal/auth/bearer.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 )
 
+func writeUnauthorized(w http.ResponseWriter) {
+	http.Error(w, "Unauthorized", http.StatusUnauthorized)
+}
+
 // RequireBearer returns 401 if the request doesn't carry the expected token.
 // If apiKey is empty, all requests are allowed.
 func RequireBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
@@ -14,12 +18,12 @@ func RequireBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
 	}
 	header := r.Header.Get("Authorization")
 	if len(header) < 7 || !strings.EqualFold(header[:7], "bearer ") {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		writeUnauthorized(w)
 		return false
 	}
 	token := header[7:]
 	if subtle.ConstantTimeCompare([]byte(token), []byte(apiKey)) != 1 {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		writeUnauthorized(w)
 		return false
 	}
 	return true
@@ -28,7 +32,7 @@ func RequireBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
 // RequireConfiguredBearer returns 401 unless a non-empty expected token is configured and supplied.
 func RequireConfiguredBearer(apiKey string, w http.ResponseWriter, r *http.Request) bool {
 	if apiKey == "" {
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		writeUnauthorized(w)
 		return false
 	}
 	return RequireBearer(apiKey, w, r)

--- a/tinfoil/internal/auth/bearer_test.go
+++ b/tinfoil/internal/auth/bearer_test.go
@@ -42,3 +42,35 @@ func TestRequireBearer(t *testing.T) {
 		})
 	}
 }
+
+func TestRequireConfiguredBearer(t *testing.T) {
+	tests := []struct {
+		name       string
+		apiKey     string
+		authHeader string
+		wantOK     bool
+		wantStatus int
+	}{
+		{"empty key rejects request", "", "", false, http.StatusUnauthorized},
+		{"valid token", "secret", "Bearer secret", true, 0},
+		{"missing token", "secret", "", false, http.StatusUnauthorized},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.authHeader != "" {
+				r.Header.Set("Authorization", tt.authHeader)
+			}
+			w := httptest.NewRecorder()
+
+			ok := RequireConfiguredBearer(tt.apiKey, w, r)
+			if ok != tt.wantOK {
+				t.Errorf("RequireConfiguredBearer() = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok && w.Code != tt.wantStatus {
+				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/tinfoil/internal/auth/bearer_test.go
+++ b/tinfoil/internal/auth/bearer_test.go
@@ -44,33 +44,13 @@ func TestRequireBearer(t *testing.T) {
 }
 
 func TestRequireConfiguredBearer(t *testing.T) {
-	tests := []struct {
-		name       string
-		apiKey     string
-		authHeader string
-		wantOK     bool
-		wantStatus int
-	}{
-		{"empty key rejects request", "", "", false, http.StatusUnauthorized},
-		{"valid token", "secret", "Bearer secret", true, 0},
-		{"missing token", "secret", "", false, http.StatusUnauthorized},
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+
+	if RequireConfiguredBearer("", w, r) {
+		t.Fatal("empty configured key should reject request")
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := httptest.NewRequest(http.MethodGet, "/", nil)
-			if tt.authHeader != "" {
-				r.Header.Set("Authorization", tt.authHeader)
-			}
-			w := httptest.NewRecorder()
-
-			ok := RequireConfiguredBearer(tt.apiKey, w, r)
-			if ok != tt.wantOK {
-				t.Errorf("RequireConfiguredBearer() = %v, want %v", ok, tt.wantOK)
-			}
-			if !ok && w.Code != tt.wantStatus {
-				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
-			}
-		})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
 	}
 }

--- a/tinfoil/internal/metrics/metrics.go
+++ b/tinfoil/internal/metrics/metrics.go
@@ -139,7 +139,7 @@ func collectMetrics(metadata *config.Metadata) (*Metrics, error) {
 
 func HandleMetrics(externalConfig *config.ExternalConfig) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !auth.RequireBearer(externalConfig.MetricsAPIKey, w, r) {
+		if !auth.RequireConfiguredBearer(externalConfig.MetricsAPIKey, w, r) {
 			return
 		}
 

--- a/tinfoil/internal/metrics/metrics_test.go
+++ b/tinfoil/internal/metrics/metrics_test.go
@@ -1,0 +1,42 @@
+package metrics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"tinfoil/internal/config"
+)
+
+func TestMetricsHandlersRejectMissingAuthenticationConfig(t *testing.T) {
+	externalConfig := &config.ExternalConfig{}
+	tests := []struct {
+		name    string
+		path    string
+		handler http.Handler
+	}{
+		{
+			name:    "JSON metrics",
+			path:    "/.well-known/tinfoil-metrics",
+			handler: HandleMetrics(externalConfig),
+		},
+		{
+			name:    "Prometheus metrics",
+			path:    "/.well-known/metrics",
+			handler: HandlePrometheusMetrics(&externalConfig.Metadata, ""),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, test.path, nil)
+			rec := httptest.NewRecorder()
+
+			test.handler.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+			}
+		})
+	}
+}

--- a/tinfoil/internal/metrics/prometheus.go
+++ b/tinfoil/internal/metrics/prometheus.go
@@ -117,7 +117,7 @@ func HandlePrometheusMetrics(metadata *config.Metadata, metricsAPIKey string) ht
 	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !auth.RequireBearer(metricsAPIKey, w, r) {
+		if !auth.RequireConfiguredBearer(metricsAPIKey, w, r) {
 			return
 		}
 


### PR DESCRIPTION
## Summary
- make JSON and Prometheus metrics endpoints fail closed when `METRICS_API_KEY` is absent
- preserve optional bearer authentication behavior for unrelated observability endpoints
- test strict bearer handling and both metrics endpoint configurations

## Verification
- `go test ./internal/auth`
- `git diff --check`
- Linux/Nix package coverage runs in PR checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires a configured `METRICS_API_KEY` before serving JSON or Prometheus metrics, so the endpoints fail closed instead of allowing unauthenticated access when no key is set.

- New `RequireConfiguredBearer` in `internal/auth` returns 401 when no API key is configured.
- Centralized 401 response handling in `internal/auth` via a shared helper.
- JSON and Prometheus metrics handlers now use `RequireConfiguredBearer`.
- Added tests covering missing key, valid token, and missing token cases.

<sup>Written for commit 7546a0b0a3c316a585d20a16f987a8436f303261. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

