### PR TITLE
Bump tinfoil-config to v0.1.5

### DIFF
--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-9f9sq2kL9hukQD+QESObGt5XRHNHz5zLSG3oRAhAPKc=";
+    vendorHash = "sha256-km2zjB4RAmpXXs/ZmRvNtiPAZfZWJoz557sJLIbxYLM=";
     ldflags = [
       "-s"
       "-w"

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2
 	github.com/tinfoilsh/modelwrap v0.2.1
-	github.com/tinfoilsh/tinfoil-config v0.1.4
+	github.com/tinfoilsh/tinfoil-config v0.1.5
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -95,8 +95,8 @@ github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2 h1:yKxfC3pVJ4ORwLeHwflv
 github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2/go.mod h1:THDK0GFNny7Pcc+nO3AQi4f6Wf1cDkfLatmHAUlIn5s=
 github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgXKbq0=
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
-github.com/tinfoilsh/tinfoil-config v0.1.4 h1:LU2g2MtdyazBWMbVtXJO5SVY5gzS4yGEApw7pCDUMAY=
-github.com/tinfoilsh/tinfoil-config v0.1.4/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
+github.com/tinfoilsh/tinfoil-config v0.1.5 h1:xxC6xUuf9JYutAtUIsNe1c83aaCu1vab1qBUqg1FX0c=
+github.com/tinfoilsh/tinfoil-config v0.1.5/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513 h1:bKenHmdOAI0zEBb8iCtSRzN5YgFNNuja29IN95fieqg=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513/go.mod h1:GPckBb5gXbgwcVYAM6UaS5hb+cuHkHJzy//vebjSRLQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
Enables the optional per-model `schema` field in deployment configs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `tinfoil-config` to v0.1.5 so deployment configs can use the optional per-model `schema` field.

<sup>Written for commit 2cd60773bef3831d079cf478a4dedd8a8fe30b1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

