### PR TITLE
feat!: rename the secret service URL

### DIFF
--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-km2zjB4RAmpXXs/ZmRvNtiPAZfZWJoz557sJLIbxYLM=";
+    vendorHash = "sha256-WK4Ars4kAwTI+FjhEk4n4fkZvHydBXNAbhU+lS+bGkM=";
     ldflags = [
       "-s"
       "-w"

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-WK4Ars4kAwTI+FjhEk4n4fkZvHydBXNAbhU+lS+bGkM=";
+    vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
     ldflags = [
       "-s"
       "-w"

--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    vendorHash = "sha256-cvenYIugJmLb00Lu2l4Vg+Zh/1gP7XwAYCjYicdvsVs=";
     ldflags = [
       "-s"
       "-w"

--- a/tinfoil/cmd/boot/keyserver.go
+++ b/tinfoil/cmd/boot/keyserver.go
@@ -25,26 +25,26 @@ import (
 )
 
 const (
-	vaultFetchTimeout     = 60 * time.Second
-	maxVaultChallengeBody = 1024
-	maxVaultResponseBody  = 8 << 20
+	keyserverFetchTimeout     = 60 * time.Second
+	maxKeyserverChallengeBody = 1024
+	maxKeyserverResponseBody  = 8 << 20
 )
 
-type vaultChallengeResponse struct {
+type keyserverChallengeResponse struct {
 	Nonce string `json:"nonce"`
 }
 
-type vaultFetchRequest struct {
+type keyserverFetchRequest struct {
 	Repo       string          `json:"repo"`
 	SecretRefs []string        `json:"secret_refs"`
 	Nonce      string          `json:"nonce"`
 	Document   json.RawMessage `json:"document"`
 }
 
-// fetchVaultSecrets asks the vault for the declared secrets the external
-// config did not populate. The vault authenticates a fresh v3 document and
-// binds it to the mTLS certificate before releasing any value.
-func fetchVaultSecrets(
+// fetchKeyserverSecrets asks the keyserver for the declared secrets the
+// external config did not populate. The keyserver authenticates a fresh v3
+// document and binds it to the mTLS certificate before releasing any value.
+func fetchKeyserverSecrets(
 	ctx context.Context,
 	config *Config,
 	ext *shimconfig.ExternalConfig,
@@ -57,12 +57,12 @@ func fetchVaultSecrets(
 		return 0, nil
 	}
 	if ext == nil || ext.Metadata.Repo == "" {
-		return 0, fmt.Errorf("vault secret fetch requires repository metadata")
+		return 0, fmt.Errorf("keyserver secret fetch requires repository metadata")
 	}
 	if nodeID == nil {
-		return 0, fmt.Errorf("vault secret fetch requires boot identity")
+		return 0, fmt.Errorf("keyserver secret fetch requires boot identity")
 	}
-	if _, err := vaultBaseURL(config.VaultURL); err != nil {
+	if _, err := keyserverBaseURL(config.KeyserverURL); err != nil {
 		return 0, err
 	}
 
@@ -73,21 +73,21 @@ func fetchVaultSecrets(
 
 	// Fetch collateral before obtaining the short-lived challenge nonce. The
 	// final document carries this untrusted transport for offline verification.
-	collateral, err := prefetchVaultCollateral(ctx, config, collateralRequest)
+	collateral, err := prefetchKeyserverCollateral(ctx, config, collateralRequest)
 	if err != nil {
 		return 0, err
 	}
 
-	client := vaultClient(cert)
-	nonce, err := vaultChallenge(ctx, client, config.VaultURL)
+	client := keyserverClient(cert)
+	nonce, err := keyserverChallenge(ctx, client, config.KeyserverURL)
 	if err != nil {
-		return 0, fmt.Errorf("requesting vault challenge: %w", err)
+		return 0, fmt.Errorf("requesting keyserver challenge: %w", err)
 	}
 	var nonce32 [envelope.NonceSize]byte
 	copy(nonce32[:], nonce)
 	deviceEvidence, err := attestation.CollectDeviceEvidence(nonce32, config.GPUs)
 	if err != nil {
-		return 0, fmt.Errorf("collecting vault device evidence: %w", err)
+		return 0, fmt.Errorf("collecting keyserver device evidence: %w", err)
 	}
 
 	identityBody := nodeID.attestationBody()
@@ -99,14 +99,14 @@ func fetchVaultSecrets(
 		collateral,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("building vault attestation: %w", err)
+		return 0, fmt.Errorf("building keyserver attestation: %w", err)
 	}
 	documentJSON, err := json.Marshal(document)
 	if err != nil {
-		return 0, fmt.Errorf("marshaling vault attestation: %w", err)
+		return 0, fmt.Errorf("marshaling keyserver attestation: %w", err)
 	}
 
-	secrets, err := vaultFetch(ctx, client, config.VaultURL, vaultFetchRequest{
+	secrets, err := keyserverFetch(ctx, client, config.KeyserverURL, keyserverFetchRequest{
 		Repo:       ext.Metadata.Repo,
 		SecretRefs: names,
 		Nonce:      hex.EncodeToString(nonce),
@@ -115,20 +115,20 @@ func fetchVaultSecrets(
 	if err != nil {
 		return 0, err
 	}
-	if err := mergeVaultSecrets(names, secrets, ext); err != nil {
+	if err := mergeKeyserverSecrets(names, secrets, ext); err != nil {
 		return 0, err
 	}
-	log.Printf("Vault released %d secret(s) for %s", len(secrets), ext.Metadata.Repo)
+	log.Printf("Keyserver released %d secret(s) for %s", len(secrets), ext.Metadata.Repo)
 	return len(secrets), nil
 }
 
-func prefetchVaultCollateral(
+func prefetchKeyserverCollateral(
 	ctx context.Context,
 	config *Config,
 	request wire.Request,
 ) ([]envelope.CollateralEntry, error) {
 	if request.Repo == "" || request.Platform == "" || request.Platform == attestation.PlatformDummy || request.QuoteBase64 == "" {
-		return nil, fmt.Errorf("vault secret fetch requires raw CPU attestation")
+		return nil, fmt.Errorf("keyserver secret fetch requires raw CPU attestation")
 	}
 	client, err := attestationmaterial.NewClient(config.ShimCfg.ATC, nil)
 	if err != nil {
@@ -136,19 +136,19 @@ func prefetchVaultCollateral(
 	}
 	response, err := client.Fetch(ctx, request)
 	if err != nil {
-		return nil, fmt.Errorf("prefetching vault collateral: %w", err)
+		return nil, fmt.Errorf("prefetching keyserver collateral: %w", err)
 	}
 	return response.Collateral, nil
 }
 
-func mergeVaultSecrets(names []string, secrets map[string]string, ext *shimconfig.ExternalConfig) error {
+func mergeKeyserverSecrets(names []string, secrets map[string]string, ext *shimconfig.ExternalConfig) error {
 	if len(secrets) != len(names) {
-		return fmt.Errorf("vault returned %d secret(s), expected %d", len(secrets), len(names))
+		return fmt.Errorf("keyserver returned %d secret(s), expected %d", len(secrets), len(names))
 	}
 	for _, name := range names {
 		value, ok := secrets[name]
 		if !ok || value == "" || value == "null" {
-			return fmt.Errorf("vault did not return declared secret %q", name)
+			return fmt.Errorf("keyserver did not return declared secret %q", name)
 		}
 	}
 
@@ -161,11 +161,12 @@ func mergeVaultSecrets(names []string, secrets map[string]string, ext *shimconfi
 	return nil
 }
 
-// vaultClient presents the enclave certificate and refuses redirects so the
-// measured vault origin is the only peer that can request that credential.
-func vaultClient(cert tls.Certificate) *http.Client {
+// keyserverClient presents the enclave certificate and refuses redirects so
+// the measured keyserver origin is the only peer that can request that
+// credential.
+func keyserverClient(cert tls.Certificate) *http.Client {
 	return &http.Client{
-		Timeout: vaultFetchTimeout,
+		Timeout: keyserverFetchTimeout,
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
@@ -178,8 +179,8 @@ func vaultClient(cert tls.Certificate) *http.Client {
 	}
 }
 
-func vaultChallenge(ctx context.Context, client *http.Client, base string) ([]byte, error) {
-	endpoint, err := vaultEndpoint(base, "challenge")
+func keyserverChallenge(ctx context.Context, client *http.Client, base string) ([]byte, error) {
+	endpoint, err := keyserverEndpoint(base, "challenge")
 	if err != nil {
 		return nil, err
 	}
@@ -192,26 +193,26 @@ func vaultChallenge(ctx context.Context, client *http.Client, base string) ([]by
 		return nil, err
 	}
 	defer resp.Body.Close()
-	var challenge vaultChallengeResponse
-	if err := decodeVaultResponse(resp, maxVaultChallengeBody, &challenge); err != nil {
+	var challenge keyserverChallengeResponse
+	if err := decodeKeyserverResponse(resp, maxKeyserverChallengeBody, &challenge); err != nil {
 		return nil, err
 	}
 	if challenge.Nonce != strings.ToLower(challenge.Nonce) {
-		return nil, fmt.Errorf("vault returned a non-canonical nonce")
+		return nil, fmt.Errorf("keyserver returned a non-canonical nonce")
 	}
 	nonce, err := hex.DecodeString(challenge.Nonce)
 	if err != nil || len(nonce) != envelope.NonceSize {
-		return nil, fmt.Errorf("vault returned an invalid nonce")
+		return nil, fmt.Errorf("keyserver returned an invalid nonce")
 	}
 	return nonce, nil
 }
 
-func vaultFetch(ctx context.Context, client *http.Client, base string, request vaultFetchRequest) (map[string]string, error) {
+func keyserverFetch(ctx context.Context, client *http.Client, base string, request keyserverFetchRequest) (map[string]string, error) {
 	body, err := json.Marshal(request)
 	if err != nil {
 		return nil, err
 	}
-	endpoint, err := vaultEndpoint(base, "fetch")
+	endpoint, err := keyserverEndpoint(base, "fetch")
 	if err != nil {
 		return nil, err
 	}
@@ -226,35 +227,35 @@ func vaultFetch(ctx context.Context, client *http.Client, base string, request v
 	}
 	defer resp.Body.Close()
 	var secrets map[string]string
-	if err := decodeVaultResponse(resp, maxVaultResponseBody, &secrets); err != nil {
+	if err := decodeKeyserverResponse(resp, maxKeyserverResponseBody, &secrets); err != nil {
 		return nil, err
 	}
 	return secrets, nil
 }
 
-func vaultEndpoint(base, path string) (string, error) {
-	parsed, err := vaultBaseURL(base)
+func keyserverEndpoint(base, path string) (string, error) {
+	parsed, err := keyserverBaseURL(base)
 	if err != nil {
 		return "", err
 	}
 	return parsed.JoinPath(path).String(), nil
 }
 
-func vaultBaseURL(base string) (*url.URL, error) {
+func keyserverBaseURL(base string) (*url.URL, error) {
 	parsed, err := url.Parse(base)
 	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil {
-		return nil, fmt.Errorf("vault-url must be an https URL without userinfo, got %q", base)
+		return nil, fmt.Errorf("keyserver-url must be an https URL without userinfo, got %q", base)
 	}
 	return parsed, nil
 }
 
-func decodeVaultResponse(response *http.Response, limit int64, target any) error {
+func decodeKeyserverResponse(response *http.Response, limit int64, target any) error {
 	body, err := io.ReadAll(io.LimitReader(response.Body, limit+1))
 	if err != nil {
-		return fmt.Errorf("reading vault response: %w", err)
+		return fmt.Errorf("reading keyserver response: %w", err)
 	}
 	if int64(len(body)) > limit {
-		return fmt.Errorf("vault response exceeds %d bytes", limit)
+		return fmt.Errorf("keyserver response exceeds %d bytes", limit)
 	}
 	if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("%s: %s", response.Status, strings.TrimSpace(string(body)))
@@ -262,10 +263,10 @@ func decodeVaultResponse(response *http.Response, limit int64, target any) error
 	decoder := json.NewDecoder(bytes.NewReader(body))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
-		return fmt.Errorf("decoding vault response: %w", err)
+		return fmt.Errorf("decoding keyserver response: %w", err)
 	}
 	if err := decoder.Decode(new(any)); err != io.EOF {
-		return fmt.Errorf("decoding vault response: trailing JSON data")
+		return fmt.Errorf("decoding keyserver response: trailing JSON data")
 	}
 	return nil
 }

--- a/tinfoil/cmd/boot/keyserver_test.go
+++ b/tinfoil/cmd/boot/keyserver_test.go
@@ -18,7 +18,7 @@ import (
 	shimconfig "tinfoil/internal/config"
 )
 
-func TestMergeVaultSecretsRequiresExactResponse(t *testing.T) {
+func TestMergeKeyserverSecretsRequiresExactResponse(t *testing.T) {
 	for _, test := range []struct {
 		name    string
 		secrets map[string]string
@@ -30,16 +30,16 @@ func TestMergeVaultSecretsRequiresExactResponse(t *testing.T) {
 		{name: "extra", secrets: map[string]string{"API_KEY": "value", "OTHER": "value"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			if err := mergeVaultSecrets([]string{"API_KEY"}, test.secrets, &shimconfig.ExternalConfig{}); err == nil {
-				t.Fatal("invalid Vault response accepted")
+			if err := mergeKeyserverSecrets([]string{"API_KEY"}, test.secrets, &shimconfig.ExternalConfig{}); err == nil {
+				t.Fatal("invalid keyserver response accepted")
 			}
 		})
 	}
 }
 
-func TestMergeVaultSecrets(t *testing.T) {
+func TestMergeKeyserverSecrets(t *testing.T) {
 	external := &shimconfig.ExternalConfig{Secrets: map[string]string{"EXISTING": "value"}}
-	if err := mergeVaultSecrets([]string{"API_KEY"}, map[string]string{"API_KEY": "secret"}, external); err != nil {
+	if err := mergeKeyserverSecrets([]string{"API_KEY"}, map[string]string{"API_KEY": "secret"}, external); err != nil {
 		t.Fatal(err)
 	}
 	if external.Secrets["API_KEY"] != "secret" || external.Secrets["EXISTING"] != "value" {
@@ -47,7 +47,7 @@ func TestMergeVaultSecrets(t *testing.T) {
 	}
 }
 
-func TestVaultChallengeAndFetchProtocol(t *testing.T) {
+func TestKeyserverChallengeAndFetchProtocol(t *testing.T) {
 	nonce := strings.Repeat("01", 32)
 	requests := 0
 	client := &http.Client{Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
@@ -68,7 +68,7 @@ func TestVaultChallengeAndFetchProtocol(t *testing.T) {
 				t.Fatal(err)
 			}
 			if _, found := decoded["token"]; found {
-				t.Fatal("vault request carried a token")
+				t.Fatal("keyserver request carried a token")
 			}
 			if string(decoded["nonce"]) != `"`+nonce+`"` ||
 				string(decoded["repo"]) != `"tinfoilsh/workload"` ||
@@ -83,11 +83,11 @@ func TestVaultChallengeAndFetchProtocol(t *testing.T) {
 		}
 	})}
 
-	challenge, err := vaultChallenge(context.Background(), client, "https://vault.example")
+	challenge, err := keyserverChallenge(context.Background(), client, "https://keyserver.example")
 	if err != nil {
 		t.Fatal(err)
 	}
-	secrets, err := vaultFetch(context.Background(), client, "https://vault.example", vaultFetchRequest{
+	secrets, err := keyserverFetch(context.Background(), client, "https://keyserver.example", keyserverFetchRequest{
 		Repo:       "tinfoilsh/workload",
 		SecretRefs: []string{"API_KEY"},
 		Nonce:      nonce,
@@ -101,23 +101,23 @@ func TestVaultChallengeAndFetchProtocol(t *testing.T) {
 	}
 }
 
-func TestVaultChallengeRejectsMalformedResponse(t *testing.T) {
+func TestKeyserverChallengeRejectsMalformedResponse(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
 		return jsonResponse(http.StatusOK, `{"nonce":"00","extra":true}`), nil
 	})}
-	if _, err := vaultChallenge(context.Background(), client, "https://vault.example"); err == nil {
+	if _, err := keyserverChallenge(context.Background(), client, "https://keyserver.example"); err == nil {
 		t.Fatal("malformed challenge accepted")
 	}
 }
 
-func TestVaultClientRejectsRedirects(t *testing.T) {
-	client := vaultClient(tls.Certificate{})
+func TestKeyserverClientRejectsRedirects(t *testing.T) {
+	client := keyserverClient(tls.Certificate{})
 	if err := client.CheckRedirect(&http.Request{}, nil); err != http.ErrUseLastResponse {
 		t.Fatalf("redirect error = %v", err)
 	}
 }
 
-func TestPrefetchVaultCollateral(t *testing.T) {
+func TestPrefetchKeyserverCollateral(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
 		if request.URL.Path != "/attestation-collaterals" {
 			t.Fatalf("path = %s", request.URL.Path)
@@ -159,7 +159,7 @@ func TestPrefetchVaultCollateral(t *testing.T) {
 	if persisted != collateralRequest {
 		t.Fatalf("persisted request = %#v, want %#v", persisted, collateralRequest)
 	}
-	collateral, err := prefetchVaultCollateral(context.Background(), config, collateralRequest)
+	collateral, err := prefetchKeyserverCollateral(context.Background(), config, collateralRequest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -163,10 +163,10 @@ func run(ctx context.Context, invocation invocation) error {
 	start = time.Now()
 	secretDetail, err := prepareSecretHandoff(ctx, config, externalConfig, secretHandoff, invocation.configHash, nodeID, collateralRequest)
 	if err != nil {
-		tracker.Record(boot.StageVaultSecrets, boot.StatusFailed, time.Since(start), err.Error())
+		tracker.Record(boot.StageKeyserverSecrets, boot.StatusFailed, time.Since(start), err.Error())
 		return err
 	}
-	tracker.Record(boot.StageVaultSecrets, boot.StatusOK, time.Since(start), secretDetail)
+	tracker.Record(boot.StageKeyserverSecrets, boot.StatusOK, time.Since(start), secretDetail)
 
 	// 8. Registry auth
 	start = time.Now()

--- a/tinfoil/cmd/boot/secrets.go
+++ b/tinfoil/cmd/boot/secrets.go
@@ -22,12 +22,12 @@ func prepareSecretHandoff(
 	collateralRequest wire.Request,
 ) (string, error) {
 	fetched := 0
-	if config.VaultURL != "" {
-		log.Println("Fetching vault secrets")
+	if config.KeyserverURL != "" {
+		log.Println("Fetching keyserver secrets")
 		var err error
-		fetched, err = fetchVaultSecrets(ctx, config, externalConfig, nodeID, collateralRequest)
+		fetched, err = fetchKeyserverSecrets(ctx, config, externalConfig, nodeID, collateralRequest)
 		if err != nil {
-			return "", fmt.Errorf("vault secret fetch failed: %w", err)
+			return "", fmt.Errorf("keyserver secret fetch failed: %w", err)
 		}
 	}
 
@@ -44,10 +44,10 @@ func prepareSecretHandoff(
 
 	detail := fmt.Sprintf("handed off %d workload secret(s)", len(workloadSecrets))
 	if fetched != 0 {
-		return fmt.Sprintf("%s; fetched %d from vault", detail, fetched), nil
+		return fmt.Sprintf("%s; fetched %d from keyserver", detail, fetched), nil
 	}
-	if config.VaultURL != "" {
+	if config.KeyserverURL != "" {
 		return detail + "; all declared secrets already populated", nil
 	}
-	return detail + "; vault not configured", nil
+	return detail + "; keyserver not configured", nil
 }

--- a/tinfoil/cmd/boot/secrets_test.go
+++ b/tinfoil/cmd/boot/secrets_test.go
@@ -28,7 +28,7 @@ func TestPrepareSecretHandoff(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if detail != "handed off 1 workload secret(s); vault not configured" {
+	if detail != "handed off 1 workload secret(s); keyserver not configured" {
 		t.Fatalf("detail = %q", detail)
 	}
 	store, err := secretstore.ReadHandoff(handoff, "config-digest", []string{"API_KEY"})

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2
 	github.com/tinfoilsh/modelwrap v0.2.1
-	github.com/tinfoilsh/tinfoil-config v0.1.6-0.20260901193317-3b0a07bb2522
+	github.com/tinfoilsh/tinfoil-config v0.1.6
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2
 	github.com/tinfoilsh/modelwrap v0.2.1
-	github.com/tinfoilsh/tinfoil-config v0.1.5
+	github.com/tinfoilsh/tinfoil-config v0.1.6-0.20260901193317-3b0a07bb2522
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -95,10 +95,8 @@ github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2 h1:yKxfC3pVJ4ORwLeHwflv
 github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2/go.mod h1:THDK0GFNny7Pcc+nO3AQi4f6Wf1cDkfLatmHAUlIn5s=
 github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgXKbq0=
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
-github.com/tinfoilsh/tinfoil-config v0.1.5 h1:xxC6xUuf9JYutAtUIsNe1c83aaCu1vab1qBUqg1FX0c=
-github.com/tinfoilsh/tinfoil-config v0.1.5/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
-github.com/tinfoilsh/tinfoil-config v0.1.6-0.20260901193317-3b0a07bb2522 h1:ElYABNqLHaPLDTRq1LCMCPQFuAulOZ3RDLo1hYeIgRw=
-github.com/tinfoilsh/tinfoil-config v0.1.6-0.20260901193317-3b0a07bb2522/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
+github.com/tinfoilsh/tinfoil-config v0.1.6 h1:jM0eWMAc6RVLAtx+yCJXqm6fjqDdE6n43nZnzAXvmNs=
+github.com/tinfoilsh/tinfoil-config v0.1.6/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513 h1:bKenHmdOAI0zEBb8iCtSRzN5YgFNNuja29IN95fieqg=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513/go.mod h1:GPckBb5gXbgwcVYAM6UaS5hb+cuHkHJzy//vebjSRLQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -97,6 +97,8 @@ github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgX
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
 github.com/tinfoilsh/tinfoil-config v0.1.5 h1:xxC6xUuf9JYutAtUIsNe1c83aaCu1vab1qBUqg1FX0c=
 github.com/tinfoilsh/tinfoil-config v0.1.5/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
+github.com/tinfoilsh/tinfoil-config v0.1.6-0.20260901193317-3b0a07bb2522 h1:ElYABNqLHaPLDTRq1LCMCPQFuAulOZ3RDLo1hYeIgRw=
+github.com/tinfoilsh/tinfoil-config v0.1.6-0.20260901193317-3b0a07bb2522/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513 h1:bKenHmdOAI0zEBb8iCtSRzN5YgFNNuja29IN95fieqg=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513/go.mod h1:GPckBb5gXbgwcVYAM6UaS5hb+cuHkHJzy//vebjSRLQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/internal/boot/state.go
+++ b/tinfoil/internal/boot/state.go
@@ -39,25 +39,25 @@ const (
 )
 
 const (
-	StageConfig         = "config"
-	StageNetwork        = "network"
-	StageIdentity       = "identity"
-	StageCPUAttestation = "cpu-attestation"
-	StageGPUAttestation = "gpu-attestation"
-	StageVaultSecrets   = "vault-secrets"
-	StageCertificate    = "certificate"
-	StageRegistryAuth   = "registry-auth"
-	StageModels         = "models"
-	StageFirewall       = "firewall"
-	StageContainers     = "containers"
-	StageShim           = "shim"
+	StageConfig           = "config"
+	StageNetwork          = "network"
+	StageIdentity         = "identity"
+	StageCPUAttestation   = "cpu-attestation"
+	StageGPUAttestation   = "gpu-attestation"
+	StageKeyserverSecrets = "keyserver-secrets"
+	StageCertificate      = "certificate"
+	StageRegistryAuth     = "registry-auth"
+	StageModels           = "models"
+	StageFirewall         = "firewall"
+	StageContainers       = "containers"
+	StageShim             = "shim"
 )
 
 // InitialStages is the ordered list of stages known at boot time.
 // Both boot and shim use this as the starting point.
 var InitialStages = []string{
 	StageConfig, StageNetwork, StageIdentity, StageCPUAttestation, StageGPUAttestation, StageCertificate,
-	StageVaultSecrets, StageRegistryAuth, StageFirewall, StageModels, StageContainers, StageShim,
+	StageKeyserverSecrets, StageRegistryAuth, StageFirewall, StageModels, StageContainers, StageShim,
 }
 
 // Tracker records boot stages as they complete.

--- a/tinfoil/internal/runtimeconfig/validation_test.go
+++ b/tinfoil/internal/runtimeconfig/validation_test.go
@@ -42,6 +42,8 @@ func TestDecodeValidatesRuntimeConfig(t *testing.T) {
 		want  string
 	}{
 		{name: "valid", yaml: validConfig},
+		{name: "keyserver URL", yaml: validConfig + "keyserver-url: https://keys.example.com\n"},
+		{name: "obsolete vault URL", yaml: validConfig + "vault-url: https://keys.example.com\n", want: "field vault-url not found"},
 		{name: "unknown field", yaml: validConfig + "unknown: true\n", want: "field unknown not found"},
 		{name: "unknown container field", yaml: strings.Replace(validConfig, "networks: [app]", "networks: [app]\n    typo: true", 1), want: "unknown container field"},
 		{name: "duplicate container field", yaml: strings.Replace(validConfig, "networks: [app]", "image: duplicate\n    networks: [app]", 1), want: "duplicate container field"},


### PR DESCRIPTION
## Summary
- consume the measured endpoint as `keyserver-url`
- use keyserver terminology throughout secret fetching and boot status
- reject the obsolete `vault-url` field through config validation

Depends on https://github.com/tinfoilsh/tinfoil-config/pull/9.

## Testing
- `go test ./internal/runtimeconfig ./internal/boot`
- `go vet ./internal/runtimeconfig ./internal/boot`
- full Linux checks deferred to CI because Nix is unavailable locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the secret service URL from `vault-url` to `keyserver-url` and replaces vault terminology with keyserver throughout boot code, status stages, and logs.

- Config validation now rejects the obsolete `vault-url` field; existing configs must use `keyserver-url` (breaking change).
- Pins `tinfoil-config` v0.1.6 to expose `keyserver-url` and refreshes the vendored dependency checksum.

<sup>Written for commit aa27c4195041039e3ea5b311c5fddcc8841c94c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

