### PR TITLE
Source declared secrets from exactly one place

### DIFF
--- a/tinfoil/cmd/boot/keyserver.go
+++ b/tinfoil/cmd/boot/keyserver.go
@@ -21,7 +21,6 @@ import (
 	"tinfoil/internal/attestationmaterial"
 	"tinfoil/internal/boot"
 	shimconfig "tinfoil/internal/config"
-	"tinfoil/internal/secretstore"
 )
 
 const (
@@ -41,53 +40,49 @@ type keyserverFetchRequest struct {
 	Document   json.RawMessage `json:"document"`
 }
 
-// fetchKeyserverSecrets asks the keyserver for the declared secrets the
-// external config did not populate. The keyserver authenticates a fresh v3
-// document and binds it to the mTLS certificate before releasing any value.
+// fetchKeyserverSecrets asks the keyserver for the named declared secrets.
+// The keyserver authenticates a fresh v3 document and binds it to the mTLS
+// certificate before releasing any value.
 func fetchKeyserverSecrets(
 	ctx context.Context,
 	config *Config,
 	ext *shimconfig.ExternalConfig,
 	nodeID *NodeIdentity,
 	collateralRequest wire.Request,
-) (int, error) {
-	names := secretstore.MissingReferences(config, ext)
-	if len(names) == 0 {
-		log.Println("All declared secrets populated by external config, nothing to fetch")
-		return 0, nil
-	}
+	names []string,
+) (map[string]string, error) {
 	if ext == nil || ext.Metadata.Repo == "" {
-		return 0, fmt.Errorf("keyserver secret fetch requires repository metadata")
+		return nil, fmt.Errorf("keyserver secret fetch requires repository metadata")
 	}
 	if nodeID == nil {
-		return 0, fmt.Errorf("keyserver secret fetch requires boot identity")
+		return nil, fmt.Errorf("keyserver secret fetch requires boot identity")
 	}
 	if _, err := keyserverBaseURL(config.KeyserverURL); err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	cert, err := tls.LoadX509KeyPair(boot.TLSCertPath, boot.TLSKeyPath)
 	if err != nil {
-		return 0, fmt.Errorf("loading enclave TLS certificate: %w", err)
+		return nil, fmt.Errorf("loading enclave TLS certificate: %w", err)
 	}
 
 	// Fetch collateral before obtaining the short-lived challenge nonce. The
 	// final document carries this untrusted transport for offline verification.
 	collateral, err := prefetchKeyserverCollateral(ctx, config, collateralRequest)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	client := keyserverClient(cert)
 	nonce, err := keyserverChallenge(ctx, client, config.KeyserverURL)
 	if err != nil {
-		return 0, fmt.Errorf("requesting keyserver challenge: %w", err)
+		return nil, fmt.Errorf("requesting keyserver challenge: %w", err)
 	}
 	var nonce32 [envelope.NonceSize]byte
 	copy(nonce32[:], nonce)
 	deviceEvidence, err := attestation.CollectDeviceEvidence(nonce32, config.GPUs)
 	if err != nil {
-		return 0, fmt.Errorf("collecting keyserver device evidence: %w", err)
+		return nil, fmt.Errorf("collecting keyserver device evidence: %w", err)
 	}
 
 	identityBody := nodeID.attestationBody()
@@ -99,11 +94,11 @@ func fetchKeyserverSecrets(
 		collateral,
 	)
 	if err != nil {
-		return 0, fmt.Errorf("building keyserver attestation: %w", err)
+		return nil, fmt.Errorf("building keyserver attestation: %w", err)
 	}
 	documentJSON, err := json.Marshal(document)
 	if err != nil {
-		return 0, fmt.Errorf("marshaling keyserver attestation: %w", err)
+		return nil, fmt.Errorf("marshaling keyserver attestation: %w", err)
 	}
 
 	secrets, err := keyserverFetch(ctx, client, config.KeyserverURL, keyserverFetchRequest{
@@ -113,13 +108,10 @@ func fetchKeyserverSecrets(
 		Document:   documentJSON,
 	})
 	if err != nil {
-		return 0, err
-	}
-	if err := mergeKeyserverSecrets(names, secrets, ext); err != nil {
-		return 0, err
+		return nil, err
 	}
 	log.Printf("Keyserver released %d secret(s) for %s", len(secrets), ext.Metadata.Repo)
-	return len(secrets), nil
+	return secrets, nil
 }
 
 func prefetchKeyserverCollateral(

--- a/tinfoil/cmd/boot/main.go
+++ b/tinfoil/cmd/boot/main.go
@@ -161,7 +161,10 @@ func run(ctx context.Context, invocation invocation) error {
 
 	// 7. Resolve declared secrets and hand workload values to the container manager.
 	start = time.Now()
-	secretDetail, err := prepareSecretHandoff(ctx, config, externalConfig, secretHandoff, invocation.configHash, nodeID, collateralRequest)
+	secretDetail, err := prepareSecretHandoff(ctx, config, externalConfig, secretHandoff, invocation.configHash, invocation.debug,
+		func(ctx context.Context, names []string) (map[string]string, error) {
+			return fetchKeyserverSecrets(ctx, config, externalConfig, nodeID, collateralRequest, names)
+		})
 	if err != nil {
 		tracker.Record(boot.StageKeyserverSecrets, boot.StatusFailed, time.Since(start), err.Error())
 		return err

--- a/tinfoil/cmd/boot/secrets.go
+++ b/tinfoil/cmd/boot/secrets.go
@@ -6,29 +6,55 @@ import (
 	"log"
 	"os"
 
-	wire "github.com/tinfoilsh/tinfoil-go/verifier/collaterals"
-
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/secretstore"
 )
 
+// keyserverFetcher releases the named secrets from the customer's keyserver.
+type keyserverFetcher func(ctx context.Context, names []string) (map[string]string, error)
+
+// prepareSecretHandoff resolves every declared secret from exactly one
+// source. With keyserver-url set that source is the keyserver: a value the
+// host supplied for a declared name is refused rather than merged, so the
+// host cannot substitute its own. Debug enclaves are the exception; the
+// keyserver rejects their attestation, so they take host values instead.
 func prepareSecretHandoff(
 	ctx context.Context,
 	config *Config,
 	externalConfig *shimconfig.ExternalConfig,
 	handoff *os.File,
 	configDigest string,
-	nodeID *NodeIdentity,
-	collateralRequest wire.Request,
+	debug bool,
+	fetch keyserverFetcher,
 ) (string, error) {
-	fetched := 0
-	if config.KeyserverURL != "" {
-		log.Println("Fetching keyserver secrets")
-		var err error
-		fetched, err = fetchKeyserverSecrets(ctx, config, externalConfig, nodeID, collateralRequest)
-		if err != nil {
-			return "", fmt.Errorf("keyserver secret fetch failed: %w", err)
+	names := secretstore.AllReferences(config)
+	var source string
+	switch {
+	case config.KeyserverURL == "":
+		source = "keyserver not configured"
+	case debug:
+		log.Println("Debug enclave: keyserver-url ignored, secrets supplied by host")
+		source = "debug enclave: keyserver-url ignored, secrets supplied by host"
+	default:
+		if externalConfig == nil {
+			return "", fmt.Errorf("keyserver secret fetch requires external config")
 		}
+		for _, name := range names {
+			if externalConfig.GetSecret(name) != "" {
+				return "", fmt.Errorf("host supplied secret %q, but keyserver-url is set and declared secrets must come from the keyserver", name)
+			}
+		}
+		if len(names) != 0 {
+			log.Println("Fetching keyserver secrets")
+			secrets, err := fetch(ctx, names)
+			if err != nil {
+				return "", fmt.Errorf("keyserver secret fetch failed: %w", err)
+			}
+			if err := mergeKeyserverSecrets(names, secrets, externalConfig); err != nil {
+				return "", fmt.Errorf("keyserver secret fetch failed: %w", err)
+			}
+		}
+		source = fmt.Sprintf("fetched %d from keyserver", len(names))
 	}
 
 	if missing := secretstore.MissingReferences(config, externalConfig); len(missing) != 0 {
@@ -41,13 +67,5 @@ func prepareSecretHandoff(
 	if err := secretstore.WriteHandoff(handoff, configDigest, workloadSecrets); err != nil {
 		return "", fmt.Errorf("creating sealed secret handoff: %w", err)
 	}
-
-	detail := fmt.Sprintf("handed off %d workload secret(s)", len(workloadSecrets))
-	if fetched != 0 {
-		return fmt.Sprintf("%s; fetched %d from keyserver", detail, fetched), nil
-	}
-	if config.KeyserverURL != "" {
-		return detail + "; all declared secrets already populated", nil
-	}
-	return detail + "; keyserver not configured", nil
+	return fmt.Sprintf("handed off %d workload secret(s); %s", len(workloadSecrets), source), nil
 }

--- a/tinfoil/cmd/boot/secrets_test.go
+++ b/tinfoil/cmd/boot/secrets_test.go
@@ -2,14 +2,30 @@ package main
 
 import (
 	"context"
+	"os"
 	"strings"
 	"testing"
-
-	wire "github.com/tinfoilsh/tinfoil-go/verifier/collaterals"
 
 	shimconfig "tinfoil/internal/config"
 	"tinfoil/internal/secretstore"
 )
+
+func newHandoff(t *testing.T) *os.File {
+	t.Helper()
+	handoff, err := secretstore.NewHandoffFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { handoff.Close() })
+	return handoff
+}
+
+func noFetch(t *testing.T) keyserverFetcher {
+	return func(context.Context, []string) (map[string]string, error) {
+		t.Fatal("keyserver fetch attempted")
+		return nil, nil
+	}
+}
 
 func TestPrepareSecretHandoff(t *testing.T) {
 	config := &Config{
@@ -18,13 +34,9 @@ func TestPrepareSecretHandoff(t *testing.T) {
 	externalConfig := &shimconfig.ExternalConfig{
 		Secrets: map[string]string{"API_KEY": "secret"},
 	}
-	handoff, err := secretstore.NewHandoffFile()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer handoff.Close()
+	handoff := newHandoff(t)
 
-	detail, err := prepareSecretHandoff(context.Background(), config, externalConfig, handoff, "config-digest", nil, wire.Request{})
+	detail, err := prepareSecretHandoff(context.Background(), config, externalConfig, handoff, "config-digest", false, noFetch(t))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,21 +56,82 @@ func TestPrepareSecretHandoffRejectsUnresolvedSecrets(t *testing.T) {
 	config := &Config{
 		Containers: []Container{{Secrets: []string{"API_KEY"}}},
 	}
-	handoff, err := secretstore.NewHandoffFile()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer handoff.Close()
-
-	_, err = prepareSecretHandoff(context.Background(), config, &shimconfig.ExternalConfig{}, handoff, "config-digest", nil, wire.Request{})
+	_, err := prepareSecretHandoff(context.Background(), config, &shimconfig.ExternalConfig{}, newHandoff(t), "config-digest", false, noFetch(t))
 	if err == nil || !strings.Contains(err.Error(), "1 declared secret(s) remain unresolved") {
 		t.Fatalf("error = %v", err)
 	}
 }
 
 func TestPrepareSecretHandoffReportsHandoffFailure(t *testing.T) {
-	_, err := prepareSecretHandoff(context.Background(), &Config{}, &shimconfig.ExternalConfig{}, nil, "config-digest", nil, wire.Request{})
+	_, err := prepareSecretHandoff(context.Background(), &Config{}, &shimconfig.ExternalConfig{}, nil, "config-digest", false, noFetch(t))
 	if err == nil || !strings.Contains(err.Error(), "creating sealed secret handoff") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPrepareSecretHandoffKeyserverFetchesEveryDeclaredSecret(t *testing.T) {
+	config := &Config{
+		KeyserverURL: "https://keys.example",
+		Models:       []ModelSpec{{Name: "model", KeySecret: "MODEL_KEY"}},
+		Containers:   []Container{{Secrets: []string{"API_KEY"}}},
+	}
+	externalConfig := &shimconfig.ExternalConfig{}
+	handoff := newHandoff(t)
+
+	var requested []string
+	fetch := func(_ context.Context, names []string) (map[string]string, error) {
+		requested = append(requested, names...)
+		return map[string]string{"API_KEY": "secret", "MODEL_KEY": "key"}, nil
+	}
+	detail, err := prepareSecretHandoff(context.Background(), config, externalConfig, handoff, "config-digest", false, fetch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Join(requested, ",") != "API_KEY,MODEL_KEY" {
+		t.Fatalf("requested = %v, want every declared secret", requested)
+	}
+	if detail != "handed off 1 workload secret(s); fetched 2 from keyserver" {
+		t.Fatalf("detail = %q", detail)
+	}
+	if externalConfig.GetSecret("MODEL_KEY") != "key" {
+		t.Fatalf("model key not merged for boot: %#v", externalConfig.Secrets)
+	}
+	store, err := secretstore.ReadHandoff(handoff, "config-digest", []string{"API_KEY"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if store["API_KEY"] != "secret" {
+		t.Fatalf("secret handoff = %#v", store)
+	}
+}
+
+func TestPrepareSecretHandoffKeyserverRejectsHostSuppliedSecret(t *testing.T) {
+	config := &Config{
+		KeyserverURL: "https://keys.example",
+		Containers:   []Container{{Secrets: []string{"API_KEY"}}},
+	}
+	externalConfig := &shimconfig.ExternalConfig{
+		Secrets: map[string]string{"API_KEY": "from-host"},
+	}
+	_, err := prepareSecretHandoff(context.Background(), config, externalConfig, newHandoff(t), "config-digest", false, noFetch(t))
+	if err == nil || !strings.Contains(err.Error(), "must come from the keyserver") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestPrepareSecretHandoffDebugIgnoresKeyserver(t *testing.T) {
+	config := &Config{
+		KeyserverURL: "https://keys.example",
+		Containers:   []Container{{Secrets: []string{"API_KEY"}}},
+	}
+	externalConfig := &shimconfig.ExternalConfig{
+		Secrets: map[string]string{"API_KEY": "secret"},
+	}
+	detail, err := prepareSecretHandoff(context.Background(), config, externalConfig, newHandoff(t), "config-digest", true, noFetch(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail != "handed off 1 workload secret(s); debug enclave: keyserver-url ignored, secrets supplied by host" {
+		t.Fatalf("detail = %q", detail)
 	}
 }


### PR DESCRIPTION
Replaces #357, which GitHub closed when its stacked base branch was deleted. With `keyserver-url` set, every declared secret now comes from the keyserver, and a value the host supplied for a declared name fails the boot instead of being merged; previously the enclave fetched only the names the host left empty, so a host could substitute its own value for any plain secret. Debug enclaves ignore `keyserver-url` and take host-supplied values, since the keyserver rejects their attestation, and the boot stage detail says so.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sources every declared secret from the keyserver when `keyserver-url` is set, so hosts can no longer substitute their own values for declared secrets.

- A value the host supplied for a declared name now fails the boot instead of being merged.
- Debug enclaves ignore `keyserver-url` and take host-supplied values because the keyserver rejects their attestation; the boot stage detail says so.

<sup>Written for commit 8374a8f3fd7d9fcfc6f8b2dac967970b42b1dae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

