### PR TITLE
feat: mount a pack executable when the model declares it

### DIFF
--- a/nix/go.nix
+++ b/nix/go.nix
@@ -29,7 +29,7 @@ let
   common = {
     version = "0";
     src = pkgs.lib.cleanSource ../tinfoil;
-    vendorHash = "sha256-m9/7qndXRWpoj2fLXtgvNCN26L8bxbtBOmpcyTvA9m0=";
+    vendorHash = "sha256-VcpsGnP7ymDx6yc3a+0y52gia/K4apK+0aw9QDXfG7o=";
     ldflags = [
       "-s"
       "-w"

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -46,6 +46,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 		}
 		seen[ref.mapperName()] = struct{}{}
 		mountPoint, legacyAlias := modelMountTarget(config, model, ref)
+		executable := runtimeconfig.ModelBacksExecutableVolume(config, model.Name)
 		if !legacyAlias {
 			containerMountPoint := boot.PublicModelsDir + "/" + model.Name
 			if err := os.MkdirAll(containerMountPoint, 0755); err != nil {
@@ -63,7 +64,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 			if err != nil {
 				return fmt.Errorf("finding model disk %d: %w", index, err)
 			}
-			if err := mountModelPack(ref, salt, sourceDevice, mountPoint, legacyAlias); err != nil {
+			if err := mountModelPack(ref, salt, sourceDevice, mountPoint, legacyAlias, executable); err != nil {
 				return fmt.Errorf("mounting model pack %s: %w", ref.raw, err)
 			}
 		case modelKindEncrypted:
@@ -71,7 +72,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 			if err != nil {
 				return fmt.Errorf("finding encrypted model partition %d: %w", index, err)
 			}
-			if err := mountEncryptedModelPack(model, externalConfig, sourceDevice, mountPoint); err != nil {
+			if err := mountEncryptedModelPack(model, externalConfig, sourceDevice, mountPoint, executable); err != nil {
 				return fmt.Errorf("mounting encrypted model pack %q: %w", model.Name, err)
 			}
 		}
@@ -92,7 +93,7 @@ func modelSalt(model ModelSpec) ([]byte, error) {
 }
 
 // mountModelPack mounts a plaintext model wrap using dm-verity.
-func mountModelPack(spec *modelPackRef, salt []byte, sourceDevice, mountPoint string, legacyAlias bool) error {
+func mountModelPack(spec *modelPackRef, salt []byte, sourceDevice, mountPoint string, legacyAlias, executable bool) error {
 	deviceName := spec.mapperName()
 
 	log.Printf("Opening verity device %s (uuid=%s)", deviceName, spec.UUID)
@@ -101,7 +102,7 @@ func mountModelPack(spec *modelPackRef, salt []byte, sourceDevice, mountPoint st
 			return err
 		}
 	}
-	if err := openAndMountVerity(sourceDevice, deviceName, spec.RootHash, spec.HashOffset, salt, mountPoint); err != nil {
+	if err := openAndMountVerity(sourceDevice, deviceName, spec.RootHash, spec.HashOffset, salt, mountPoint, executable); err != nil {
 		if legacyAlias {
 			removeLegacyModelPackAlias(spec)
 		}
@@ -119,6 +120,7 @@ func mountEncryptedModelPack(
 	model ModelSpec,
 	externalConfig *shimconfig.ExternalConfig,
 	sourceDevice, mountPoint string,
+	executable bool,
 ) error {
 	spec, err := parseModelPackRef(model.EMWP)
 	if err != nil {
@@ -148,6 +150,7 @@ func mountEncryptedModelPack(
 		salt,
 		mountPoint,
 		key,
+		executable,
 	); err != nil {
 		return err
 	}
@@ -278,15 +281,15 @@ func encryptedModelKey(keySecret string, spec *modelPackRef, externalConfig *shi
 	return modelwrap.DeriveKey(key, spec.ArtifactRef)
 }
 
-func openAndMountVerity(sourceDevice, deviceName, rootHash, hashOffset string, salt []byte, mountPoint string) error {
-	return openAndMountVerityWithOps(directModelVolumeOps{}, sourceDevice, deviceName, rootHash, hashOffset, salt, mountPoint)
+func openAndMountVerity(sourceDevice, deviceName, rootHash, hashOffset string, salt []byte, mountPoint string, executable bool) error {
+	return openAndMountVerityWithOps(directModelVolumeOps{}, sourceDevice, deviceName, rootHash, hashOffset, salt, mountPoint, executable)
 }
 
 type modelVolumeOps interface {
 	openVerity(sourceDevice, name, rootHash, hashOffset string, salt []byte) (string, error)
 	openCrypt(sourceDevice, name string, key []byte) (string, error)
 	remove(name string) error
-	mount(sourceDevice, mountPoint string) error
+	mount(sourceDevice, mountPoint string, executable bool) error
 }
 
 type directModelVolumeOps struct{}
@@ -329,17 +332,19 @@ func (directModelVolumeOps) remove(name string) error {
 	return devicemapper.Remove(control, name)
 }
 
-func (directModelVolumeOps) mount(sourceDevice, mountPoint string) error {
+func (directModelVolumeOps) mount(sourceDevice, mountPoint string, executable bool) error {
 	if err := os.MkdirAll(mountPoint, 0755); err != nil {
 		return fmt.Errorf("creating model mount point: %w", err)
 	}
-	if err := unix.Mount(
-		sourceDevice,
-		mountPoint,
-		"erofs",
-		unix.MS_RDONLY|unix.MS_NODEV|unix.MS_NOSUID|unix.MS_NOEXEC,
-		"",
-	); err != nil {
+	// Weights are never programs, so a pack is noexec unless the measured
+	// config backs an executable volume with it. Then the pack holds a store,
+	// and the merged view above cannot make its contents runnable: the lower
+	// layer's noexec is enforced through it.
+	flags := uintptr(unix.MS_RDONLY | unix.MS_NODEV | unix.MS_NOSUID)
+	if !executable {
+		flags |= unix.MS_NOEXEC
+	}
+	if err := unix.Mount(sourceDevice, mountPoint, "erofs", flags, ""); err != nil {
 		return fmt.Errorf("mounting verified model volume: %w", err)
 	}
 	return nil
@@ -350,12 +355,13 @@ func openAndMountVerityWithOps(
 	sourceDevice, deviceName, rootHash, hashOffset string,
 	salt []byte,
 	mountPoint string,
+	executable bool,
 ) error {
 	mapperNode, err := ops.openVerity(sourceDevice, deviceName, rootHash, hashOffset, salt)
 	if err != nil {
 		return err
 	}
-	if err := ops.mount(mapperNode, mountPoint); err != nil {
+	if err := ops.mount(mapperNode, mountPoint, executable); err != nil {
 		if removeErr := ops.remove(deviceName); removeErr != nil {
 			return errors.Join(err, fmt.Errorf("removing failed verity mapping: %w", removeErr))
 		}
@@ -370,13 +376,14 @@ func openEncryptedAndMount(
 	salt []byte,
 	mountPoint string,
 	key []byte,
+	executable bool,
 ) error {
 	defer zeroBytes(key)
 	cryptDevice, err := ops.openCrypt(sourceDevice, cryptName, key)
 	if err != nil {
 		return err
 	}
-	if err := openAndMountVerityWithOps(ops, cryptDevice, verityName, rootHash, hashOffset, salt, mountPoint); err != nil {
+	if err := openAndMountVerityWithOps(ops, cryptDevice, verityName, rootHash, hashOffset, salt, mountPoint, executable); err != nil {
 		if removeErr := ops.remove(cryptName); removeErr != nil {
 			return errors.Join(err, fmt.Errorf("removing failed crypt mapping: %w", removeErr))
 		}

--- a/tinfoil/cmd/boot/models.go
+++ b/tinfoil/cmd/boot/models.go
@@ -46,7 +46,7 @@ func mountModels(config *Config, externalConfig *shimconfig.ExternalConfig) erro
 		}
 		seen[ref.mapperName()] = struct{}{}
 		mountPoint, legacyAlias := modelMountTarget(config, model, ref)
-		executable := runtimeconfig.ModelBacksExecutableVolume(config, model.Name)
+		executable := model.Exec
 		if !legacyAlias {
 			containerMountPoint := boot.PublicModelsDir + "/" + model.Name
 			if err := os.MkdirAll(containerMountPoint, 0755); err != nil {
@@ -336,10 +336,7 @@ func (directModelVolumeOps) mount(sourceDevice, mountPoint string, executable bo
 	if err := os.MkdirAll(mountPoint, 0755); err != nil {
 		return fmt.Errorf("creating model mount point: %w", err)
 	}
-	// Weights are never programs, so a pack is noexec unless the measured
-	// config backs an executable volume with it. Then the pack holds a store,
-	// and the merged view above cannot make its contents runnable: the lower
-	// layer's noexec is enforced through it.
+	// No view stacked above the pack can launder this flag away.
 	flags := uintptr(unix.MS_RDONLY | unix.MS_NODEV | unix.MS_NOSUID)
 	if !executable {
 		flags |= unix.MS_NOEXEC

--- a/tinfoil/cmd/boot/models_test.go
+++ b/tinfoil/cmd/boot/models_test.go
@@ -105,11 +105,11 @@ func TestModelSalt(t *testing.T) {
 
 func TestOpenAndMountVerityCleansUpMountFailure(t *testing.T) {
 	ops := &fakeModelVolumeOps{mountErr: errors.New("mount failed")}
-	err := openAndMountVerityWithOps(ops, "/dev/source", "mwp-test", strings.Repeat("a", 64), "4096", testSalt(), "/mnt/model")
+	err := openAndMountVerityWithOps(ops, "/dev/source", "mwp-test", strings.Repeat("a", 64), "4096", testSalt(), "/mnt/model", false)
 	if err == nil || !strings.Contains(err.Error(), "mount failed") {
 		t.Fatalf("error = %v, want mount failure", err)
 	}
-	wantCalls := []string{"verity:mwp-test", "mount:/dev/mapper/mwp-test", "remove:mwp-test"}
+	wantCalls := []string{"verity:mwp-test", "mount:/dev/mapper/mwp-test:exec=false", "remove:mwp-test"}
 	if fmt.Sprint(ops.calls) != fmt.Sprint(wantCalls) {
 		t.Fatalf("calls = %v, want %v", ops.calls, wantCalls)
 	}
@@ -128,6 +128,7 @@ func TestOpenEncryptedAndMountZeroesKeyAndCleansUp(t *testing.T) {
 		testSalt(),
 		"/mnt/model",
 		key,
+		false,
 	)
 	if err == nil || !strings.Contains(err.Error(), "verity failed") {
 		t.Fatalf("error = %v, want verity failure", err)
@@ -157,6 +158,7 @@ func TestOpenEncryptedAndMountCleansBothMappingsAfterMountFailure(t *testing.T) 
 		testSalt(),
 		"/mnt/model",
 		key,
+		true,
 	)
 	if err == nil || !strings.Contains(err.Error(), "mount failed") {
 		t.Fatalf("error = %v, want mount failure", err)
@@ -164,7 +166,7 @@ func TestOpenEncryptedAndMountCleansBothMappingsAfterMountFailure(t *testing.T) 
 	wantCalls := []string{
 		"crypt:emwp-test-crypt",
 		"verity:mwp-test",
-		"mount:/dev/mapper/mwp-test",
+		"mount:/dev/mapper/mwp-test:exec=true",
 		"remove:mwp-test",
 		"remove:emwp-test-crypt",
 	}
@@ -211,8 +213,8 @@ func (ops *fakeModelVolumeOps) remove(name string) error {
 	return ops.removeErr
 }
 
-func (ops *fakeModelVolumeOps) mount(sourceDevice, _ string) error {
-	ops.calls = append(ops.calls, "mount:"+sourceDevice)
+func (ops *fakeModelVolumeOps) mount(sourceDevice, _ string, executable bool) error {
+	ops.calls = append(ops.calls, fmt.Sprintf("mount:%s:exec=%t", sourceDevice, executable))
 	return ops.mountErr
 }
 

--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -579,6 +579,10 @@ func startVolumeWorkers(ctx context.Context, deps lifecycleDeps) error {
 			fmt.Sprintf("--exec=%t", volume.Exec),
 			"--owner="+strconv.Itoa(volume.Owner),
 		)
+		for _, overlay := range volume.Overlays {
+			command.Args = append(command.Args,
+				"--overlay="+overlay.Model+":"+overlay.Source+":"+overlay.Target)
+		}
 		command.Name = volumesName + "-" + volume.Name
 		if err := deps.services.Start(ctx, supervisor.Service{
 			Name:    command.Name,

--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -579,10 +579,6 @@ func startVolumeWorkers(ctx context.Context, deps lifecycleDeps) error {
 			fmt.Sprintf("--exec=%t", volume.Exec),
 			"--owner="+strconv.Itoa(volume.Owner),
 		)
-		for _, overlay := range volume.Overlays {
-			command.Args = append(command.Args,
-				"--overlay="+overlay.Model+":"+overlay.Source+":"+overlay.Target)
-		}
 		command.Name = volumesName + "-" + volume.Name
 		if err := deps.services.Start(ctx, supervisor.Service{
 			Name:    command.Name,

--- a/tinfoil/cmd/pid1/main.go
+++ b/tinfoil/cmd/pid1/main.go
@@ -572,13 +572,17 @@ func startVolumeWorkers(ctx context.Context, deps lifecycleDeps) error {
 		return nil
 	}
 	for index, volume := range config.Volumes {
-		command := hardenedCommand(hardening.ServiceVolumes, boot.VolumeWorkerBinary,
-			"--models="+strconv.Itoa(len(config.Models)),
-			"--index="+strconv.Itoa(index),
-			"--name="+volume.Name,
+		args := []string{
+			"--models=" + strconv.Itoa(len(config.Models)),
+			"--index=" + strconv.Itoa(index),
+			"--name=" + volume.Name,
 			fmt.Sprintf("--exec=%t", volume.Exec),
-			"--owner="+strconv.Itoa(volume.Owner),
-		)
+			"--owner=" + strconv.Itoa(volume.Owner),
+		}
+		for _, overlay := range volume.Overlays {
+			args = append(args, "--overlay="+overlay.Model+":"+overlay.Source+":"+overlay.Target)
+		}
+		command := hardenedCommand(hardening.ServiceVolumes, boot.VolumeWorkerBinary, args...)
 		command.Name = volumesName + "-" + volume.Name
 		if err := deps.services.Start(ctx, supervisor.Service{
 			Name:    command.Name,

--- a/tinfoil/cmd/volumeworker/main.go
+++ b/tinfoil/cmd/volumeworker/main.go
@@ -35,14 +35,7 @@ const (
 	formatMode  = "--format"
 	selfPath    = "/proc/self/exe"
 
-	maxOwner    = 65534
-	maxOverlays = 8
-	modelsRoot  = boot.PrivateModelsDir
-
-	// Siblings of the merged mount point, on the same volume because overlayfs
-	// requires the upper layer and its work directory to share a filesystem.
-	upperSuffix    = ".upper"
-	workSuffix     = ".work"
+	maxOwner       = 65534
 	keyBytes       = 64
 	blankProbeSize = 1 << 20
 	requestTimeout = 5 * time.Second
@@ -57,23 +50,7 @@ const (
 	responseLocked   byte = 3
 )
 
-var (
-	namePattern  = regexp.MustCompile(`^[a-z][a-z0-9-]{0,62}$`)
-	modelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
-
-	// Every segment has to begin with something other than a dot, which is what
-	// keeps `.` and `..` out, and the character class is what keeps the comma
-	// and colon that delimit mount options and this flag out of both paths.
-	overlayPathPattern = regexp.MustCompile(`^[A-Za-z0-9_-][A-Za-z0-9._-]*(/[A-Za-z0-9_-][A-Za-z0-9._-]*)*$`)
-)
-
-// overlay is one model pack merged into this volume: source inside the pack is
-// the lower layer, target inside the volume is where the merged tree appears.
-type overlay struct {
-	model  string
-	source string
-	target string
-}
+var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,62}$`)
 
 type invocation struct {
 	models     int
@@ -81,7 +58,6 @@ type invocation struct {
 	name       string
 	executable bool
 	owner      int
-	overlays   []overlay
 }
 
 type mountState struct {
@@ -93,7 +69,6 @@ type worker struct {
 	name       string
 	executable bool
 	owner      int
-	overlays   []overlay
 	control    *os.File
 	source     *os.File
 	unlocked   bool
@@ -130,14 +105,6 @@ func parseInvocation(args []string) (invocation, error) {
 	flags.StringVar(&parsed.name, "name", "", "")
 	flags.BoolVar(&parsed.executable, "exec", false, "")
 	flags.IntVar(&parsed.owner, "owner", 0, "")
-	flags.Func("overlay", "", func(value string) error {
-		parts := strings.Split(value, ":")
-		if len(parts) != 3 {
-			return fmt.Errorf("overlay %q is not model:source:target", value)
-		}
-		parsed.overlays = append(parsed.overlays, overlay{model: parts[0], source: parts[1], target: parts[2]})
-		return nil
-	})
 	if err := flags.Parse(args[1:]); err != nil {
 		return invocation{}, err
 	}
@@ -158,23 +125,6 @@ func parseInvocation(args []string) (invocation, error) {
 	}
 	if err := device.StorageSlots(parsed.models, parsed.index+1); err != nil {
 		return invocation{}, err
-	}
-	// Re-checked here rather than trusted from the caller, because these two
-	// paths are spliced into mount options and one of them names a directory
-	// this worker creates on the volume.
-	if len(parsed.overlays) > maxOverlays {
-		return invocation{}, fmt.Errorf("too many overlays: %d", len(parsed.overlays))
-	}
-	for _, spec := range parsed.overlays {
-		if !modelPattern.MatchString(spec.model) {
-			return invocation{}, fmt.Errorf("invalid overlay model %q", spec.model)
-		}
-		if !overlayPathPattern.MatchString(spec.source) || !overlayPathPattern.MatchString(spec.target) {
-			return invocation{}, fmt.Errorf("invalid overlay path in %q", spec.model)
-		}
-	}
-	if !parsed.executable && len(parsed.overlays) > 0 {
-		return invocation{}, errors.New("overlays require an executable volume")
 	}
 	return parsed, nil
 }
@@ -246,7 +196,6 @@ func openWorker(parsed invocation) (*worker, error) {
 		name:       parsed.name,
 		executable: parsed.executable,
 		owner:      parsed.owner,
-		overlays:   parsed.overlays,
 		control:    control,
 		source:     source,
 	}, nil
@@ -420,58 +369,6 @@ func (w *worker) activate(key []byte, initialize bool) (result error) {
 	}
 	if target.device != mappedDevice {
 		return fmt.Errorf("mounted unexpected device %d:%d", unix.Major(target.device), unix.Minor(target.device))
-	}
-	// Last, so that nothing after it can fail and leave the rollback above
-	// unable to unmount a volume with an overlay still on top of it.
-	return w.mountOverlays()
-}
-
-// mountOverlays merges each declared pack into the volume: the pack is the
-// lower layer and the volume holds the upper, so a container writes into a
-// tree whose contents are the attested pack until it writes over them. This
-// mount is also the one a container executes through, which is why the pack's
-// own noexec mount does not reach the programs in it.
-func (w *worker) mountOverlays() (result error) {
-	merged := make([]string, 0, len(w.overlays))
-	defer func() {
-		if result == nil {
-			return
-		}
-		for index := len(merged) - 1; index >= 0; index-- {
-			result = errors.Join(result, unix.Unmount(merged[index], 0))
-		}
-	}()
-	for _, spec := range w.overlays {
-		lower := filepath.Join(modelsRoot, spec.model, spec.source)
-		if _, err := os.Stat(lower); err != nil {
-			return fmt.Errorf("overlay lower layer: %w", err)
-		}
-		mountPoint := filepath.Join(w.dataPath(), spec.target)
-		upper, work := mountPoint+upperSuffix, mountPoint+workSuffix
-		// The upper and work layers stay this worker's: overlayfs creates a
-		// directory inside the work layer as the mounting process, and giving
-		// it away first is what makes that fail -- quietly, by mounting the
-		// merged tree read-only. Only the merged root is handed over, below.
-		for _, directory := range []string{mountPoint, upper, work} {
-			if err := os.MkdirAll(directory, 0o755); err != nil {
-				return err
-			}
-		}
-		flags := uintptr(unix.MS_NODEV | unix.MS_NOSUID)
-		if !w.executable {
-			flags |= unix.MS_NOEXEC
-		}
-		if err := unix.Mount("overlay", mountPoint, "overlay", flags,
-			"lowerdir="+lower+",upperdir="+upper+",workdir="+work); err != nil {
-			return fmt.Errorf("mounting overlay at %s: %w", mountPoint, err)
-		}
-		merged = append(merged, mountPoint)
-		// The merged root is the pack's directory until something writes to it,
-		// so the owner is given it here instead of inheriting root from below.
-		// This is also the write that proves the mount is not read-only.
-		if err := os.Chown(mountPoint, w.owner, w.owner); err != nil {
-			return err
-		}
 	}
 	return nil
 }

--- a/tinfoil/cmd/volumeworker/main.go
+++ b/tinfoil/cmd/volumeworker/main.go
@@ -35,7 +35,14 @@ const (
 	formatMode  = "--format"
 	selfPath    = "/proc/self/exe"
 
-	maxOwner       = 65534
+	maxOwner    = 65534
+	maxOverlays = 8
+	modelsRoot  = boot.PrivateModelsDir
+
+	// Siblings of the merged mount point, on the same volume because overlayfs
+	// requires the upper layer and its work directory to share a filesystem.
+	upperSuffix    = ".upper"
+	workSuffix     = ".work"
 	keyBytes       = 64
 	blankProbeSize = 1 << 20
 	requestTimeout = 5 * time.Second
@@ -50,7 +57,23 @@ const (
 	responseLocked   byte = 3
 )
 
-var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,62}$`)
+var (
+	namePattern  = regexp.MustCompile(`^[a-z][a-z0-9-]{0,62}$`)
+	modelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+
+	// Every segment has to begin with something other than a dot, which is what
+	// keeps `.` and `..` out, and the character class is what keeps the comma
+	// and colon that delimit mount options and this flag out of both paths.
+	overlayPathPattern = regexp.MustCompile(`^[A-Za-z0-9_-][A-Za-z0-9._-]*(/[A-Za-z0-9_-][A-Za-z0-9._-]*)*$`)
+)
+
+// overlay is one model pack merged into this volume: source inside the pack is
+// the lower layer, target inside the volume is where the merged tree appears.
+type overlay struct {
+	model  string
+	source string
+	target string
+}
 
 type invocation struct {
 	models     int
@@ -58,6 +81,7 @@ type invocation struct {
 	name       string
 	executable bool
 	owner      int
+	overlays   []overlay
 }
 
 type mountState struct {
@@ -69,6 +93,7 @@ type worker struct {
 	name       string
 	executable bool
 	owner      int
+	overlays   []overlay
 	control    *os.File
 	source     *os.File
 	unlocked   bool
@@ -105,6 +130,14 @@ func parseInvocation(args []string) (invocation, error) {
 	flags.StringVar(&parsed.name, "name", "", "")
 	flags.BoolVar(&parsed.executable, "exec", false, "")
 	flags.IntVar(&parsed.owner, "owner", 0, "")
+	flags.Func("overlay", "", func(value string) error {
+		parts := strings.Split(value, ":")
+		if len(parts) != 3 {
+			return fmt.Errorf("overlay %q is not model:source:target", value)
+		}
+		parsed.overlays = append(parsed.overlays, overlay{model: parts[0], source: parts[1], target: parts[2]})
+		return nil
+	})
 	if err := flags.Parse(args[1:]); err != nil {
 		return invocation{}, err
 	}
@@ -125,6 +158,23 @@ func parseInvocation(args []string) (invocation, error) {
 	}
 	if err := device.StorageSlots(parsed.models, parsed.index+1); err != nil {
 		return invocation{}, err
+	}
+	// Re-checked here rather than trusted from the caller, because these two
+	// paths are spliced into mount options and one of them names a directory
+	// this worker creates on the volume.
+	if len(parsed.overlays) > maxOverlays {
+		return invocation{}, fmt.Errorf("too many overlays: %d", len(parsed.overlays))
+	}
+	for _, spec := range parsed.overlays {
+		if !modelPattern.MatchString(spec.model) {
+			return invocation{}, fmt.Errorf("invalid overlay model %q", spec.model)
+		}
+		if !overlayPathPattern.MatchString(spec.source) || !overlayPathPattern.MatchString(spec.target) {
+			return invocation{}, fmt.Errorf("invalid overlay path in %q", spec.model)
+		}
+	}
+	if !parsed.executable && len(parsed.overlays) > 0 {
+		return invocation{}, errors.New("overlays require an executable volume")
 	}
 	return parsed, nil
 }
@@ -196,6 +246,7 @@ func openWorker(parsed invocation) (*worker, error) {
 		name:       parsed.name,
 		executable: parsed.executable,
 		owner:      parsed.owner,
+		overlays:   parsed.overlays,
 		control:    control,
 		source:     source,
 	}, nil
@@ -369,6 +420,58 @@ func (w *worker) activate(key []byte, initialize bool) (result error) {
 	}
 	if target.device != mappedDevice {
 		return fmt.Errorf("mounted unexpected device %d:%d", unix.Major(target.device), unix.Minor(target.device))
+	}
+	// Last, so that nothing after it can fail and leave the rollback above
+	// unable to unmount a volume with an overlay still on top of it.
+	return w.mountOverlays()
+}
+
+// mountOverlays merges each declared pack into the volume: the pack is the
+// lower layer and the volume holds the upper, so a container writes into a
+// tree whose contents are the attested pack until it writes over them. This
+// mount is also the one a container executes through, which is why the pack's
+// own noexec mount does not reach the programs in it.
+func (w *worker) mountOverlays() (result error) {
+	merged := make([]string, 0, len(w.overlays))
+	defer func() {
+		if result == nil {
+			return
+		}
+		for index := len(merged) - 1; index >= 0; index-- {
+			result = errors.Join(result, unix.Unmount(merged[index], 0))
+		}
+	}()
+	for _, spec := range w.overlays {
+		lower := filepath.Join(modelsRoot, spec.model, spec.source)
+		if _, err := os.Stat(lower); err != nil {
+			return fmt.Errorf("overlay lower layer: %w", err)
+		}
+		mountPoint := filepath.Join(w.dataPath(), spec.target)
+		upper, work := mountPoint+upperSuffix, mountPoint+workSuffix
+		// The upper and work layers stay this worker's: overlayfs creates a
+		// directory inside the work layer as the mounting process, and giving
+		// it away first is what makes that fail -- quietly, by mounting the
+		// merged tree read-only. Only the merged root is handed over, below.
+		for _, directory := range []string{mountPoint, upper, work} {
+			if err := os.MkdirAll(directory, 0o755); err != nil {
+				return err
+			}
+		}
+		flags := uintptr(unix.MS_NODEV | unix.MS_NOSUID)
+		if !w.executable {
+			flags |= unix.MS_NOEXEC
+		}
+		if err := unix.Mount("overlay", mountPoint, "overlay", flags,
+			"lowerdir="+lower+",upperdir="+upper+",workdir="+work); err != nil {
+			return fmt.Errorf("mounting overlay at %s: %w", mountPoint, err)
+		}
+		merged = append(merged, mountPoint)
+		// The merged root is the pack's directory until something writes to it,
+		// so the owner is given it here instead of inheriting root from below.
+		// This is also the write that proves the mount is not read-only.
+		if err := os.Chown(mountPoint, w.owner, w.owner); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/tinfoil/cmd/volumeworker/main.go
+++ b/tinfoil/cmd/volumeworker/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -35,22 +37,43 @@ const (
 	formatMode  = "--format"
 	selfPath    = "/proc/self/exe"
 
-	maxOwner       = 65534
-	keyBytes       = 64
-	blankProbeSize = 1 << 20
-	requestTimeout = 5 * time.Second
+	upperSuffix = ".upper"
+	workSuffix  = ".work"
 
-	opStatus     byte = 0
-	opUnlock     byte = 1
-	opInitialize byte = 2
+	maxOwner        = 65534
+	maxOverlays     = 8
+	keyBytes        = 64
+	maxRequestBytes = 512
+	blankProbeSize  = 1 << 20
+	requestTimeout  = 5 * time.Second
 
-	responseOK       byte = 0
-	responseRejected byte = 1
-	responseFailed   byte = 2
-	responseLocked   byte = 3
+	opStatus     = "status"
+	opUnlock     = "unlock"
+	opInitialize = "initialize"
+
+	statusOK       = "ok"
+	statusRejected = "rejected"
+	statusFailed   = "failed"
+	statusLocked   = "locked"
 )
 
-var namePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,62}$`)
+var (
+	namePattern  = regexp.MustCompile(`^[a-z][a-z0-9-]{0,62}$`)
+	modelPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
+	// A source may hold slashes; every segment begins with a non-dot to keep out
+	// `.`/`..`, and the class keeps out the comma and colon that would inject
+	// extra layers or mount options.
+	sourcePattern = regexp.MustCompile(`^[A-Za-z0-9_-][A-Za-z0-9._-]*(/[A-Za-z0-9_-][A-Za-z0-9._-]*)*$`)
+)
+
+// overlay merges one model pack into this volume, entirely from the measured
+// invocation: source inside the pack is the read-only lower, target inside the
+// volume is where the merged tree appears.
+type overlay struct {
+	model  string
+	source string
+	target string
+}
 
 type invocation struct {
 	models     int
@@ -58,6 +81,7 @@ type invocation struct {
 	name       string
 	executable bool
 	owner      int
+	overlays   []overlay
 }
 
 type mountState struct {
@@ -65,10 +89,23 @@ type mountState struct {
 	device uint64
 }
 
+// request is one JSON object per SOCK_SEQPACKET datagram. The overlay layout is
+// measured and reaches the worker through its invocation, so the caller supplies
+// only the operation and the unlock key.
+type request struct {
+	Op  string `json:"op"`
+	Key []byte `json:"key,omitempty"`
+}
+
+type response struct {
+	Status string `json:"status"`
+}
+
 type worker struct {
 	name       string
 	executable bool
 	owner      int
+	overlays   []overlay
 	control    *os.File
 	source     *os.File
 	unlocked   bool
@@ -105,6 +142,14 @@ func parseInvocation(args []string) (invocation, error) {
 	flags.StringVar(&parsed.name, "name", "", "")
 	flags.BoolVar(&parsed.executable, "exec", false, "")
 	flags.IntVar(&parsed.owner, "owner", 0, "")
+	flags.Func("overlay", "", func(value string) error {
+		parts := strings.Split(value, ":")
+		if len(parts) != 3 {
+			return fmt.Errorf("overlay %q is not model:source:target", value)
+		}
+		parsed.overlays = append(parsed.overlays, overlay{model: parts[0], source: parts[1], target: parts[2]})
+		return nil
+	})
 	if err := flags.Parse(args[1:]); err != nil {
 		return invocation{}, err
 	}
@@ -125,6 +170,21 @@ func parseInvocation(args []string) (invocation, error) {
 	}
 	if err := device.StorageSlots(parsed.models, parsed.index+1); err != nil {
 		return invocation{}, err
+	}
+	// Re-checked here, not trusted from the caller: these strings are spliced
+	// into mount options and one names a directory this worker creates on the
+	// volume. The same paths are measured in tinfoil-config; this is the second
+	// gate.
+	if len(parsed.overlays) > maxOverlays {
+		return invocation{}, fmt.Errorf("too many overlays: %d", len(parsed.overlays))
+	}
+	if len(parsed.overlays) > 0 && !parsed.executable {
+		return invocation{}, errors.New("overlays require an executable volume")
+	}
+	for _, spec := range parsed.overlays {
+		if !modelPattern.MatchString(spec.model) || !sourcePattern.MatchString(spec.source) || !namePattern.MatchString(spec.target) {
+			return invocation{}, fmt.Errorf("invalid overlay %q", spec.model)
+		}
 	}
 	return parsed, nil
 }
@@ -196,6 +256,7 @@ func openWorker(parsed invocation) (*worker, error) {
 		name:       parsed.name,
 		executable: parsed.executable,
 		owner:      parsed.owner,
+		overlays:   parsed.overlays,
 		control:    control,
 		source:     source,
 	}, nil
@@ -291,48 +352,61 @@ func (w *worker) serve(connection *net.UnixConn) error {
 	if err := connection.SetDeadline(time.Now().Add(requestTimeout)); err != nil {
 		return err
 	}
-	var packet [keyBytes + 2]byte
+	var packet [maxRequestBytes + 1]byte
 	defer clear(packet[:])
 	n, err := connection.Read(packet[:])
 	if err != nil {
 		return err
 	}
 	status, requestErr := w.handle(packet[:n])
-	if _, err := connection.Write([]byte{status}); err != nil {
+	reply, err := json.Marshal(response{Status: status})
+	if err != nil {
+		return errors.Join(requestErr, err)
+	}
+	if _, err := connection.Write(reply); err != nil {
 		return errors.Join(requestErr, err)
 	}
 	return requestErr
 }
 
-func (w *worker) handle(packet []byte) (byte, error) {
-	if len(packet) == 1 && packet[0] == opStatus {
-		return responseLocked, nil
+func (w *worker) handle(packet []byte) (string, error) {
+	if len(packet) > maxRequestBytes {
+		return statusRejected, errors.New("request is too large")
 	}
-	if len(packet) != keyBytes+1 {
-		return responseRejected, errors.New("invalid request size")
+	var spec request
+	defer func() { clear(spec.Key) }()
+	decoder := json.NewDecoder(bytes.NewReader(packet))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&spec); err != nil {
+		return statusRejected, err
 	}
-	if packet[0] != opUnlock && packet[0] != opInitialize {
-		return responseRejected, errors.New("invalid request operation")
+	if spec.Op == opStatus {
+		return statusLocked, nil
 	}
-	initialize := packet[0] == opInitialize
-	if initialize {
+	if spec.Op != opUnlock && spec.Op != opInitialize {
+		return statusRejected, fmt.Errorf("invalid request operation %q", spec.Op)
+	}
+	if len(spec.Key) != keyBytes {
+		return statusRejected, fmt.Errorf("key is %d bytes, want %d", len(spec.Key), keyBytes)
+	}
+	if spec.Op == opInitialize {
 		blank, err := blockDeviceBlank(w.source)
 		if err != nil {
-			return responseFailed, err
+			return statusFailed, err
 		}
 		if !blank {
-			return responseRejected, errors.New("storage volume is not blank")
+			return statusRejected, errors.New("storage volume is not blank")
 		}
 	}
-	if err := w.activate(packet[1:], initialize); err != nil {
-		return responseFailed, err
+	if err := w.activate(spec); err != nil {
+		return statusFailed, err
 	}
 	w.unlocked = true
-	return responseOK, nil
+	return statusOK, nil
 }
 
-func (w *worker) activate(key []byte, initialize bool) (result error) {
-	mappedDevice, err := devicemapper.ActivateWritableCrypt(w.control, w.source, w.mapperName(), key)
+func (w *worker) activate(spec request) (result error) {
+	mappedDevice, err := devicemapper.ActivateWritableCrypt(w.control, w.source, w.mapperName(), spec.Key)
 	if err != nil {
 		return err
 	}
@@ -346,7 +420,7 @@ func (w *worker) activate(key []byte, initialize bool) (result error) {
 		}
 		result = errors.Join(result, devicemapper.Remove(w.control, w.mapperName()))
 	}()
-	if initialize {
+	if spec.Op == opInitialize {
 		command := exec.Command(selfPath, formatMode, w.mapperNode(), strconv.Itoa(w.owner))
 		command.Env = []string{}
 		command.Stdout = io.Discard
@@ -370,7 +444,71 @@ func (w *worker) activate(key []byte, initialize bool) (result error) {
 	if target.device != mappedDevice {
 		return fmt.Errorf("mounted unexpected device %d:%d", unix.Major(target.device), unix.Minor(target.device))
 	}
+	// Last, so a later failure never leaves the rollback above unable to unmount
+	// a volume with an overlay still on top of it.
+	return w.mountOverlays()
+}
+
+func (w *worker) mountOverlays() (result error) {
+	merged := make([]string, 0, len(w.overlays))
+	defer func() {
+		if result == nil {
+			return
+		}
+		for index := len(merged) - 1; index >= 0; index-- {
+			result = errors.Join(result, unix.Unmount(merged[index], 0))
+		}
+	}()
+	for _, spec := range w.overlays {
+		mountPoint, err := w.overlay(spec)
+		if err != nil {
+			return err
+		}
+		merged = append(merged, mountPoint)
+	}
 	return nil
+}
+
+func (w *worker) overlay(spec overlay) (string, error) {
+	lower := filepath.Join(boot.PrivateModelsDir, spec.model, spec.source)
+	// sourcePattern keeps the spec inside the pack, but a symlink in the pack
+	// would still resolve the lower layer out of it, so the path has to be real.
+	resolved, err := filepath.EvalSymlinks(lower)
+	if err != nil {
+		return "", err
+	}
+	if resolved != lower {
+		return "", fmt.Errorf("overlay source %s is not a real path in the pack", lower)
+	}
+	mountPoint := filepath.Join(w.dataPath(), spec.target)
+	upper, work := mountPoint+upperSuffix, mountPoint+workSuffix
+	for _, directory := range []string{mountPoint, upper, work} {
+		if err := os.Mkdir(directory, 0o755); err != nil && !errors.Is(err, os.ErrExist) {
+			return "", err
+		}
+		// A pre-existing entry is tolerated because the volume persists, but a
+		// symlink here would send the mount, or the upper writes, off the volume.
+		info, err := os.Lstat(directory)
+		if err != nil {
+			return "", err
+		}
+		if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+			return "", fmt.Errorf("overlay path %s is not a directory", directory)
+		}
+	}
+	flags := uintptr(unix.MS_NODEV | unix.MS_NOSUID)
+	if !w.executable {
+		flags |= unix.MS_NOEXEC
+	}
+	options := "lowerdir=" + lower + ",upperdir=" + upper + ",workdir=" + work
+	if err := unix.Mount("overlay", mountPoint, "overlay", flags, options); err != nil {
+		return "", fmt.Errorf("merging %s into %s: %w", lower, mountPoint, err)
+	}
+	// overlayfs performs every upper-layer operation as the mounter, so upper and work stay ours.
+	if err := os.Chown(mountPoint, w.owner, w.owner); err != nil {
+		return "", errors.Join(err, unix.Unmount(mountPoint, 0))
+	}
+	return mountPoint, nil
 }
 
 func runFormatter(args []string) error {
@@ -406,7 +544,7 @@ func runFormatter(args []string) error {
 	// with the volume gid and no CAP_DAC_OVERRIDE, and new directories have to
 	// stay in the group as it grows. mkfs has to set both: it writes the root
 	// inode directly, whereas a chmod afterwards would need CAP_FOWNER, which
-	// the volume worker is not given.
+	// this formatter has just dropped.
 	root := fmt.Sprintf("root_owner=%d:%d,root_perms=2775", owner, owner)
 	return syscall.Exec(mkfsPath, []string{mkfsPath, "-F", "-q", "-E", root, args[2]}, []string{})
 }

--- a/tinfoil/cmd/volumeworker/main_test.go
+++ b/tinfoil/cmd/volumeworker/main_test.go
@@ -1,9 +1,6 @@
 package main
 
-import (
-	"reflect"
-	"testing"
-)
+import "testing"
 
 func TestParseInvocationRejectsUnusableRequests(t *testing.T) {
 	for _, test := range []struct {
@@ -17,9 +14,6 @@ func TestParseInvocationRejectsUnusableRequests(t *testing.T) {
 		{"owner beyond range", []string{"worker", "--name=workspace", "--owner=65535"}},
 		{"more disks than slots", []string{"worker", "--name=workspace", "--models=24", "--index=0"}},
 		{"trailing arguments", []string{"worker", "--name=workspace", "extra"}},
-		{"overlay without three fields", []string{"worker", "--name=workspace", "--overlay=nix:store"}},
-		{"overlay escaping the pack", []string{"worker", "--name=workspace", "--exec=true", "--overlay=nix:../store:nix/store"}},
-		{"overlay on a noexec volume", []string{"worker", "--name=workspace", "--overlay=nix:store:nix/store"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if _, err := parseInvocation(test.args); err == nil {
@@ -30,18 +24,12 @@ func TestParseInvocationRejectsUnusableRequests(t *testing.T) {
 }
 
 func TestParseInvocationAcceptsDeclaredVolume(t *testing.T) {
-	parsed, err := parseInvocation([]string{
-		"worker", "--models=2", "--index=1", "--name=workspace", "--exec=true", "--owner=1000",
-		"--overlay=nix:store:nix/store",
-	})
+	parsed, err := parseInvocation([]string{"worker", "--models=2", "--index=1", "--name=workspace", "--exec=true", "--owner=1000"})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := invocation{
-		models: 2, index: 1, name: "workspace", executable: true, owner: 1000,
-		overlays: []overlay{{model: "nix", source: "store", target: "nix/store"}},
-	}
-	if !reflect.DeepEqual(parsed, want) {
+	want := invocation{models: 2, index: 1, name: "workspace", executable: true, owner: 1000}
+	if parsed != want {
 		t.Fatalf("parsed = %+v, want %+v", parsed, want)
 	}
 }

--- a/tinfoil/cmd/volumeworker/main_test.go
+++ b/tinfoil/cmd/volumeworker/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseInvocationRejectsUnusableRequests(t *testing.T) {
 	for _, test := range []struct {
@@ -14,6 +17,9 @@ func TestParseInvocationRejectsUnusableRequests(t *testing.T) {
 		{"owner beyond range", []string{"worker", "--name=workspace", "--owner=65535"}},
 		{"more disks than slots", []string{"worker", "--name=workspace", "--models=24", "--index=0"}},
 		{"trailing arguments", []string{"worker", "--name=workspace", "extra"}},
+		{"overlay without three fields", []string{"worker", "--name=workspace", "--overlay=nix:store"}},
+		{"overlay escaping the pack", []string{"worker", "--name=workspace", "--exec=true", "--overlay=nix:../store:nix/store"}},
+		{"overlay on a noexec volume", []string{"worker", "--name=workspace", "--overlay=nix:store:nix/store"}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			if _, err := parseInvocation(test.args); err == nil {
@@ -24,12 +30,18 @@ func TestParseInvocationRejectsUnusableRequests(t *testing.T) {
 }
 
 func TestParseInvocationAcceptsDeclaredVolume(t *testing.T) {
-	parsed, err := parseInvocation([]string{"worker", "--models=2", "--index=1", "--name=workspace", "--exec=true", "--owner=1000"})
+	parsed, err := parseInvocation([]string{
+		"worker", "--models=2", "--index=1", "--name=workspace", "--exec=true", "--owner=1000",
+		"--overlay=nix:store:nix/store",
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := invocation{models: 2, index: 1, name: "workspace", executable: true, owner: 1000}
-	if parsed != want {
+	want := invocation{
+		models: 2, index: 1, name: "workspace", executable: true, owner: 1000,
+		overlays: []overlay{{model: "nix", source: "store", target: "nix/store"}},
+	}
+	if !reflect.DeepEqual(parsed, want) {
 		t.Fatalf("parsed = %+v, want %+v", parsed, want)
 	}
 }

--- a/tinfoil/cmd/volumeworker/main_test.go
+++ b/tinfoil/cmd/volumeworker/main_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseInvocationRejectsUnusableRequests(t *testing.T) {
 	for _, test := range []struct {
@@ -29,8 +32,32 @@ func TestParseInvocationAcceptsDeclaredVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := invocation{models: 2, index: 1, name: "workspace", executable: true, owner: 1000}
-	if parsed != want {
+	if !reflect.DeepEqual(parsed, want) {
 		t.Fatalf("parsed = %+v, want %+v", parsed, want)
+	}
+}
+
+func TestParseInvocationOverlays(t *testing.T) {
+	base := []string{"worker", "--name=workspace", "--exec=true", "--owner=1000"}
+	for _, bad := range []string{
+		"nix:nix/store:st:ore",            // target splits a fourth field
+		"nix:nix/store:Store",             // target is not a single lowercase name
+		"nix:nix/store:store/x",           // target holds a separator
+		"nix:../etc:store",                // source escapes the pack
+		"nix:nix/store,upperdir=/x:store", // option injection in source
+		"n/x:nix/store:store",             // model holds a separator
+	} {
+		if _, err := parseInvocation(append(base, "--overlay="+bad)); err == nil {
+			t.Fatalf("parseInvocation accepted overlay %q", bad)
+		}
+	}
+	parsed, err := parseInvocation(append(base, "--overlay=nix:nix/store:store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []overlay{{model: "nix", source: "nix/store", target: "store"}}
+	if !reflect.DeepEqual(parsed.overlays, want) {
+		t.Fatalf("overlays = %+v, want %+v", parsed.overlays, want)
 	}
 }
 

--- a/tinfoil/go.mod
+++ b/tinfoil/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2
 	github.com/tinfoilsh/modelwrap v0.2.1
-	github.com/tinfoilsh/tinfoil-config v0.1.7
+	github.com/tinfoilsh/tinfoil-config v0.1.8
 	golang.org/x/net v0.57.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0

--- a/tinfoil/go.sum
+++ b/tinfoil/go.sum
@@ -95,8 +95,8 @@ github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2 h1:yKxfC3pVJ4ORwLeHwflv
 github.com/tinfoilsh/encrypted-http-body-protocol v0.3.2/go.mod h1:THDK0GFNny7Pcc+nO3AQi4f6Wf1cDkfLatmHAUlIn5s=
 github.com/tinfoilsh/modelwrap v0.2.1 h1:2Up98rhP+BtEtQowjHm+DpZtZiWORa3p0XWVzgXKbq0=
 github.com/tinfoilsh/modelwrap v0.2.1/go.mod h1:y3ov37f4WkQVA0jwJ/Rg7yQtKZuZloaQC+U7GgSoa8w=
-github.com/tinfoilsh/tinfoil-config v0.1.7 h1:Il/PeD5f2Yy5z3hpso9UYxXN159xvJ2An5h6Ata1E00=
-github.com/tinfoilsh/tinfoil-config v0.1.7/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
+github.com/tinfoilsh/tinfoil-config v0.1.8 h1:IUBP9IwhXFHuzC7r3+48baqO+RP2wvRMDXRqNpc58+U=
+github.com/tinfoilsh/tinfoil-config v0.1.8/go.mod h1:xgZOb0BSJ3+n7ZOIRObH6RSzekvtpa1dEX0p1osS4Lw=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513 h1:bKenHmdOAI0zEBb8iCtSRzN5YgFNNuja29IN95fieqg=
 github.com/tinfoilsh/tinfoil-go v0.15.1-0.20260810234756-ff634ede9513/go.mod h1:GPckBb5gXbgwcVYAM6UaS5hb+cuHkHJzy//vebjSRLQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -520,9 +520,14 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 		})
 	}
 
-	// Volume mounts
+	// Volume mounts. A volume named twice mounts at both targets but brings its
+	// control socket along only once, which is what docker will accept.
 	for _, vol := range c.Volumes {
-		hostConfig.Binds = append(hostConfig.Binds, volumeBinds(vol, cfg)...)
+		for _, bind := range volumeBinds(vol, cfg) {
+			if !slices.Contains(hostConfig.Binds, bind) {
+				hostConfig.Binds = append(hostConfig.Binds, bind)
+			}
+		}
 	}
 
 	hostIP := netip.MustParseAddr(containernet.PublishedHostIP)

--- a/tinfoil/internal/containers/containers.go
+++ b/tinfoil/internal/containers/containers.go
@@ -520,8 +520,7 @@ func buildContainerCreateSpec(c Container, cfg *Config, extConfig *shimconfig.Ex
 		})
 	}
 
-	// Volume mounts. A volume named twice mounts at both targets but brings its
-	// control socket along only once, which is what docker will accept.
+	// Volume mounts. A volume named twice brings its control socket only once.
 	for _, vol := range c.Volumes {
 		for _, bind := range volumeBinds(vol, cfg) {
 			if !slices.Contains(hostConfig.Binds, bind) {

--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -149,15 +149,8 @@ func policyFor(service Service) (servicePolicy, bool) {
 		return policy, true
 	case ServiceVolumes:
 		return servicePolicy{
-			noNewPrivileges: true,
-			// DAC_OVERRIDE because this service builds and mounts directories
-			// inside a volume it hands to another uid, and grants nothing that
-			// SYS_ADMIN above does not already imply. FOWNER because overlayfs
-			// applies metadata changes to the upper layer under the credentials
-			// of whoever mounted it: without it the volume's owner cannot chmod
-			// or unlink its own files through an overlay this service mounted,
-			// and CHOWN above already implies it.
-			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN, unix.CAP_DAC_OVERRIDE, unix.CAP_FOWNER},
+			noNewPrivileges:      true,
+			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN},
 			deniedSyscalls:       volumeServiceSyscalls,
 			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_UNIX},

--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -149,8 +149,13 @@ func policyFor(service Service) (servicePolicy, bool) {
 		return policy, true
 	case ServiceVolumes:
 		return servicePolicy{
-			noNewPrivileges:      true,
-			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN},
+			noNewPrivileges: true,
+			// FOWNER because overlayfs applies upper-layer metadata changes
+			// under the credentials of whoever mounted it.
+			boundCapabilities: []int{
+				unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN,
+				unix.CAP_DAC_OVERRIDE, unix.CAP_FOWNER,
+			},
 			deniedSyscalls:       volumeServiceSyscalls,
 			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_UNIX},

--- a/tinfoil/internal/pid1/hardening/hardening.go
+++ b/tinfoil/internal/pid1/hardening/hardening.go
@@ -149,8 +149,15 @@ func policyFor(service Service) (servicePolicy, bool) {
 		return policy, true
 	case ServiceVolumes:
 		return servicePolicy{
-			noNewPrivileges:      true,
-			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN},
+			noNewPrivileges: true,
+			// DAC_OVERRIDE because this service builds and mounts directories
+			// inside a volume it hands to another uid, and grants nothing that
+			// SYS_ADMIN above does not already imply. FOWNER because overlayfs
+			// applies metadata changes to the upper layer under the credentials
+			// of whoever mounted it: without it the volume's owner cannot chmod
+			// or unlink its own files through an overlay this service mounted,
+			// and CHOWN above already implies it.
+			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN, unix.CAP_DAC_OVERRIDE, unix.CAP_FOWNER},
 			deniedSyscalls:       volumeServiceSyscalls,
 			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_UNIX},

--- a/tinfoil/internal/pid1/hardening/hardening_test.go
+++ b/tinfoil/internal/pid1/hardening/hardening_test.go
@@ -43,8 +43,11 @@ func TestServicePoliciesAreExact(t *testing.T) {
 			allowedSocketDomains:     []uint32{unix.AF_INET, unix.AF_INET6},
 		},
 		ServiceVolumes: {
-			noNewPrivileges:      true,
-			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN},
+			noNewPrivileges: true,
+			boundCapabilities: []int{
+				unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN,
+				unix.CAP_DAC_OVERRIDE, unix.CAP_FOWNER,
+			},
 			deniedSyscalls:       volumeServiceSyscalls,
 			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_UNIX},

--- a/tinfoil/internal/pid1/hardening/hardening_test.go
+++ b/tinfoil/internal/pid1/hardening/hardening_test.go
@@ -44,7 +44,7 @@ func TestServicePoliciesAreExact(t *testing.T) {
 		},
 		ServiceVolumes: {
 			noNewPrivileges:      true,
-			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN, unix.CAP_DAC_OVERRIDE, unix.CAP_FOWNER},
+			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN},
 			deniedSyscalls:       volumeServiceSyscalls,
 			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_UNIX},

--- a/tinfoil/internal/pid1/hardening/hardening_test.go
+++ b/tinfoil/internal/pid1/hardening/hardening_test.go
@@ -44,7 +44,7 @@ func TestServicePoliciesAreExact(t *testing.T) {
 		},
 		ServiceVolumes: {
 			noNewPrivileges:      true,
-			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN},
+			boundCapabilities:    []int{unix.CAP_SYS_ADMIN, unix.CAP_MKNOD, unix.CAP_CHOWN, unix.CAP_DAC_OVERRIDE, unix.CAP_FOWNER},
 			deniedSyscalls:       volumeServiceSyscalls,
 			restrictNamespaceOps: true,
 			allowedSocketDomains: []uint32{unix.AF_UNIX},

--- a/tinfoil/internal/runtimeconfig/types.go
+++ b/tinfoil/internal/runtimeconfig/types.go
@@ -35,6 +35,10 @@ func ModelIsIsolated(config *Config, name string) bool {
 	return sharedconfig.ModelIsIsolated(config, name)
 }
 
+func ModelBacksExecutableVolume(config *Config, name string) bool {
+	return sharedconfig.ModelBacksExecutableVolume(config, name)
+}
+
 func ReservedDebugRuntimeEnabled(containerName string, debug bool) bool {
 	return sharedconfig.ReservedDebugRuntimeEnabled(containerName, options(debug))
 }

--- a/tinfoil/internal/runtimeconfig/types.go
+++ b/tinfoil/internal/runtimeconfig/types.go
@@ -35,10 +35,6 @@ func ModelIsIsolated(config *Config, name string) bool {
 	return sharedconfig.ModelIsIsolated(config, name)
 }
 
-func ModelBacksExecutableVolume(config *Config, name string) bool {
-	return sharedconfig.ModelBacksExecutableVolume(config, name)
-}
-
 func ReservedDebugRuntimeEnabled(containerName string, debug bool) bool {
 	return sharedconfig.ReservedDebugRuntimeEnabled(containerName, options(debug))
 }


### PR DESCRIPTION
Honors `ModelSpec.Exec` when mounting a model pack, so a pack holding programs can be executed from where it is mounted.

- `MS_NOEXEC` is applied to the erofs mount unless the model declares `exec: true`. `MS_RDONLY`, `MS_NODEV` and `MS_NOSUID` are unconditional, and no view stacked above the pack can launder the flag away. Threaded through both the plaintext (dm-verity) and encrypted (dm-crypt + dm-verity) paths.
- A volume named twice in a container's `volumes` now contributes its bind once. `confidential-agent-sandbox` mounts one volume at both `/workspace` and `/nix`, which previously duplicated the control-socket bind.

## Blocked

This branch does not compile against the pinned `tinfoil-config v0.1.7`:

```
cmd/boot/models.go:49:23: model.Exec undefined (type tinfoilconfig.ModelSpec has no field or method Exec)
```

It needs tinfoilsh/tinfoil-config#10 merged and tagged, then a `go.mod` bump in this branch. Draft until then.

Second of three in the unlock refactor:

1. `tinfoil-config` — declare pack exec and allow mount capabilities (tinfoilsh/tinfoil-config#10)
2. **this PR**
3. `confidential-agent-sandbox` — mount the toolchain store in the container

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors `ModelSpec.Exec` when mounting a model pack: packs declaring `exec: true` mount without `MS_NOEXEC`, others stay noexec. Volume workers can now merge model packs into volumes with overlayfs, and duplicate volume binds are deduplicated so a volume named twice contributes its bind only once.

**Overlays**
- `--overlay=model:source:target` args mount the pack source as the read-only lower layer at the volume target.
- The worker control protocol switched from raw bytes to JSON, and overlay specs are re-validated in the worker to keep sources inside the pack, out of mount options, and free of symlink escapes.
- Overlays require an executable volume, cap at 8 per volume, and the worker gained capabilities to mount and own the merged trees.

<sup>Written for commit f758147ea9e19346baa5df89c4feff2fac29eab0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

