### PR TITLE
fix: initialize the blocks mkfs reads before formatting a volume

### DIFF
--- a/tinfoil/cmd/volumeworker/main.go
+++ b/tinfoil/cmd/volumeworker/main.go
@@ -33,13 +33,14 @@ import (
 )
 
 const (
-	controlRoot = boot.VolumeControlDir
-	dataRoot    = boot.VolumeDataDir
-	socketName  = boot.VolumeSocketName
-	mapperRoot  = "tinfoil-volume-"
-	mkfsPath    = "/usr/sbin/mkfs.ext4"
-	formatMode  = "--format"
-	selfPath    = "/proc/self/exe"
+	controlRoot   = boot.VolumeControlDir
+	dataRoot      = boot.VolumeDataDir
+	socketName    = boot.VolumeSocketName
+	mapperRoot    = "tinfoil-volume-"
+	mkfsPath      = "/usr/sbin/mkfs.ext4"
+	backupHeading = "Superblock backups stored on blocks:"
+	formatMode    = "--format"
+	selfPath      = "/proc/self/exe"
 
 	upperSuffix     = ".upper"
 	workSuffix      = ".work"
@@ -60,6 +61,11 @@ const (
 	maxRequestBytes = 512
 	blankProbeSize  = 1 << 20
 	requestTimeout  = 5 * time.Second
+
+	formatEdgeBytes   = 8 << 20
+	formatBackupBytes = 4 << 20
+	formatChunkBytes  = 1 << 20
+	formatBlockBytes  = 4096
 
 	opStatus     = "status"
 	opUnlock     = "unlock"
@@ -376,7 +382,7 @@ func (w *worker) removeUnopened(name string) error {
 
 func (w *worker) serve(connection *net.UnixConn) error {
 	defer connection.Close()
-	if err := connection.SetDeadline(time.Now().Add(requestTimeout)); err != nil {
+	if err := connection.SetReadDeadline(time.Now().Add(requestTimeout)); err != nil {
 		return err
 	}
 	var packet [maxRequestBytes + 1]byte
@@ -388,6 +394,10 @@ func (w *worker) serve(connection *net.UnixConn) error {
 	status, requestErr := w.handle(packet[:n])
 	reply, err := json.Marshal(response{Status: status})
 	if err != nil {
+		return errors.Join(requestErr, err)
+	}
+	// Set after handle, which formats a fresh volume and takes minutes on a large one.
+	if err := connection.SetWriteDeadline(time.Now().Add(requestTimeout)); err != nil {
 		return errors.Join(requestErr, err)
 	}
 	if _, err := connection.Write(reply); err != nil {
@@ -466,6 +476,9 @@ func (w *worker) activate(spec request) (result error) {
 		result = errors.Join(result, devicemapper.Remove(w.control, w.mapperName()))
 	}()
 	if spec.Op == opInitialize {
+		if err := prepareFormat(w.mapperNode(), w.owner); err != nil {
+			return fmt.Errorf("preparing volume for format: %w", err)
+		}
 		command := exec.Command(selfPath, formatMode, w.mapperNode(), strconv.Itoa(w.owner))
 		command.Env = []string{}
 		command.Stdout = io.Discard
@@ -594,6 +607,110 @@ func (w *worker) overlay(spec overlay) (string, error) {
 	return mountPoint, nil
 }
 
+func mkfsArgs(owner int) []string {
+	// root_owner hands the volume to the login account. root_perms adds group
+	// write and setgid, because the container writing this tree runs as uid 0
+	// with the volume gid and no CAP_DAC_OVERRIDE, and new directories have to
+	// stay in the group as it grows. mkfs has to set both: it writes the root
+	// inode directly, whereas a chmod afterwards would need CAP_FOWNER, which
+	// this formatter has just dropped.
+	root := fmt.Sprintf("root_owner=%d:%d,root_perms=2775", owner, owner)
+	// Nothing is left to first use: dm-integrity holds no tag for a block that was
+	// never written, so a lazy table or journal reads back as an I/O error.
+	return []string{
+		mkfsPath, "-F",
+		"-b", strconv.Itoa(formatBlockBytes),
+		"-E", root + ",lazy_itable_init=0,lazy_journal_init=0",
+	}
+}
+
+// prepareFormat writes a tag over every block mkfs reads, leaving the rest of
+// the volume unwritten so its image stays sparse.
+func prepareFormat(node string, owner int) error {
+	backups, err := backupSuperblocks(node, owner)
+	if err != nil {
+		return err
+	}
+	device, err := os.OpenFile(node, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer device.Close()
+	size, err := device.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+	zeros := make([]byte, formatChunkBytes)
+	write := func(offset, length int64) error {
+		if offset < 0 {
+			length += offset
+			offset = 0
+		}
+		if offset+length > size {
+			length = size - offset
+		}
+		for length > 0 {
+			chunk := min(length, int64(len(zeros)))
+			if _, err := device.WriteAt(zeros[:chunk], offset); err != nil {
+				return err
+			}
+			offset += chunk
+			length -= chunk
+		}
+		return nil
+	}
+	if err := write(0, formatEdgeBytes); err != nil {
+		return err
+	}
+	if err := write(size-formatEdgeBytes, formatEdgeBytes); err != nil {
+		return err
+	}
+	for _, block := range backups {
+		if err := write(int64(block)*formatBlockBytes, formatBackupBytes); err != nil {
+			return err
+		}
+	}
+	return device.Sync()
+}
+
+// backupSuperblocks asks mkfs where the backups will land. The dry run writes
+// nothing and reports read errors it works around, so only stdout matters.
+func backupSuperblocks(node string, owner int) ([]uint64, error) {
+	output, _ := exec.Command(mkfsPath, append(mkfsArgs(owner)[1:], "-n", node)...).Output()
+	fields := strings.Fields(strings.ReplaceAll(backupList(string(output)), ",", " "))
+	blocks := make([]uint64, 0, len(fields))
+	for _, field := range fields {
+		block, err := strconv.ParseUint(field, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("unexpected block %q in the mkfs layout", field)
+		}
+		blocks = append(blocks, block)
+	}
+	if len(blocks) == 0 {
+		return nil, errors.New("mkfs reported no backup superblocks")
+	}
+	return blocks, nil
+}
+
+// backupList reads the blocks under the heading, which mkfs wraps over as many
+// indented lines as it needs and closes with a blank one.
+func backupList(output string) string {
+	_, rest, found := strings.Cut(output, backupHeading)
+	if !found {
+		return ""
+	}
+	var list strings.Builder
+	for index, line := range strings.Split(rest, "\n") {
+		// Index 0 trails the heading on its own line, blank or not.
+		if index > 0 && strings.TrimSpace(line) == "" {
+			break
+		}
+		list.WriteString(line)
+		list.WriteByte(' ')
+	}
+	return list.String()
+}
+
 func runFormatter(args []string) error {
 	if len(args) != 4 {
 		return errors.New("invalid formatter invocation")
@@ -622,16 +739,7 @@ func runFormatter(args []string) error {
 			return errors.New("formatter retained capabilities")
 		}
 	}
-	// root_owner hands the volume to the login account. root_perms adds group
-	// write and setgid, because the container writing this tree runs as uid 0
-	// with the volume gid and no CAP_DAC_OVERRIDE, and new directories have to
-	// stay in the group as it grows. mkfs has to set both: it writes the root
-	// inode directly, whereas a chmod afterwards would need CAP_FOWNER, which
-	// this formatter has just dropped.
-	root := fmt.Sprintf("root_owner=%d:%d,root_perms=2775", owner, owner)
-	// Nothing is left to first use: dm-integrity holds no tag for a block that was
-	// never written, so a lazy table or journal reads back as an I/O error.
-	return syscall.Exec(mkfsPath, []string{mkfsPath, "-F", "-q", "-E", root + ",lazy_itable_init=0,lazy_journal_init=0", args[2]}, []string{})
+	return syscall.Exec(mkfsPath, append(mkfsArgs(owner), "-q", args[2]), []string{})
 }
 
 func listen(path string, owner int) (*net.UnixListener, error) {


### PR DESCRIPTION
## The issue

No new workspace volume can be formatted. Every sandbox created on cvm-version 0.14.4 fails its first enrollment, and cannot be recovered by restarting.

dm-integrity holds no tag for a block that was never written, so reading such a block is a hard I/O error. `mkfs.ext4` reads before it writes: it probes block 0, erases the first sectors, and read-modify-writes *every* backup superblock. On a virgin volume each of those reads fails:

```
Warning: could not erase sector 2: Input/output error
Warning: could not read block 0: Input/output error
mkfs.ext4: Input/output error while writing out and closing file system
```

`lazy_itable_init=0,lazy_journal_init=0` covers the other half of this — ext4 leaving metadata uninitialized for first use — but nothing stops mkfs reading blocks it has not written yet. The backup superblocks are scattered across the whole device (32768, 98304, 163840, … 14 of them on a 100 GiB volume), so this is not confined to the edges.

The `activate` error surfaces to the caller as a refused *workspace key*, which is misleading: the key is never the problem. Worse, the volume is left carrying a valid dm-integrity superblock and a partial ext4, so it is no longer blank. Every later boot therefore rejects `initialize`, falls through to `unlock`, activates the mapping, and then fails to mount — permanently.

Reproduced with the exact table parameters from `devicemapper.go`. A failed mkfs leaves 602568 allocated blocks on the backing image, matching a volume broken this way in production byte for byte.

## Second issue in the same path

Once formatting succeeds it is slow, because it writes the whole inode table and journal: ~2.2 GiB and 16–34s for a 100 GiB volume, longer on two vCPUs. `serve` set a single 5s deadline spanning the request read, the work, and the reply write, so the reply was lost to a deadline consumed by the format. The unlock had fully succeeded and the volume was mounted, but the caller was told it failed — and since the volume was no longer blank, nothing could open it afterwards.

## Verified

Against a real dm-integrity + aead dm-crypt stack, using the guest's own pinned `mke2fs 1.47.2`, at 10 GiB and 100 GiB: mkfs succeeds, the volume mounts with root `drwxrwsr-x 1000:1000`, survives fsck, unmount and remount with data intact, and a 100 GiB volume occupies 2253 MiB at rest (2%) and grows about 1.03 GiB per GiB written — so the backing image stays sparse.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes formatting of new workspace volumes failing because `mkfs.ext4` reads blocks that `dm-integrity` has no tag for, and prevents the success reply from being lost while a large volume formats.

- Pre-initializes the volume edges and backup superblocks with zeros before formatting, so mkfs's read-before-write passes succeed; the rest of the volume stays unwritten and the backing image stays sparse.
- Moves the request deadline to cover only reading the request and writing the reply, not the format itself, which can take minutes and previously caused a successful mount to be reported as a failure.

<sup>Written for commit ee2b229655fd43b338c0a2c1376283ebc645f870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

