### PR TITLE
Raise the NVIDIA service readiness deadline to 120 s

### DIFF
--- a/tinfoil/internal/nvidia/services.go
+++ b/tinfoil/internal/nvidia/services.go
@@ -19,7 +19,7 @@ import (
 const (
 	persistencedUID     = 143
 	persistencedGID     = 143
-	serviceReadyWait    = 30 * time.Second
+	serviceReadyWait    = 120 * time.Second
 	servicePollInterval = 500 * time.Millisecond
 	maxPIDFileSize      = 32
 )


### PR DESCRIPTION
## Why
pid1 waits `serviceReadyWait` for nvidia-persistenced's socket, which appears only after persistenced has attached every GPU sequentially. On inf16 (8× B200, TDX, CC on) each attach takes 3.1–4.3 s, so eight GPUs need 25–35 s against the current 30 s. A boot that lands over the deadline is killed mid-attach and dies silently at `gpu-attestation` (no shim, tinfoild stuck on `started`); every later attach in that VM then fails with `RmInitAdapter failed (0x22:0x56:894)` / `GSP offload -- GPU not supported`, because a CC-mode GPU cannot re-initialise without a reset. That signature looked like a wedged GPU and cost an unnecessary SBR on 2026-09-11.

## Evidence (inf16, 2026-09-11)
| build | deadline | GPUs attached before kill | outcome |
|---|---|---|---|
| debug 282479b (pre-#339) | 15 s | 4–5 of 8 | fail |
| shipping 0.14.2 | 30 s | n/a (no console) | 44 min silent `started`, no traffic after the TD quote |
| debug 282479b + this change | 120 s | 8 of 8, socket at 26 s | boots, GPU attestation passes, vLLM serves |

Per-GPU timeline from guest dmesg: 31.9 / 35.1 / 38.1 / 41.3 / 44.4 / 47.6 / 50.9 / 54.3 s. glm-5-2 booted here on Aug 24 with the same 30 s only because that run landed under it.

## What
One constant, 30 s → 120 s (~4× the measured need). A per-GPU scaling or a smarter readiness check would be better long-term; this unblocks 8-GPU CC launches now.

Full analysis: model-ops `launches/deepseek-v4-1-flash/state.md` (B1).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the NVIDIA service readiness deadline from 30 s to 120 s so 8-GPU confidential-computing boots no longer die silently.

The old 30 s deadline was too tight: nvidia-persistenced only publishes its socket after attaching every GPU, and each B200 attach takes 3.1–4.3 s under CC, so eight GPUs need 25–35 s. Boots that exceeded the deadline were killed mid-attach and failed at `gpu-attestation` with no error; later attaches in that VM then failed with `RmInitAdapter` errors because a CC GPU cannot re-initialise without a reset. Measured on inf16 with this change: readiness in 26 s, boot completes. A per-GPU scaling or smarter readiness check is left as a future improvement.

<sup>Written for commit e8421702252e835b5066033fd165408d90b5e3f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tinfoilsh/cvmimage/pull/363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

